### PR TITLE
add ping protocol, multistream-select, and stream-multiplexed transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,12 +390,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "minip2p-multistream-select"
+version = "0.1.0"
+
+[[package]]
+name = "minip2p-ping"
+version = "0.1.0"
+dependencies = [
+ "minip2p-core",
+ "minip2p-transport",
+ "thiserror",
+]
+
+[[package]]
 name = "minip2p-quic"
 version = "0.1.0"
 dependencies = [
  "getrandom 0.3.4",
  "minip2p-core",
  "minip2p-identity",
+ "minip2p-multistream-select",
+ "minip2p-ping",
  "minip2p-transport",
  "quiche",
  "rcgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,10 @@ dependencies = [
 [[package]]
 name = "minip2p-multistream-select"
 version = "0.1.0"
+dependencies = [
+ "minip2p-core",
+ "thiserror",
+]
 
 [[package]]
 name = "minip2p-ping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
 [workspace]
 resolver = "3"
-members = ["packages/core", "packages/identity", "packages/transport", "transports/quic"]
+members = [
+    "packages/core",
+    "packages/identity",
+    "packages/multistream-select",
+    "packages/ping",
+    "packages/transport",
+    "transports/quic",
+]

--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ Current crates:
 
 - `packages/identity` (`minip2p-identity`): peer identity primitives and validation.
 - `packages/core` (`minip2p-core`): transport-agnostic address/types (`Multiaddr`, `PeerAddr`, `PeerId` re-export).
-- `packages/transport` (`minip2p-transport`): transport contract types, connection lifecycle, events, and errors.
+- `packages/transport` (`minip2p-transport`): transport contract types, connection+stream lifecycle, events, and errors.
+- `packages/multistream-select` (`minip2p-multistream-select`): Sans-I/O protocol negotiation state machine (`/multistream/1.0.0`).
+- `packages/ping` (`minip2p-ping`): Sans-I/O ping protocol state machine (`/ipfs/ping/1.0.0`).
 - `transports/quic` (`minip2p-quic`): `std` QUIC transport adapter built on `quiche`.
 
 Current validated behavior:
 
 - Two local peers connect over QUIC in integration tests.
-- Peers exchange bytes bidirectionally.
-- Multiple simultaneous connections per peer are supported.
+- Peers open QUIC streams and exchange stream data bidirectionally.
+- Stream half-close (close write) propagates as transport events.
 - Identity upgrade events are emitted and peer indexing updates correctly.
 
 ## Architecture boundaries

--- a/packages/core/src/error.rs
+++ b/packages/core/src/error.rs
@@ -9,24 +9,23 @@ pub enum MultiaddrError {
     EmptyInput,
     #[error("multiaddr must start with '/' (example: /ip4/127.0.0.1/udp/4001/quic-v1)")]
     MissingLeadingSlash,
-    #[error("empty protocol segment at index {segment}")]
-    EmptyProtocol { segment: usize },
-    #[error("missing value for protocol '{protocol}' at segment {segment}")]
-    MissingValue { protocol: String, segment: usize },
-    #[error("unknown protocol '{protocol}' at segment {segment}")]
-    UnknownProtocol { protocol: String, segment: usize },
-    #[error("invalid ip4 value '{value}' at segment {segment}")]
-    InvalidIp4 { value: String, segment: usize },
-    #[error("invalid ip6 value '{value}' at segment {segment}")]
-    InvalidIp6 { value: String, segment: usize },
-    #[error("invalid udp port '{value}' at segment {segment}")]
-    InvalidPort { value: String, segment: usize },
-    #[error("invalid dns value '{value}' at segment {segment}")]
-    InvalidDnsName { value: String, segment: usize },
-    #[error("invalid peer id '{value}' at segment {segment}: {source}")]
+    #[error("empty protocol segment in multiaddr")]
+    EmptyProtocol,
+    #[error("missing value for protocol '{protocol}'")]
+    MissingValue { protocol: String },
+    #[error("unknown protocol '{protocol}'")]
+    UnknownProtocol { protocol: String },
+    #[error("invalid ip4 value '{value}'")]
+    InvalidIp4 { value: String },
+    #[error("invalid ip6 value '{value}'")]
+    InvalidIp6 { value: String },
+    #[error("invalid udp port '{value}'")]
+    InvalidPort { value: String },
+    #[error("invalid dns value '{value}'")]
+    InvalidDnsName { value: String },
+    #[error("invalid peer id '{value}': {source}")]
     InvalidPeerId {
         value: String,
-        segment: usize,
         #[source]
         source: PeerIdError,
     },
@@ -38,8 +37,8 @@ pub enum PeerAddrError {
     Multiaddr(#[from] MultiaddrError),
     #[error("peer address must end with /p2p/<peer-id>")]
     MissingPeerId,
-    #[error("peer id protocol must be terminal (found at segment {segment})")]
-    NonTerminalPeerId { segment: usize },
+    #[error("peer id protocol must be terminal")]
+    NonTerminalPeerId,
     #[error("transport address must not already contain /p2p")]
     TransportContainsPeerId,
     #[error("transport address must contain at least one protocol before /p2p/<peer-id>")]

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -9,6 +9,7 @@ mod protocol;
 
 pub use error::{MultiaddrError, PeerAddrError};
 pub use minip2p_identity::PeerId;
+pub use minip2p_identity::{VarintError, read_uvarint, uvarint_len, write_uvarint};
 pub use multiaddr::Multiaddr;
 pub use peer_addr::PeerAddr;
 pub use protocol::Protocol;

--- a/packages/core/src/multiaddr.rs
+++ b/packages/core/src/multiaddr.rs
@@ -143,7 +143,7 @@ fn parse_multiaddr(input: &str) -> Result<Multiaddr, MultiaddrError> {
     while idx < segments.len() {
         let protocol = segments[idx];
         if protocol.is_empty() {
-            return Err(MultiaddrError::EmptyProtocol { segment: idx });
+            return Err(MultiaddrError::EmptyProtocol);
         }
 
         match protocol {
@@ -151,7 +151,6 @@ fn parse_multiaddr(input: &str) -> Result<Multiaddr, MultiaddrError> {
                 let value = require_value(&segments, idx, "ip4")?;
                 let parsed = parse_ip4(value).ok_or_else(|| MultiaddrError::InvalidIp4 {
                     value: value.to_string(),
-                    segment: idx + 1,
                 })?;
                 protocols.push(Protocol::Ip4(parsed));
                 idx += 2;
@@ -162,7 +161,6 @@ fn parse_multiaddr(input: &str) -> Result<Multiaddr, MultiaddrError> {
                     .parse::<Ipv6Addr>()
                     .map_err(|_| MultiaddrError::InvalidIp6 {
                         value: value.to_string(),
-                        segment: idx + 1,
                     })?
                     .octets();
                 protocols.push(Protocol::Ip6(parsed));
@@ -173,7 +171,6 @@ fn parse_multiaddr(input: &str) -> Result<Multiaddr, MultiaddrError> {
                 if !is_valid_dns(value) {
                     return Err(MultiaddrError::InvalidDnsName {
                         value: value.to_string(),
-                        segment: idx + 1,
                     });
                 }
 
@@ -192,7 +189,6 @@ fn parse_multiaddr(input: &str) -> Result<Multiaddr, MultiaddrError> {
                     .parse::<u16>()
                     .map_err(|_| MultiaddrError::InvalidPort {
                         value: value.to_string(),
-                        segment: idx + 1,
                     })?;
                 protocols.push(Protocol::Udp(parsed));
                 idx += 2;
@@ -208,7 +204,6 @@ fn parse_multiaddr(input: &str) -> Result<Multiaddr, MultiaddrError> {
                         .parse::<PeerId>()
                         .map_err(|source| MultiaddrError::InvalidPeerId {
                             value: value.to_string(),
-                            segment: idx + 1,
                             source,
                         })?;
                 protocols.push(Protocol::P2p(parsed));
@@ -217,7 +212,6 @@ fn parse_multiaddr(input: &str) -> Result<Multiaddr, MultiaddrError> {
             _ => {
                 return Err(MultiaddrError::UnknownProtocol {
                     protocol: protocol.to_string(),
-                    segment: idx,
                 });
             }
         }
@@ -235,7 +229,6 @@ fn require_value<'a>(
         Some(value) if !value.is_empty() => Ok(value),
         _ => Err(MultiaddrError::MissingValue {
             protocol: protocol.to_string(),
-            segment: idx,
         }),
     }
 }

--- a/packages/core/src/peer_addr.rs
+++ b/packages/core/src/peer_addr.rs
@@ -35,7 +35,7 @@ impl PeerAddr {
             .ok_or(PeerAddrError::MissingPeerId)?;
 
         if last != protocols.len() - 1 {
-            return Err(PeerAddrError::NonTerminalPeerId { segment: last + 1 });
+            return Err(PeerAddrError::NonTerminalPeerId);
         }
 
         let first = protocols
@@ -44,7 +44,7 @@ impl PeerAddr {
             .ok_or(PeerAddrError::MissingPeerId)?;
 
         if first != last {
-            return Err(PeerAddrError::NonTerminalPeerId { segment: first + 1 });
+            return Err(PeerAddrError::NonTerminalPeerId);
         }
 
         let peer_id = match &protocols[last] {
@@ -127,7 +127,7 @@ mod tests {
     fn rejects_non_terminal_peer_id() {
         let input = format!("/ip4/127.0.0.1/p2p/{PEER_ID}/udp/4001/quic-v1");
         let err = PeerAddr::from_str(&input).expect_err("must fail");
-        assert!(matches!(err, PeerAddrError::NonTerminalPeerId { .. }));
+        assert!(matches!(err, PeerAddrError::NonTerminalPeerId));
     }
 
     #[test]

--- a/packages/identity/src/lib.rs
+++ b/packages/identity/src/lib.rs
@@ -16,6 +16,9 @@ pub use ed25519::{
 #[cfg(feature = "ed25519")]
 pub use key::VerifyError;
 pub use key::{KeyType, PublicKey, PublicKeyError};
-pub use peer_id::{PEER_ID_MULTIHASH_SIZE, PeerId, PeerIdError, PeerMultihash, VarintError};
+pub use peer_id::{
+    PEER_ID_MULTIHASH_SIZE, PeerId, PeerIdError, PeerMultihash, VarintError, read_uvarint,
+    uvarint_len, write_uvarint,
+};
 #[cfg(feature = "ed25519")]
 pub use signed::SignedBytes;

--- a/packages/identity/src/peer_id.rs
+++ b/packages/identity/src/peer_id.rs
@@ -198,7 +198,7 @@ pub enum VarintError {
     NonCanonical,
 }
 
-pub(crate) fn uvarint_len(mut value: u64) -> usize {
+pub fn uvarint_len(mut value: u64) -> usize {
     let mut len = 1;
     while value >= 0x80 {
         value >>= 7;
@@ -208,7 +208,7 @@ pub(crate) fn uvarint_len(mut value: u64) -> usize {
 }
 
 /// Writes minimally-encoded unsigned varint bytes.
-pub(crate) fn write_uvarint(mut value: u64, out: &mut Vec<u8>) {
+pub fn write_uvarint(mut value: u64, out: &mut Vec<u8>) {
     loop {
         let mut byte = (value & 0x7f) as u8;
         value >>= 7;
@@ -223,7 +223,7 @@ pub(crate) fn write_uvarint(mut value: u64, out: &mut Vec<u8>) {
 }
 
 /// Reads an unsigned varint and enforces canonical (minimal) encoding.
-pub(crate) fn read_uvarint(input: &[u8]) -> Result<(u64, usize), VarintError> {
+pub fn read_uvarint(input: &[u8]) -> Result<(u64, usize), VarintError> {
     let mut value = 0u64;
     let mut shift = 0u32;
 

--- a/packages/multistream-select/Cargo.toml
+++ b/packages/multistream-select/Cargo.toml
@@ -2,6 +2,7 @@
 name = "minip2p-multistream-select"
 version = "0.1.0"
 edition = "2024"
+readme = "README.md"
 
 [features]
 default = ["std"]

--- a/packages/multistream-select/Cargo.toml
+++ b/packages/multistream-select/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "minip2p-multistream-select"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+default = ["std"]
+std = []
+
+[dependencies]

--- a/packages/multistream-select/Cargo.toml
+++ b/packages/multistream-select/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2024"
 
 [features]
 default = ["std"]
-std = []
+std = ["minip2p-core/std", "thiserror/std"]
 
 [dependencies]
+minip2p-core = { path = "../core", default-features = false }
+thiserror = { version = "2", default-features = false }

--- a/packages/multistream-select/README.md
+++ b/packages/multistream-select/README.md
@@ -1,0 +1,59 @@
+# minip2p-multistream-select
+
+Sans-IO state machine for the `/multistream/1.0.0` protocol negotiation. `no_std` + `alloc` compatible.
+
+This crate implements the [multistream-select](https://github.com/multiformats/multistream-select) handshake used by libp2p to agree on a protocol for a newly opened stream.
+
+## Features
+
+- Varint-length-prefixed wire format (spec-compliant framing).
+- Dialer and listener roles.
+- Incremental `receive()` API that handles chunked/partial input.
+- `MultistreamOutput` events for outbound data, negotiation result, and errors.
+- Typed `MultistreamError` with actionable context.
+- Zero-copy decoding where possible.
+
+## Wire format
+
+Each message is framed as:
+
+```
+<uvarint: length of payload + newline> <payload> <\n>
+```
+
+## Usage
+
+Negotiate a protocol between a dialer and listener:
+
+```rust
+use minip2p_multistream_select::{MultistreamSelect, MultistreamOutput, MULTISTREAM_PROTOCOL_ID};
+
+// Dialer side
+let mut dialer = MultistreamSelect::dialer("/ipfs/ping/1.0.0");
+let outbound = dialer.start(); // sends multistream header
+
+// Listener side
+let mut listener = MultistreamSelect::listener(["/ipfs/ping/1.0.0".to_string()]);
+let outbound = listener.start(); // sends multistream header
+
+// Feed received bytes into each side:
+// let outputs = dialer.receive(&bytes_from_listener);
+// let outputs = listener.receive(&bytes_from_dialer);
+//
+// Check outputs for MultistreamOutput::Negotiated { protocol } to know
+// when negotiation succeeds, or MultistreamOutput::NotAvailable if the
+// listener does not support the requested protocol.
+```
+
+## no_std
+
+Disable default features:
+
+```toml
+[dependencies]
+minip2p-multistream-select = { path = "packages/multistream-select", default-features = false }
+```
+
+## Scope
+
+This crate handles single-protocol negotiation only. It does not implement `ls` or multi-protocol fallback. Concrete transport integration (feeding stream bytes in, sending outbound data out) is the caller's responsibility.

--- a/packages/multistream-select/src/lib.rs
+++ b/packages/multistream-select/src/lib.rs
@@ -1,0 +1,296 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::collections::BTreeSet;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+pub const MULTISTREAM_PROTOCOL_ID: &str = "/multistream/1.0.0";
+const NOT_AVAILABLE: &str = "na";
+const MAX_LINE_LEN: usize = 1024;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MultistreamOutput {
+    OutboundData(Vec<u8>),
+    Negotiated { protocol: String },
+    NotAvailable,
+    ProtocolError { reason: &'static str },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Role {
+    Dialer,
+    Listener,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum State {
+    WaitingForRemoteHeader,
+    WaitingForProtocolRequest,
+    WaitingForProtocolResponse,
+    Done,
+}
+
+pub struct MultistreamSelect {
+    role: Role,
+    state: State,
+    desired_protocol: Option<String>,
+    supported_protocols: BTreeSet<String>,
+    recv_buf: Vec<u8>,
+    started: bool,
+}
+
+impl MultistreamSelect {
+    pub fn dialer(desired_protocol: impl Into<String>) -> Self {
+        Self {
+            role: Role::Dialer,
+            state: State::WaitingForRemoteHeader,
+            desired_protocol: Some(desired_protocol.into()),
+            supported_protocols: BTreeSet::new(),
+            recv_buf: Vec::new(),
+            started: false,
+        }
+    }
+
+    pub fn listener(protocols: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            role: Role::Listener,
+            state: State::WaitingForRemoteHeader,
+            desired_protocol: None,
+            supported_protocols: protocols.into_iter().collect(),
+            recv_buf: Vec::new(),
+            started: false,
+        }
+    }
+
+    pub fn start(&mut self) -> Vec<MultistreamOutput> {
+        if self.started {
+            return Vec::new();
+        }
+
+        self.started = true;
+        vec![MultistreamOutput::OutboundData(encode_line(
+            MULTISTREAM_PROTOCOL_ID,
+        ))]
+    }
+
+    pub fn receive(&mut self, bytes: &[u8]) -> Vec<MultistreamOutput> {
+        if self.state == State::Done {
+            return Vec::new();
+        }
+
+        self.recv_buf.extend_from_slice(bytes);
+        let mut outputs = Vec::new();
+
+        loop {
+            if self.recv_buf.len() > MAX_LINE_LEN {
+                outputs.extend(self.protocol_error("line exceeds max length"));
+                break;
+            }
+
+            let Some(newline_idx) = self.recv_buf.iter().position(|b| *b == b'\n') else {
+                break;
+            };
+
+            let mut line = self.recv_buf.drain(..=newline_idx).collect::<Vec<_>>();
+            if line.last() == Some(&b'\n') {
+                line.pop();
+            }
+
+            let parsed = match core::str::from_utf8(&line) {
+                Ok(line) if !line.is_empty() => line,
+                Ok(_) => {
+                    outputs.extend(self.protocol_error("empty protocol line"));
+                    break;
+                }
+                Err(_) => {
+                    outputs.extend(self.protocol_error("non-utf8 protocol line"));
+                    break;
+                }
+            };
+
+            outputs.extend(self.on_line(parsed));
+            if self.state == State::Done {
+                break;
+            }
+        }
+
+        outputs
+    }
+
+    fn on_line(&mut self, line: &str) -> Vec<MultistreamOutput> {
+        match self.state {
+            State::WaitingForRemoteHeader => {
+                if line != MULTISTREAM_PROTOCOL_ID {
+                    return self.protocol_error("unexpected multistream header");
+                }
+
+                match self.role {
+                    Role::Dialer => {
+                        let desired = self
+                            .desired_protocol
+                            .as_ref()
+                            .expect("dialer must have desired protocol");
+                        self.state = State::WaitingForProtocolResponse;
+                        vec![MultistreamOutput::OutboundData(encode_line(desired))]
+                    }
+                    Role::Listener => {
+                        self.state = State::WaitingForProtocolRequest;
+                        Vec::new()
+                    }
+                }
+            }
+            State::WaitingForProtocolRequest => {
+                if self.supported_protocols.contains(line) {
+                    self.state = State::Done;
+                    vec![
+                        MultistreamOutput::OutboundData(encode_line(line)),
+                        MultistreamOutput::Negotiated {
+                            protocol: line.to_string(),
+                        },
+                    ]
+                } else {
+                    self.state = State::Done;
+                    vec![
+                        MultistreamOutput::OutboundData(encode_line(NOT_AVAILABLE)),
+                        MultistreamOutput::NotAvailable,
+                    ]
+                }
+            }
+            State::WaitingForProtocolResponse => {
+                let desired = self
+                    .desired_protocol
+                    .as_ref()
+                    .expect("dialer must have desired protocol");
+
+                if line == desired {
+                    self.state = State::Done;
+                    vec![MultistreamOutput::Negotiated {
+                        protocol: desired.clone(),
+                    }]
+                } else if line == NOT_AVAILABLE {
+                    self.state = State::Done;
+                    vec![MultistreamOutput::NotAvailable]
+                } else {
+                    self.protocol_error("unexpected protocol response")
+                }
+            }
+            State::Done => Vec::new(),
+        }
+    }
+
+    fn protocol_error(&mut self, reason: &'static str) -> Vec<MultistreamOutput> {
+        self.state = State::Done;
+        vec![MultistreamOutput::ProtocolError { reason }]
+    }
+}
+
+fn encode_line(line: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(line.len() + 1);
+    out.extend_from_slice(line.as_bytes());
+    out.push(b'\n');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PING: &str = "/ipfs/ping/1.0.0";
+
+    #[test]
+    fn dialer_and_listener_negotiate_ping() {
+        let mut dialer = MultistreamSelect::dialer(PING);
+        let mut listener = MultistreamSelect::listener([PING.to_string()]);
+
+        let listener_start = listener.start();
+        let dialer_start = dialer.start();
+
+        assert_eq!(
+            listener_start,
+            vec![MultistreamOutput::OutboundData(encode_line(
+                MULTISTREAM_PROTOCOL_ID
+            ))]
+        );
+        assert_eq!(
+            dialer_start,
+            vec![MultistreamOutput::OutboundData(encode_line(
+                MULTISTREAM_PROTOCOL_ID
+            ))]
+        );
+
+        let dialer_after_header = dialer.receive(&encode_line(MULTISTREAM_PROTOCOL_ID));
+        assert_eq!(
+            dialer_after_header,
+            vec![MultistreamOutput::OutboundData(encode_line(PING))]
+        );
+
+        let listener_after_header = listener.receive(&encode_line(MULTISTREAM_PROTOCOL_ID));
+        assert!(listener_after_header.is_empty());
+
+        let listener_after_request = listener.receive(&encode_line(PING));
+        assert_eq!(
+            listener_after_request,
+            vec![
+                MultistreamOutput::OutboundData(encode_line(PING)),
+                MultistreamOutput::Negotiated {
+                    protocol: PING.to_string()
+                }
+            ]
+        );
+
+        let dialer_after_response = dialer.receive(&encode_line(PING));
+        assert_eq!(
+            dialer_after_response,
+            vec![MultistreamOutput::Negotiated {
+                protocol: PING.to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn listener_rejects_unsupported_protocol() {
+        let mut listener = MultistreamSelect::listener(["/ipfs/identify/1.0.0".to_string()]);
+        let _ = listener.start();
+        let _ = listener.receive(&encode_line(MULTISTREAM_PROTOCOL_ID));
+
+        let out = listener.receive(&encode_line(PING));
+        assert_eq!(
+            out,
+            vec![
+                MultistreamOutput::OutboundData(encode_line("na")),
+                MultistreamOutput::NotAvailable
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_chunked_input_lines() {
+        let mut dialer = MultistreamSelect::dialer(PING);
+        let _ = dialer.start();
+
+        let mut out = dialer.receive(b"/multistream/1.");
+        assert!(out.is_empty());
+
+        out = dialer.receive(b"0.0\n");
+        assert_eq!(
+            out,
+            vec![MultistreamOutput::OutboundData(encode_line(PING))]
+        );
+    }
+
+    #[test]
+    fn errors_on_unexpected_header() {
+        let mut dialer = MultistreamSelect::dialer(PING);
+        let _ = dialer.start();
+
+        let out = dialer.receive(&encode_line("/wrong/1.0.0"));
+        assert_eq!(
+            out,
+            vec![MultistreamOutput::ProtocolError {
+                reason: "unexpected multistream header"
+            }]
+        );
+    }
+}

--- a/packages/multistream-select/src/lib.rs
+++ b/packages/multistream-select/src/lib.rs
@@ -5,17 +5,37 @@ extern crate alloc;
 use alloc::collections::BTreeSet;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use minip2p_core::{read_uvarint, uvarint_len, write_uvarint, VarintError};
+use thiserror::Error;
 
 pub const MULTISTREAM_PROTOCOL_ID: &str = "/multistream/1.0.0";
 const NOT_AVAILABLE: &str = "na";
-const MAX_LINE_LEN: usize = 1024;
+const MAX_MESSAGE_LEN: usize = 1024;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum MultistreamOutput {
     OutboundData(Vec<u8>),
     Negotiated { protocol: String },
     NotAvailable,
-    ProtocolError { reason: &'static str },
+    ProtocolError { reason: String },
+}
+
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum MultistreamError {
+    #[error("message exceeds maximum length ({len} > {MAX_MESSAGE_LEN})")]
+    MessageTooLong { len: usize },
+    #[error("invalid varint in message frame: {0}")]
+    InvalidVarint(VarintError),
+    #[error("non-utf8 message payload")]
+    NonUtf8,
+    #[error("message missing trailing newline")]
+    MissingNewline,
+    #[error("empty protocol line")]
+    EmptyProtocol,
+    #[error("unexpected multistream header: {actual}")]
+    UnexpectedHeader { actual: String },
+    #[error("unexpected protocol response: {actual}")]
+    UnexpectedProtocolResponse { actual: String },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -70,7 +90,7 @@ impl MultistreamSelect {
         }
 
         self.started = true;
-        vec![MultistreamOutput::OutboundData(encode_line(
+        vec![MultistreamOutput::OutboundData(encode_message(
             MULTISTREAM_PROTOCOL_ID,
         ))]
     }
@@ -84,46 +104,34 @@ impl MultistreamSelect {
         let mut outputs = Vec::new();
 
         loop {
-            if self.recv_buf.len() > MAX_LINE_LEN {
-                outputs.extend(self.protocol_error("line exceeds max length"));
-                break;
-            }
-
-            let Some(newline_idx) = self.recv_buf.iter().position(|b| *b == b'\n') else {
-                break;
-            };
-
-            let mut line = self.recv_buf.drain(..=newline_idx).collect::<Vec<_>>();
-            if line.last() == Some(&b'\n') {
-                line.pop();
-            }
-
-            let parsed = match core::str::from_utf8(&line) {
-                Ok(line) if !line.is_empty() => line,
-                Ok(_) => {
-                    outputs.extend(self.protocol_error("empty protocol line"));
-                    break;
-                }
-                Err(_) => {
-                    outputs.extend(self.protocol_error("non-utf8 protocol line"));
-                    break;
-                }
-            };
-
-            outputs.extend(self.on_line(parsed));
             if self.state == State::Done {
                 break;
             }
+
+            let (payload, consumed) = match decode_message(&self.recv_buf) {
+                DecodeResult::Complete { payload, consumed } => {
+                    (payload.to_string(), consumed)
+                }
+                DecodeResult::Incomplete => break,
+                DecodeResult::Error(err) => {
+                    outputs.extend(self.protocol_error(err));
+                    break;
+                }
+            };
+            self.recv_buf.drain(..consumed);
+            outputs.extend(self.on_message(&payload));
         }
 
         outputs
     }
 
-    fn on_line(&mut self, line: &str) -> Vec<MultistreamOutput> {
+    fn on_message(&mut self, line: &str) -> Vec<MultistreamOutput> {
         match self.state {
             State::WaitingForRemoteHeader => {
                 if line != MULTISTREAM_PROTOCOL_ID {
-                    return self.protocol_error("unexpected multistream header");
+                    return self.protocol_error(MultistreamError::UnexpectedHeader {
+                        actual: line.to_string(),
+                    });
                 }
 
                 match self.role {
@@ -133,7 +141,7 @@ impl MultistreamSelect {
                             .as_ref()
                             .expect("dialer must have desired protocol");
                         self.state = State::WaitingForProtocolResponse;
-                        vec![MultistreamOutput::OutboundData(encode_line(desired))]
+                        vec![MultistreamOutput::OutboundData(encode_message(desired))]
                     }
                     Role::Listener => {
                         self.state = State::WaitingForProtocolRequest;
@@ -145,7 +153,7 @@ impl MultistreamSelect {
                 if self.supported_protocols.contains(line) {
                     self.state = State::Done;
                     vec![
-                        MultistreamOutput::OutboundData(encode_line(line)),
+                        MultistreamOutput::OutboundData(encode_message(line)),
                         MultistreamOutput::Negotiated {
                             protocol: line.to_string(),
                         },
@@ -153,7 +161,7 @@ impl MultistreamSelect {
                 } else {
                     self.state = State::Done;
                     vec![
-                        MultistreamOutput::OutboundData(encode_line(NOT_AVAILABLE)),
+                        MultistreamOutput::OutboundData(encode_message(NOT_AVAILABLE)),
                         MultistreamOutput::NotAvailable,
                     ]
                 }
@@ -173,24 +181,90 @@ impl MultistreamSelect {
                     self.state = State::Done;
                     vec![MultistreamOutput::NotAvailable]
                 } else {
-                    self.protocol_error("unexpected protocol response")
+                    self.protocol_error(MultistreamError::UnexpectedProtocolResponse {
+                        actual: line.to_string(),
+                    })
                 }
             }
             State::Done => Vec::new(),
         }
     }
 
-    fn protocol_error(&mut self, reason: &'static str) -> Vec<MultistreamOutput> {
+    fn protocol_error(&mut self, error: MultistreamError) -> Vec<MultistreamOutput> {
         self.state = State::Done;
-        vec![MultistreamOutput::ProtocolError { reason }]
+        vec![MultistreamOutput::ProtocolError {
+            reason: error.to_string(),
+        }]
     }
 }
 
-fn encode_line(line: &str) -> Vec<u8> {
-    let mut out = Vec::with_capacity(line.len() + 1);
-    out.extend_from_slice(line.as_bytes());
+/// Encodes a protocol string as a varint-length-prefixed message.
+///
+/// Wire format: `<uvarint: len(payload + '\n')> <payload> <'\n'>`
+fn encode_message(protocol: &str) -> Vec<u8> {
+    let payload_len = protocol.len() + 1; // +1 for trailing '\n'
+    let mut out = Vec::with_capacity(uvarint_len(payload_len as u64) + payload_len);
+    write_uvarint(payload_len as u64, &mut out);
+    out.extend_from_slice(protocol.as_bytes());
     out.push(b'\n');
     out
+}
+
+enum DecodeResult<'a> {
+    /// A complete message was decoded.
+    Complete { payload: &'a str, consumed: usize },
+    /// Not enough data yet.
+    Incomplete,
+    /// Framing or content error.
+    Error(MultistreamError),
+}
+
+/// Attempts to decode one varint-length-prefixed message from the buffer.
+fn decode_message(buf: &[u8]) -> DecodeResult<'_> {
+    if buf.is_empty() {
+        return DecodeResult::Incomplete;
+    }
+
+    let (msg_len, varint_bytes) = match read_uvarint(buf) {
+        Ok(pair) => pair,
+        Err(VarintError::BufferTooShort) => return DecodeResult::Incomplete,
+        Err(e) => return DecodeResult::Error(MultistreamError::InvalidVarint(e)),
+    };
+
+    let msg_len = msg_len as usize;
+
+    if msg_len > MAX_MESSAGE_LEN {
+        return DecodeResult::Error(MultistreamError::MessageTooLong { len: msg_len });
+    }
+
+    let total = varint_bytes + msg_len;
+    if buf.len() < total {
+        return DecodeResult::Incomplete;
+    }
+
+    let msg_bytes = &buf[varint_bytes..total];
+
+    // The message must end with '\n' per the spec.
+    if msg_bytes.last() != Some(&b'\n') {
+        return DecodeResult::Error(MultistreamError::MissingNewline);
+    }
+
+    // Strip the trailing newline to get the payload.
+    let payload_bytes = &msg_bytes[..msg_bytes.len() - 1];
+
+    let payload = match core::str::from_utf8(payload_bytes) {
+        Ok(s) => s,
+        Err(_) => return DecodeResult::Error(MultistreamError::NonUtf8),
+    };
+
+    if payload.is_empty() {
+        return DecodeResult::Error(MultistreamError::EmptyProtocol);
+    }
+
+    DecodeResult::Complete {
+        payload,
+        consumed: total,
+    }
 }
 
 #[cfg(test)]
@@ -209,38 +283,38 @@ mod tests {
 
         assert_eq!(
             listener_start,
-            vec![MultistreamOutput::OutboundData(encode_line(
+            vec![MultistreamOutput::OutboundData(encode_message(
                 MULTISTREAM_PROTOCOL_ID
             ))]
         );
         assert_eq!(
             dialer_start,
-            vec![MultistreamOutput::OutboundData(encode_line(
+            vec![MultistreamOutput::OutboundData(encode_message(
                 MULTISTREAM_PROTOCOL_ID
             ))]
         );
 
-        let dialer_after_header = dialer.receive(&encode_line(MULTISTREAM_PROTOCOL_ID));
+        let dialer_after_header = dialer.receive(&encode_message(MULTISTREAM_PROTOCOL_ID));
         assert_eq!(
             dialer_after_header,
-            vec![MultistreamOutput::OutboundData(encode_line(PING))]
+            vec![MultistreamOutput::OutboundData(encode_message(PING))]
         );
 
-        let listener_after_header = listener.receive(&encode_line(MULTISTREAM_PROTOCOL_ID));
+        let listener_after_header = listener.receive(&encode_message(MULTISTREAM_PROTOCOL_ID));
         assert!(listener_after_header.is_empty());
 
-        let listener_after_request = listener.receive(&encode_line(PING));
+        let listener_after_request = listener.receive(&encode_message(PING));
         assert_eq!(
             listener_after_request,
             vec![
-                MultistreamOutput::OutboundData(encode_line(PING)),
+                MultistreamOutput::OutboundData(encode_message(PING)),
                 MultistreamOutput::Negotiated {
                     protocol: PING.to_string()
                 }
             ]
         );
 
-        let dialer_after_response = dialer.receive(&encode_line(PING));
+        let dialer_after_response = dialer.receive(&encode_message(PING));
         assert_eq!(
             dialer_after_response,
             vec![MultistreamOutput::Negotiated {
@@ -253,30 +327,33 @@ mod tests {
     fn listener_rejects_unsupported_protocol() {
         let mut listener = MultistreamSelect::listener(["/ipfs/identify/1.0.0".to_string()]);
         let _ = listener.start();
-        let _ = listener.receive(&encode_line(MULTISTREAM_PROTOCOL_ID));
+        let _ = listener.receive(&encode_message(MULTISTREAM_PROTOCOL_ID));
 
-        let out = listener.receive(&encode_line(PING));
+        let out = listener.receive(&encode_message(PING));
         assert_eq!(
             out,
             vec![
-                MultistreamOutput::OutboundData(encode_line("na")),
+                MultistreamOutput::OutboundData(encode_message("na")),
                 MultistreamOutput::NotAvailable
             ]
         );
     }
 
     #[test]
-    fn parses_chunked_input_lines() {
+    fn parses_chunked_input() {
         let mut dialer = MultistreamSelect::dialer(PING);
         let _ = dialer.start();
 
-        let mut out = dialer.receive(b"/multistream/1.");
+        let full = encode_message(MULTISTREAM_PROTOCOL_ID);
+        let (a, b) = full.split_at(full.len() / 2);
+
+        let out = dialer.receive(a);
         assert!(out.is_empty());
 
-        out = dialer.receive(b"0.0\n");
+        let out = dialer.receive(b);
         assert_eq!(
             out,
-            vec![MultistreamOutput::OutboundData(encode_line(PING))]
+            vec![MultistreamOutput::OutboundData(encode_message(PING))]
         );
     }
 
@@ -285,12 +362,92 @@ mod tests {
         let mut dialer = MultistreamSelect::dialer(PING);
         let _ = dialer.start();
 
-        let out = dialer.receive(&encode_line("/wrong/1.0.0"));
+        let out = dialer.receive(&encode_message("/wrong/1.0.0"));
+        assert!(matches!(
+            out.as_slice(),
+            [MultistreamOutput::ProtocolError { .. }]
+        ));
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let encoded = encode_message("/ipfs/ping/1.0.0");
+
+        // Verify wire format: varint + payload + newline
+        let (msg_len, varint_bytes) = read_uvarint(&encoded).unwrap();
+        assert_eq!(msg_len as usize, "/ipfs/ping/1.0.0".len() + 1); // +1 for '\n'
+        assert_eq!(encoded.len(), varint_bytes + msg_len as usize);
+        assert_eq!(encoded.last(), Some(&b'\n'));
+
+        match decode_message(&encoded) {
+            DecodeResult::Complete { payload, consumed } => {
+                assert_eq!(payload, "/ipfs/ping/1.0.0");
+                assert_eq!(consumed, encoded.len());
+            }
+            _ => panic!("expected Complete"),
+        }
+    }
+
+    #[test]
+    fn rejects_non_utf8_payload() {
+        // Build a message with invalid UTF-8: varint(3) + [0xFF, 0xFE] + '\n'
+        let mut msg = Vec::new();
+        write_uvarint(3, &mut msg);
+        msg.push(0xFF);
+        msg.push(0xFE);
+        msg.push(b'\n');
+
+        let mut dialer = MultistreamSelect::dialer(PING);
+        let _ = dialer.start();
+        let out = dialer.receive(&msg);
+        assert!(matches!(
+            out.as_slice(),
+            [MultistreamOutput::ProtocolError { .. }]
+        ));
+    }
+
+    #[test]
+    fn rejects_oversized_message() {
+        let long_protocol = "x".repeat(MAX_MESSAGE_LEN + 1);
+        let encoded = encode_message(&long_protocol);
+
+        let mut dialer = MultistreamSelect::dialer(PING);
+        let _ = dialer.start();
+        let out = dialer.receive(&encoded);
+        assert!(matches!(
+            out.as_slice(),
+            [MultistreamOutput::ProtocolError { .. }]
+        ));
+    }
+
+    #[test]
+    fn multiple_messages_in_one_receive() {
+        let mut dialer = MultistreamSelect::dialer(PING);
+        let _ = dialer.start();
+
+        // Send header + protocol confirmation in a single buffer
+        let mut combined = encode_message(MULTISTREAM_PROTOCOL_ID);
+        combined.extend_from_slice(&encode_message(PING));
+
+        let out = dialer.receive(&combined);
         assert_eq!(
             out,
-            vec![MultistreamOutput::ProtocolError {
-                reason: "unexpected multistream header"
-            }]
+            vec![
+                MultistreamOutput::OutboundData(encode_message(PING)),
+                MultistreamOutput::Negotiated {
+                    protocol: PING.to_string()
+                }
+            ]
         );
+    }
+
+    #[test]
+    fn dialer_receives_na() {
+        let mut dialer = MultistreamSelect::dialer(PING);
+        let _ = dialer.start();
+        let _ = dialer.receive(&encode_message(MULTISTREAM_PROTOCOL_ID));
+
+        let out = dialer.receive(&encode_message("na"));
+        assert_eq!(out, vec![MultistreamOutput::NotAvailable]);
     }
 }

--- a/packages/ping/Cargo.toml
+++ b/packages/ping/Cargo.toml
@@ -2,6 +2,7 @@
 name = "minip2p-ping"
 version = "0.1.0"
 edition = "2024"
+readme = "README.md"
 
 [features]
 default = ["std"]

--- a/packages/ping/Cargo.toml
+++ b/packages/ping/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "minip2p-ping"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+default = ["std"]
+std = [
+    "minip2p-core/std",
+    "minip2p-transport/std",
+    "thiserror/std",
+]
+
+[dependencies]
+minip2p-core = { path = "../core", default-features = false }
+minip2p-transport = { path = "../transport", default-features = false }
+thiserror = { version = "2", default-features = false }

--- a/packages/ping/README.md
+++ b/packages/ping/README.md
@@ -1,0 +1,61 @@
+# minip2p-ping
+
+Sans-IO state machine for the `/ipfs/ping/1.0.0` protocol. `no_std` + `alloc` compatible.
+
+Ping measures round-trip latency by sending a 32-byte payload and waiting for the remote peer to echo it back verbatim.
+
+## Features
+
+- Dialer sends ping, listener echoes -- both handled by the same `PingProtocol` instance.
+- Fragmentation-safe: buffers partial payloads on both inbound and outbound paths.
+- Configurable request timeout with `PingConfig`.
+- RTT measurement via caller-provided timestamps (no internal clock dependency).
+- `PingAction` commands (`Send`, `CloseStreamWrite`, `ResetStream`) for the host to execute.
+- `PingEvent` notifications (`RttMeasured`, `Timeout`, `ProtocolViolation`, etc.).
+- Per-peer state tracking with inbound stream limits.
+
+## Usage
+
+```rust
+use minip2p_ping::{PingProtocol, PingConfig, PingAction, PingEvent, PING_PAYLOAD_LEN};
+use minip2p_transport::StreamId;
+use minip2p_core::PeerId;
+
+let mut ping = PingProtocol::new(PingConfig::default());
+
+// After protocol negotiation succeeds on a stream, register it:
+// ping.register_outbound_stream(&peer_id, stream_id);
+// ping.register_inbound_stream(&peer_id, stream_id);
+
+// Send a ping (caller provides the payload and current timestamp):
+// let actions = ping.send_ping(&peer_id, payload, now_ms)?;
+
+// Feed incoming stream data:
+// let actions = ping.on_stream_data(&peer_id, stream_id, &data, now_ms);
+
+// Check for timeouts periodically:
+// let actions = ping.on_tick(now_ms);
+
+// Drain events:
+// let events = ping.poll_events();
+```
+
+## Protocol
+
+- Protocol ID: `/ipfs/ping/1.0.0`
+- Payload: exactly 32 bytes
+- The dialer writes a 32-byte payload, the listener reads it and echoes it back unchanged.
+- Either side can half-close or reset the stream to end the ping session.
+
+## no_std
+
+Disable default features:
+
+```toml
+[dependencies]
+minip2p-ping = { path = "packages/ping", default-features = false }
+```
+
+## Scope
+
+This crate implements the ping protocol state machine only. It does not open streams, send bytes over the network, or negotiate protocols. The host is responsible for wiring `PingAction` commands to the transport and feeding transport events back into `PingProtocol`.

--- a/packages/ping/src/lib.rs
+++ b/packages/ping/src/lib.rs
@@ -1,0 +1,523 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use minip2p_core::PeerId;
+use minip2p_transport::StreamId;
+use thiserror::Error;
+
+pub const PING_PROTOCOL_ID: &str = "/ipfs/ping/1.0.0";
+pub const PING_PAYLOAD_LEN: usize = 32;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PingConfig {
+    pub request_timeout_ms: u64,
+}
+
+impl Default for PingConfig {
+    fn default() -> Self {
+        Self {
+            request_timeout_ms: 10_000,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PingAction {
+    Send {
+        peer_id: PeerId,
+        stream_id: StreamId,
+        data: [u8; PING_PAYLOAD_LEN],
+    },
+    CloseStreamWrite {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+    ResetStream {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PingEvent {
+    OutboundStreamRegistered {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+    InboundStreamAccepted {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+    RttMeasured {
+        peer_id: PeerId,
+        stream_id: StreamId,
+        rtt_ms: u64,
+    },
+    Timeout {
+        peer_id: PeerId,
+        stream_id: StreamId,
+        timeout_ms: u64,
+    },
+    StreamLimitExceeded {
+        peer_id: PeerId,
+        stream_id: StreamId,
+        limit: usize,
+    },
+    ProtocolViolation {
+        peer_id: PeerId,
+        stream_id: StreamId,
+        reason: String,
+    },
+}
+
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum PingError {
+    #[error("peer {peer_id} already has outbound ping stream {existing_stream}")]
+    OutboundStreamExists {
+        peer_id: PeerId,
+        existing_stream: StreamId,
+    },
+    #[error("peer {peer_id} has no outbound ping stream")]
+    OutboundStreamMissing { peer_id: PeerId },
+    #[error("peer {peer_id} already has ping request in flight on stream {stream_id}")]
+    PingAlreadyInFlight {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+    #[error("invalid ping payload length {actual}; expected {PING_PAYLOAD_LEN}")]
+    InvalidPayloadLength { actual: usize },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PendingPing {
+    payload: [u8; PING_PAYLOAD_LEN],
+    sent_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct PeerPingState {
+    outbound_stream: Option<StreamId>,
+    inbound_streams: BTreeSet<StreamId>,
+    pending_ping: Option<PendingPing>,
+}
+
+pub struct PingProtocol {
+    peers: BTreeMap<PeerId, PeerPingState>,
+    pending_events: Vec<PingEvent>,
+    config: PingConfig,
+}
+
+impl Default for PingProtocol {
+    fn default() -> Self {
+        Self::new(PingConfig::default())
+    }
+}
+
+impl PingProtocol {
+    pub fn new(config: PingConfig) -> Self {
+        Self {
+            peers: BTreeMap::new(),
+            pending_events: Vec::new(),
+            config,
+        }
+    }
+
+    pub fn register_outbound_stream(
+        &mut self,
+        peer_id: PeerId,
+        stream_id: StreamId,
+    ) -> Result<(), PingError> {
+        let peer = self.peers.entry(peer_id.clone()).or_default();
+
+        if let Some(existing) = peer.outbound_stream {
+            if existing != stream_id {
+                return Err(PingError::OutboundStreamExists {
+                    peer_id,
+                    existing_stream: existing,
+                });
+            }
+
+            return Ok(());
+        }
+
+        peer.outbound_stream = Some(stream_id);
+        self.pending_events
+            .push(PingEvent::OutboundStreamRegistered { peer_id, stream_id });
+        Ok(())
+    }
+
+    pub fn register_inbound_stream(
+        &mut self,
+        peer_id: PeerId,
+        stream_id: StreamId,
+    ) -> Vec<PingAction> {
+        let peer = self.peers.entry(peer_id.clone()).or_default();
+        if peer.inbound_streams.contains(&stream_id) {
+            return Vec::new();
+        }
+
+        if peer.inbound_streams.len() >= 2 {
+            self.pending_events.push(PingEvent::StreamLimitExceeded {
+                peer_id: peer_id.clone(),
+                stream_id,
+                limit: 2,
+            });
+
+            return vec![PingAction::ResetStream { peer_id, stream_id }];
+        }
+
+        peer.inbound_streams.insert(stream_id);
+        self.pending_events
+            .push(PingEvent::InboundStreamAccepted { peer_id, stream_id });
+        Vec::new()
+    }
+
+    pub fn send_ping(
+        &mut self,
+        peer_id: &PeerId,
+        payload: &[u8],
+        now_ms: u64,
+    ) -> Result<PingAction, PingError> {
+        if payload.len() != PING_PAYLOAD_LEN {
+            return Err(PingError::InvalidPayloadLength {
+                actual: payload.len(),
+            });
+        }
+
+        let peer = self.peers.entry(peer_id.clone()).or_default();
+        let stream_id = peer
+            .outbound_stream
+            .ok_or_else(|| PingError::OutboundStreamMissing {
+                peer_id: peer_id.clone(),
+            })?;
+
+        if peer.pending_ping.is_some() {
+            return Err(PingError::PingAlreadyInFlight {
+                peer_id: peer_id.clone(),
+                stream_id,
+            });
+        }
+
+        let mut frame = [0u8; PING_PAYLOAD_LEN];
+        frame.copy_from_slice(payload);
+        peer.pending_ping = Some(PendingPing {
+            payload: frame,
+            sent_at_ms: now_ms,
+        });
+
+        Ok(PingAction::Send {
+            peer_id: peer_id.clone(),
+            stream_id,
+            data: frame,
+        })
+    }
+
+    pub fn close_outbound_stream_write(
+        &mut self,
+        peer_id: &PeerId,
+    ) -> Result<PingAction, PingError> {
+        let peer = self.peers.entry(peer_id.clone()).or_default();
+        let stream_id = peer
+            .outbound_stream
+            .ok_or_else(|| PingError::OutboundStreamMissing {
+                peer_id: peer_id.clone(),
+            })?;
+
+        Ok(PingAction::CloseStreamWrite {
+            peer_id: peer_id.clone(),
+            stream_id,
+        })
+    }
+
+    pub fn on_stream_data(
+        &mut self,
+        peer_id: &PeerId,
+        stream_id: StreamId,
+        data: &[u8],
+        now_ms: u64,
+    ) -> Vec<PingAction> {
+        if data.len() != PING_PAYLOAD_LEN {
+            return self.protocol_violation(
+                peer_id,
+                stream_id,
+                format!(
+                    "payload length {} does not match required {}",
+                    data.len(),
+                    PING_PAYLOAD_LEN
+                ),
+            );
+        }
+
+        let peer = self.peers.entry(peer_id.clone()).or_default();
+
+        if peer.outbound_stream == Some(stream_id) {
+            let Some(pending) = peer.pending_ping.take() else {
+                return self.protocol_violation(
+                    peer_id,
+                    stream_id,
+                    "received ping response with no in-flight request".into(),
+                );
+            };
+
+            if pending.payload.as_slice() != data {
+                return self.protocol_violation(
+                    peer_id,
+                    stream_id,
+                    "ping response payload mismatch".into(),
+                );
+            }
+
+            let rtt_ms = now_ms.saturating_sub(pending.sent_at_ms);
+            self.pending_events.push(PingEvent::RttMeasured {
+                peer_id: peer_id.clone(),
+                stream_id,
+                rtt_ms,
+            });
+            return Vec::new();
+        }
+
+        if peer.inbound_streams.contains(&stream_id) {
+            let mut out = [0u8; PING_PAYLOAD_LEN];
+            out.copy_from_slice(data);
+
+            return vec![PingAction::Send {
+                peer_id: peer_id.clone(),
+                stream_id,
+                data: out,
+            }];
+        }
+
+        self.protocol_violation(peer_id, stream_id, "ping data on unknown stream".into())
+    }
+
+    pub fn on_stream_remote_write_closed(
+        &mut self,
+        peer_id: &PeerId,
+        stream_id: StreamId,
+    ) -> Vec<PingAction> {
+        let peer = self.peers.entry(peer_id.clone()).or_default();
+
+        if peer.inbound_streams.remove(&stream_id) {
+            return Vec::new();
+        }
+
+        if peer.outbound_stream == Some(stream_id) {
+            if peer.pending_ping.is_some() {
+                return self.protocol_violation(
+                    peer_id,
+                    stream_id,
+                    "outbound stream closed before ping response".into(),
+                );
+            }
+
+            peer.outbound_stream = None;
+            return Vec::new();
+        }
+
+        Vec::new()
+    }
+
+    pub fn on_stream_closed(&mut self, peer_id: &PeerId, stream_id: StreamId) {
+        let Some(peer) = self.peers.get_mut(peer_id) else {
+            return;
+        };
+
+        peer.inbound_streams.remove(&stream_id);
+        if peer.outbound_stream == Some(stream_id) {
+            peer.outbound_stream = None;
+            peer.pending_ping = None;
+        }
+    }
+
+    pub fn on_tick(&mut self, now_ms: u64) -> Vec<PingAction> {
+        let mut actions = Vec::new();
+
+        for (peer_id, peer) in self.peers.iter_mut() {
+            let Some(stream_id) = peer.outbound_stream else {
+                continue;
+            };
+            let Some(pending) = peer.pending_ping.as_ref() else {
+                continue;
+            };
+
+            let elapsed = now_ms.saturating_sub(pending.sent_at_ms);
+            if elapsed > self.config.request_timeout_ms {
+                peer.pending_ping = None;
+                peer.outbound_stream = None;
+                self.pending_events.push(PingEvent::Timeout {
+                    peer_id: peer_id.clone(),
+                    stream_id,
+                    timeout_ms: self.config.request_timeout_ms,
+                });
+                actions.push(PingAction::ResetStream {
+                    peer_id: peer_id.clone(),
+                    stream_id,
+                });
+            }
+        }
+
+        actions
+    }
+
+    pub fn poll_events(&mut self) -> Vec<PingEvent> {
+        core::mem::take(&mut self.pending_events)
+    }
+
+    fn protocol_violation(
+        &mut self,
+        peer_id: &PeerId,
+        stream_id: StreamId,
+        reason: String,
+    ) -> Vec<PingAction> {
+        self.pending_events.push(PingEvent::ProtocolViolation {
+            peer_id: peer_id.clone(),
+            stream_id,
+            reason,
+        });
+
+        vec![PingAction::ResetStream {
+            peer_id: peer_id.clone(),
+            stream_id,
+        }]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use super::*;
+
+    fn peer(id: &str) -> PeerId {
+        PeerId::from_str(id).expect("peer id")
+    }
+
+    fn test_peer() -> PeerId {
+        peer("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N")
+    }
+
+    #[test]
+    fn outbound_ping_roundtrip_emits_rtt() {
+        let mut ping = PingProtocol::default();
+        let peer = test_peer();
+        let stream = StreamId::new(0);
+
+        ping.register_outbound_stream(peer.clone(), stream)
+            .expect("register stream");
+
+        let payload = [42u8; PING_PAYLOAD_LEN];
+        let send = ping
+            .send_ping(&peer, &payload, 100)
+            .expect("send ping action");
+        assert!(matches!(
+            send,
+            PingAction::Send {
+                stream_id,
+                data,
+                ..
+            } if stream_id == stream && data == payload
+        ));
+
+        let response_actions = ping.on_stream_data(&peer, stream, &payload, 135);
+        assert!(response_actions.is_empty());
+
+        let events = ping.poll_events();
+        assert!(events.iter().any(|event| {
+            matches!(
+                event,
+                PingEvent::RttMeasured {
+                    peer_id,
+                    stream_id,
+                    rtt_ms
+                } if peer_id == &peer && *stream_id == stream && *rtt_ms == 35
+            )
+        }));
+    }
+
+    #[test]
+    fn inbound_stream_limit_is_enforced() {
+        let mut ping = PingProtocol::default();
+        let peer = test_peer();
+
+        let a = ping.register_inbound_stream(peer.clone(), StreamId::new(1));
+        let b = ping.register_inbound_stream(peer.clone(), StreamId::new(5));
+        let c = ping.register_inbound_stream(peer.clone(), StreamId::new(9));
+
+        assert!(a.is_empty());
+        assert!(b.is_empty());
+        assert_eq!(
+            c,
+            vec![PingAction::ResetStream {
+                peer_id: peer.clone(),
+                stream_id: StreamId::new(9),
+            }]
+        );
+
+        let events = ping.poll_events();
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, PingEvent::StreamLimitExceeded { .. }))
+        );
+    }
+
+    #[test]
+    fn inbound_payload_is_echoed() {
+        let mut ping = PingProtocol::default();
+        let peer = test_peer();
+        let stream = StreamId::new(3);
+
+        let _ = ping.register_inbound_stream(peer.clone(), stream);
+
+        let payload = [7u8; PING_PAYLOAD_LEN];
+        let out = ping.on_stream_data(&peer, stream, &payload, 5);
+        assert_eq!(
+            out,
+            vec![PingAction::Send {
+                peer_id: peer,
+                stream_id: stream,
+                data: payload,
+            }]
+        );
+    }
+
+    #[test]
+    fn timeout_emits_event_and_reset_action() {
+        let mut ping = PingProtocol::new(PingConfig {
+            request_timeout_ms: 10,
+        });
+        let peer = test_peer();
+        let stream = StreamId::new(0);
+
+        ping.register_outbound_stream(peer.clone(), stream)
+            .expect("register stream");
+        let payload = [1u8; PING_PAYLOAD_LEN];
+        let _ = ping.send_ping(&peer, &payload, 100).expect("send ping");
+
+        let actions = ping.on_tick(111);
+        assert_eq!(
+            actions,
+            vec![PingAction::ResetStream {
+                peer_id: peer.clone(),
+                stream_id: stream,
+            }]
+        );
+
+        let events = ping.poll_events();
+        assert!(events.iter().any(|event| {
+            matches!(
+                event,
+                PingEvent::Timeout {
+                    peer_id,
+                    stream_id,
+                    timeout_ms
+                } if peer_id == &peer && *stream_id == stream && *timeout_ms == 10
+            )
+        }));
+    }
+}

--- a/packages/ping/src/lib.rs
+++ b/packages/ping/src/lib.rs
@@ -63,6 +63,10 @@ pub enum PingEvent {
         stream_id: StreamId,
         timeout_ms: u64,
     },
+    OutboundStreamClosed {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
     StreamLimitExceeded {
         peer_id: PeerId,
         stream_id: StreamId,
@@ -104,6 +108,8 @@ struct PeerPingState {
     outbound_stream: Option<StreamId>,
     inbound_streams: BTreeSet<StreamId>,
     pending_ping: Option<PendingPing>,
+    /// Per-stream receive buffers to handle fragmented data delivery.
+    recv_bufs: BTreeMap<StreamId, Vec<u8>>,
 }
 
 pub struct PingProtocol {
@@ -142,6 +148,7 @@ impl PingProtocol {
                 });
             }
 
+            // Already registered with this exact stream -- idempotent no-op.
             return Ok(());
         }
 
@@ -228,6 +235,13 @@ impl PingProtocol {
                 peer_id: peer_id.clone(),
             })?;
 
+        if peer.pending_ping.is_some() {
+            return Err(PingError::PingAlreadyInFlight {
+                peer_id: peer_id.clone(),
+                stream_id,
+            });
+        }
+
         Ok(PingAction::CloseStreamWrite {
             peer_id: peer_id.clone(),
             stream_id,
@@ -241,19 +255,66 @@ impl PingProtocol {
         data: &[u8],
         now_ms: u64,
     ) -> Vec<PingAction> {
-        if data.len() != PING_PAYLOAD_LEN {
+        // Check stream is known, collecting info before mutating.
+        let is_known = self.peers.get(peer_id).is_some_and(|p| {
+            p.outbound_stream == Some(stream_id) || p.inbound_streams.contains(&stream_id)
+        });
+
+        if !is_known {
+            return self.protocol_violation(
+                peer_id,
+                stream_id,
+                "ping data on unknown stream".into(),
+            );
+        }
+
+        // Append data to the per-stream receive buffer.
+        {
+            let peer = self.peers.get_mut(peer_id).expect("peer exists");
+            let buf = peer.recv_bufs.entry(stream_id).or_default();
+            buf.extend_from_slice(data);
+        }
+
+        // Check buffer length (re-borrow to get the size).
+        let buf_len = self.peers[peer_id].recv_bufs[&stream_id].len();
+
+        if buf_len > PING_PAYLOAD_LEN {
+            self.peers
+                .get_mut(peer_id)
+                .map(|p| p.recv_bufs.remove(&stream_id));
             return self.protocol_violation(
                 peer_id,
                 stream_id,
                 format!(
-                    "payload length {} does not match required {}",
-                    data.len(),
-                    PING_PAYLOAD_LEN
+                    "recv buffer {} bytes exceeds payload size {}",
+                    buf_len, PING_PAYLOAD_LEN
                 ),
             );
         }
 
-        let peer = self.peers.entry(peer_id.clone()).or_default();
+        if buf_len < PING_PAYLOAD_LEN {
+            return Vec::new();
+        }
+
+        // Exactly PING_PAYLOAD_LEN bytes -- extract payload and drop the buffer.
+        let mut payload = [0u8; PING_PAYLOAD_LEN];
+        {
+            let peer = self.peers.get_mut(peer_id).expect("peer exists");
+            payload.copy_from_slice(&peer.recv_bufs[&stream_id]);
+            peer.recv_bufs.remove(&stream_id);
+        }
+
+        self.process_complete_payload(peer_id, stream_id, payload, now_ms)
+    }
+
+    fn process_complete_payload(
+        &mut self,
+        peer_id: &PeerId,
+        stream_id: StreamId,
+        payload: [u8; PING_PAYLOAD_LEN],
+        now_ms: u64,
+    ) -> Vec<PingAction> {
+        let peer = self.peers.get_mut(peer_id).expect("peer exists");
 
         if peer.outbound_stream == Some(stream_id) {
             let Some(pending) = peer.pending_ping.take() else {
@@ -264,7 +325,7 @@ impl PingProtocol {
                 );
             };
 
-            if pending.payload.as_slice() != data {
+            if pending.payload != payload {
                 return self.protocol_violation(
                     peer_id,
                     stream_id,
@@ -282,17 +343,14 @@ impl PingProtocol {
         }
 
         if peer.inbound_streams.contains(&stream_id) {
-            let mut out = [0u8; PING_PAYLOAD_LEN];
-            out.copy_from_slice(data);
-
             return vec![PingAction::Send {
                 peer_id: peer_id.clone(),
                 stream_id,
-                data: out,
+                data: payload,
             }];
         }
 
-        self.protocol_violation(peer_id, stream_id, "ping data on unknown stream".into())
+        Vec::new()
     }
 
     pub fn on_stream_remote_write_closed(
@@ -303,6 +361,7 @@ impl PingProtocol {
         let peer = self.peers.entry(peer_id.clone()).or_default();
 
         if peer.inbound_streams.remove(&stream_id) {
+            peer.recv_bufs.remove(&stream_id);
             return Vec::new();
         }
 
@@ -316,6 +375,11 @@ impl PingProtocol {
             }
 
             peer.outbound_stream = None;
+            peer.recv_bufs.remove(&stream_id);
+            self.pending_events.push(PingEvent::OutboundStreamClosed {
+                peer_id: peer_id.clone(),
+                stream_id,
+            });
             return Vec::new();
         }
 
@@ -328,10 +392,17 @@ impl PingProtocol {
         };
 
         peer.inbound_streams.remove(&stream_id);
+        peer.recv_bufs.remove(&stream_id);
         if peer.outbound_stream == Some(stream_id) {
             peer.outbound_stream = None;
             peer.pending_ping = None;
         }
+    }
+
+    /// Remove all state for a peer. Call this when the connection to a peer is
+    /// closed to prevent unbounded memory growth.
+    pub fn remove_peer(&mut self, peer_id: &PeerId) {
+        self.peers.remove(peer_id);
     }
 
     pub fn on_tick(&mut self, now_ms: u64) -> Vec<PingAction> {
@@ -349,10 +420,15 @@ impl PingProtocol {
             if elapsed > self.config.request_timeout_ms {
                 peer.pending_ping = None;
                 peer.outbound_stream = None;
+                peer.recv_bufs.remove(&stream_id);
                 self.pending_events.push(PingEvent::Timeout {
                     peer_id: peer_id.clone(),
                     stream_id,
                     timeout_ms: self.config.request_timeout_ms,
+                });
+                self.pending_events.push(PingEvent::OutboundStreamClosed {
+                    peer_id: peer_id.clone(),
+                    stream_id,
                 });
                 actions.push(PingAction::ResetStream {
                     peer_id: peer_id.clone(),
@@ -517,6 +593,169 @@ mod tests {
                     stream_id,
                     timeout_ms
                 } if peer_id == &peer && *stream_id == stream && *timeout_ms == 10
+            )
+        }));
+        assert!(events.iter().any(|event| {
+            matches!(
+                event,
+                PingEvent::OutboundStreamClosed {
+                    peer_id,
+                    stream_id,
+                } if peer_id == &peer && *stream_id == stream
+            )
+        }));
+    }
+
+    #[test]
+    fn fragmented_inbound_payload_is_buffered_then_echoed() {
+        let mut ping = PingProtocol::default();
+        let peer = test_peer();
+        let stream = StreamId::new(3);
+
+        let _ = ping.register_inbound_stream(peer.clone(), stream);
+
+        let payload = [7u8; PING_PAYLOAD_LEN];
+
+        // Send first 16 bytes -- should buffer, no action yet.
+        let out = ping.on_stream_data(&peer, stream, &payload[..16], 5);
+        assert!(out.is_empty());
+
+        // Send remaining 16 bytes -- should now echo the full payload.
+        let out = ping.on_stream_data(&peer, stream, &payload[16..], 6);
+        assert_eq!(
+            out,
+            vec![PingAction::Send {
+                peer_id: peer,
+                stream_id: stream,
+                data: payload,
+            }]
+        );
+    }
+
+    #[test]
+    fn fragmented_outbound_response_is_buffered_then_measures_rtt() {
+        let mut ping = PingProtocol::default();
+        let peer = test_peer();
+        let stream = StreamId::new(0);
+
+        ping.register_outbound_stream(peer.clone(), stream)
+            .expect("register stream");
+
+        let payload = [42u8; PING_PAYLOAD_LEN];
+        let _ = ping.send_ping(&peer, &payload, 100).expect("send ping");
+
+        // Drain the OutboundStreamRegistered event from registration.
+        let _ = ping.poll_events();
+
+        // First chunk -- buffered.
+        let actions = ping.on_stream_data(&peer, stream, &payload[..10], 120);
+        assert!(actions.is_empty());
+        assert!(ping.poll_events().is_empty());
+
+        // Second chunk -- completes the payload.
+        let actions = ping.on_stream_data(&peer, stream, &payload[10..], 135);
+        assert!(actions.is_empty());
+
+        let events = ping.poll_events();
+        assert!(events.iter().any(|event| {
+            matches!(
+                event,
+                PingEvent::RttMeasured {
+                    peer_id,
+                    stream_id,
+                    rtt_ms
+                } if peer_id == &peer && *stream_id == stream && *rtt_ms == 35
+            )
+        }));
+    }
+
+    #[test]
+    fn oversized_buffer_is_protocol_violation() {
+        let mut ping = PingProtocol::default();
+        let peer = test_peer();
+        let stream = StreamId::new(3);
+
+        let _ = ping.register_inbound_stream(peer.clone(), stream);
+
+        // Send more than 32 bytes in one shot.
+        let oversized = [0u8; PING_PAYLOAD_LEN + 1];
+        let actions = ping.on_stream_data(&peer, stream, &oversized, 5);
+        assert_eq!(
+            actions,
+            vec![PingAction::ResetStream {
+                peer_id: peer.clone(),
+                stream_id: stream,
+            }]
+        );
+
+        let events = ping.poll_events();
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, PingEvent::ProtocolViolation { .. })));
+    }
+
+    #[test]
+    fn close_outbound_write_rejected_while_ping_in_flight() {
+        let mut ping = PingProtocol::default();
+        let peer = test_peer();
+        let stream = StreamId::new(0);
+
+        ping.register_outbound_stream(peer.clone(), stream)
+            .expect("register stream");
+
+        let payload = [1u8; PING_PAYLOAD_LEN];
+        let _ = ping.send_ping(&peer, &payload, 100).expect("send ping");
+
+        let result = ping.close_outbound_stream_write(&peer);
+        assert!(matches!(
+            result,
+            Err(PingError::PingAlreadyInFlight { .. })
+        ));
+    }
+
+    #[test]
+    fn remove_peer_clears_all_state() {
+        let mut ping = PingProtocol::default();
+        let peer = test_peer();
+        let stream = StreamId::new(0);
+
+        ping.register_outbound_stream(peer.clone(), stream)
+            .expect("register stream");
+        let _ = ping.register_inbound_stream(peer.clone(), StreamId::new(1));
+
+        let payload = [1u8; PING_PAYLOAD_LEN];
+        let _ = ping.send_ping(&peer, &payload, 100).expect("send ping");
+
+        ping.remove_peer(&peer);
+
+        // After removal, we can re-register everything fresh.
+        ping.register_outbound_stream(peer.clone(), StreamId::new(10))
+            .expect("re-register outbound stream after remove_peer");
+        let actions = ping.register_inbound_stream(peer.clone(), StreamId::new(11));
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn outbound_stream_closed_emitted_on_remote_write_close() {
+        let mut ping = PingProtocol::default();
+        let peer = test_peer();
+        let stream = StreamId::new(0);
+
+        ping.register_outbound_stream(peer.clone(), stream)
+            .expect("register stream");
+
+        // No ping in flight -- remote closes write side.
+        let actions = ping.on_stream_remote_write_closed(&peer, stream);
+        assert!(actions.is_empty());
+
+        let events = ping.poll_events();
+        assert!(events.iter().any(|event| {
+            matches!(
+                event,
+                PingEvent::OutboundStreamClosed {
+                    peer_id,
+                    stream_id,
+                } if peer_id == &peer && *stream_id == stream
             )
         }));
     }

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -1,156 +1,68 @@
 # minip2p-transport
 
-Sans-IO transport trait and connection types for minip2p. `no_std` + `alloc` compatible.
+Sans-IO transport trait and connection/stream types for minip2p. `no_std` + `alloc` compatible.
 
-This crate defines the transport abstraction that concrete adapters (QUIC, WebSocket, etc.) implement. It contains no runtime or networking code — only types and a trait.
+This crate defines the transport abstraction that concrete adapters (QUIC, WebSocket, etc.) implement. It contains no runtime or networking code.
 
 ## Features
 
 - `Transport` trait with a `poll()`-based event model.
-- `ConnectionId` — lightweight `u64`-backed connection identifier.
-- `ConnectionEndpoint` — transport endpoint + optional remote `PeerId`.
-- `ConnectionState` — connection lifecycle: `Connecting`, `Connected`, `Closing`, `Closed`.
-- `PeerSendPolicy` — peer-level connection selection for `send_to_peer` style APIs.
-- `TransportAction` — host-side intents: `Dial`, `Listen`, `Send`, `Close`.
-- `TransportEvent` — transport-side outcomes: `Connected`, `Received`, `Closed`, `Error`, `IncomingConnection`, `PeerIdentityVerified`, `Listening`.
-- `TransportError` — typed errors with connection, address, and config context.
-- `no_std` support (`alloc`-based), with `std` enabled by default.
+- `ConnectionId` and `StreamId` identifiers.
+- Connection lifecycle events (`Connected`, `Closed`, `IncomingConnection`, `PeerIdentityVerified`, `Listening`).
+- Stream lifecycle events (`StreamOpened`, `IncomingStream`, `StreamData`, `StreamRemoteWriteClosed`, `StreamClosed`).
+- Host intents via trait methods: `dial`, `listen`, `open_stream`, `send_stream`, `close_stream_write`, `reset_stream`, `close`.
+- Typed error model with transport, connection, and stream context.
 
 ## Usage
 
 Implement the `Transport` trait for your adapter:
 
 ```rust
-use minip2p_transport::{
-    ConnectionId, ConnectionState, Transport, TransportError, TransportEvent,
-};
 use minip2p_core::{Multiaddr, PeerAddr};
+use minip2p_transport::{ConnectionId, StreamId, Transport, TransportError, TransportEvent};
 
 struct MyTransport;
 
 impl Transport for MyTransport {
-    fn dial(
-        &mut self,
-        id: ConnectionId,
-        addr: &PeerAddr,
-    ) -> Result<(), TransportError> {
-        todo!("initiate an outgoing connection")
+    fn dial(&mut self, id: ConnectionId, addr: &PeerAddr) -> Result<(), TransportError> {
+        todo!("initiate outgoing connection")
     }
 
     fn listen(&mut self, addr: &Multiaddr) -> Result<(), TransportError> {
-        todo!("start listening on the given address")
+        todo!("start listening")
     }
 
-    fn send(
+    fn open_stream(&mut self, id: ConnectionId) -> Result<StreamId, TransportError> {
+        todo!("open a new outbound stream")
+    }
+
+    fn send_stream(
         &mut self,
         id: ConnectionId,
+        stream_id: StreamId,
         data: Vec<u8>,
     ) -> Result<(), TransportError> {
-        todo!("send data on an established connection")
+        todo!("write stream data")
+    }
+
+    fn close_stream_write(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+    ) -> Result<(), TransportError> {
+        todo!("half-close stream write side")
+    }
+
+    fn reset_stream(&mut self, id: ConnectionId, stream_id: StreamId) -> Result<(), TransportError> {
+        todo!("reset stream")
     }
 
     fn close(&mut self, id: ConnectionId) -> Result<(), TransportError> {
-        todo!("close a connection gracefully")
+        todo!("close connection")
     }
 
     fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError> {
-        todo!("drive the transport and return pending events")
-    }
-}
-```
-
-Drive the transport in a synchronous loop:
-
-```rust
-use minip2p_transport::{ConnectionId, Transport, TransportEvent};
-
-fn event_loop(transport: &mut impl Transport) {
-    loop {
-        let events = transport.poll().expect("poll failure");
-
-        for event in events {
-            match event {
-                TransportEvent::Connected { id, endpoint } => {
-                    if let Some(peer_id) = endpoint.peer_id() {
-                        println!("connected: {id} -> {} (peer: {peer_id})", endpoint.transport());
-                    } else {
-                        println!("connected: {id} -> {}", endpoint.transport());
-                    }
-                }
-                TransportEvent::Received { id, data } => {
-                    println!("received {} bytes on {id}", data.len());
-                }
-                TransportEvent::Closed { id } => {
-                    println!("connection {id} closed");
-                }
-                TransportEvent::Error { id, message } => {
-                    eprintln!("error on {id}: {message}");
-                }
-                TransportEvent::IncomingConnection { id, endpoint } => {
-                    println!("incoming connection {id} from {}", endpoint.transport());
-                }
-                TransportEvent::PeerIdentityVerified { id, endpoint, .. } => {
-                    println!("connection {id} identity verified as {:?}", endpoint.peer_id());
-                }
-                TransportEvent::Listening { addr } => {
-                    println!("listening on {addr}");
-                }
-            }
-        }
-    }
-}
-```
-
-## Error handling
-
-All fallible methods return `Result<_, TransportError>`. Errors include connection, address, and configuration context so callers can act on failures quickly:
-
-```rust
-use minip2p_transport::{ConnectionId, TransportError};
-
-fn handle_error(err: TransportError) {
-    match err {
-        TransportError::InvalidAddress { context, reason } => {
-            eprintln!("invalid address for {context}: {reason}");
-        }
-        TransportError::InvalidConfig { reason } => {
-            eprintln!("invalid config: {reason}");
-        }
-        TransportError::ResourceExhausted { resource } => {
-            eprintln!("resource exhausted: {resource}");
-        }
-        TransportError::PeerNotConnected { peer_id } => {
-            eprintln!("no connected connections for peer {peer_id}");
-        }
-        TransportError::ConnectionNotFound { id } => {
-            eprintln!("connection {id} does not exist");
-        }
-        TransportError::ConnectionExists { id } => {
-            eprintln!("connection {id} already exists");
-        }
-        TransportError::InvalidState { id, state, expected } => {
-            eprintln!(
-                "connection {id} is {state}, expected {expected}"
-            );
-        }
-        TransportError::DialFailed { id, reason } => {
-            eprintln!("dial failed for {id}: {reason}");
-        }
-        TransportError::SendFailed { id, reason } => {
-            eprintln!("send failed for {id}: {reason}");
-        }
-        TransportError::CloseFailed { id, reason } => {
-            eprintln!("close failed for {id}: {reason}");
-        }
-        TransportError::ListenFailed { reason } => {
-            eprintln!("listen failed: {reason}");
-        }
-        TransportError::NotListening => {
-            eprintln!("not listening on any address");
-        }
-        TransportError::PollError { reason } => {
-            eprintln!("poll error: {reason}");
-        }
+        todo!("drive transport and emit events")
     }
 }
 ```
@@ -166,4 +78,4 @@ minip2p-transport = { path = "packages/transport", default-features = false }
 
 ## Scope
 
-This crate defines the transport interface only. Concrete implementations live in separate crates (e.g. `minip2p-quic`).
+This crate defines the transport contract only. Concrete runtime adapters live in separate crates (e.g. `minip2p-quic`).

--- a/packages/transport/src/action.rs
+++ b/packages/transport/src/action.rs
@@ -2,12 +2,34 @@ use alloc::vec::Vec;
 
 use minip2p_core::{Multiaddr, PeerAddr};
 
-use crate::ConnectionId;
+use crate::{ConnectionId, StreamId};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TransportAction {
-    Dial { id: ConnectionId, addr: PeerAddr },
-    Listen { addr: Multiaddr },
-    Send { id: ConnectionId, data: Vec<u8> },
-    Close { id: ConnectionId },
+    Dial {
+        id: ConnectionId,
+        addr: PeerAddr,
+    },
+    Listen {
+        addr: Multiaddr,
+    },
+    OpenStream {
+        id: ConnectionId,
+    },
+    SendStream {
+        id: ConnectionId,
+        stream_id: StreamId,
+        data: Vec<u8>,
+    },
+    CloseStreamWrite {
+        id: ConnectionId,
+        stream_id: StreamId,
+    },
+    ResetStream {
+        id: ConnectionId,
+        stream_id: StreamId,
+    },
+    Close {
+        id: ConnectionId,
+    },
 }

--- a/packages/transport/src/error.rs
+++ b/packages/transport/src/error.rs
@@ -1,9 +1,8 @@
 use alloc::string::String;
 
-use minip2p_core::PeerId;
 use thiserror::Error;
 
-use crate::ConnectionId;
+use crate::{ConnectionId, StreamId};
 
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum TransportError {
@@ -16,8 +15,6 @@ pub enum TransportError {
     InvalidConfig { reason: String },
     #[error("resource exhausted: {resource}")]
     ResourceExhausted { resource: &'static str },
-    #[error("peer {peer_id} has no connected transport connections")]
-    PeerNotConnected { peer_id: PeerId },
     #[error("connection {id} not found")]
     ConnectionNotFound { id: ConnectionId },
     #[error("connection {id} already exists")]
@@ -34,8 +31,36 @@ pub enum TransportError {
     ListenFailed { reason: String },
     #[error("dial failed for {id}: {reason}")]
     DialFailed { id: ConnectionId, reason: String },
-    #[error("send failed for {id}: {reason}")]
-    SendFailed { id: ConnectionId, reason: String },
+    #[error("stream {stream_id} not found on connection {id}")]
+    StreamNotFound {
+        id: ConnectionId,
+        stream_id: StreamId,
+    },
+    #[error("stream {stream_id} already exists on connection {id}")]
+    StreamExists {
+        id: ConnectionId,
+        stream_id: StreamId,
+    },
+    #[error("failed to open stream on {id}: {reason}")]
+    OpenStreamFailed { id: ConnectionId, reason: String },
+    #[error("stream send failed for {id}/{stream_id}: {reason}")]
+    StreamSendFailed {
+        id: ConnectionId,
+        stream_id: StreamId,
+        reason: String,
+    },
+    #[error("stream close write failed for {id}/{stream_id}: {reason}")]
+    StreamCloseWriteFailed {
+        id: ConnectionId,
+        stream_id: StreamId,
+        reason: String,
+    },
+    #[error("stream reset failed for {id}/{stream_id}: {reason}")]
+    StreamResetFailed {
+        id: ConnectionId,
+        stream_id: StreamId,
+        reason: String,
+    },
     #[error("close failed for {id}: {reason}")]
     CloseFailed { id: ConnectionId, reason: String },
     #[error("poll error: {reason}")]

--- a/packages/transport/src/event.rs
+++ b/packages/transport/src/event.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use minip2p_core::{Multiaddr, PeerId};
 
-use crate::{ConnectionEndpoint, ConnectionId};
+use crate::{ConnectionEndpoint, ConnectionId, StreamId};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TransportEvent {
@@ -11,9 +11,26 @@ pub enum TransportEvent {
         id: ConnectionId,
         endpoint: ConnectionEndpoint,
     },
-    Received {
+    StreamOpened {
         id: ConnectionId,
+        stream_id: StreamId,
+    },
+    IncomingStream {
+        id: ConnectionId,
+        stream_id: StreamId,
+    },
+    StreamData {
+        id: ConnectionId,
+        stream_id: StreamId,
         data: Vec<u8>,
+    },
+    StreamRemoteWriteClosed {
+        id: ConnectionId,
+        stream_id: StreamId,
+    },
+    StreamClosed {
+        id: ConnectionId,
+        stream_id: StreamId,
     },
     Closed {
         id: ConnectionId,

--- a/packages/transport/src/lib.rs
+++ b/packages/transport/src/lib.rs
@@ -8,7 +8,7 @@ mod connection_id;
 mod connection_state;
 mod error;
 mod event;
-mod peer_send_policy;
+mod stream_id;
 mod transport;
 
 pub use action::TransportAction;
@@ -17,5 +17,5 @@ pub use connection_id::ConnectionId;
 pub use connection_state::ConnectionState;
 pub use error::TransportError;
 pub use event::TransportEvent;
-pub use peer_send_policy::PeerSendPolicy;
+pub use stream_id::StreamId;
 pub use transport::Transport;

--- a/packages/transport/src/peer_send_policy.rs
+++ b/packages/transport/src/peer_send_policy.rs
@@ -1,7 +1,0 @@
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub enum PeerSendPolicy {
-    #[default]
-    Primary,
-    OldestConnected,
-    NewestConnected,
-}

--- a/packages/transport/src/stream_id.rs
+++ b/packages/transport/src/stream_id.rs
@@ -1,0 +1,32 @@
+use core::fmt;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct StreamId(u64);
+
+impl StreamId {
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for StreamId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<u64> for StreamId {
+    fn from(value: u64) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<StreamId> for u64 {
+    fn from(value: StreamId) -> Self {
+        value.0
+    }
+}

--- a/packages/transport/src/transport.rs
+++ b/packages/transport/src/transport.rs
@@ -2,14 +2,30 @@ use alloc::vec::Vec;
 
 use minip2p_core::{Multiaddr, PeerAddr};
 
-use crate::{ConnectionId, TransportError, TransportEvent};
+use crate::{ConnectionId, StreamId, TransportError, TransportEvent};
 
 pub trait Transport {
     fn dial(&mut self, id: ConnectionId, addr: &PeerAddr) -> Result<(), TransportError>;
 
     fn listen(&mut self, addr: &Multiaddr) -> Result<(), TransportError>;
 
-    fn send(&mut self, id: ConnectionId, data: Vec<u8>) -> Result<(), TransportError>;
+    fn open_stream(&mut self, id: ConnectionId) -> Result<StreamId, TransportError>;
+
+    fn send_stream(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+        data: Vec<u8>,
+    ) -> Result<(), TransportError>;
+
+    fn close_stream_write(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+    ) -> Result<(), TransportError>;
+
+    fn reset_stream(&mut self, id: ConnectionId, stream_id: StreamId)
+    -> Result<(), TransportError>;
 
     fn close(&mut self, id: ConnectionId) -> Result<(), TransportError>;
 

--- a/plan.md
+++ b/plan.md
@@ -16,14 +16,17 @@ Implemented crates:
 
 - `packages/identity` (`minip2p-identity`)
 - `packages/core` (`minip2p-core`)
+- `packages/multistream-select` (`minip2p-multistream-select`)
+- `packages/ping` (`minip2p-ping`)
 - `packages/transport` (`minip2p-transport`)
 - `transports/quic` (`minip2p-quic`)
 
 Current validated capabilities:
 
 - Local two-peer QUIC connectivity in integration tests.
-- Bidirectional byte exchange.
-- Multiple connections per peer with policy-based selection.
+- Bidirectional stream data exchange.
+- Stream half-close/write-close event flow.
+- Multiple connections per peer.
 - Identity upgrade event flow and peer index updates.
 
 ## Architecture Boundaries

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -11,5 +11,7 @@ quiche = "0.28"
 getrandom = "0.3"
 
 [dev-dependencies]
+minip2p-multistream-select = { path = "../../packages/multistream-select" }
+minip2p-ping = { path = "../../packages/ping" }
 rcgen = "0.14"
 tempfile = "3"

--- a/transports/quic/README.md
+++ b/transports/quic/README.md
@@ -2,233 +2,56 @@
 
 Synchronous QUIC transport adapter for minip2p, powered by [quiche](https://github.com/cloudflare/quiche).
 
-No async runtime required. The host calls `poll()` in their own loop.
+No async runtime required. The host drives the transport by calling `poll()`.
 
 ## Features
 
-- Implements the `minip2p_transport::Transport` trait.
-- Synchronous, non-blocking UDP socket — no tokio, no futures.
-- Self-signed TLS certificate support via PEM files on disk.
-- Server-side incoming connection detection.
-- Peer-aware endpoint events (`peer_id` is optional for inbound connections).
-- Explicit identity-upgrade hook via `verify_connection_peer_id(...)`.
-- Length-prefixed message framing for `send`/`Received` payload boundaries.
-- Dial supports `/ip4`, `/ip6`, `/dns`, `/dns4`, and `/dns6` QUIC transport addresses.
-- `listen()` validates the requested `/ip4|ip6/.../udp/.../quic-v1` address against the bound socket.
-- Multiple concurrent connections per peer.
-- Peer-level send API with connection selection policy.
-- Node-centric config API with listener/dialer role helpers.
+- Implements `minip2p_transport::Transport`.
+- Non-blocking UDP socket integration.
+- Connection lifecycle events (`IncomingConnection`, `Connected`, `Closed`).
+- Native QUIC stream operations:
+  - `open_stream`
+  - `send_stream`
+  - `close_stream_write`
+  - `reset_stream`
+- Stream events (`StreamOpened`, `IncomingStream`, `StreamData`, `StreamRemoteWriteClosed`, `StreamClosed`).
+- Optional peer-id binding with `verify_connection_peer_id(...)`.
+- Dial supports `/ip4`, `/ip6`, `/dns`, `/dns4`, `/dns6` QUIC transport addresses.
 
-## Usage
-
-### Basic listener role + dialer role
+## Basic usage
 
 ```rust
 use minip2p_core::{Multiaddr, PeerAddr, Protocol};
 use minip2p_identity::PeerId;
 use minip2p_quic::{QuicNodeConfig, QuicTransport};
-use minip2p_transport::{ConnectionId, Transport, TransportEvent};
+use minip2p_transport::{ConnectionId, Transport};
 use std::str::FromStr;
 
-// --- Listener role (server-like) ---
-let listener_node_config = QuicNodeConfig::dev_listener_with_tls(
-    "/path/to/cert.pem",
-    "/path/to/key.pem",
-);
+let listener_cfg = QuicNodeConfig::dev_listener_with_tls("cert.pem", "key.pem");
+let mut listener = QuicTransport::new(listener_cfg, "127.0.0.1:0")?;
 
-let mut listener = QuicTransport::new(listener_node_config, "127.0.0.1:0")
-    .expect("server bind");
-
-let listener_addr = listener.local_addr().expect("local addr");
+let local = listener.local_addr()?;
 let listen_addr = Multiaddr::from_protocols(vec![
     Protocol::Ip4([127, 0, 0, 1]),
-    Protocol::Udp(listener_addr.port()),
+    Protocol::Udp(local.port()),
     Protocol::QuicV1,
 ]);
+listener.listen(&listen_addr)?;
 
-listener.listen(&listen_addr).expect("listen");
+let dialer_cfg = QuicNodeConfig::dev_dialer();
+let mut dialer = QuicTransport::new(dialer_cfg, "127.0.0.1:0")?;
 
-// --- Dialer role (client-like) ---
-let dialer_node_config = QuicNodeConfig::dev_dialer();
-let mut dialer = QuicTransport::new(dialer_node_config, "127.0.0.1:0")
-    .expect("client bind");
-
-let peer_id = PeerId::from_str(
-    "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N"
-)
-.expect("peer id");
-
-let peer_addr = PeerAddr::new(listen_addr.clone(), peer_id)
-    .expect("peer addr");
+let peer_id = PeerId::from_str("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N")?;
+let peer_addr = PeerAddr::new(listen_addr, peer_id)?;
 
 let conn_id = ConnectionId::new(1);
-dialer.dial(conn_id, &peer_addr).expect("dial");
-```
-
-### Driving the event loop
-
-Call `poll()` in a loop. No async runtime needed — just a regular `loop`:
-
-```rust
-use minip2p_transport::{ConnectionId, Transport, TransportEvent};
-use std::time::Duration;
-
-fn drive(transport: &mut impl Transport) {
-    loop {
-        let events = transport.poll().expect("poll failure");
-
-        for event in events {
-            match event {
-                TransportEvent::Connected { id, endpoint } => {
-                    if let Some(peer_id) = endpoint.peer_id() {
-                        println!("connected: {id} -> {} (peer: {peer_id})", endpoint.transport());
-                    } else {
-                        println!("connected: {id} -> {}", endpoint.transport());
-                    }
-                }
-                TransportEvent::Received { id, data } => {
-                    println!("got {} bytes on {id}", data.len());
-                }
-                TransportEvent::IncomingConnection { id, endpoint } => {
-                    println!("incoming: {id} from {}", endpoint.transport());
-                }
-                TransportEvent::Closed { id } => {
-                    println!("closed: {id}");
-                    return;
-                }
-                _ => {}
-            }
-        }
-
-        std::thread::sleep(Duration::from_millis(1));
-    }
-}
-```
-
-### Dialing ergonomics and peer connection lookup
-
-`QuicTransport` provides convenience helpers on top of the `Transport` trait:
-
-```rust
-use minip2p_identity::PeerId;
-use minip2p_quic::QuicTransport;
-use minip2p_transport::{PeerSendPolicy, Transport};
-
-fn connect_and_pick_primary(
-    transport: &mut QuicTransport,
-    peer_addr: &minip2p_core::PeerAddr,
-    peer_id: &PeerId,
-) {
-    let _id = transport.dial_auto(peer_addr).expect("dial");
-
-    let ids = transport.connection_ids_for_peer(peer_id);
-    println!("known connection ids for peer: {ids:?}");
-
-    if let Some(primary) = transport.primary_connection_for_peer(peer_id) {
-        println!("primary connection: {primary}");
-    }
-
-    let used = transport
-        .send_to_peer(peer_id, b"hello".to_vec(), PeerSendPolicy::Primary)
-        .expect("send");
-    println!("sent using connection: {used}");
-}
-```
-
-### Identity upgrade event
-
-Inbound connections can start with `peer_id: None`. Once your auth layer verifies identity, bind it to the connection:
-
-```rust
-use minip2p_identity::PeerId;
-use minip2p_transport::TransportEvent;
-use std::str::FromStr;
-
-fn verify_identity(transport: &mut minip2p_quic::QuicTransport, id: minip2p_transport::ConnectionId) {
-    let verified = PeerId::from_str(
-        "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N"
-    )
-    .expect("peer id");
-
-    transport
-        .verify_connection_peer_id(id, verified)
-        .expect("verify peer id");
-
-    for event in transport.poll().expect("poll") {
-        if let TransportEvent::PeerIdentityVerified { id, endpoint, .. } = event {
-            println!("verified {id} as {:?}", endpoint.peer_id());
-        }
-    }
-}
-```
-
-### Sending data
-
-```rust
-use minip2p_transport::{ConnectionId, Transport};
-
-fn send_message(
-    transport: &mut impl Transport,
-    conn_id: ConnectionId,
-    msg: &[u8],
-) {
-    transport
-        .send(conn_id, msg.to_vec())
-        .expect("send");
-}
-```
-
-### Closing a connection
-
-```rust
-use minip2p_transport::{ConnectionId, Transport};
-
-fn close_connection(
-    transport: &mut impl Transport,
-    conn_id: ConnectionId,
-) {
-    transport.close(conn_id).expect("close");
-    // TransportEvent::Closed will be emitted on the next poll()
-    // when the connection is fully closed.
-}
-```
-
-## Configuration
-
-`QuicNodeConfig` is a node-centric builder. The same type supports listener and dialer roles:
-
-| Method | Description |
-|--------|-------------|
-| `QuicNodeConfig::new()` | Base node config, no local TLS files, peer verification disabled. |
-| `QuicNodeConfig::dev_dialer()` | Local development dialer preset. |
-| `QuicNodeConfig::dev_listener_with_tls(cert, key)` | Local development listener preset with TLS files. |
-| `.with_local_tls_files(cert, key)` | Set PEM paths for local listener identity. Required for `listen()`. |
-| `.with_peer_verification(bool)` | Enable/disable peer certificate verification. Default: `false`. |
-
-```rust
-use minip2p_quic::QuicNodeConfig;
-
-let config = QuicNodeConfig::new()
-    .with_local_tls_files("cert.pem", "key.pem")
-    .with_peer_verification(true);
-```
-
-## TLS certificates
-
-quiche requires TLS certificates loaded from PEM files on disk. For local development, generate self-signed certs at runtime:
-
-```rust
-use std::io::Write;
-
-let mut params = rcgen::CertificateParams::new(Vec::new())?;
-params.distinguished_name.push(rcgen::DnType::CommonName, "minip2p");
-let key_pair = rcgen::KeyPair::generate()?;
-let cert = params.self_signed(&key_pair)?;
-
-std::fs::write("cert.pem", cert.pem())?;
-std::fs::write("key.pem", key_pair.serialize_pem())?;
+dialer.dial(conn_id, &peer_addr)?;
+let stream_id = dialer.open_stream(conn_id)?;
+dialer.send_stream(conn_id, stream_id, b"hello".to_vec())?;
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
 ## Scope
 
-This crate is a concrete transport adapter. It depends on `std` (quiche links BoringSSL and requires a UDP socket). For the transport interface without runtime dependencies, see `minip2p-transport`.
+This crate is a concrete transport adapter and depends on `std`.
+For Sans-I/O contracts and shared types, use `minip2p-transport`.

--- a/transports/quic/src/connection.rs
+++ b/transports/quic/src/connection.rs
@@ -3,12 +3,58 @@ use std::net::{SocketAddr, UdpSocket};
 
 use minip2p_core::PeerId;
 use minip2p_transport::{
-    ConnectionEndpoint, ConnectionId, ConnectionState, TransportError, TransportEvent,
+    ConnectionEndpoint, ConnectionId, ConnectionState, StreamId, TransportError, TransportEvent,
 };
 
 const SEND_BUF_SIZE: usize = 1350;
-const FRAME_LEN_BYTES: usize = 4;
-const MAX_FRAME_SIZE: usize = 1024 * 1024;
+
+#[derive(Clone, Debug)]
+struct PendingStreamWrite {
+    bytes: Vec<u8>,
+    offset: usize,
+    fin: bool,
+}
+
+impl PendingStreamWrite {
+    fn data(bytes: Vec<u8>) -> Self {
+        Self {
+            bytes,
+            offset: 0,
+            fin: false,
+        }
+    }
+
+    fn fin() -> Self {
+        Self {
+            bytes: Vec::new(),
+            offset: 0,
+            fin: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct StreamRuntimeState {
+    pending_writes: VecDeque<PendingStreamWrite>,
+    local_write_closed: bool,
+    remote_write_closed: bool,
+    incoming_notified: bool,
+    closed_notified: bool,
+}
+
+impl StreamRuntimeState {
+    fn on_local_write_closed(&mut self) {
+        self.local_write_closed = true;
+    }
+
+    fn on_remote_write_closed(&mut self) {
+        self.remote_write_closed = true;
+    }
+
+    fn is_fully_closed(&self) -> bool {
+        self.local_write_closed && self.remote_write_closed
+    }
+}
 
 pub struct QuicConnection {
     id: ConnectionId,
@@ -16,8 +62,8 @@ pub struct QuicConnection {
     peer_addr: SocketAddr,
     endpoint: ConnectionEndpoint,
     state: ConnectionState,
-    pending_stream_frames: VecDeque<(Vec<u8>, usize)>,
-    stream_recv_buffers: HashMap<u64, Vec<u8>>,
+    stream_states: HashMap<u64, StreamRuntimeState>,
+    next_local_bidi_stream_id: u64,
 }
 
 impl QuicConnection {
@@ -27,14 +73,16 @@ impl QuicConnection {
         peer_addr: SocketAddr,
         endpoint: ConnectionEndpoint,
     ) -> Self {
+        let next_local_bidi_stream_id = if conn.is_server() { 1 } else { 0 };
+
         Self {
             id,
             conn,
             peer_addr,
             endpoint,
             state: ConnectionState::Connecting,
-            pending_stream_frames: VecDeque::new(),
-            stream_recv_buffers: HashMap::new(),
+            stream_states: HashMap::new(),
+            next_local_bidi_stream_id,
         }
     }
 
@@ -44,14 +92,6 @@ impl QuicConnection {
 
     pub fn endpoint(&self) -> &ConnectionEndpoint {
         &self.endpoint
-    }
-
-    pub fn state(&self) -> ConnectionState {
-        self.state
-    }
-
-    pub fn is_connected(&self) -> bool {
-        self.state == ConnectionState::Connected
     }
 
     pub fn set_peer_id(&mut self, peer_id: PeerId) {
@@ -86,7 +126,7 @@ impl QuicConnection {
 
         if self.state == ConnectionState::Connecting && self.conn.is_established() {
             self.state = ConnectionState::Connected;
-            self.drain_send_queue()?;
+            self.drain_send_queue(events)?;
             self.flush(socket)?;
 
             events.push(TransportEvent::Connected {
@@ -94,37 +134,129 @@ impl QuicConnection {
                 endpoint: self.endpoint.clone(),
             });
         } else {
-            self.drain_send_queue()?;
+            self.drain_send_queue(events)?;
             self.flush(socket)?;
         }
 
         Ok(())
     }
 
-    pub fn send_data(&mut self, data: &[u8], socket: &UdpSocket) -> Result<(), TransportError> {
-        if data.len() > MAX_FRAME_SIZE {
-            return Err(TransportError::SendFailed {
+    pub fn open_stream(&mut self) -> Result<StreamId, TransportError> {
+        if self.state != ConnectionState::Connected {
+            return Err(TransportError::InvalidState {
                 id: self.id,
-                reason: format!(
-                    "message size {} exceeds max frame size {MAX_FRAME_SIZE}",
-                    data.len()
-                ),
+                state: self.state,
+                expected: ConnectionState::Connected,
             });
         }
 
-        let frame_len = u32::try_from(data.len()).map_err(|_| TransportError::SendFailed {
-            id: self.id,
-            reason: format!("message size {} exceeds u32 framing limit", data.len()),
-        })?;
+        let raw_stream_id = self.next_local_bidi_stream_id;
+        self.next_local_bidi_stream_id = self.next_local_bidi_stream_id.wrapping_add(4);
 
-        let mut frame = Vec::with_capacity(FRAME_LEN_BYTES + data.len());
-        frame.extend_from_slice(&frame_len.to_be_bytes());
-        frame.extend_from_slice(data);
+        if self.stream_states.contains_key(&raw_stream_id) {
+            return Err(TransportError::StreamExists {
+                id: self.id,
+                stream_id: StreamId::new(raw_stream_id),
+            });
+        }
 
-        self.pending_stream_frames.push_back((frame, 0));
-        self.drain_send_queue()?;
+        self.stream_states
+            .insert(raw_stream_id, StreamRuntimeState::default());
+        Ok(StreamId::new(raw_stream_id))
+    }
 
+    pub fn send_stream(
+        &mut self,
+        stream_id: StreamId,
+        data: Vec<u8>,
+        socket: &UdpSocket,
+        events: &mut Vec<TransportEvent>,
+    ) -> Result<(), TransportError> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let state = self.get_or_create_local_stream_state(stream_id)?;
+        if state.local_write_closed {
+            return Err(TransportError::StreamSendFailed {
+                id: self.id,
+                stream_id,
+                reason: "local stream write side is already closed".into(),
+            });
+        }
+
+        state
+            .pending_writes
+            .push_back(PendingStreamWrite::data(data));
+
+        self.drain_send_queue(events)?;
         self.flush(socket)?;
+        Ok(())
+    }
+
+    pub fn close_stream_write(
+        &mut self,
+        stream_id: StreamId,
+        socket: &UdpSocket,
+        events: &mut Vec<TransportEvent>,
+    ) -> Result<(), TransportError> {
+        let state = self.get_or_create_local_stream_state(stream_id)?;
+
+        if state.local_write_closed {
+            return Err(TransportError::StreamCloseWriteFailed {
+                id: self.id,
+                stream_id,
+                reason: "local stream write side is already closed".into(),
+            });
+        }
+
+        state.on_local_write_closed();
+        state.pending_writes.push_back(PendingStreamWrite::fin());
+
+        self.drain_send_queue(events)?;
+        self.flush(socket)?;
+        Ok(())
+    }
+
+    pub fn reset_stream(
+        &mut self,
+        stream_id: StreamId,
+        events: &mut Vec<TransportEvent>,
+    ) -> Result<(), TransportError> {
+        let state = self.stream_states.get_mut(&stream_id.as_u64()).ok_or(
+            TransportError::StreamNotFound {
+                id: self.id,
+                stream_id,
+            },
+        )?;
+
+        self.conn
+            .stream_shutdown(stream_id.as_u64(), quiche::Shutdown::Write, 0x00)
+            .map_err(|e| TransportError::StreamResetFailed {
+                id: self.id,
+                stream_id,
+                reason: format!("failed to shutdown stream write side: {e}"),
+            })?;
+
+        self.conn
+            .stream_shutdown(stream_id.as_u64(), quiche::Shutdown::Read, 0x00)
+            .map_err(|e| TransportError::StreamResetFailed {
+                id: self.id,
+                stream_id,
+                reason: format!("failed to shutdown stream read side: {e}"),
+            })?;
+
+        state.local_write_closed = true;
+        state.remote_write_closed = true;
+
+        if !state.closed_notified {
+            state.closed_notified = true;
+            events.push(TransportEvent::StreamClosed {
+                id: self.id,
+                stream_id,
+            });
+        }
+
         Ok(())
     }
 
@@ -137,7 +269,8 @@ impl QuicConnection {
             })?;
 
         self.state = ConnectionState::Closing;
-        self.drain_send_queue()?;
+        let mut drain_events = Vec::new();
+        self.drain_send_queue(&mut drain_events)?;
         self.flush(socket)?;
         Ok(())
     }
@@ -153,16 +286,32 @@ impl QuicConnection {
 
         let mut buf = [0u8; 65535];
 
-        for stream_id in self.conn.readable() {
+        for raw_stream_id in self.conn.readable() {
+            let stream_id = StreamId::new(raw_stream_id);
+            self.ensure_stream_discovered(stream_id, events);
+
             loop {
-                match self.conn.stream_recv(stream_id, &mut buf) {
+                match self.conn.stream_recv(raw_stream_id, &mut buf) {
                     Ok((read, fin)) => {
                         if read > 0 {
-                            self.process_stream_chunk(stream_id, &buf[..read], events, socket)?;
+                            events.push(TransportEvent::StreamData {
+                                id: self.id,
+                                stream_id,
+                                data: buf[..read].to_vec(),
+                            });
                         }
 
                         if fin {
-                            self.stream_recv_buffers.remove(&stream_id);
+                            if let Some(state) = self.stream_states.get_mut(&raw_stream_id) {
+                                state.on_remote_write_closed();
+                            }
+
+                            events.push(TransportEvent::StreamRemoteWriteClosed {
+                                id: self.id,
+                                stream_id,
+                            });
+
+                            self.note_stream_closed_if_finished(stream_id, events);
                             break;
                         }
                     }
@@ -178,7 +327,9 @@ impl QuicConnection {
             }
         }
 
+        self.drain_send_queue(events)?;
         self.flush(socket)?;
+        self.gc_closed_streams();
         Ok(())
     }
 
@@ -189,7 +340,7 @@ impl QuicConnection {
                 Ok(v) => v,
                 Err(quiche::Error::Done) => break,
                 Err(e) => {
-                    return Err(TransportError::SendFailed {
+                    return Err(TransportError::CloseFailed {
                         id: self.id,
                         reason: format!("quiche send error: {e}"),
                     });
@@ -197,7 +348,7 @@ impl QuicConnection {
             };
 
             socket.send_to(&out[..written], send_info.to).map_err(|e| {
-                TransportError::SendFailed {
+                TransportError::CloseFailed {
                     id: self.id,
                     reason: format!("udp send error: {e}"),
                 }
@@ -206,88 +357,135 @@ impl QuicConnection {
         Ok(())
     }
 
-    fn drain_send_queue(&mut self) -> Result<(), TransportError> {
-        let stream_id = if self.conn.is_server() { 1 } else { 0 };
+    fn drain_send_queue(&mut self, events: &mut Vec<TransportEvent>) -> Result<(), TransportError> {
+        let stream_ids: Vec<u64> = self.stream_states.keys().copied().collect();
 
-        while let Some((frame, mut sent)) = self.pending_stream_frames.pop_front() {
-            while sent < frame.len() {
-                match self.conn.stream_send(stream_id, &frame[sent..], false) {
-                    Ok(written) => {
-                        if written == 0 {
-                            self.pending_stream_frames.push_front((frame, sent));
-                            return Ok(());
-                        }
-                        sent += written;
-                    }
-                    Err(quiche::Error::Done) => {
-                        self.pending_stream_frames.push_front((frame, sent));
-                        return Ok(());
-                    }
+        for raw_stream_id in stream_ids {
+            loop {
+                let pending = self
+                    .stream_states
+                    .get(&raw_stream_id)
+                    .and_then(|state| state.pending_writes.front().cloned());
+
+                let Some(pending) = pending else {
+                    break;
+                };
+
+                let stream_id = StreamId::new(raw_stream_id);
+                let payload = &pending.bytes[pending.offset..];
+                let fin = pending.fin && payload.is_empty();
+
+                let written = match self.conn.stream_send(raw_stream_id, payload, fin) {
+                    Ok(written) => written,
+                    Err(quiche::Error::Done) => break,
                     Err(e) => {
-                        return Err(TransportError::SendFailed {
+                        return Err(TransportError::StreamSendFailed {
                             id: self.id,
+                            stream_id,
                             reason: format!("stream_send error: {e}"),
                         });
                     }
+                };
+
+                if let Some(state) = self.stream_states.get_mut(&raw_stream_id) {
+                    if let Some(front) = state.pending_writes.front_mut() {
+                        if front.fin && front.bytes.is_empty() {
+                            state.pending_writes.pop_front();
+                        } else {
+                            if written == 0 {
+                                break;
+                            }
+
+                            front.offset = front.offset.saturating_add(written);
+                            if front.offset >= front.bytes.len() {
+                                state.pending_writes.pop_front();
+                            }
+                        }
+                    }
                 }
+
+                self.note_stream_closed_if_finished(stream_id, events);
             }
         }
 
         Ok(())
     }
 
-    fn process_stream_chunk(
+    fn ensure_stream_discovered(&mut self, stream_id: StreamId, events: &mut Vec<TransportEvent>) {
+        let is_remote = self.is_remote_initiated_stream(stream_id.as_u64());
+        let state = self.stream_states.entry(stream_id.as_u64()).or_default();
+
+        if is_remote && !state.incoming_notified {
+            state.incoming_notified = true;
+            events.push(TransportEvent::IncomingStream {
+                id: self.id,
+                stream_id,
+            });
+        }
+    }
+
+    fn note_stream_closed_if_finished(
         &mut self,
-        stream_id: u64,
-        chunk: &[u8],
+        stream_id: StreamId,
         events: &mut Vec<TransportEvent>,
-        socket: &UdpSocket,
-    ) -> Result<(), TransportError> {
-        let mut close_due_to_frame_size = false;
-
-        {
-            let buffer = self.stream_recv_buffers.entry(stream_id).or_default();
-            buffer.extend_from_slice(chunk);
-
-            loop {
-                if buffer.len() < FRAME_LEN_BYTES {
-                    break;
-                }
-
-                let frame_len =
-                    u32::from_be_bytes([buffer[0], buffer[1], buffer[2], buffer[3]]) as usize;
-
-                if frame_len > MAX_FRAME_SIZE {
-                    events.push(TransportEvent::Error {
-                        id: self.id,
-                        message: format!(
-                            "received frame of {frame_len} bytes exceeding max {MAX_FRAME_SIZE}"
-                        ),
-                    });
-
-                    buffer.clear();
-                    close_due_to_frame_size = true;
-                    break;
-                }
-
-                let total_len = FRAME_LEN_BYTES + frame_len;
-                if buffer.len() < total_len {
-                    break;
-                }
-
-                events.push(TransportEvent::Received {
+    ) {
+        if let Some(state) = self.stream_states.get_mut(&stream_id.as_u64()) {
+            if state.is_fully_closed() && !state.closed_notified {
+                state.closed_notified = true;
+                events.push(TransportEvent::StreamClosed {
                     id: self.id,
-                    data: buffer[FRAME_LEN_BYTES..total_len].to_vec(),
+                    stream_id,
                 });
-                buffer.drain(..total_len);
             }
         }
+    }
 
-        if close_due_to_frame_size {
-            self.close(socket)?;
+    fn gc_closed_streams(&mut self) {
+        let to_remove: Vec<u64> = self
+            .stream_states
+            .iter()
+            .filter_map(|(stream_id, state)| {
+                if state.closed_notified && state.pending_writes.is_empty() {
+                    Some(*stream_id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for stream_id in to_remove {
+            self.stream_states.remove(&stream_id);
+        }
+    }
+
+    fn get_or_create_local_stream_state(
+        &mut self,
+        stream_id: StreamId,
+    ) -> Result<&mut StreamRuntimeState, TransportError> {
+        if self.stream_states.contains_key(&stream_id.as_u64()) {
+            return Ok(self
+                .stream_states
+                .get_mut(&stream_id.as_u64())
+                .expect("stream state must exist"));
         }
 
-        Ok(())
+        if !self.is_local_initiated_stream(stream_id.as_u64()) {
+            return Err(TransportError::StreamNotFound {
+                id: self.id,
+                stream_id,
+            });
+        }
+
+        Ok(self.stream_states.entry(stream_id.as_u64()).or_default())
+    }
+
+    fn is_local_initiated_stream(&self, stream_id: u64) -> bool {
+        let local_initiator_bit = if self.conn.is_server() { 1 } else { 0 };
+        (stream_id & 0x1) == local_initiator_bit
+    }
+
+    fn is_remote_initiated_stream(&self, stream_id: u64) -> bool {
+        !self.is_local_initiated_stream(stream_id)
     }
 
     pub fn matches_peer(&self, addr: SocketAddr) -> bool {

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -3,8 +3,7 @@ use std::net::{IpAddr, SocketAddr, ToSocketAddrs, UdpSocket};
 
 use minip2p_core::{Multiaddr, PeerAddr, PeerId, Protocol};
 use minip2p_transport::{
-    ConnectionEndpoint, ConnectionId, ConnectionState, PeerSendPolicy, Transport, TransportError,
-    TransportEvent,
+    ConnectionEndpoint, ConnectionId, StreamId, Transport, TransportError, TransportEvent,
 };
 use quiche::ConnectionId as QuicConnectionId;
 
@@ -178,11 +177,9 @@ pub struct QuicTransport {
     connections: HashMap<ConnectionId, QuicConnection>,
     cid_to_connection: HashMap<Vec<u8>, ConnectionId>,
     peer_connections: HashMap<PeerId, BTreeSet<ConnectionId>>,
-    connection_connected_seq: HashMap<ConnectionId, u64>,
     pending_events: Vec<TransportEvent>,
     listen_addr: Option<SocketAddr>,
     next_connection_id: u64,
-    next_connected_seq: u64,
     node_config: QuicNodeConfig,
 }
 
@@ -240,11 +237,9 @@ impl QuicTransport {
             connections: HashMap::new(),
             cid_to_connection: HashMap::new(),
             peer_connections: HashMap::new(),
-            connection_connected_seq: HashMap::new(),
             pending_events: Vec::new(),
             listen_addr: None,
             next_connection_id: 1,
-            next_connected_seq: 1,
             node_config,
         })
     }
@@ -268,10 +263,6 @@ impl QuicTransport {
             .get(peer_id)
             .map(|ids| ids.iter().copied().collect())
             .unwrap_or_default()
-    }
-
-    pub fn primary_connection_for_peer(&self, peer_id: &PeerId) -> Option<ConnectionId> {
-        self.select_connection_for_peer(peer_id, PeerSendPolicy::Primary)
     }
 
     pub fn verify_connection_peer_id(
@@ -309,22 +300,6 @@ impl QuicTransport {
         Ok(())
     }
 
-    pub fn send_to_peer(
-        &mut self,
-        peer_id: &PeerId,
-        data: Vec<u8>,
-        policy: PeerSendPolicy,
-    ) -> Result<ConnectionId, TransportError> {
-        let connection_id = self
-            .select_connection_for_peer(peer_id, policy)
-            .ok_or_else(|| TransportError::PeerNotConnected {
-                peer_id: peer_id.clone(),
-            })?;
-
-        self.send(connection_id, data)?;
-        Ok(connection_id)
-    }
-
     fn allocate_connection_id(&mut self) -> Result<ConnectionId, TransportError> {
         let start = self.next_connection_id;
 
@@ -359,16 +334,6 @@ impl QuicTransport {
         self.peer_connections.entry(peer_id).or_default().insert(id);
     }
 
-    fn note_connection_established(&mut self, id: ConnectionId) {
-        if self.connection_connected_seq.contains_key(&id) {
-            return;
-        }
-
-        let seq = self.next_connected_seq;
-        self.next_connected_seq = self.next_connected_seq.wrapping_add(1);
-        self.connection_connected_seq.insert(id, seq);
-    }
-
     fn remove_peer_connection(&mut self, peer_id: &PeerId, id: ConnectionId) {
         let mut remove_entry = false;
 
@@ -382,41 +347,8 @@ impl QuicTransport {
         }
     }
 
-    fn select_connection_for_peer(
-        &self,
-        peer_id: &PeerId,
-        policy: PeerSendPolicy,
-    ) -> Option<ConnectionId> {
-        let ids = self.peer_connections.get(peer_id)?;
-
-        let is_connected = |id: &ConnectionId| {
-            self.connections
-                .get(id)
-                .is_some_and(QuicConnection::is_connected)
-        };
-
-        match policy {
-            PeerSendPolicy::Primary | PeerSendPolicy::OldestConnected => ids
-                .iter()
-                .filter(|id| is_connected(id))
-                .min_by_key(|id| {
-                    self.connection_connected_seq
-                        .get(id)
-                        .copied()
-                        .unwrap_or(u64::MAX)
-                })
-                .copied(),
-            PeerSendPolicy::NewestConnected => ids
-                .iter()
-                .filter(|id| is_connected(id))
-                .max_by_key(|id| self.connection_connected_seq.get(id).copied().unwrap_or(0))
-                .copied(),
-        }
-    }
-
     fn unindex_connection(&mut self, id: ConnectionId, peer_id: Option<PeerId>) {
         self.cid_to_connection.retain(|_, mapped| *mapped != id);
-        self.connection_connected_seq.remove(&id);
 
         if let Some(peer_id) = peer_id {
             self.remove_peer_connection(&peer_id, id);
@@ -509,21 +441,60 @@ impl Transport for QuicTransport {
         Ok(())
     }
 
-    fn send(&mut self, id: ConnectionId, data: Vec<u8>) -> Result<(), TransportError> {
+    fn open_stream(&mut self, id: ConnectionId) -> Result<StreamId, TransportError> {
         let conn = self
             .connections
             .get_mut(&id)
             .ok_or(TransportError::ConnectionNotFound { id })?;
 
-        if conn.state() != ConnectionState::Connected {
-            return Err(TransportError::InvalidState {
-                id,
-                state: conn.state(),
-                expected: ConnectionState::Connected,
-            });
-        }
+        let stream_id = conn.open_stream()?;
+        self.pending_events
+            .push(TransportEvent::StreamOpened { id, stream_id });
+        Ok(stream_id)
+    }
 
-        conn.send_data(&data, &self.socket)?;
+    fn send_stream(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+        data: Vec<u8>,
+    ) -> Result<(), TransportError> {
+        let conn = self
+            .connections
+            .get_mut(&id)
+            .ok_or(TransportError::ConnectionNotFound { id })?;
+
+        conn.send_stream(stream_id, data, &self.socket, &mut self.pending_events)?;
+
+        Ok(())
+    }
+
+    fn close_stream_write(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+    ) -> Result<(), TransportError> {
+        let conn = self
+            .connections
+            .get_mut(&id)
+            .ok_or(TransportError::ConnectionNotFound { id })?;
+
+        conn.close_stream_write(stream_id, &self.socket, &mut self.pending_events)?;
+
+        Ok(())
+    }
+
+    fn reset_stream(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+    ) -> Result<(), TransportError> {
+        let conn = self
+            .connections
+            .get_mut(&id)
+            .ok_or(TransportError::ConnectionNotFound { id })?;
+
+        conn.reset_stream(stream_id, &mut self.pending_events)?;
 
         Ok(())
     }
@@ -542,7 +513,6 @@ impl Transport for QuicTransport {
     fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError> {
         let mut buf = [0u8; 65535];
         let mut events = std::mem::take(&mut self.pending_events);
-        let mut newly_connected_ids = Vec::new();
 
         loop {
             let (len, from) = match self.socket.recv_from(&mut buf) {
@@ -628,26 +598,15 @@ impl Transport for QuicTransport {
 
             if let Some(id) = target_conn_id {
                 let mut source_cid: Option<Vec<u8>> = None;
-                let mut became_connected = false;
                 if let Some(conn) = self.connections.get_mut(&id) {
-                    let was_connected = conn.is_connected();
                     conn.recv_packet(packet, from, local_addr, &self.socket, &mut events)?;
                     source_cid = Some(conn.source_cid_bytes());
-                    became_connected = !was_connected && conn.is_connected();
                 }
 
                 if let Some(source_cid) = source_cid {
                     self.cid_to_connection.insert(source_cid, id);
                 }
-
-                if became_connected {
-                    newly_connected_ids.push(id);
-                }
             }
-        }
-
-        for id in newly_connected_ids {
-            self.note_connection_established(id);
         }
 
         let mut to_remove = Vec::new();

--- a/transports/quic/tests/ping_e2e.rs
+++ b/transports/quic/tests/ping_e2e.rs
@@ -1,0 +1,703 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write;
+use std::str::FromStr;
+use std::time::Instant;
+
+use minip2p_core::{Multiaddr, PeerAddr, Protocol};
+use minip2p_identity::PeerId;
+use minip2p_multistream_select::{MultistreamOutput, MultistreamSelect};
+use minip2p_ping::{PING_PAYLOAD_LEN, PING_PROTOCOL_ID, PingAction, PingEvent, PingProtocol};
+use minip2p_quic::{QuicNodeConfig, QuicTransport};
+use minip2p_transport::{ConnectionId, StreamId, Transport, TransportEvent};
+use tempfile::TempDir;
+
+fn generate_cert_pair() -> (TempDir, String, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let mut params = rcgen::CertificateParams::new(Vec::new()).expect("params");
+    params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "minip2p-test");
+
+    let key_pair = rcgen::KeyPair::generate().expect("keypair");
+    let cert = params.self_signed(&key_pair).expect("cert");
+
+    let cert_path = dir.path().join("cert.pem");
+    let key_path = dir.path().join("key.pem");
+
+    std::fs::File::create(&cert_path)
+        .expect("create cert file")
+        .write_all(cert.pem().as_bytes())
+        .expect("write cert");
+
+    std::fs::File::create(&key_path)
+        .expect("create key file")
+        .write_all(key_pair.serialize_pem().as_bytes())
+        .expect("write key");
+
+    let cert_str = cert_path.to_str().expect("cert path").to_string();
+    let key_str = key_path.to_str().expect("key path").to_string();
+
+    (dir, cert_str, key_str)
+}
+
+fn make_listen_multiaddr(port: u16) -> Multiaddr {
+    Multiaddr::from_protocols(vec![
+        Protocol::Ip4([127, 0, 0, 1]),
+        Protocol::Udp(port),
+        Protocol::QuicV1,
+    ])
+}
+
+fn test_peer_id() -> PeerId {
+    PeerId::from_str("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N").expect("peer id")
+}
+
+fn setup_pair() -> (QuicTransport, QuicTransport, PeerAddr, TempDir) {
+    let (cert_dir, cert_path, key_path) = generate_cert_pair();
+
+    let listener_cfg = QuicNodeConfig::dev_listener_with_tls(&cert_path, &key_path);
+    let dialer_cfg = QuicNodeConfig::dev_dialer();
+
+    let mut server = QuicTransport::new(listener_cfg, "127.0.0.1:0").expect("server bind");
+    let client = QuicTransport::new(dialer_cfg, "127.0.0.1:0").expect("client bind");
+
+    let server_addr = server.local_addr().expect("server local addr");
+    let listen_ma = make_listen_multiaddr(server_addr.port());
+    server.listen(&listen_ma).expect("server listen");
+
+    let peer_addr = PeerAddr::new(listen_ma, test_peer_id()).expect("peer addr");
+
+    (server, client, peer_addr, cert_dir)
+}
+
+fn drive_pair_once(
+    server: &mut QuicTransport,
+    client: &mut QuicTransport,
+) -> (Vec<TransportEvent>, Vec<TransportEvent>) {
+    std::thread::sleep(std::time::Duration::from_millis(5));
+    let server_events = server.poll().expect("server poll");
+    let client_events = client.poll().expect("client poll");
+    (server_events, client_events)
+}
+
+fn wait_for_connection(
+    server: &mut QuicTransport,
+    client: &mut QuicTransport,
+    expected_client_conn: ConnectionId,
+    expected_peer: &PeerAddr,
+    max_iters: usize,
+) -> Option<ConnectionId> {
+    let mut server_conn = None;
+    let mut client_connected = false;
+
+    for _ in 0..max_iters {
+        let (server_events, client_events) = drive_pair_once(server, client);
+
+        for event in server_events {
+            match event {
+                TransportEvent::IncomingConnection { id, endpoint } => {
+                    assert!(endpoint.peer_id().is_none());
+                    server_conn = Some(id);
+                }
+                TransportEvent::Connected { id, .. } => {
+                    if server_conn.is_none() {
+                        server_conn = Some(id);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        for event in client_events {
+            if let TransportEvent::Connected { id, endpoint } = event {
+                if id == expected_client_conn {
+                    assert_eq!(endpoint.peer_id(), Some(expected_peer.peer_id()));
+                    client_connected = true;
+                }
+            }
+        }
+
+        if client_connected && server_conn.is_some() {
+            return server_conn;
+        }
+    }
+
+    None
+}
+
+fn apply_ping_actions(
+    transport: &mut QuicTransport,
+    connection_id: ConnectionId,
+    actions: Vec<PingAction>,
+) {
+    for action in actions {
+        match action {
+            PingAction::Send {
+                stream_id, data, ..
+            } => {
+                transport
+                    .send_stream(connection_id, stream_id, data.to_vec())
+                    .expect("send ping payload");
+            }
+            PingAction::CloseStreamWrite { stream_id, .. } => {
+                transport
+                    .close_stream_write(connection_id, stream_id)
+                    .expect("close ping stream write");
+            }
+            PingAction::ResetStream { stream_id, .. } => {
+                transport
+                    .reset_stream(connection_id, stream_id)
+                    .expect("reset ping stream");
+            }
+        }
+    }
+}
+
+fn assert_no_protocol_violations(events: Vec<PingEvent>) {
+    for event in events {
+        if let PingEvent::ProtocolViolation {
+            peer_id,
+            stream_id,
+            reason,
+        } = event
+        {
+            panic!(
+                "ping protocol violation on peer {peer_id} stream {stream_id}: {reason}"
+            );
+        }
+    }
+}
+
+#[test]
+fn ping_roundtrip_after_identity_verification_and_multistream_negotiation() {
+    let (mut server, mut client, peer_addr, _cert_dir) = setup_pair();
+
+    let client_conn_id = ConnectionId::new(400);
+    client
+        .dial(client_conn_id, &peer_addr)
+        .expect("client dial");
+
+    let server_conn_id = wait_for_connection(&mut server, &mut client, client_conn_id, &peer_addr, 250)
+        .expect("server should observe connection");
+
+    server
+        .verify_connection_peer_id(server_conn_id, peer_addr.peer_id().clone())
+        .expect("verify server-side peer id");
+
+    let mut server_verified = false;
+    for _ in 0..50 {
+        let (server_events, _) = drive_pair_once(&mut server, &mut client);
+        for event in server_events {
+            if let TransportEvent::PeerIdentityVerified { id, endpoint, .. } = event {
+                if id == server_conn_id {
+                    assert_eq!(endpoint.peer_id(), Some(peer_addr.peer_id()));
+                    server_verified = true;
+                }
+            }
+        }
+
+        if server_verified {
+            break;
+        }
+    }
+    assert!(server_verified, "server should emit peer verified event");
+
+    let client_stream = client
+        .open_stream(client_conn_id)
+        .expect("open client ping stream");
+
+    let mut client_negotiator = MultistreamSelect::dialer(PING_PROTOCOL_ID);
+    for output in client_negotiator.start() {
+        if let MultistreamOutput::OutboundData(bytes) = output {
+            client
+                .send_stream(client_conn_id, client_stream, bytes)
+                .expect("send dialer multistream header");
+        }
+    }
+
+    let mut server_negotiators: BTreeMap<StreamId, MultistreamSelect> = BTreeMap::new();
+    let mut server_ping_streams: BTreeSet<StreamId> = BTreeSet::new();
+
+    let mut client_ping = PingProtocol::default();
+    let mut server_ping = PingProtocol::default();
+
+    let mut client_negotiated = false;
+    let mut ping_sent = false;
+    let start = Instant::now();
+    let payload: [u8; PING_PAYLOAD_LEN] = core::array::from_fn(|i| i as u8);
+    let mut measured_rtt_ms = None;
+
+    for _ in 0..400 {
+        let (server_events, client_events) = drive_pair_once(&mut server, &mut client);
+
+        for event in server_events {
+            match event {
+                TransportEvent::IncomingStream { id, stream_id } => {
+                    assert_eq!(id, server_conn_id);
+                    let mut listener = MultistreamSelect::listener([PING_PROTOCOL_ID.to_string()]);
+                    let start_outputs = listener.start();
+                    server_negotiators.insert(stream_id, listener);
+
+                    for output in start_outputs {
+                        if let MultistreamOutput::OutboundData(bytes) = output {
+                            server
+                                .send_stream(server_conn_id, stream_id, bytes)
+                                .expect("send listener multistream header");
+                        }
+                    }
+                }
+                TransportEvent::StreamData {
+                    id,
+                    stream_id,
+                    data,
+                } => {
+                    assert_eq!(id, server_conn_id);
+                    if let Some(negotiator) = server_negotiators.get_mut(&stream_id) {
+                        let outputs = negotiator.receive(&data);
+                        let mut negotiated_ping = false;
+
+                        for output in outputs {
+                            match output {
+                                MultistreamOutput::OutboundData(bytes) => {
+                                    server
+                                        .send_stream(server_conn_id, stream_id, bytes)
+                                        .expect("send listener negotiation bytes");
+                                }
+                                MultistreamOutput::Negotiated { protocol } => {
+                                    assert_eq!(protocol, PING_PROTOCOL_ID);
+                                    negotiated_ping = true;
+
+                                    let actions = server_ping
+                                        .register_inbound_stream(peer_addr.peer_id().clone(), stream_id);
+                                    apply_ping_actions(&mut server, server_conn_id, actions);
+                                }
+                                MultistreamOutput::NotAvailable => {
+                                    panic!("listener reported protocol not available unexpectedly")
+                                }
+                                MultistreamOutput::ProtocolError { reason } => {
+                                    panic!("listener multistream protocol error: {reason}")
+                                }
+                            }
+                        }
+
+                        if negotiated_ping {
+                            server_negotiators.remove(&stream_id);
+                            server_ping_streams.insert(stream_id);
+                        }
+                    } else if server_ping_streams.contains(&stream_id) {
+                        let actions = server_ping.on_stream_data(
+                            peer_addr.peer_id(),
+                            stream_id,
+                            &data,
+                            start.elapsed().as_millis() as u64,
+                        );
+                        apply_ping_actions(&mut server, server_conn_id, actions);
+                    } else {
+                        panic!("server received data for unknown stream {stream_id}");
+                    }
+                }
+                TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
+                    assert_eq!(id, server_conn_id);
+                    let actions =
+                        server_ping.on_stream_remote_write_closed(peer_addr.peer_id(), stream_id);
+                    apply_ping_actions(&mut server, server_conn_id, actions);
+                }
+                TransportEvent::StreamClosed { id, stream_id } => {
+                    assert_eq!(id, server_conn_id);
+                    server_ping.on_stream_closed(peer_addr.peer_id(), stream_id);
+                    server_ping_streams.remove(&stream_id);
+                    server_negotiators.remove(&stream_id);
+                }
+                _ => {}
+            }
+        }
+
+        for event in client_events {
+            match event {
+                TransportEvent::StreamData {
+                    id,
+                    stream_id,
+                    data,
+                } => {
+                    assert_eq!(id, client_conn_id);
+                    if !client_negotiated {
+                        let outputs = client_negotiator.receive(&data);
+                        for output in outputs {
+                            match output {
+                                MultistreamOutput::OutboundData(bytes) => {
+                                    client
+                                        .send_stream(client_conn_id, client_stream, bytes)
+                                        .expect("send dialer negotiation bytes");
+                                }
+                                MultistreamOutput::Negotiated { protocol } => {
+                                    assert_eq!(protocol, PING_PROTOCOL_ID);
+                                    assert_eq!(stream_id, client_stream);
+                                    client_ping
+                                        .register_outbound_stream(peer_addr.peer_id().clone(), client_stream)
+                                        .expect("register outbound ping stream");
+                                    client_negotiated = true;
+                                }
+                                MultistreamOutput::NotAvailable => {
+                                    panic!("dialer reported protocol not available unexpectedly")
+                                }
+                                MultistreamOutput::ProtocolError { reason } => {
+                                    panic!("dialer multistream protocol error: {reason}")
+                                }
+                            }
+                        }
+                    } else {
+                        let actions = client_ping.on_stream_data(
+                            peer_addr.peer_id(),
+                            stream_id,
+                            &data,
+                            start.elapsed().as_millis() as u64,
+                        );
+                        apply_ping_actions(&mut client, client_conn_id, actions);
+                    }
+                }
+                TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
+                    assert_eq!(id, client_conn_id);
+                    let actions =
+                        client_ping.on_stream_remote_write_closed(peer_addr.peer_id(), stream_id);
+                    apply_ping_actions(&mut client, client_conn_id, actions);
+                }
+                TransportEvent::StreamClosed { id, stream_id } => {
+                    assert_eq!(id, client_conn_id);
+                    client_ping.on_stream_closed(peer_addr.peer_id(), stream_id);
+                }
+                _ => {}
+            }
+        }
+
+        let now_ms = start.elapsed().as_millis() as u64;
+        apply_ping_actions(&mut client, client_conn_id, client_ping.on_tick(now_ms));
+        apply_ping_actions(&mut server, server_conn_id, server_ping.on_tick(now_ms));
+
+        if client_negotiated && !ping_sent {
+            let send = client_ping
+                .send_ping(peer_addr.peer_id(), &payload, now_ms)
+                .expect("prepare ping request");
+            apply_ping_actions(&mut client, client_conn_id, vec![send]);
+            ping_sent = true;
+        }
+
+        for event in client_ping.poll_events() {
+            match event {
+                PingEvent::RttMeasured {
+                    peer_id,
+                    stream_id,
+                    rtt_ms,
+                } => {
+                    assert_eq!(peer_id, *peer_addr.peer_id());
+                    assert_eq!(stream_id, client_stream);
+                    measured_rtt_ms = Some(rtt_ms);
+                }
+                PingEvent::ProtocolViolation {
+                    peer_id,
+                    stream_id,
+                    reason,
+                } => {
+                    panic!(
+                        "client ping protocol violation on peer {peer_id} stream {stream_id}: {reason}"
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        assert_no_protocol_violations(server_ping.poll_events());
+
+        if measured_rtt_ms.is_some() {
+            break;
+        }
+    }
+
+    let measured_rtt_ms = measured_rtt_ms.expect("ping roundtrip should complete");
+    assert!(measured_rtt_ms < 5_000, "rtt should be bounded in test env");
+}
+
+#[test]
+fn repeated_ping_on_same_stream_then_close_write_exits_listener_loop() {
+    let (mut server, mut client, peer_addr, _cert_dir) = setup_pair();
+
+    let client_conn_id = ConnectionId::new(401);
+    client
+        .dial(client_conn_id, &peer_addr)
+        .expect("client dial");
+
+    let server_conn_id =
+        wait_for_connection(&mut server, &mut client, client_conn_id, &peer_addr, 250)
+            .expect("server should observe connection");
+
+    server
+        .verify_connection_peer_id(server_conn_id, peer_addr.peer_id().clone())
+        .expect("verify server-side peer id");
+
+    let mut server_verified = false;
+    for _ in 0..50 {
+        let (server_events, _) = drive_pair_once(&mut server, &mut client);
+        for event in server_events {
+            if let TransportEvent::PeerIdentityVerified { id, endpoint, .. } = event {
+                if id == server_conn_id {
+                    assert_eq!(endpoint.peer_id(), Some(peer_addr.peer_id()));
+                    server_verified = true;
+                }
+            }
+        }
+
+        if server_verified {
+            break;
+        }
+    }
+    assert!(server_verified, "server should emit peer verified event");
+
+    let client_stream = client
+        .open_stream(client_conn_id)
+        .expect("open client ping stream");
+
+    let mut client_negotiator = MultistreamSelect::dialer(PING_PROTOCOL_ID);
+    for output in client_negotiator.start() {
+        if let MultistreamOutput::OutboundData(bytes) = output {
+            client
+                .send_stream(client_conn_id, client_stream, bytes)
+                .expect("send dialer multistream header");
+        }
+    }
+
+    let mut server_negotiators: BTreeMap<StreamId, MultistreamSelect> = BTreeMap::new();
+    let mut server_ping_streams: BTreeSet<StreamId> = BTreeSet::new();
+
+    let mut client_ping = PingProtocol::default();
+    let mut server_ping = PingProtocol::default();
+
+    let payloads = [
+        core::array::from_fn::<_, PING_PAYLOAD_LEN, _>(|i| i as u8),
+        core::array::from_fn::<_, PING_PAYLOAD_LEN, _>(|i| (i as u8).wrapping_add(17)),
+    ];
+
+    let mut client_negotiated = false;
+    let mut next_ping_idx = 0usize;
+    let mut measured_rtts: Vec<u64> = Vec::new();
+    let mut close_requested = false;
+    let mut server_saw_remote_write_closed = false;
+    let mut client_saw_remote_write_closed = false;
+
+    let start = Instant::now();
+
+    for _ in 0..500 {
+        let (server_events, client_events) = drive_pair_once(&mut server, &mut client);
+
+        for event in server_events {
+            match event {
+                TransportEvent::IncomingStream { id, stream_id } => {
+                    assert_eq!(id, server_conn_id);
+                    let mut listener = MultistreamSelect::listener([PING_PROTOCOL_ID.to_string()]);
+                    let start_outputs = listener.start();
+                    server_negotiators.insert(stream_id, listener);
+
+                    for output in start_outputs {
+                        if let MultistreamOutput::OutboundData(bytes) = output {
+                            server
+                                .send_stream(server_conn_id, stream_id, bytes)
+                                .expect("send listener multistream header");
+                        }
+                    }
+                }
+                TransportEvent::StreamData {
+                    id,
+                    stream_id,
+                    data,
+                } => {
+                    assert_eq!(id, server_conn_id);
+                    if let Some(negotiator) = server_negotiators.get_mut(&stream_id) {
+                        let outputs = negotiator.receive(&data);
+                        let mut negotiated_ping = false;
+
+                        for output in outputs {
+                            match output {
+                                MultistreamOutput::OutboundData(bytes) => {
+                                    server
+                                        .send_stream(server_conn_id, stream_id, bytes)
+                                        .expect("send listener negotiation bytes");
+                                }
+                                MultistreamOutput::Negotiated { protocol } => {
+                                    assert_eq!(protocol, PING_PROTOCOL_ID);
+                                    negotiated_ping = true;
+
+                                    let actions = server_ping
+                                        .register_inbound_stream(peer_addr.peer_id().clone(), stream_id);
+                                    apply_ping_actions(&mut server, server_conn_id, actions);
+                                }
+                                MultistreamOutput::NotAvailable => {
+                                    panic!("listener reported protocol not available unexpectedly")
+                                }
+                                MultistreamOutput::ProtocolError { reason } => {
+                                    panic!("listener multistream protocol error: {reason}")
+                                }
+                            }
+                        }
+
+                        if negotiated_ping {
+                            server_negotiators.remove(&stream_id);
+                            server_ping_streams.insert(stream_id);
+                        }
+                    } else if server_ping_streams.contains(&stream_id) {
+                        let actions = server_ping.on_stream_data(
+                            peer_addr.peer_id(),
+                            stream_id,
+                            &data,
+                            start.elapsed().as_millis() as u64,
+                        );
+                        apply_ping_actions(&mut server, server_conn_id, actions);
+                    } else {
+                        panic!("server received data for unknown stream {stream_id}");
+                    }
+                }
+                TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
+                    assert_eq!(id, server_conn_id);
+                    assert_eq!(stream_id, client_stream);
+                    let actions =
+                        server_ping.on_stream_remote_write_closed(peer_addr.peer_id(), stream_id);
+                    apply_ping_actions(&mut server, server_conn_id, actions);
+
+                    server
+                        .close_stream_write(server_conn_id, stream_id)
+                        .expect("server closes ping stream write after remote close");
+                    server_saw_remote_write_closed = true;
+                }
+                TransportEvent::StreamClosed { id, stream_id } => {
+                    assert_eq!(id, server_conn_id);
+                    server_ping.on_stream_closed(peer_addr.peer_id(), stream_id);
+                    server_ping_streams.remove(&stream_id);
+                    server_negotiators.remove(&stream_id);
+                }
+                _ => {}
+            }
+        }
+
+        for event in client_events {
+            match event {
+                TransportEvent::StreamData {
+                    id,
+                    stream_id,
+                    data,
+                } => {
+                    assert_eq!(id, client_conn_id);
+                    if !client_negotiated {
+                        let outputs = client_negotiator.receive(&data);
+                        for output in outputs {
+                            match output {
+                                MultistreamOutput::OutboundData(bytes) => {
+                                    client
+                                        .send_stream(client_conn_id, client_stream, bytes)
+                                        .expect("send dialer negotiation bytes");
+                                }
+                                MultistreamOutput::Negotiated { protocol } => {
+                                    assert_eq!(protocol, PING_PROTOCOL_ID);
+                                    assert_eq!(stream_id, client_stream);
+                                    client_ping
+                                        .register_outbound_stream(peer_addr.peer_id().clone(), client_stream)
+                                        .expect("register outbound ping stream");
+                                    client_negotiated = true;
+                                }
+                                MultistreamOutput::NotAvailable => {
+                                    panic!("dialer reported protocol not available unexpectedly")
+                                }
+                                MultistreamOutput::ProtocolError { reason } => {
+                                    panic!("dialer multistream protocol error: {reason}")
+                                }
+                            }
+                        }
+                    } else {
+                        let actions = client_ping.on_stream_data(
+                            peer_addr.peer_id(),
+                            stream_id,
+                            &data,
+                            start.elapsed().as_millis() as u64,
+                        );
+                        apply_ping_actions(&mut client, client_conn_id, actions);
+                    }
+                }
+                TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
+                    assert_eq!(id, client_conn_id);
+                    if stream_id == client_stream {
+                        client_saw_remote_write_closed = true;
+                    }
+                    let actions =
+                        client_ping.on_stream_remote_write_closed(peer_addr.peer_id(), stream_id);
+                    apply_ping_actions(&mut client, client_conn_id, actions);
+                }
+                TransportEvent::StreamClosed { id, stream_id } => {
+                    assert_eq!(id, client_conn_id);
+                    client_ping.on_stream_closed(peer_addr.peer_id(), stream_id);
+                }
+                _ => {}
+            }
+        }
+
+        let now_ms = start.elapsed().as_millis() as u64;
+        apply_ping_actions(&mut client, client_conn_id, client_ping.on_tick(now_ms));
+        apply_ping_actions(&mut server, server_conn_id, server_ping.on_tick(now_ms));
+
+        if client_negotiated && next_ping_idx < payloads.len() && measured_rtts.len() == next_ping_idx {
+            let send = client_ping
+                .send_ping(peer_addr.peer_id(), &payloads[next_ping_idx], now_ms)
+                .expect("prepare ping request");
+            apply_ping_actions(&mut client, client_conn_id, vec![send]);
+            next_ping_idx += 1;
+        }
+
+        for event in client_ping.poll_events() {
+            match event {
+                PingEvent::RttMeasured {
+                    peer_id,
+                    stream_id,
+                    rtt_ms,
+                } => {
+                    assert_eq!(peer_id, *peer_addr.peer_id());
+                    assert_eq!(stream_id, client_stream);
+                    measured_rtts.push(rtt_ms);
+                }
+                PingEvent::ProtocolViolation {
+                    peer_id,
+                    stream_id,
+                    reason,
+                } => {
+                    panic!(
+                        "client ping protocol violation on peer {peer_id} stream {stream_id}: {reason}"
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        assert_no_protocol_violations(server_ping.poll_events());
+
+        if measured_rtts.len() == payloads.len() && !close_requested {
+            let close = client_ping
+                .close_outbound_stream_write(peer_addr.peer_id())
+                .expect("close ping write side");
+            apply_ping_actions(&mut client, client_conn_id, vec![close]);
+            close_requested = true;
+        }
+
+        if close_requested && server_saw_remote_write_closed && client_saw_remote_write_closed {
+            break;
+        }
+    }
+
+    assert_eq!(measured_rtts.len(), payloads.len(), "both ping RTTs should be measured");
+    assert!(
+        measured_rtts.iter().all(|rtt| *rtt < 5_000),
+        "rtts should be bounded in test env"
+    );
+    assert!(
+        server_saw_remote_write_closed,
+        "listener should observe dialer write close"
+    );
+    assert!(
+        client_saw_remote_write_closed,
+        "dialer should observe listener loop exit via remote write close"
+    );
+}

--- a/transports/quic/tests/ping_e2e.rs
+++ b/transports/quic/tests/ping_e2e.rs
@@ -11,6 +11,10 @@ use minip2p_quic::{QuicNodeConfig, QuicTransport};
 use minip2p_transport::{ConnectionId, StreamId, Transport, TransportEvent};
 use tempfile::TempDir;
 
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
 fn generate_cert_pair() -> (TempDir, String, String) {
     let dir = tempfile::tempdir().expect("tempdir");
 
@@ -53,24 +57,6 @@ fn test_peer_id() -> PeerId {
     PeerId::from_str("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N").expect("peer id")
 }
 
-fn setup_pair() -> (QuicTransport, QuicTransport, PeerAddr, TempDir) {
-    let (cert_dir, cert_path, key_path) = generate_cert_pair();
-
-    let listener_cfg = QuicNodeConfig::dev_listener_with_tls(&cert_path, &key_path);
-    let dialer_cfg = QuicNodeConfig::dev_dialer();
-
-    let mut server = QuicTransport::new(listener_cfg, "127.0.0.1:0").expect("server bind");
-    let client = QuicTransport::new(dialer_cfg, "127.0.0.1:0").expect("client bind");
-
-    let server_addr = server.local_addr().expect("server local addr");
-    let listen_ma = make_listen_multiaddr(server_addr.port());
-    server.listen(&listen_ma).expect("server listen");
-
-    let peer_addr = PeerAddr::new(listen_ma, test_peer_id()).expect("peer addr");
-
-    (server, client, peer_addr, cert_dir)
-}
-
 fn drive_pair_once(
     server: &mut QuicTransport,
     client: &mut QuicTransport,
@@ -79,51 +65,6 @@ fn drive_pair_once(
     let server_events = server.poll().expect("server poll");
     let client_events = client.poll().expect("client poll");
     (server_events, client_events)
-}
-
-fn wait_for_connection(
-    server: &mut QuicTransport,
-    client: &mut QuicTransport,
-    expected_client_conn: ConnectionId,
-    expected_peer: &PeerAddr,
-    max_iters: usize,
-) -> Option<ConnectionId> {
-    let mut server_conn = None;
-    let mut client_connected = false;
-
-    for _ in 0..max_iters {
-        let (server_events, client_events) = drive_pair_once(server, client);
-
-        for event in server_events {
-            match event {
-                TransportEvent::IncomingConnection { id, endpoint } => {
-                    assert!(endpoint.peer_id().is_none());
-                    server_conn = Some(id);
-                }
-                TransportEvent::Connected { id, .. } => {
-                    if server_conn.is_none() {
-                        server_conn = Some(id);
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        for event in client_events {
-            if let TransportEvent::Connected { id, endpoint } = event {
-                if id == expected_client_conn {
-                    assert_eq!(endpoint.peer_id(), Some(expected_peer.peer_id()));
-                    client_connected = true;
-                }
-            }
-        }
-
-        if client_connected && server_conn.is_some() {
-            return server_conn;
-        }
-    }
-
-    None
 }
 
 fn apply_ping_actions(
@@ -154,7 +95,7 @@ fn apply_ping_actions(
     }
 }
 
-fn assert_no_protocol_violations(events: Vec<PingEvent>) {
+fn assert_no_protocol_violations(events: &[PingEvent]) {
     for event in events {
         if let PingEvent::ProtocolViolation {
             peer_id,
@@ -162,164 +103,125 @@ fn assert_no_protocol_violations(events: Vec<PingEvent>) {
             reason,
         } = event
         {
-            panic!(
-                "ping protocol violation on peer {peer_id} stream {stream_id}: {reason}"
-            );
+            panic!("ping protocol violation on peer {peer_id} stream {stream_id}: {reason}");
         }
     }
 }
 
-#[test]
-fn ping_roundtrip_after_identity_verification_and_multistream_negotiation() {
-    let (mut server, mut client, peer_addr, _cert_dir) = setup_pair();
+/// Fully connected + verified + negotiated ping harness ready for use.
+struct PingHarness {
+    server: QuicTransport,
+    client: QuicTransport,
+    peer_addr: PeerAddr,
+    _cert_dir: TempDir,
+    server_conn_id: ConnectionId,
+    client_conn_id: ConnectionId,
+    client_stream: StreamId,
+    client_ping: PingProtocol,
+    server_ping: PingProtocol,
+    server_negotiators: BTreeMap<StreamId, MultistreamSelect>,
+    server_ping_streams: BTreeSet<StreamId>,
+    start: Instant,
+}
 
-    let client_conn_id = ConnectionId::new(400);
-    client
-        .dial(client_conn_id, &peer_addr)
-        .expect("client dial");
+impl PingHarness {
+    /// Create a connected, verified, and multistream-negotiated ping pair.
+    fn new(client_conn_id_raw: u64) -> Self {
+        let (cert_dir, cert_path, key_path) = generate_cert_pair();
 
-    let server_conn_id = wait_for_connection(&mut server, &mut client, client_conn_id, &peer_addr, 250)
+        let listener_cfg = QuicNodeConfig::dev_listener_with_tls(&cert_path, &key_path);
+        let dialer_cfg = QuicNodeConfig::dev_dialer();
+
+        let mut server = QuicTransport::new(listener_cfg, "127.0.0.1:0").expect("server bind");
+        let mut client = QuicTransport::new(dialer_cfg, "127.0.0.1:0").expect("client bind");
+
+        let server_addr = server.local_addr().expect("server local addr");
+        let listen_ma = make_listen_multiaddr(server_addr.port());
+        server.listen(&listen_ma).expect("server listen");
+
+        let peer_addr = PeerAddr::new(listen_ma, test_peer_id()).expect("peer addr");
+
+        // Connect.
+        let client_conn_id = ConnectionId::new(client_conn_id_raw);
+        client
+            .dial(client_conn_id, &peer_addr)
+            .expect("client dial");
+
+        let server_conn_id = Self::wait_for_connection(
+            &mut server,
+            &mut client,
+            client_conn_id,
+            &peer_addr,
+            250,
+        )
         .expect("server should observe connection");
 
-    server
-        .verify_connection_peer_id(server_conn_id, peer_addr.peer_id().clone())
-        .expect("verify server-side peer id");
+        // Verify identity.
+        server
+            .verify_connection_peer_id(server_conn_id, peer_addr.peer_id().clone())
+            .expect("verify server-side peer id");
 
-    let mut server_verified = false;
-    for _ in 0..50 {
-        let (server_events, _) = drive_pair_once(&mut server, &mut client);
-        for event in server_events {
-            if let TransportEvent::PeerIdentityVerified { id, endpoint, .. } = event {
-                if id == server_conn_id {
-                    assert_eq!(endpoint.peer_id(), Some(peer_addr.peer_id()));
-                    server_verified = true;
+        let mut server_verified = false;
+        for _ in 0..50 {
+            let (server_events, _) = drive_pair_once(&mut server, &mut client);
+            for event in server_events {
+                if let TransportEvent::PeerIdentityVerified { id, endpoint, .. } = event {
+                    if id == server_conn_id {
+                        assert_eq!(endpoint.peer_id(), Some(peer_addr.peer_id()));
+                        server_verified = true;
+                    }
                 }
+            }
+            if server_verified {
+                break;
+            }
+        }
+        assert!(server_verified, "server should emit peer verified event");
+
+        // Open stream and negotiate multistream-select for ping.
+        let client_stream = client
+            .open_stream(client_conn_id)
+            .expect("open client ping stream");
+
+        let mut client_negotiator = MultistreamSelect::dialer(PING_PROTOCOL_ID);
+        for output in client_negotiator.start() {
+            if let MultistreamOutput::OutboundData(bytes) = output {
+                client
+                    .send_stream(client_conn_id, client_stream, bytes)
+                    .expect("send dialer multistream header");
             }
         }
 
-        if server_verified {
-            break;
-        }
-    }
-    assert!(server_verified, "server should emit peer verified event");
+        let mut server_negotiators: BTreeMap<StreamId, MultistreamSelect> = BTreeMap::new();
+        let mut server_ping_streams: BTreeSet<StreamId> = BTreeSet::new();
+        let mut client_ping = PingProtocol::default();
+        let mut server_ping = PingProtocol::default();
 
-    let client_stream = client
-        .open_stream(client_conn_id)
-        .expect("open client ping stream");
+        let start = Instant::now();
+        let mut client_negotiated = false;
 
-    let mut client_negotiator = MultistreamSelect::dialer(PING_PROTOCOL_ID);
-    for output in client_negotiator.start() {
-        if let MultistreamOutput::OutboundData(bytes) = output {
-            client
-                .send_stream(client_conn_id, client_stream, bytes)
-                .expect("send dialer multistream header");
-        }
-    }
+        for _ in 0..200 {
+            let (server_events, client_events) = drive_pair_once(&mut server, &mut client);
 
-    let mut server_negotiators: BTreeMap<StreamId, MultistreamSelect> = BTreeMap::new();
-    let mut server_ping_streams: BTreeSet<StreamId> = BTreeSet::new();
+            Self::handle_server_events(
+                &server_events,
+                &mut server,
+                server_conn_id,
+                &peer_addr,
+                &mut server_negotiators,
+                &mut server_ping_streams,
+                &mut server_ping,
+                &start,
+                &mut None,
+            );
 
-    let mut client_ping = PingProtocol::default();
-    let mut server_ping = PingProtocol::default();
-
-    let mut client_negotiated = false;
-    let mut ping_sent = false;
-    let start = Instant::now();
-    let payload: [u8; PING_PAYLOAD_LEN] = core::array::from_fn(|i| i as u8);
-    let mut measured_rtt_ms = None;
-
-    for _ in 0..400 {
-        let (server_events, client_events) = drive_pair_once(&mut server, &mut client);
-
-        for event in server_events {
-            match event {
-                TransportEvent::IncomingStream { id, stream_id } => {
-                    assert_eq!(id, server_conn_id);
-                    let mut listener = MultistreamSelect::listener([PING_PROTOCOL_ID.to_string()]);
-                    let start_outputs = listener.start();
-                    server_negotiators.insert(stream_id, listener);
-
-                    for output in start_outputs {
-                        if let MultistreamOutput::OutboundData(bytes) = output {
-                            server
-                                .send_stream(server_conn_id, stream_id, bytes)
-                                .expect("send listener multistream header");
-                        }
-                    }
-                }
-                TransportEvent::StreamData {
+            for event in client_events {
+                if let TransportEvent::StreamData {
                     id,
                     stream_id,
                     data,
-                } => {
-                    assert_eq!(id, server_conn_id);
-                    if let Some(negotiator) = server_negotiators.get_mut(&stream_id) {
-                        let outputs = negotiator.receive(&data);
-                        let mut negotiated_ping = false;
-
-                        for output in outputs {
-                            match output {
-                                MultistreamOutput::OutboundData(bytes) => {
-                                    server
-                                        .send_stream(server_conn_id, stream_id, bytes)
-                                        .expect("send listener negotiation bytes");
-                                }
-                                MultistreamOutput::Negotiated { protocol } => {
-                                    assert_eq!(protocol, PING_PROTOCOL_ID);
-                                    negotiated_ping = true;
-
-                                    let actions = server_ping
-                                        .register_inbound_stream(peer_addr.peer_id().clone(), stream_id);
-                                    apply_ping_actions(&mut server, server_conn_id, actions);
-                                }
-                                MultistreamOutput::NotAvailable => {
-                                    panic!("listener reported protocol not available unexpectedly")
-                                }
-                                MultistreamOutput::ProtocolError { reason } => {
-                                    panic!("listener multistream protocol error: {reason}")
-                                }
-                            }
-                        }
-
-                        if negotiated_ping {
-                            server_negotiators.remove(&stream_id);
-                            server_ping_streams.insert(stream_id);
-                        }
-                    } else if server_ping_streams.contains(&stream_id) {
-                        let actions = server_ping.on_stream_data(
-                            peer_addr.peer_id(),
-                            stream_id,
-                            &data,
-                            start.elapsed().as_millis() as u64,
-                        );
-                        apply_ping_actions(&mut server, server_conn_id, actions);
-                    } else {
-                        panic!("server received data for unknown stream {stream_id}");
-                    }
-                }
-                TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
-                    assert_eq!(id, server_conn_id);
-                    let actions =
-                        server_ping.on_stream_remote_write_closed(peer_addr.peer_id(), stream_id);
-                    apply_ping_actions(&mut server, server_conn_id, actions);
-                }
-                TransportEvent::StreamClosed { id, stream_id } => {
-                    assert_eq!(id, server_conn_id);
-                    server_ping.on_stream_closed(peer_addr.peer_id(), stream_id);
-                    server_ping_streams.remove(&stream_id);
-                    server_negotiators.remove(&stream_id);
-                }
-                _ => {}
-            }
-        }
-
-        for event in client_events {
-            match event {
-                TransportEvent::StreamData {
-                    id,
-                    stream_id,
-                    data,
-                } => {
+                } = event
+                {
                     assert_eq!(id, client_conn_id);
                     if !client_negotiated {
                         let outputs = client_negotiator.receive(&data);
@@ -334,63 +236,337 @@ fn ping_roundtrip_after_identity_verification_and_multistream_negotiation() {
                                     assert_eq!(protocol, PING_PROTOCOL_ID);
                                     assert_eq!(stream_id, client_stream);
                                     client_ping
-                                        .register_outbound_stream(peer_addr.peer_id().clone(), client_stream)
+                                        .register_outbound_stream(
+                                            peer_addr.peer_id().clone(),
+                                            client_stream,
+                                        )
                                         .expect("register outbound ping stream");
                                     client_negotiated = true;
                                 }
                                 MultistreamOutput::NotAvailable => {
-                                    panic!("dialer reported protocol not available unexpectedly")
+                                    panic!(
+                                        "dialer reported protocol not available unexpectedly"
+                                    )
                                 }
                                 MultistreamOutput::ProtocolError { reason } => {
                                     panic!("dialer multistream protocol error: {reason}")
                                 }
                             }
                         }
-                    } else {
-                        let actions = client_ping.on_stream_data(
+                    }
+                }
+            }
+
+            if client_negotiated {
+                break;
+            }
+        }
+        assert!(client_negotiated, "multistream negotiation should complete");
+
+        Self {
+            server,
+            client,
+            peer_addr,
+            _cert_dir: cert_dir,
+            server_conn_id,
+            client_conn_id,
+            client_stream,
+            client_ping,
+            server_ping,
+            server_negotiators,
+            server_ping_streams,
+            start,
+        }
+    }
+
+    fn wait_for_connection(
+        server: &mut QuicTransport,
+        client: &mut QuicTransport,
+        expected_client_conn: ConnectionId,
+        expected_peer: &PeerAddr,
+        max_iters: usize,
+    ) -> Option<ConnectionId> {
+        let mut server_conn = None;
+        let mut client_connected = false;
+
+        for _ in 0..max_iters {
+            let (server_events, client_events) = drive_pair_once(server, client);
+
+            for event in server_events {
+                match event {
+                    TransportEvent::IncomingConnection { id, endpoint } => {
+                        assert!(endpoint.peer_id().is_none());
+                        server_conn = Some(id);
+                    }
+                    TransportEvent::Connected { id, .. } => {
+                        if server_conn.is_none() {
+                            server_conn = Some(id);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            for event in client_events {
+                if let TransportEvent::Connected { id, endpoint } = event {
+                    if id == expected_client_conn {
+                        assert_eq!(endpoint.peer_id(), Some(expected_peer.peer_id()));
+                        client_connected = true;
+                    }
+                }
+            }
+
+            if client_connected && server_conn.is_some() {
+                return server_conn;
+            }
+        }
+
+        None
+    }
+
+    /// Process server-side transport events (negotiation + ping echo).
+    fn handle_server_events(
+        events: &[TransportEvent],
+        server: &mut QuicTransport,
+        server_conn_id: ConnectionId,
+        peer_addr: &PeerAddr,
+        negotiators: &mut BTreeMap<StreamId, MultistreamSelect>,
+        ping_streams: &mut BTreeSet<StreamId>,
+        server_ping: &mut PingProtocol,
+        start: &Instant,
+        on_remote_write_closed: &mut Option<StreamId>,
+    ) {
+        for event in events {
+            match event {
+                TransportEvent::IncomingStream { id, stream_id } => {
+                    assert_eq!(*id, server_conn_id);
+                    let mut listener =
+                        MultistreamSelect::listener([PING_PROTOCOL_ID.to_string()]);
+                    let start_outputs = listener.start();
+                    negotiators.insert(*stream_id, listener);
+
+                    for output in start_outputs {
+                        if let MultistreamOutput::OutboundData(bytes) = output {
+                            server
+                                .send_stream(server_conn_id, *stream_id, bytes)
+                                .expect("send listener multistream header");
+                        }
+                    }
+                }
+                TransportEvent::StreamData {
+                    id,
+                    stream_id,
+                    data,
+                } => {
+                    assert_eq!(*id, server_conn_id);
+                    if let Some(negotiator) = negotiators.get_mut(stream_id) {
+                        let outputs = negotiator.receive(data);
+                        let mut negotiated_ping = false;
+
+                        for output in outputs {
+                            match output {
+                                MultistreamOutput::OutboundData(bytes) => {
+                                    server
+                                        .send_stream(server_conn_id, *stream_id, bytes)
+                                        .expect("send listener negotiation bytes");
+                                }
+                                MultistreamOutput::Negotiated { protocol } => {
+                                    assert_eq!(protocol, PING_PROTOCOL_ID);
+                                    negotiated_ping = true;
+
+                                    let actions = server_ping.register_inbound_stream(
+                                        peer_addr.peer_id().clone(),
+                                        *stream_id,
+                                    );
+                                    apply_ping_actions(server, server_conn_id, actions);
+                                }
+                                MultistreamOutput::NotAvailable => {
+                                    panic!(
+                                        "listener reported protocol not available unexpectedly"
+                                    )
+                                }
+                                MultistreamOutput::ProtocolError { reason } => {
+                                    panic!("listener multistream protocol error: {reason}")
+                                }
+                            }
+                        }
+
+                        if negotiated_ping {
+                            negotiators.remove(stream_id);
+                            ping_streams.insert(*stream_id);
+                        }
+                    } else if ping_streams.contains(stream_id) {
+                        let actions = server_ping.on_stream_data(
                             peer_addr.peer_id(),
-                            stream_id,
-                            &data,
+                            *stream_id,
+                            data,
                             start.elapsed().as_millis() as u64,
                         );
-                        apply_ping_actions(&mut client, client_conn_id, actions);
+                        apply_ping_actions(server, server_conn_id, actions);
+                    } else {
+                        panic!("server received data for unknown stream {stream_id}");
                     }
                 }
                 TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
-                    assert_eq!(id, client_conn_id);
-                    let actions =
-                        client_ping.on_stream_remote_write_closed(peer_addr.peer_id(), stream_id);
-                    apply_ping_actions(&mut client, client_conn_id, actions);
+                    assert_eq!(*id, server_conn_id);
+                    let actions = server_ping
+                        .on_stream_remote_write_closed(peer_addr.peer_id(), *stream_id);
+                    apply_ping_actions(server, server_conn_id, actions);
+                    *on_remote_write_closed = Some(*stream_id);
                 }
                 TransportEvent::StreamClosed { id, stream_id } => {
-                    assert_eq!(id, client_conn_id);
-                    client_ping.on_stream_closed(peer_addr.peer_id(), stream_id);
+                    assert_eq!(*id, server_conn_id);
+                    server_ping.on_stream_closed(peer_addr.peer_id(), *stream_id);
+                    ping_streams.remove(stream_id);
+                    negotiators.remove(stream_id);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Run the event loop for one iteration, returning all client events.
+    fn drive_once(&mut self) -> Vec<TransportEvent> {
+        let (server_events, client_events) = drive_pair_once(&mut self.server, &mut self.client);
+
+        Self::handle_server_events(
+            &server_events,
+            &mut self.server,
+            self.server_conn_id,
+            &self.peer_addr,
+            &mut self.server_negotiators,
+            &mut self.server_ping_streams,
+            &mut self.server_ping,
+            &self.start,
+            &mut None,
+        );
+
+        let now_ms = self.start.elapsed().as_millis() as u64;
+        apply_ping_actions(
+            &mut self.server,
+            self.server_conn_id,
+            self.server_ping.on_tick(now_ms),
+        );
+        assert_no_protocol_violations(&self.server_ping.poll_events());
+
+        client_events
+    }
+
+    /// Drive the event loop including a custom server-side remote-write-closed
+    /// callback (needed by the close-write test).
+    fn drive_once_with_server_close_hook(
+        &mut self,
+    ) -> (Vec<TransportEvent>, Option<StreamId>) {
+        let (server_events, client_events) = drive_pair_once(&mut self.server, &mut self.client);
+
+        let mut closed_stream = None;
+        Self::handle_server_events(
+            &server_events,
+            &mut self.server,
+            self.server_conn_id,
+            &self.peer_addr,
+            &mut self.server_negotiators,
+            &mut self.server_ping_streams,
+            &mut self.server_ping,
+            &self.start,
+            &mut closed_stream,
+        );
+
+        // When server sees remote write closed, it closes its own write side.
+        if let Some(stream_id) = closed_stream {
+            self.server
+                .close_stream_write(self.server_conn_id, stream_id)
+                .expect("server closes ping stream write after remote close");
+        }
+
+        let now_ms = self.start.elapsed().as_millis() as u64;
+        apply_ping_actions(
+            &mut self.server,
+            self.server_conn_id,
+            self.server_ping.on_tick(now_ms),
+        );
+        assert_no_protocol_violations(&self.server_ping.poll_events());
+
+        (client_events, closed_stream)
+    }
+
+    fn now_ms(&self) -> u64 {
+        self.start.elapsed().as_millis() as u64
+    }
+
+    fn peer_id(&self) -> &PeerId {
+        self.peer_addr.peer_id()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ping_roundtrip_after_identity_verification_and_multistream_negotiation() {
+    let mut h = PingHarness::new(400);
+    let peer_id = h.peer_id().clone();
+
+    let payload: [u8; PING_PAYLOAD_LEN] = core::array::from_fn(|i| i as u8);
+    let mut ping_sent = false;
+    let mut measured_rtt_ms = None;
+
+    for _ in 0..400 {
+        let client_events = h.drive_once();
+
+        for event in client_events {
+            match event {
+                TransportEvent::StreamData {
+                    id,
+                    stream_id,
+                    data,
+                } => {
+                    assert_eq!(id, h.client_conn_id);
+                    let now = h.now_ms();
+                    let actions =
+                        h.client_ping.on_stream_data(&peer_id, stream_id, &data, now);
+                    apply_ping_actions(&mut h.client, h.client_conn_id, actions);
+                }
+                TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
+                    assert_eq!(id, h.client_conn_id);
+                    let actions =
+                        h.client_ping.on_stream_remote_write_closed(&peer_id, stream_id);
+                    apply_ping_actions(&mut h.client, h.client_conn_id, actions);
+                }
+                TransportEvent::StreamClosed { id, stream_id } => {
+                    assert_eq!(id, h.client_conn_id);
+                    h.client_ping.on_stream_closed(&peer_id, stream_id);
                 }
                 _ => {}
             }
         }
 
-        let now_ms = start.elapsed().as_millis() as u64;
-        apply_ping_actions(&mut client, client_conn_id, client_ping.on_tick(now_ms));
-        apply_ping_actions(&mut server, server_conn_id, server_ping.on_tick(now_ms));
+        let now_ms = h.now_ms();
+        apply_ping_actions(
+            &mut h.client,
+            h.client_conn_id,
+            h.client_ping.on_tick(now_ms),
+        );
 
-        if client_negotiated && !ping_sent {
-            let send = client_ping
-                .send_ping(peer_addr.peer_id(), &payload, now_ms)
+        if !ping_sent {
+            let send = h
+                .client_ping
+                .send_ping(&peer_id, &payload, now_ms)
                 .expect("prepare ping request");
-            apply_ping_actions(&mut client, client_conn_id, vec![send]);
+            apply_ping_actions(&mut h.client, h.client_conn_id, vec![send]);
             ping_sent = true;
         }
 
-        for event in client_ping.poll_events() {
+        for event in h.client_ping.poll_events() {
             match event {
                 PingEvent::RttMeasured {
-                    peer_id,
+                    peer_id: pid,
                     stream_id,
                     rtt_ms,
                 } => {
-                    assert_eq!(peer_id, *peer_addr.peer_id());
-                    assert_eq!(stream_id, client_stream);
+                    assert_eq!(pid, peer_id);
+                    assert_eq!(stream_id, h.client_stream);
                     measured_rtt_ms = Some(rtt_ms);
                 }
                 PingEvent::ProtocolViolation {
@@ -406,8 +582,6 @@ fn ping_roundtrip_after_identity_verification_and_multistream_negotiation() {
             }
         }
 
-        assert_no_protocol_violations(server_ping.poll_events());
-
         if measured_rtt_ms.is_some() {
             break;
         }
@@ -419,161 +593,25 @@ fn ping_roundtrip_after_identity_verification_and_multistream_negotiation() {
 
 #[test]
 fn repeated_ping_on_same_stream_then_close_write_exits_listener_loop() {
-    let (mut server, mut client, peer_addr, _cert_dir) = setup_pair();
-
-    let client_conn_id = ConnectionId::new(401);
-    client
-        .dial(client_conn_id, &peer_addr)
-        .expect("client dial");
-
-    let server_conn_id =
-        wait_for_connection(&mut server, &mut client, client_conn_id, &peer_addr, 250)
-            .expect("server should observe connection");
-
-    server
-        .verify_connection_peer_id(server_conn_id, peer_addr.peer_id().clone())
-        .expect("verify server-side peer id");
-
-    let mut server_verified = false;
-    for _ in 0..50 {
-        let (server_events, _) = drive_pair_once(&mut server, &mut client);
-        for event in server_events {
-            if let TransportEvent::PeerIdentityVerified { id, endpoint, .. } = event {
-                if id == server_conn_id {
-                    assert_eq!(endpoint.peer_id(), Some(peer_addr.peer_id()));
-                    server_verified = true;
-                }
-            }
-        }
-
-        if server_verified {
-            break;
-        }
-    }
-    assert!(server_verified, "server should emit peer verified event");
-
-    let client_stream = client
-        .open_stream(client_conn_id)
-        .expect("open client ping stream");
-
-    let mut client_negotiator = MultistreamSelect::dialer(PING_PROTOCOL_ID);
-    for output in client_negotiator.start() {
-        if let MultistreamOutput::OutboundData(bytes) = output {
-            client
-                .send_stream(client_conn_id, client_stream, bytes)
-                .expect("send dialer multistream header");
-        }
-    }
-
-    let mut server_negotiators: BTreeMap<StreamId, MultistreamSelect> = BTreeMap::new();
-    let mut server_ping_streams: BTreeSet<StreamId> = BTreeSet::new();
-
-    let mut client_ping = PingProtocol::default();
-    let mut server_ping = PingProtocol::default();
+    let mut h = PingHarness::new(401);
+    let peer_id = h.peer_id().clone();
 
     let payloads = [
         core::array::from_fn::<_, PING_PAYLOAD_LEN, _>(|i| i as u8),
         core::array::from_fn::<_, PING_PAYLOAD_LEN, _>(|i| (i as u8).wrapping_add(17)),
     ];
 
-    let mut client_negotiated = false;
     let mut next_ping_idx = 0usize;
     let mut measured_rtts: Vec<u64> = Vec::new();
     let mut close_requested = false;
     let mut server_saw_remote_write_closed = false;
     let mut client_saw_remote_write_closed = false;
 
-    let start = Instant::now();
-
     for _ in 0..500 {
-        let (server_events, client_events) = drive_pair_once(&mut server, &mut client);
+        let (client_events, server_closed_stream) = h.drive_once_with_server_close_hook();
 
-        for event in server_events {
-            match event {
-                TransportEvent::IncomingStream { id, stream_id } => {
-                    assert_eq!(id, server_conn_id);
-                    let mut listener = MultistreamSelect::listener([PING_PROTOCOL_ID.to_string()]);
-                    let start_outputs = listener.start();
-                    server_negotiators.insert(stream_id, listener);
-
-                    for output in start_outputs {
-                        if let MultistreamOutput::OutboundData(bytes) = output {
-                            server
-                                .send_stream(server_conn_id, stream_id, bytes)
-                                .expect("send listener multistream header");
-                        }
-                    }
-                }
-                TransportEvent::StreamData {
-                    id,
-                    stream_id,
-                    data,
-                } => {
-                    assert_eq!(id, server_conn_id);
-                    if let Some(negotiator) = server_negotiators.get_mut(&stream_id) {
-                        let outputs = negotiator.receive(&data);
-                        let mut negotiated_ping = false;
-
-                        for output in outputs {
-                            match output {
-                                MultistreamOutput::OutboundData(bytes) => {
-                                    server
-                                        .send_stream(server_conn_id, stream_id, bytes)
-                                        .expect("send listener negotiation bytes");
-                                }
-                                MultistreamOutput::Negotiated { protocol } => {
-                                    assert_eq!(protocol, PING_PROTOCOL_ID);
-                                    negotiated_ping = true;
-
-                                    let actions = server_ping
-                                        .register_inbound_stream(peer_addr.peer_id().clone(), stream_id);
-                                    apply_ping_actions(&mut server, server_conn_id, actions);
-                                }
-                                MultistreamOutput::NotAvailable => {
-                                    panic!("listener reported protocol not available unexpectedly")
-                                }
-                                MultistreamOutput::ProtocolError { reason } => {
-                                    panic!("listener multistream protocol error: {reason}")
-                                }
-                            }
-                        }
-
-                        if negotiated_ping {
-                            server_negotiators.remove(&stream_id);
-                            server_ping_streams.insert(stream_id);
-                        }
-                    } else if server_ping_streams.contains(&stream_id) {
-                        let actions = server_ping.on_stream_data(
-                            peer_addr.peer_id(),
-                            stream_id,
-                            &data,
-                            start.elapsed().as_millis() as u64,
-                        );
-                        apply_ping_actions(&mut server, server_conn_id, actions);
-                    } else {
-                        panic!("server received data for unknown stream {stream_id}");
-                    }
-                }
-                TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
-                    assert_eq!(id, server_conn_id);
-                    assert_eq!(stream_id, client_stream);
-                    let actions =
-                        server_ping.on_stream_remote_write_closed(peer_addr.peer_id(), stream_id);
-                    apply_ping_actions(&mut server, server_conn_id, actions);
-
-                    server
-                        .close_stream_write(server_conn_id, stream_id)
-                        .expect("server closes ping stream write after remote close");
-                    server_saw_remote_write_closed = true;
-                }
-                TransportEvent::StreamClosed { id, stream_id } => {
-                    assert_eq!(id, server_conn_id);
-                    server_ping.on_stream_closed(peer_addr.peer_id(), stream_id);
-                    server_ping_streams.remove(&stream_id);
-                    server_negotiators.remove(&stream_id);
-                }
-                _ => {}
-            }
+        if server_closed_stream.is_some() {
+            server_saw_remote_write_closed = true;
         }
 
         for event in client_events {
@@ -583,80 +621,54 @@ fn repeated_ping_on_same_stream_then_close_write_exits_listener_loop() {
                     stream_id,
                     data,
                 } => {
-                    assert_eq!(id, client_conn_id);
-                    if !client_negotiated {
-                        let outputs = client_negotiator.receive(&data);
-                        for output in outputs {
-                            match output {
-                                MultistreamOutput::OutboundData(bytes) => {
-                                    client
-                                        .send_stream(client_conn_id, client_stream, bytes)
-                                        .expect("send dialer negotiation bytes");
-                                }
-                                MultistreamOutput::Negotiated { protocol } => {
-                                    assert_eq!(protocol, PING_PROTOCOL_ID);
-                                    assert_eq!(stream_id, client_stream);
-                                    client_ping
-                                        .register_outbound_stream(peer_addr.peer_id().clone(), client_stream)
-                                        .expect("register outbound ping stream");
-                                    client_negotiated = true;
-                                }
-                                MultistreamOutput::NotAvailable => {
-                                    panic!("dialer reported protocol not available unexpectedly")
-                                }
-                                MultistreamOutput::ProtocolError { reason } => {
-                                    panic!("dialer multistream protocol error: {reason}")
-                                }
-                            }
-                        }
-                    } else {
-                        let actions = client_ping.on_stream_data(
-                            peer_addr.peer_id(),
-                            stream_id,
-                            &data,
-                            start.elapsed().as_millis() as u64,
-                        );
-                        apply_ping_actions(&mut client, client_conn_id, actions);
-                    }
+                    assert_eq!(id, h.client_conn_id);
+                    let now = h.now_ms();
+                    let actions =
+                        h.client_ping.on_stream_data(&peer_id, stream_id, &data, now);
+                    apply_ping_actions(&mut h.client, h.client_conn_id, actions);
                 }
                 TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
-                    assert_eq!(id, client_conn_id);
-                    if stream_id == client_stream {
+                    assert_eq!(id, h.client_conn_id);
+                    if stream_id == h.client_stream {
                         client_saw_remote_write_closed = true;
                     }
                     let actions =
-                        client_ping.on_stream_remote_write_closed(peer_addr.peer_id(), stream_id);
-                    apply_ping_actions(&mut client, client_conn_id, actions);
+                        h.client_ping.on_stream_remote_write_closed(&peer_id, stream_id);
+                    apply_ping_actions(&mut h.client, h.client_conn_id, actions);
                 }
                 TransportEvent::StreamClosed { id, stream_id } => {
-                    assert_eq!(id, client_conn_id);
-                    client_ping.on_stream_closed(peer_addr.peer_id(), stream_id);
+                    assert_eq!(id, h.client_conn_id);
+                    h.client_ping.on_stream_closed(&peer_id, stream_id);
                 }
                 _ => {}
             }
         }
 
-        let now_ms = start.elapsed().as_millis() as u64;
-        apply_ping_actions(&mut client, client_conn_id, client_ping.on_tick(now_ms));
-        apply_ping_actions(&mut server, server_conn_id, server_ping.on_tick(now_ms));
+        let now_ms = h.now_ms();
+        apply_ping_actions(
+            &mut h.client,
+            h.client_conn_id,
+            h.client_ping.on_tick(now_ms),
+        );
 
-        if client_negotiated && next_ping_idx < payloads.len() && measured_rtts.len() == next_ping_idx {
-            let send = client_ping
-                .send_ping(peer_addr.peer_id(), &payloads[next_ping_idx], now_ms)
+        if next_ping_idx < payloads.len() && measured_rtts.len() == next_ping_idx {
+            let send = h
+                .client_ping
+                .send_ping(&peer_id, &payloads[next_ping_idx], now_ms)
                 .expect("prepare ping request");
-            apply_ping_actions(&mut client, client_conn_id, vec![send]);
+            apply_ping_actions(&mut h.client, h.client_conn_id, vec![send]);
             next_ping_idx += 1;
         }
 
-        for event in client_ping.poll_events() {
+        for event in h.client_ping.poll_events() {
             match event {
                 PingEvent::RttMeasured {
-                    peer_id,
+                    peer_id: pid,
                     stream_id,
                     rtt_ms,
                 } => {
-                    assert_eq!(peer_id, *peer_addr.peer_id());
-                    assert_eq!(stream_id, client_stream);
+                    assert_eq!(pid, peer_id);
+                    assert_eq!(stream_id, h.client_stream);
                     measured_rtts.push(rtt_ms);
                 }
                 PingEvent::ProtocolViolation {
@@ -672,13 +684,12 @@ fn repeated_ping_on_same_stream_then_close_write_exits_listener_loop() {
             }
         }
 
-        assert_no_protocol_violations(server_ping.poll_events());
-
         if measured_rtts.len() == payloads.len() && !close_requested {
-            let close = client_ping
-                .close_outbound_stream_write(peer_addr.peer_id())
+            let close = h
+                .client_ping
+                .close_outbound_stream_write(&peer_id)
                 .expect("close ping write side");
-            apply_ping_actions(&mut client, client_conn_id, vec![close]);
+            apply_ping_actions(&mut h.client, h.client_conn_id, vec![close]);
             close_requested = true;
         }
 
@@ -687,7 +698,11 @@ fn repeated_ping_on_same_stream_then_close_write_exits_listener_loop() {
         }
     }
 
-    assert_eq!(measured_rtts.len(), payloads.len(), "both ping RTTs should be measured");
+    assert_eq!(
+        measured_rtts.len(),
+        payloads.len(),
+        "both ping RTTs should be measured"
+    );
     assert!(
         measured_rtts.iter().all(|rtt| *rtt < 5_000),
         "rtts should be bounded in test env"

--- a/transports/quic/tests/two_peer.rs
+++ b/transports/quic/tests/two_peer.rs
@@ -1,11 +1,10 @@
-use std::collections::BTreeSet;
 use std::io::Write;
 use std::str::FromStr;
 
 use minip2p_core::{Multiaddr, PeerAddr, Protocol};
 use minip2p_identity::PeerId;
 use minip2p_quic::{QuicNodeConfig, QuicTransport};
-use minip2p_transport::{ConnectionId, PeerSendPolicy, Transport, TransportError, TransportEvent};
+use minip2p_transport::{ConnectionId, StreamId, Transport, TransportError, TransportEvent};
 use tempfile::TempDir;
 
 fn generate_cert_pair() -> (TempDir, String, String) {
@@ -54,7 +53,6 @@ fn setup_pair() -> (QuicTransport, QuicTransport, PeerAddr, TempDir) {
     let (cert_dir, cert_path, key_path) = generate_cert_pair();
 
     let listener_node_config = QuicNodeConfig::dev_listener_with_tls(&cert_path, &key_path);
-
     let dialer_node_config = QuicNodeConfig::dev_dialer();
 
     let mut server = QuicTransport::new(listener_node_config, "127.0.0.1:0").expect("server bind");
@@ -80,30 +78,53 @@ fn drive_pair_once(
     (server_events, client_events)
 }
 
-fn wait_for_client_connection(
+fn wait_for_connection(
     server: &mut QuicTransport,
     client: &mut QuicTransport,
-    expected: ConnectionId,
-    peer_addr: &PeerAddr,
+    expected_client_conn: ConnectionId,
+    expected_peer: &PeerAddr,
     max_iters: usize,
-) -> bool {
+) -> Option<ConnectionId> {
+    let mut server_conn = None;
+    let mut client_connected = false;
+
     for _ in 0..max_iters {
-        let (_, client_events) = drive_pair_once(server, client);
+        let (server_events, client_events) = drive_pair_once(server, client);
+
+        for event in server_events {
+            match event {
+                TransportEvent::IncomingConnection { id, endpoint } => {
+                    assert!(endpoint.peer_id().is_none());
+                    server_conn = Some(id);
+                }
+                TransportEvent::Connected { id, .. } => {
+                    if server_conn.is_none() {
+                        server_conn = Some(id);
+                    }
+                }
+                _ => {}
+            }
+        }
+
         for event in client_events {
             if let TransportEvent::Connected { id, endpoint } = event {
-                if id == expected {
-                    assert_eq!(endpoint.peer_id(), Some(peer_addr.peer_id()));
-                    return true;
+                if id == expected_client_conn {
+                    assert_eq!(endpoint.peer_id(), Some(expected_peer.peer_id()));
+                    client_connected = true;
                 }
             }
         }
+
+        if client_connected && server_conn.is_some() {
+            return server_conn;
+        }
     }
 
-    false
+    None
 }
 
 #[test]
-fn two_peers_connect_and_exchange_data() {
+fn two_peers_open_stream_and_exchange_data() {
     let (mut server, mut client, peer_addr, _cert_dir) = setup_pair();
 
     let client_conn_id = ConnectionId::new(1);
@@ -111,210 +132,142 @@ fn two_peers_connect_and_exchange_data() {
         .dial(client_conn_id, &peer_addr)
         .expect("client dial");
 
-    let mut server_got_connection = false;
-    let mut client_got_connected = false;
-    let mut server_received = false;
-    let mut client_received = false;
+    let server_conn_id =
+        wait_for_connection(&mut server, &mut client, client_conn_id, &peer_addr, 250)
+            .expect("server should observe incoming connection");
 
-    let mut server_conn_id = ConnectionId::new(0);
-
-    for _ in 0..200 {
-        std::thread::sleep(std::time::Duration::from_millis(5));
-
-        let server_events = server.poll().expect("server poll");
-        for event in &server_events {
-            match event {
-                TransportEvent::IncomingConnection { id, endpoint } => {
-                    server_got_connection = true;
-                    server_conn_id = *id;
-                    assert!(endpoint.peer_id().is_none());
-                }
-                TransportEvent::Connected { id, .. } => {
-                    if !server_got_connection {
-                        server_got_connection = true;
-                        server_conn_id = *id;
-                    }
-                }
-                TransportEvent::Received { data, .. } => {
-                    assert_eq!(data, b"hello from client");
-                    server_received = true;
-                }
-                _ => {}
-            }
-        }
-
-        let client_events = client.poll().expect("client poll");
-        for event in &client_events {
-            match event {
-                TransportEvent::Connected { endpoint, .. } => {
-                    assert_eq!(endpoint.peer_id(), Some(peer_addr.peer_id()));
-                    client_got_connected = true;
-                }
-                TransportEvent::Received { data, .. } => {
-                    assert_eq!(data, b"hello from server");
-                    client_received = true;
-                }
-                _ => {}
-            }
-        }
-
-        if client_got_connected && server_got_connection {
-            break;
-        }
-    }
-
-    assert!(
-        server_got_connection,
-        "server should see incoming connection"
-    );
-    assert!(client_got_connected, "client should be connected");
-
+    let client_stream = client.open_stream(client_conn_id).expect("open stream");
     client
-        .send(client_conn_id, b"hello from client".to_vec())
-        .expect("client send");
+        .send_stream(client_conn_id, client_stream, b"hello from client".to_vec())
+        .expect("send stream data");
 
-    for _ in 0..200 {
-        std::thread::sleep(std::time::Duration::from_millis(5));
-
-        let server_events = server.poll().expect("server poll");
-        for event in &server_events {
-            if let TransportEvent::Received { data, .. } = event {
-                assert_eq!(data, b"hello from client");
-                server_received = true;
+    let mut server_stream = None;
+    for _ in 0..250 {
+        let (server_events, client_events) = drive_pair_once(&mut server, &mut client);
+        for event in client_events {
+            if let TransportEvent::StreamOpened { id, stream_id } = event {
+                if id == client_conn_id {
+                    assert_eq!(stream_id, client_stream);
+                }
             }
         }
 
-        if server_received {
+        for event in server_events {
+            match event {
+                TransportEvent::IncomingStream { id, stream_id } => {
+                    assert_eq!(id, server_conn_id);
+                    server_stream = Some(stream_id);
+                }
+                TransportEvent::StreamData {
+                    id,
+                    stream_id,
+                    data,
+                } => {
+                    assert_eq!(id, server_conn_id);
+                    assert_eq!(data, b"hello from client");
+                    server_stream = Some(stream_id);
+                }
+                _ => {}
+            }
+        }
+
+        if server_stream.is_some() {
             break;
         }
     }
 
-    assert!(server_received, "server should receive client data");
-
+    let server_stream = server_stream.expect("server should see stream and data");
     server
-        .send(server_conn_id, b"hello from server".to_vec())
-        .expect("server send");
+        .send_stream(server_conn_id, server_stream, b"hello from server".to_vec())
+        .expect("server response");
 
-    for _ in 0..200 {
-        std::thread::sleep(std::time::Duration::from_millis(5));
-
-        let client_events = client.poll().expect("client poll");
-        for event in &client_events {
-            if let TransportEvent::Received { data, .. } = event {
-                assert_eq!(data, b"hello from server");
-                client_received = true;
+    for _ in 0..250 {
+        let (_, client_events) = drive_pair_once(&mut server, &mut client);
+        for event in client_events {
+            if let TransportEvent::StreamData {
+                id,
+                stream_id,
+                data,
+            } = event
+            {
+                if id == client_conn_id && stream_id == client_stream {
+                    assert_eq!(data, b"hello from server");
+                    return;
+                }
             }
-        }
-
-        if client_received {
-            break;
         }
     }
 
-    assert!(client_received, "client should receive server data");
+    panic!("client did not receive server stream data in time");
 }
 
 #[test]
-fn same_peer_supports_multiple_connections() {
+fn close_stream_write_emits_remote_write_closed() {
     let (mut server, mut client, peer_addr, _cert_dir) = setup_pair();
 
-    let conn_a = ConnectionId::new(10);
-    let conn_b = ConnectionId::new(11);
+    let client_conn_id = ConnectionId::new(5);
+    client.dial(client_conn_id, &peer_addr).expect("dial");
 
-    client.dial(conn_a, &peer_addr).expect("dial conn_a");
-    client.dial(conn_b, &peer_addr).expect("dial conn_b");
+    let server_conn_id =
+        wait_for_connection(&mut server, &mut client, client_conn_id, &peer_addr, 250)
+            .expect("server connection");
 
-    let mut client_connected = BTreeSet::new();
-    let mut server_connection_ids = BTreeSet::new();
+    let client_stream = client.open_stream(client_conn_id).expect("open stream");
+    client
+        .send_stream(client_conn_id, client_stream, b"payload".to_vec())
+        .expect("send payload");
+    client
+        .close_stream_write(client_conn_id, client_stream)
+        .expect("close write");
 
-    for _ in 0..400 {
-        std::thread::sleep(std::time::Duration::from_millis(5));
+    let mut server_saw_remote_write_closed = false;
+    let mut server_stream = None;
 
-        let server_events = server.poll().expect("server poll");
+    for _ in 0..250 {
+        let (server_events, _) = drive_pair_once(&mut server, &mut client);
         for event in server_events {
             match event {
-                TransportEvent::IncomingConnection { id, endpoint } => {
-                    assert!(endpoint.peer_id().is_none());
-                    server_connection_ids.insert(id);
+                TransportEvent::IncomingStream { stream_id, .. } => {
+                    server_stream = Some(stream_id);
                 }
-                TransportEvent::Connected { id, .. } => {
-                    server_connection_ids.insert(id);
+                TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
+                    assert_eq!(id, server_conn_id);
+                    server_stream = Some(stream_id);
+                    server_saw_remote_write_closed = true;
                 }
                 _ => {}
             }
         }
 
-        let client_events = client.poll().expect("client poll");
-        for event in client_events {
-            if let TransportEvent::Connected { id, endpoint } = event {
-                assert_eq!(endpoint.peer_id(), Some(peer_addr.peer_id()));
-                client_connected.insert(id);
-            }
-        }
-
-        if client_connected.len() == 2 && server_connection_ids.len() >= 2 {
+        if server_saw_remote_write_closed {
             break;
         }
     }
 
-    assert_eq!(client_connected.len(), 2, "client should connect twice");
     assert!(
-        server_connection_ids.len() >= 2,
-        "server should track two incoming connections"
+        server_saw_remote_write_closed,
+        "server should observe remote write close"
     );
 
-    let known = client.connection_ids_for_peer(peer_addr.peer_id());
-    assert_eq!(known, vec![conn_a, conn_b]);
-    assert_eq!(
-        client.primary_connection_for_peer(peer_addr.peer_id()),
-        Some(conn_a)
-    );
+    let server_stream = server_stream.expect("server stream id should be known");
+    server
+        .close_stream_write(server_conn_id, server_stream)
+        .expect("server close write");
 
-    let used_primary = client
-        .send_to_peer(
-            peer_addr.peer_id(),
-            b"msg-a".to_vec(),
-            PeerSendPolicy::Primary,
-        )
-        .expect("send primary");
-    let used_newest = client
-        .send_to_peer(
-            peer_addr.peer_id(),
-            b"msg-b".to_vec(),
-            PeerSendPolicy::NewestConnected,
-        )
-        .expect("send newest");
-
-    assert_eq!(used_primary, conn_a);
-    assert_eq!(used_newest, conn_b);
-
-    let mut got_a = false;
-    let mut got_b = false;
-
-    for _ in 0..400 {
-        std::thread::sleep(std::time::Duration::from_millis(5));
-
-        let server_events = server.poll().expect("server poll");
-        for event in server_events {
-            if let TransportEvent::Received { data, .. } = event {
-                if data == b"msg-a" {
-                    got_a = true;
-                }
-                if data == b"msg-b" {
-                    got_b = true;
-                }
-            }
-        }
-
-        let _ = client.poll().expect("client poll");
-
-        if got_a && got_b {
-            break;
+    for _ in 0..250 {
+        let (_, client_events) = drive_pair_once(&mut server, &mut client);
+        if client_events.iter().any(|event| {
+            matches!(
+                event,
+                TransportEvent::StreamRemoteWriteClosed { id, stream_id }
+                if *id == client_conn_id && *stream_id == client_stream
+            )
+        }) {
+            return;
         }
     }
 
-    assert!(got_a, "server should receive message on conn_a");
-    assert!(got_b, "server should receive message on conn_b");
+    panic!("client should observe server close stream write");
 }
 
 #[test]
@@ -348,38 +301,9 @@ fn identity_upgrade_emits_verified_event_and_updates_peer_index() {
         .dial(client_conn_id, &peer_addr)
         .expect("client dial");
 
-    let mut server_conn_id = None;
-    let mut client_connected = false;
-
-    for _ in 0..200 {
-        std::thread::sleep(std::time::Duration::from_millis(5));
-
-        for event in server.poll().expect("server poll") {
-            match event {
-                TransportEvent::IncomingConnection { id, endpoint } => {
-                    assert!(endpoint.peer_id().is_none());
-                    server_conn_id = Some(id);
-                }
-                TransportEvent::Connected { id, .. } => {
-                    server_conn_id = Some(id);
-                }
-                _ => {}
-            }
-        }
-
-        for event in client.poll().expect("client poll") {
-            if let TransportEvent::Connected { .. } = event {
-                client_connected = true;
-            }
-        }
-
-        if server_conn_id.is_some() && client_connected {
-            break;
-        }
-    }
-
-    let server_conn_id = server_conn_id.expect("server connection id");
-    assert!(client_connected, "client should be connected");
+    let server_conn_id =
+        wait_for_connection(&mut server, &mut client, client_conn_id, &peer_addr, 250)
+            .expect("server connection");
 
     let verified_peer_id = test_peer_id();
     server
@@ -431,9 +355,8 @@ fn dial_supports_dns4_target_for_quic_transport() {
     let conn_id = ConnectionId::new(77);
     client.dial(conn_id, &dns_peer_addr).expect("dial via dns4");
 
-    let connected =
-        wait_for_client_connection(&mut server, &mut client, conn_id, &dns_peer_addr, 200);
-    assert!(connected, "client should connect via dns4 target");
+    let connected = wait_for_connection(&mut server, &mut client, conn_id, &dns_peer_addr, 250);
+    assert!(connected.is_some(), "client should connect via dns4 target");
 }
 
 #[test]
@@ -472,87 +395,30 @@ fn listen_rejects_address_mismatch_with_bound_socket() {
 }
 
 #[test]
-fn peer_send_policy_prefers_connection_age_over_connection_id_order() {
-    let (mut server, mut client, peer_addr, _cert_dir) = setup_pair();
+fn open_stream_before_connected_returns_invalid_state() {
+    let (_cert_dir, cert_path, key_path) = generate_cert_pair();
+    let listener_cfg = QuicNodeConfig::dev_listener_with_tls(&cert_path, &key_path);
+    let mut listener = QuicTransport::new(listener_cfg, "127.0.0.1:0").expect("listener");
 
-    let older_conn = ConnectionId::new(100);
-    let newer_conn = ConnectionId::new(1);
+    let listen_port = listener.local_addr().expect("local addr").port();
+    let listen_ma = make_listen_multiaddr(listen_port);
+    listener.listen(&listen_ma).expect("listen");
 
-    client
-        .dial(older_conn, &peer_addr)
-        .expect("dial older conn");
-    let older_connected =
-        wait_for_client_connection(&mut server, &mut client, older_conn, &peer_addr, 250);
-    assert!(older_connected, "older connection should establish");
+    let dialer_cfg = QuicNodeConfig::dev_dialer();
+    let mut dialer = QuicTransport::new(dialer_cfg, "127.0.0.1:0").expect("dialer");
 
-    client
-        .dial(newer_conn, &peer_addr)
-        .expect("dial newer conn");
-    let newer_connected =
-        wait_for_client_connection(&mut server, &mut client, newer_conn, &peer_addr, 250);
-    assert!(newer_connected, "newer connection should establish");
+    let peer_addr = PeerAddr::new(listen_ma, test_peer_id()).expect("peer addr");
+    let conn_id = ConnectionId::new(999);
+    dialer.dial(conn_id, &peer_addr).expect("dial");
 
-    let used_primary = client
-        .send_to_peer(
-            peer_addr.peer_id(),
-            b"primary-oldest".to_vec(),
-            PeerSendPolicy::Primary,
-        )
-        .expect("send with primary policy");
-    let used_oldest = client
-        .send_to_peer(
-            peer_addr.peer_id(),
-            b"explicit-oldest".to_vec(),
-            PeerSendPolicy::OldestConnected,
-        )
-        .expect("send with oldest policy");
-    let used_newest = client
-        .send_to_peer(
-            peer_addr.peer_id(),
-            b"newest".to_vec(),
-            PeerSendPolicy::NewestConnected,
-        )
-        .expect("send with newest policy");
-
-    assert_eq!(used_primary, older_conn);
-    assert_eq!(used_oldest, older_conn);
-    assert_eq!(used_newest, newer_conn);
+    let err = dialer
+        .open_stream(conn_id)
+        .expect_err("open stream before connected should fail");
+    assert!(matches!(err, TransportError::InvalidState { .. }));
 }
 
 #[test]
-fn large_payload_is_delivered_as_single_received_event() {
-    let (mut server, mut client, peer_addr, _cert_dir) = setup_pair();
-
-    let conn_id = ConnectionId::new(501);
-    client.dial(conn_id, &peer_addr).expect("dial");
-    let connected = wait_for_client_connection(&mut server, &mut client, conn_id, &peer_addr, 250);
-    assert!(connected, "client should connect");
-
-    let payload = vec![42u8; 32 * 1024];
-    client
-        .send(conn_id, payload.clone())
-        .expect("send large payload");
-
-    for _ in 0..250 {
-        let (server_events, _) = drive_pair_once(&mut server, &mut client);
-
-        let received: Vec<Vec<u8>> = server_events
-            .into_iter()
-            .filter_map(|event| {
-                if let TransportEvent::Received { data, .. } = event {
-                    Some(data)
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        if !received.is_empty() {
-            assert_eq!(received.len(), 1, "payload should arrive as one message");
-            assert_eq!(received[0], payload, "payload bytes should be preserved");
-            return;
-        }
-    }
-
-    panic!("server did not receive large payload in time");
+fn stream_id_round_trips_as_u64() {
+    let id = StreamId::new(1234);
+    assert_eq!(id.as_u64(), 1234);
 }


### PR DESCRIPTION
Refactor transport from connection-level byte pipe to QUIC-native stream multiplexing with open/send/close/reset per stream. Add sans-I/O multistream-select negotiation and ping protocol state machines. Include unit tests for both protocols and E2E integration tests exercising the full QUIC + multistream + ping stack.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch transport to QUIC-native stream multiplexing and add sans‑I/O `multistream-select` and `ping` protocols. Multistream now uses spec-compliant varint-length framing; ping handling is hardened for fragmentation and stream lifecycle.

- **New Features**
  - Added `packages/multistream-select` (`/multistream/1.0.0`) negotiation state machine with varint-length-prefixed framing.
  - Added `packages/ping` (`/ipfs/ping/1.0.0`) with timeouts, 32‑byte payloads, per‑stream fragmentation buffering, `OutboundStreamClosed`, close‑while‑in‑flight rejection, and `remove_peer`.
  - `minip2p-transport`: per‑stream API (`open_stream`, `send_stream`, `close_stream_write`, `reset_stream`) and `StreamId`; stream open/data/half‑close/close events.
  - `minip2p-quic`: direct QUIC stream mapping (no message framing) with half‑close support.
  - Varint helpers (`read_uvarint`, `write_uvarint`, `uvarint_len`) are public via `minip2p-core`; simplified `MultiaddrError`/`PeerAddrError` variants.
  - Tests: unit tests for multistream (incl. varint framing) and ping; E2E `transports/quic/tests/ping_e2e.rs` for QUIC + multistream + ping.
  - Docs: added READMEs for `packages/multistream-select` and `packages/ping`.

- **Migration**
  - Replace `send(id, data)` with: `open_stream(id) -> StreamId`, `send_stream(id, stream_id, data)`, then `close_stream_write(id, stream_id)` when done.
  - Read via `StreamData` and handle stream open/half‑close/close events.
  - Remove `PeerSendPolicy`; choose a `ConnectionId` directly.
  - If you relied on message framing, implement it at the protocol layer (QUIC adapter no longer frames).

<sup>Written for commit fbaa7cb929fc4fb4b49f691aa28d8bb10c8943f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

