### PR TITLE
examples/peer: relay-mode listen + dial (Steps 4-5 + DX fixes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
 name = "minip2p-peer"
 version = "0.1.0"
 dependencies = [
+ "getrandom 0.4.2",
  "minip2p-core",
  "minip2p-dcutr",
  "minip2p-identify",

--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ cargo doc --workspace --no-deps --open
 - [ ] Mutual TLS on the QUIC transport so the listener learns the client PeerId at handshake time.
 - [ ] Additional transport adapters (TCP, WebSocket, WebRTC).
 
-See `plan.md` for the detailed execution plan and milestones, and `holepunch-plan.md` for the ongoing CLI work.
+See `plan.md` for the detailed execution plan and milestones, `holepunch-plan.md` for the ongoing CLI work, and `dx-plan.md` for the developer-experience roadmap (landed improvements + prioritized backlog).

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -35,6 +35,25 @@ assert!(addr.is_quic_transport());
 assert_eq!(addr.to_string(), "/dns4/example.com/udp/4001/quic-v1");
 ```
 
+Binary multicodec encoding (on-wire form used by Identify, DCUtR, etc.):
+
+```rust
+use core::str::FromStr;
+use minip2p_core::Multiaddr;
+
+let addr = Multiaddr::from_str("/ip4/127.0.0.1/udp/4001/quic-v1").unwrap();
+let bytes = addr.to_bytes();
+// [0x04, 0x7F, 0x00, 0x00, 0x01, 0x91, 0x02, 0x0F, 0xA1, 0xCC, 0x03]
+let decoded = Multiaddr::from_bytes(&bytes).unwrap();
+assert_eq!(decoded, addr);
+```
+
+Wire layout: each component is `<varint(multicodec)><value>`. Value
+shape depends on the protocol: fixed-size bytes for ip4/ip6/udp,
+varint-length-prefixed UTF-8 for dns*, varint-length-prefixed
+multihash for p2p, absent for quic-v1. See
+<https://github.com/multiformats/multiaddr> for the full spec.
+
 Work with peer-qualified addresses:
 
 ```rust

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,9 +1,9 @@
 use alloc::string::String;
 
-use minip2p_identity::PeerIdError;
+use minip2p_identity::{PeerIdError, VarintError};
 use thiserror::Error;
 
-/// Errors from parsing a multiaddr string.
+/// Errors from parsing a multiaddr (string or binary).
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum MultiaddrError {
     #[error("multiaddr input is empty")]
@@ -30,6 +30,23 @@ pub enum MultiaddrError {
         #[source]
         source: PeerIdError,
     },
+    /// The binary decoder encountered a multicodec code it does not know.
+    #[error("unknown multicodec protocol code {code:#x}")]
+    UnknownProtocolCode { code: u64 },
+    /// The binary decoder ran out of bytes partway through a protocol's
+    /// fixed- or variable-length value.
+    #[error("truncated binary value for protocol '{protocol}'")]
+    TruncatedBinaryValue { protocol: &'static str },
+    /// A binary protocol value failed validation (e.g. malformed
+    /// multihash for `/p2p/`, non-UTF-8 DNS name).
+    #[error("invalid binary value for protocol '{protocol}': {reason}")]
+    InvalidBinaryValue {
+        protocol: &'static str,
+        reason: String,
+    },
+    /// A varint in the binary encoding was malformed.
+    #[error("invalid varint in binary multiaddr: {0}")]
+    Varint(#[from] VarintError),
 }
 
 /// Errors from parsing or constructing a peer address.

--- a/crates/core/src/multiaddr.rs
+++ b/crates/core/src/multiaddr.rs
@@ -96,6 +96,45 @@ impl Multiaddr {
     pub fn is_quic_transport(&self) -> bool {
         is_quic_transport_slice(&self.protocols)
     }
+
+    /// Encodes this multiaddr to its binary multicodec wire form.
+    ///
+    /// Shape: for each component, a varint multicodec code followed by
+    /// the value (fixed-size, length-prefixed, or absent depending on
+    /// the protocol). See the multiformats multiaddr specification at
+    /// <https://github.com/multiformats/multiaddr>.
+    ///
+    /// This is the on-wire encoding used by interoperable libp2p
+    /// components (Identify's `listen_addrs` / `observed_addr`, DCUtR
+    /// observed addresses, etc.).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        for protocol in &self.protocols {
+            protocol.write_binary(&mut out);
+        }
+        out
+    }
+
+    /// Decodes a multiaddr from its binary multicodec wire form.
+    ///
+    /// Errors:
+    /// - `Varint` — a multicodec code or length prefix is malformed.
+    /// - `UnknownProtocolCode` — a component uses a code we don't
+    ///   implement.
+    /// - `TruncatedBinaryValue` — a component declared more bytes than
+    ///   the buffer contains.
+    /// - `InvalidBinaryValue` — a component's body failed validation
+    ///   (e.g. non-UTF-8 DNS name, malformed `/p2p/` multihash).
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, MultiaddrError> {
+        let mut protocols = Vec::new();
+        let mut offset = 0;
+        while offset < bytes.len() {
+            let (protocol, consumed) = Protocol::read_binary(&bytes[offset..])?;
+            offset += consumed;
+            protocols.push(protocol);
+        }
+        Ok(Self { protocols })
+    }
 }
 
 impl fmt::Display for Multiaddr {
@@ -329,5 +368,102 @@ mod tests {
 
         let decapsulated = full.decapsulate(&peer).expect("suffix should be found");
         assert_eq!(decapsulated, base);
+    }
+
+    // ---------------------------------------------------------------------
+    // Binary codec
+    // ---------------------------------------------------------------------
+
+    /// Hand-derived reference vector for `/ip4/127.0.0.1/udp/4001/quic-v1`.
+    ///
+    /// - `/ip4`: varint code 0x04, value 127.0.0.1 = 7F 00 00 01
+    /// - `/udp`: varint code 0x0111 -> 91 02, value 4001 (big-endian) = 0F A1
+    /// - `/quic-v1`: varint code 0x01cc -> CC 03, no value
+    #[test]
+    fn binary_codec_reference_vector_ip4_quic() {
+        let addr = Multiaddr::from_str("/ip4/127.0.0.1/udp/4001/quic-v1").unwrap();
+        let expected: Vec<u8> = vec![
+            0x04, 0x7F, 0x00, 0x00, 0x01, // ip4 127.0.0.1
+            0x91, 0x02, 0x0F, 0xA1, // udp 4001
+            0xCC, 0x03, // quic-v1
+        ];
+        assert_eq!(addr.to_bytes(), expected);
+        assert_eq!(Multiaddr::from_bytes(&expected).unwrap(), addr);
+    }
+
+    #[test]
+    fn binary_codec_round_trips_ip6() {
+        let input = "/ip6/2001:db8::1/udp/9000/quic-v1";
+        let addr = Multiaddr::from_str(input).unwrap();
+        let bytes = addr.to_bytes();
+        let decoded = Multiaddr::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.to_string(), input);
+    }
+
+    #[test]
+    fn binary_codec_round_trips_dns_variants() {
+        for proto in ["dns", "dns4", "dns6"] {
+            let input = alloc::format!("/{proto}/example.com/udp/443/quic-v1");
+            let addr = Multiaddr::from_str(&input).unwrap();
+            let bytes = addr.to_bytes();
+            let decoded = Multiaddr::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.to_string(), input);
+        }
+    }
+
+    #[test]
+    fn binary_codec_round_trips_p2p_suffix() {
+        let input = format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p/{PEER_ID}");
+        let addr = Multiaddr::from_str(&input).unwrap();
+        let bytes = addr.to_bytes();
+        let decoded = Multiaddr::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.to_string(), input);
+    }
+
+    #[test]
+    fn binary_codec_round_trips_empty_multiaddr() {
+        let addr = Multiaddr::new();
+        assert_eq!(addr.to_bytes(), Vec::<u8>::new());
+        assert_eq!(Multiaddr::from_bytes(&[]).unwrap(), addr);
+    }
+
+    #[test]
+    fn binary_codec_rejects_unknown_code() {
+        // 0xC1 0x01 is varint for 193; not a code we implement.
+        let err = Multiaddr::from_bytes(&[0xC1, 0x01, 0xFF]).unwrap_err();
+        assert!(matches!(
+            err,
+            MultiaddrError::UnknownProtocolCode { code: 193 }
+        ));
+    }
+
+    #[test]
+    fn binary_codec_rejects_truncated_ip4() {
+        // ip4 code (0x04) followed by only 2 bytes of value.
+        let err = Multiaddr::from_bytes(&[0x04, 0x7F, 0x00]).unwrap_err();
+        assert!(matches!(
+            err,
+            MultiaddrError::TruncatedBinaryValue { protocol: "ip4" }
+        ));
+    }
+
+    #[test]
+    fn binary_codec_rejects_truncated_length_prefix() {
+        // dns code (0x35) + length 10 + only 3 body bytes.
+        let err = Multiaddr::from_bytes(&[0x35, 0x0A, b'a', b'b', b'c']).unwrap_err();
+        assert!(matches!(
+            err,
+            MultiaddrError::TruncatedBinaryValue { protocol: "dns" }
+        ));
+    }
+
+    #[test]
+    fn binary_codec_rejects_invalid_dns_utf8() {
+        // dns code (0x35) + length 2 + invalid utf-8 bytes (0xFF 0xFE).
+        let err = Multiaddr::from_bytes(&[0x35, 0x02, 0xFF, 0xFE]).unwrap_err();
+        assert!(matches!(
+            err,
+            MultiaddrError::InvalidBinaryValue { protocol: "dns", .. }
+        ));
     }
 }

--- a/crates/core/src/protocol.rs
+++ b/crates/core/src/protocol.rs
@@ -1,6 +1,36 @@
-use alloc::string::String;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
-use minip2p_identity::PeerId;
+use minip2p_identity::{PeerId, read_uvarint, write_uvarint};
+
+use crate::MultiaddrError;
+
+// ---------------------------------------------------------------------------
+// Multicodec codes
+// ---------------------------------------------------------------------------
+//
+// Per the multiformats/multicodec table at
+// <https://github.com/multiformats/multicodec/blob/master/table.csv>. Each
+// component of a binary multiaddr is `<varint(code)><value>`; the shape of
+// `<value>` depends on the code (fixed-size bytes, length-prefixed bytes,
+// or absent).
+
+/// Multicodec code for `/ip4/<a.b.c.d>`. 4 raw bytes.
+pub const IP4_CODE: u64 = 0x04;
+/// Multicodec code for `/ip6/<address>`. 16 raw bytes.
+pub const IP6_CODE: u64 = 0x29;
+/// Multicodec code for `/dns/<name>`. Varint-length-prefixed UTF-8.
+pub const DNS_CODE: u64 = 0x35;
+/// Multicodec code for `/dns4/<name>`. Varint-length-prefixed UTF-8.
+pub const DNS4_CODE: u64 = 0x36;
+/// Multicodec code for `/dns6/<name>`. Varint-length-prefixed UTF-8.
+pub const DNS6_CODE: u64 = 0x37;
+/// Multicodec code for `/udp/<port>`. 2 raw bytes (big-endian).
+pub const UDP_CODE: u64 = 0x0111;
+/// Multicodec code for `/quic-v1`. No value.
+pub const QUIC_V1_CODE: u64 = 0x01cc;
+/// Multicodec code for `/p2p/<peer-id>`. Varint-length-prefixed multihash.
+pub const P2P_CODE: u64 = 0x01a5;
 
 /// A single component of a multiaddr.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -23,4 +53,131 @@ impl Protocol {
             Self::Ip4(_) | Self::Ip6(_) | Self::Dns(_) | Self::Dns4(_) | Self::Dns6(_)
         )
     }
+
+    /// Returns the multicodec code for this protocol.
+    pub fn code(&self) -> u64 {
+        match self {
+            Self::Ip4(_) => IP4_CODE,
+            Self::Ip6(_) => IP6_CODE,
+            Self::Dns(_) => DNS_CODE,
+            Self::Dns4(_) => DNS4_CODE,
+            Self::Dns6(_) => DNS6_CODE,
+            Self::Udp(_) => UDP_CODE,
+            Self::QuicV1 => QUIC_V1_CODE,
+            Self::P2p(_) => P2P_CODE,
+        }
+    }
+
+    /// Writes the binary multicodec encoding for this protocol into `out`.
+    ///
+    /// Shape: `<varint(code)><value>` where the value layout is determined
+    /// by the protocol. Length-prefixed protocols prepend another varint
+    /// before their body.
+    pub(crate) fn write_binary(&self, out: &mut Vec<u8>) {
+        write_uvarint(self.code(), out);
+        match self {
+            Self::Ip4(bytes) => out.extend_from_slice(bytes),
+            Self::Ip6(bytes) => out.extend_from_slice(bytes),
+            Self::Dns(name) | Self::Dns4(name) | Self::Dns6(name) => {
+                let body = name.as_bytes();
+                write_uvarint(body.len() as u64, out);
+                out.extend_from_slice(body);
+            }
+            Self::Udp(port) => out.extend_from_slice(&port.to_be_bytes()),
+            Self::QuicV1 => {}
+            Self::P2p(peer_id) => {
+                let body = peer_id.to_bytes();
+                write_uvarint(body.len() as u64, out);
+                out.extend_from_slice(&body);
+            }
+        }
+    }
+
+    /// Reads a single protocol component from the front of `bytes`.
+    ///
+    /// Returns the decoded protocol plus the number of bytes consumed.
+    pub(crate) fn read_binary(bytes: &[u8]) -> Result<(Self, usize), MultiaddrError> {
+        let (code, mut consumed) = read_uvarint(bytes)?;
+        let rest = &bytes[consumed..];
+
+        match code {
+            IP4_CODE => {
+                let value = fixed::<4>(rest, "ip4")?;
+                consumed += 4;
+                Ok((Self::Ip4(value), consumed))
+            }
+            IP6_CODE => {
+                let value = fixed::<16>(rest, "ip6")?;
+                consumed += 16;
+                Ok((Self::Ip6(value), consumed))
+            }
+            UDP_CODE => {
+                let value = fixed::<2>(rest, "udp")?;
+                consumed += 2;
+                Ok((Self::Udp(u16::from_be_bytes(value)), consumed))
+            }
+            QUIC_V1_CODE => Ok((Self::QuicV1, consumed)),
+            DNS_CODE | DNS4_CODE | DNS6_CODE => {
+                let label = match code {
+                    DNS_CODE => "dns",
+                    DNS4_CODE => "dns4",
+                    _ => "dns6",
+                };
+                let (body, used) = length_prefixed(rest, label)?;
+                consumed += used;
+                let name = core::str::from_utf8(body)
+                    .map_err(|e| MultiaddrError::InvalidBinaryValue {
+                        protocol: label,
+                        reason: e.to_string(),
+                    })?
+                    .to_string();
+                let protocol = match code {
+                    DNS_CODE => Self::Dns(name),
+                    DNS4_CODE => Self::Dns4(name),
+                    _ => Self::Dns6(name),
+                };
+                Ok((protocol, consumed))
+            }
+            P2P_CODE => {
+                let (body, used) = length_prefixed(rest, "p2p")?;
+                consumed += used;
+                let peer_id = PeerId::from_bytes(body).map_err(|e| {
+                    MultiaddrError::InvalidBinaryValue {
+                        protocol: "p2p",
+                        reason: e.to_string(),
+                    }
+                })?;
+                Ok((Self::P2p(peer_id), consumed))
+            }
+            _ => Err(MultiaddrError::UnknownProtocolCode { code }),
+        }
+    }
+}
+
+/// Reads `N` bytes from the front of `bytes` as a fixed-size value.
+fn fixed<const N: usize>(
+    bytes: &[u8],
+    protocol: &'static str,
+) -> Result<[u8; N], MultiaddrError> {
+    if bytes.len() < N {
+        return Err(MultiaddrError::TruncatedBinaryValue { protocol });
+    }
+    let mut out = [0u8; N];
+    out.copy_from_slice(&bytes[..N]);
+    Ok(out)
+}
+
+/// Reads a varint length prefix and returns a slice of that many bytes
+/// plus the total number of bytes consumed (prefix + body).
+fn length_prefixed<'a>(
+    bytes: &'a [u8],
+    protocol: &'static str,
+) -> Result<(&'a [u8], usize), MultiaddrError> {
+    let (len, consumed) = read_uvarint(bytes)?;
+    let len = len as usize;
+    let available = bytes.len() - consumed;
+    if len > available {
+        return Err(MultiaddrError::TruncatedBinaryValue { protocol });
+    }
+    Ok((&bytes[consumed..consumed + len], consumed + len))
 }

--- a/crates/dcutr/README.md
+++ b/crates/dcutr/README.md
@@ -14,8 +14,10 @@ This crate implements the message state machines only. It does **not**:
 
 ## State machines
 
-- **`DcutrInitiator`** -- the peer that initiates the upgrade after being connected via relay. Sends `CONNECT`, waits for the remote `CONNECT`, computes its own RTT, then issues `SYNC` and emits `InitiatorOutcome::DialNow { remote_addrs, rtt_ms }`.
-- **`DcutrResponder`** -- the remote peer. Receives the initiator's `CONNECT`, emits `ResponderEvent::ConnectReceived { remote_addrs }`, replies with its own `CONNECT`, then emits `ResponderEvent::SyncReceived` when the initiator's `SYNC` arrives. The caller kicks off the hole-punch bombardment on `SyncReceived`.
+- **`DcutrInitiator`** -- the peer that initiates the upgrade after being connected via relay. Sends `CONNECT`, waits for the remote `CONNECT`, records its own RTT, then issues `SYNC` and emits `InitiatorOutcome::DialNow { remote_addrs, remote_addr_bytes, rtt_ms }`.
+- **`DcutrResponder`** -- the remote peer. Receives the initiator's `CONNECT`, emits `ResponderEvent::ConnectReceived { remote_addrs, remote_addr_bytes }`, replies with its own `CONNECT`, then emits `ResponderEvent::SyncReceived` when the initiator's `SYNC` arrives. The caller kicks off the hole-punch bombardment on `SyncReceived`.
+
+Both machines accept `&[Multiaddr]` at construction time and automatically serialize them to the wire using multicodec-binary encoding (via `Multiaddr::to_bytes()` in `minip2p-core`). Incoming `obs_addrs` are decoded the same way; entries that fail to parse are dropped silently but remain available as raw bytes in `remote_addr_bytes` for diagnostics.
 
 Each machine accepts raw bytes via `on_data(&[u8])` and exposes pending outbound bytes via `take_outbound()`. The wire format is length-prefixed protobuf `HolePunch` messages; the frame helpers (`encode_frame`, `decode_frame`, `FrameDecode`) are re-exported from the crate root.
 
@@ -27,16 +29,16 @@ Each machine accepts raw bytes via `on_data(&[u8])` and exposes pending outbound
 ## Usage sketch
 
 ```rust
+use minip2p_core::Multiaddr;
 use minip2p_dcutr::{DcutrInitiator, InitiatorOutcome};
 
-let mut initiator = DcutrInitiator::new(our_observed_addrs);
-let out = initiator.start(now_ms); // send these bytes on the negotiated stream
+let mut initiator = DcutrInitiator::new(&our_observed_addrs); // &[Multiaddr]
+let out = initiator.take_outbound(); // send these bytes on the negotiated stream
 
-// Feed incoming bytes:
-// initiator.on_data(&data, now_ms);
-// for event in initiator.poll_events() { ... }
-// if let Some(InitiatorOutcome::DialNow { remote_addrs, rtt_ms }) = initiator.outcome() {
-//     // dial each remote_addr directly, wait rtt_ms for a connection,
+// Feed incoming bytes + measured RTT:
+// initiator.on_data(&data, rtt_ms)?;
+// if let Some(InitiatorOutcome::DialNow { remote_addrs, rtt_ms, .. }) = initiator.outcome() {
+//     // dial each remote Multiaddr directly, wait rtt_ms for a connection,
 //     // fall back to relayed ping if none succeeds.
 // }
 ```

--- a/crates/dcutr/src/lib.rs
+++ b/crates/dcutr/src/lib.rs
@@ -28,7 +28,7 @@ extern crate alloc;
 
 mod message;
 
-use alloc::string::{String, ToString};
+use alloc::string::String;
 use alloc::vec::Vec;
 
 use minip2p_core::Multiaddr;
@@ -418,29 +418,20 @@ fn enforce_max_size(buf: &[u8]) -> Result<(), DcutrError> {
 }
 
 /// Encodes a [`Multiaddr`] for transmission in a `HolePunch` `obs_addrs`
-/// field.
-///
-/// The libp2p DCUtR spec calls for the multicodec-based binary encoding.
-/// minip2p-core does not yet implement that encoder, so we transmit the
-/// display-string form as UTF-8 bytes; two minip2p peers round-trip
-/// cleanly through this encoding and foreign libp2p peers will see the
-/// entries as opaque bytes until the binary encoder lands in core.
+/// field using the libp2p-spec multicodec-based binary encoding.
 fn encode_multiaddr(addr: &Multiaddr) -> Vec<u8> {
-    addr.to_string().into_bytes()
+    addr.to_bytes()
 }
 
 /// Decodes a list of raw observed-address bytes into [`Multiaddr`]
-/// values, dropping any entry that fails to parse as valid UTF-8 or
-/// a well-formed multiaddr.
+/// values, dropping any entry that fails to decode as a well-formed
+/// binary multiaddr.
 ///
 /// The raw bytes remain available in the surrounding event/outcome so
 /// callers can emit diagnostics for dropped entries if they care.
 fn decode_remote_addrs(raw: &[Vec<u8>]) -> Vec<Multiaddr> {
     raw.iter()
-        .filter_map(|bytes| {
-            let s = core::str::from_utf8(bytes).ok()?;
-            <Multiaddr as core::str::FromStr>::from_str(s).ok()
-        })
+        .filter_map(|bytes| Multiaddr::from_bytes(bytes).ok())
         .collect()
 }
 
@@ -476,7 +467,8 @@ mod tests {
 
         // Remote replies with its own CONNECT.
         let remote_str = "/ip4/5.6.7.8/udp/2222/quic-v1";
-        let remote_bytes = vec![remote_str.as_bytes().to_vec()];
+        let remote_addr = addr(remote_str);
+        let remote_bytes = vec![remote_addr.to_bytes()];
         let reply = frame(HolePunch {
             kind: HolePunchType::Connect,
             obs_addrs: remote_bytes.clone(),
@@ -490,7 +482,7 @@ mod tests {
                 rtt_ms,
             }) => {
                 assert_eq!(remote_addrs.len(), 1);
-                assert_eq!(remote_addrs[0], addr(remote_str));
+                assert_eq!(remote_addrs[0], remote_addr);
                 assert_eq!(*remote_addr_bytes, remote_bytes);
                 assert_eq!(*rtt_ms, 42);
             }
@@ -548,7 +540,7 @@ mod tests {
 
         let reply = frame(HolePunch {
             kind: HolePunchType::Connect,
-            obs_addrs: vec![b"/ip4/1.2.3.4/udp/1/quic-v1".to_vec()],
+            obs_addrs: vec![addr("/ip4/1.2.3.4/udp/1/quic-v1").to_bytes()],
         });
         for byte in &reply {
             init.on_data(&[*byte], 10).unwrap();
@@ -568,9 +560,9 @@ mod tests {
         let reply = frame(HolePunch {
             kind: HolePunchType::Connect,
             obs_addrs: vec![
-                b"/ip4/1.2.3.4/udp/1/quic-v1".to_vec(), // valid
-                b"not-a-multiaddr".to_vec(),           // dropped
-                vec![0xFF, 0xFE],                      // dropped (not utf8)
+                addr("/ip4/1.2.3.4/udp/1/quic-v1").to_bytes(), // valid binary
+                vec![0xFF, 0x7F, 0x00],                        // unknown code
+                vec![0x04, 0x7F],                              // truncated ip4
             ],
         });
         init.on_data(&reply, 10).unwrap();
@@ -595,21 +587,22 @@ mod tests {
 
         // Feed initiator's CONNECT.
         let remote_str = "/ip4/5.5.5.5/udp/7000/quic-v1";
-        let remote_bytes = vec![remote_str.as_bytes().to_vec()];
+        let remote_addr = addr(remote_str);
+        let remote_bytes = vec![remote_addr.to_bytes()];
         let connect = frame(HolePunch {
             kind: HolePunchType::Connect,
             obs_addrs: remote_bytes.clone(),
         });
         resp.on_data(&connect).unwrap();
 
-        // Reply should be queued with our own addr (string-encoded).
+        // Reply should be queued with our own addr (binary-encoded).
         let outbound = resp.take_outbound();
         let FrameDecode::Complete { payload, .. } = decode_frame(&outbound) else {
             panic!();
         };
         let reply = HolePunch::decode(payload).unwrap();
         assert_eq!(reply.kind, HolePunchType::Connect);
-        assert_eq!(reply.obs_addrs, vec![own[0].to_string().into_bytes()]);
+        assert_eq!(reply.obs_addrs, vec![own[0].to_bytes()]);
 
         // ConnectReceived event should surface parsed multiaddrs.
         let events = resp.poll_events();
@@ -620,7 +613,7 @@ mod tests {
                 remote_addr_bytes,
             } => {
                 assert_eq!(remote_addrs.len(), 1);
-                assert_eq!(remote_addrs[0], addr(remote_str));
+                assert_eq!(remote_addrs[0], remote_addr);
                 assert_eq!(*remote_addr_bytes, remote_bytes);
             }
             _ => panic!(),

--- a/crates/dcutr/src/lib.rs
+++ b/crates/dcutr/src/lib.rs
@@ -28,8 +28,10 @@ extern crate alloc;
 
 mod message;
 
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+
+use minip2p_core::Multiaddr;
 
 pub use message::{
     decode_frame, encode_frame, DcutrMessageError, FrameDecode, HolePunch, HolePunchType,
@@ -69,8 +71,14 @@ pub enum InitiatorOutcome {
     /// The remote has replied with their observed addresses. The caller
     /// should immediately dial these addresses.
     DialNow {
-        /// Addresses observed by the remote (multiaddr binary).
-        remote_addrs: Vec<Vec<u8>>,
+        /// Addresses observed by the remote. Entries that fail to parse
+        /// as a valid [`Multiaddr`] are silently dropped; the raw bytes
+        /// are still available via [`InitiatorOutcome::DialNow::remote_addr_bytes`].
+        remote_addrs: Vec<Multiaddr>,
+        /// Raw observed-address bytes as received on the wire, before
+        /// parsing. Kept available so callers can surface diagnostics
+        /// about malformed entries.
+        remote_addr_bytes: Vec<Vec<u8>>,
         /// Measured relay RTT in milliseconds (wall clock between sending
         /// CONNECT and receiving the reply). Timing is the caller's
         /// responsibility; this is just the reported measurement.
@@ -112,12 +120,14 @@ enum InitiatorState {
 impl DcutrInitiator {
     /// Creates a new initiator, queuing the outbound CONNECT message.
     ///
-    /// `own_addrs` are our observed (and possibly predicted) multiaddrs
-    /// in binary form.
-    pub fn new(own_addrs: Vec<Vec<u8>>) -> Self {
+    /// `own_addrs` are our observed (and possibly predicted) multiaddrs.
+    /// They are serialized via [`Multiaddr`]'s `Display` for the wire
+    /// (see the crate-level note on binary vs string encoding).
+    pub fn new(own_addrs: &[Multiaddr]) -> Self {
+        let obs_addrs = own_addrs.iter().map(encode_multiaddr).collect();
         let msg = HolePunch {
             kind: HolePunchType::Connect,
-            obs_addrs: own_addrs,
+            obs_addrs,
         };
         let outbound = encode_frame(&msg.encode());
 
@@ -228,8 +238,10 @@ impl DcutrInitiator {
         }
 
         self.state = InitiatorState::ReadyToSync;
+        let remote_addrs = decode_remote_addrs(&reply.obs_addrs);
         self.outcome = Some(InitiatorOutcome::DialNow {
-            remote_addrs: reply.obs_addrs,
+            remote_addrs,
+            remote_addr_bytes: reply.obs_addrs,
             rtt_ms,
         });
 
@@ -248,7 +260,14 @@ pub enum ResponderEvent {
     ///
     /// We have already queued our own CONNECT reply via the constructor, but
     /// the caller now knows which addresses to NAT-punch towards.
-    ConnectReceived { remote_addrs: Vec<Vec<u8>> },
+    ConnectReceived {
+        /// Decoded remote observed addresses. Malformed entries are
+        /// dropped silently; the raw bytes remain in `remote_addr_bytes`
+        /// for diagnostics.
+        remote_addrs: Vec<Multiaddr>,
+        /// Raw bytes of the observed addresses as received on the wire.
+        remote_addr_bytes: Vec<Vec<u8>>,
+    },
     /// The initiator has sent SYNC. Per the spec, the responder should wait
     /// RTT/2 and then start sending random UDP packets to the remote's
     /// addresses to open its NAT binding.
@@ -287,9 +306,9 @@ impl DcutrResponder {
     /// `own_addrs` are the addresses we want the initiator to try dialing us
     /// on. The CONNECT reply is lazily queued once we actually receive the
     /// initiator's CONNECT.
-    pub fn new(own_addrs: Vec<Vec<u8>>) -> Self {
+    pub fn new(own_addrs: &[Multiaddr]) -> Self {
         Self {
-            own_addrs,
+            own_addrs: own_addrs.iter().map(encode_multiaddr).collect(),
             outbound: Vec::new(),
             recv_buf: Vec::new(),
             state: ResponderState::AwaitingConnect,
@@ -362,8 +381,11 @@ impl DcutrResponder {
                     };
                     self.outbound.extend(encode_frame(&reply.encode()));
 
+                    let remote_addr_bytes = msg.obs_addrs;
+                    let remote_addrs = decode_remote_addrs(&remote_addr_bytes);
                     self.events.push(ResponderEvent::ConnectReceived {
-                        remote_addrs: msg.obs_addrs,
+                        remote_addrs,
+                        remote_addr_bytes,
                     });
                     self.state = ResponderState::AwaitingSync;
                 }
@@ -395,6 +417,33 @@ fn enforce_max_size(buf: &[u8]) -> Result<(), DcutrError> {
     Ok(())
 }
 
+/// Encodes a [`Multiaddr`] for transmission in a `HolePunch` `obs_addrs`
+/// field.
+///
+/// The libp2p DCUtR spec calls for the multicodec-based binary encoding.
+/// minip2p-core does not yet implement that encoder, so we transmit the
+/// display-string form as UTF-8 bytes; two minip2p peers round-trip
+/// cleanly through this encoding and foreign libp2p peers will see the
+/// entries as opaque bytes until the binary encoder lands in core.
+fn encode_multiaddr(addr: &Multiaddr) -> Vec<u8> {
+    addr.to_string().into_bytes()
+}
+
+/// Decodes a list of raw observed-address bytes into [`Multiaddr`]
+/// values, dropping any entry that fails to parse as valid UTF-8 or
+/// a well-formed multiaddr.
+///
+/// The raw bytes remain available in the surrounding event/outcome so
+/// callers can emit diagnostics for dropped entries if they care.
+fn decode_remote_addrs(raw: &[Vec<u8>]) -> Vec<Multiaddr> {
+    raw.iter()
+        .filter_map(|bytes| {
+            let s = core::str::from_utf8(bytes).ok()?;
+            <Multiaddr as core::str::FromStr>::from_str(s).ok()
+        })
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -407,10 +456,14 @@ mod tests {
         encode_frame(&msg.encode())
     }
 
+    fn addr(s: &str) -> Multiaddr {
+        <Multiaddr as core::str::FromStr>::from_str(s).expect("test multiaddr")
+    }
+
     #[test]
     fn initiator_sends_connect_then_dials_on_reply() {
-        let own = vec![vec![0x04, 1, 2, 3, 4]];
-        let mut init = DcutrInitiator::new(own);
+        let own = [addr("/ip4/1.2.3.4/udp/1111/quic-v1")];
+        let mut init = DcutrInitiator::new(&own);
 
         // Take the initial CONNECT.
         let outbound = init.take_outbound();
@@ -419,18 +472,26 @@ mod tests {
         };
         let req = HolePunch::decode(payload).unwrap();
         assert_eq!(req.kind, HolePunchType::Connect);
+        assert_eq!(req.obs_addrs.len(), 1);
 
         // Remote replies with its own CONNECT.
-        let remote_addrs = vec![vec![0x04, 5, 6, 7, 8]];
+        let remote_str = "/ip4/5.6.7.8/udp/2222/quic-v1";
+        let remote_bytes = vec![remote_str.as_bytes().to_vec()];
         let reply = frame(HolePunch {
             kind: HolePunchType::Connect,
-            obs_addrs: remote_addrs.clone(),
+            obs_addrs: remote_bytes.clone(),
         });
         init.on_data(&reply, 42).unwrap();
 
         match init.outcome() {
-            Some(InitiatorOutcome::DialNow { remote_addrs: got, rtt_ms }) => {
-                assert_eq!(*got, remote_addrs);
+            Some(InitiatorOutcome::DialNow {
+                remote_addrs,
+                remote_addr_bytes,
+                rtt_ms,
+            }) => {
+                assert_eq!(remote_addrs.len(), 1);
+                assert_eq!(remote_addrs[0], addr(remote_str));
+                assert_eq!(*remote_addr_bytes, remote_bytes);
                 assert_eq!(*rtt_ms, 42);
             }
             other => panic!("unexpected outcome: {other:?}"),
@@ -439,7 +500,7 @@ mod tests {
 
     #[test]
     fn initiator_send_sync_after_reply() {
-        let mut init = DcutrInitiator::new(Vec::new());
+        let mut init = DcutrInitiator::new(&[]);
         let _ = init.take_outbound();
 
         let reply = frame(HolePunch {
@@ -460,7 +521,7 @@ mod tests {
 
     #[test]
     fn initiator_send_sync_before_reply_fails() {
-        let mut init = DcutrInitiator::new(Vec::new());
+        let mut init = DcutrInitiator::new(&[]);
         let _ = init.take_outbound();
 
         let err = init.send_sync().unwrap_err();
@@ -469,7 +530,7 @@ mod tests {
 
     #[test]
     fn initiator_rejects_sync_as_reply() {
-        let mut init = DcutrInitiator::new(Vec::new());
+        let mut init = DcutrInitiator::new(&[]);
         let _ = init.take_outbound();
 
         let wrong = frame(HolePunch {
@@ -482,12 +543,12 @@ mod tests {
 
     #[test]
     fn initiator_handles_fragmented_reply() {
-        let mut init = DcutrInitiator::new(Vec::new());
+        let mut init = DcutrInitiator::new(&[]);
         let _ = init.take_outbound();
 
         let reply = frame(HolePunch {
             kind: HolePunchType::Connect,
-            obs_addrs: vec![vec![0x04, 1, 2, 3, 4]],
+            obs_addrs: vec![b"/ip4/1.2.3.4/udp/1/quic-v1".to_vec()],
         });
         for byte in &reply {
             init.on_data(&[*byte], 10).unwrap();
@@ -500,33 +561,67 @@ mod tests {
     }
 
     #[test]
+    fn initiator_drops_malformed_remote_addrs_but_keeps_bytes() {
+        let mut init = DcutrInitiator::new(&[]);
+        let _ = init.take_outbound();
+
+        let reply = frame(HolePunch {
+            kind: HolePunchType::Connect,
+            obs_addrs: vec![
+                b"/ip4/1.2.3.4/udp/1/quic-v1".to_vec(), // valid
+                b"not-a-multiaddr".to_vec(),           // dropped
+                vec![0xFF, 0xFE],                      // dropped (not utf8)
+            ],
+        });
+        init.on_data(&reply, 10).unwrap();
+
+        match init.outcome() {
+            Some(InitiatorOutcome::DialNow {
+                remote_addrs,
+                remote_addr_bytes,
+                ..
+            }) => {
+                assert_eq!(remote_addrs.len(), 1);
+                assert_eq!(remote_addr_bytes.len(), 3);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
     fn responder_replies_on_connect_then_surfaces_sync() {
-        let own_addrs = vec![vec![0x04, 10, 0, 0, 1]];
-        let mut resp = DcutrResponder::new(own_addrs.clone());
+        let own = [addr("/ip4/10.0.0.1/udp/1234/quic-v1")];
+        let mut resp = DcutrResponder::new(&own);
 
         // Feed initiator's CONNECT.
-        let remote = vec![vec![0x04, 5, 5, 5, 5]];
+        let remote_str = "/ip4/5.5.5.5/udp/7000/quic-v1";
+        let remote_bytes = vec![remote_str.as_bytes().to_vec()];
         let connect = frame(HolePunch {
             kind: HolePunchType::Connect,
-            obs_addrs: remote.clone(),
+            obs_addrs: remote_bytes.clone(),
         });
         resp.on_data(&connect).unwrap();
 
-        // Reply should be queued.
+        // Reply should be queued with our own addr (string-encoded).
         let outbound = resp.take_outbound();
         let FrameDecode::Complete { payload, .. } = decode_frame(&outbound) else {
             panic!();
         };
         let reply = HolePunch::decode(payload).unwrap();
         assert_eq!(reply.kind, HolePunchType::Connect);
-        assert_eq!(reply.obs_addrs, own_addrs);
+        assert_eq!(reply.obs_addrs, vec![own[0].to_string().into_bytes()]);
 
-        // ConnectReceived event should be queued.
+        // ConnectReceived event should surface parsed multiaddrs.
         let events = resp.poll_events();
         assert_eq!(events.len(), 1);
         match &events[0] {
-            ResponderEvent::ConnectReceived { remote_addrs } => {
-                assert_eq!(*remote_addrs, remote);
+            ResponderEvent::ConnectReceived {
+                remote_addrs,
+                remote_addr_bytes,
+            } => {
+                assert_eq!(remote_addrs.len(), 1);
+                assert_eq!(remote_addrs[0], addr(remote_str));
+                assert_eq!(*remote_addr_bytes, remote_bytes);
             }
             _ => panic!(),
         }
@@ -545,7 +640,7 @@ mod tests {
 
     #[test]
     fn responder_handles_pipelined_connect_and_sync() {
-        let mut resp = DcutrResponder::new(Vec::new());
+        let mut resp = DcutrResponder::new(&[]);
 
         // Send CONNECT and SYNC in one packet (unusual but possible).
         let mut packet = frame(HolePunch {
@@ -571,7 +666,7 @@ mod tests {
 
     #[test]
     fn responder_rejects_sync_before_connect() {
-        let mut resp = DcutrResponder::new(Vec::new());
+        let mut resp = DcutrResponder::new(&[]);
         let sync = frame(HolePunch {
             kind: HolePunchType::Sync,
             obs_addrs: Vec::new(),
@@ -582,7 +677,7 @@ mod tests {
 
     #[test]
     fn responder_rejects_duplicate_connect() {
-        let mut resp = DcutrResponder::new(Vec::new());
+        let mut resp = DcutrResponder::new(&[]);
 
         let connect = frame(HolePunch {
             kind: HolePunchType::Connect,
@@ -596,7 +691,7 @@ mod tests {
 
     #[test]
     fn rejects_oversized_message() {
-        let mut resp = DcutrResponder::new(Vec::new());
+        let mut resp = DcutrResponder::new(&[]);
         let large = vec![0u8; MAX_MESSAGE_SIZE + 1];
         let err = resp.on_data(&large).unwrap_err();
         assert!(matches!(err, DcutrError::MessageTooLarge { .. }));

--- a/crates/identify/README.md
+++ b/crates/identify/README.md
@@ -27,14 +27,18 @@ let config = IdentifyConfig {
     protocol_version: "minip2p/0.1.0".into(),
     agent_version: "my-app/0.1.0".into(),
     protocols: vec!["/ipfs/ping/1.0.0".into()],
-    listen_addrs: vec![/* multiaddr bytes */],
     public_key: vec![/* protobuf PublicKey */],
 };
 let mut identify = IdentifyProtocol::new(config);
 
 // After multistream-select negotiates /ipfs/id/1.0.0:
 //   - inbound stream (we respond):
-//     let actions = identify.register_outbound_stream(peer_id, stream_id, Some(remote_addr))?;
+//     let actions = identify.register_outbound_stream(
+//         peer_id,
+//         stream_id,
+//         Some(remote_addr),   // observed_addr
+//         &listen_addrs,       // from the transport
+//     )?;
 //   - outbound stream (we receive the remote's info):
 //     identify.register_inbound_stream(peer_id, stream_id);
 
@@ -49,11 +53,13 @@ let mut identify = IdentifyProtocol::new(config);
 
 `observed_addr` should be the transport address we observed the remote dialing us from. Pass `None` when the information is not available.
 
+`listen_addrs` is the set of multiaddrs we're currently listening on. Typically the swarm driver snapshots this from the transport's `local_addresses()` on each `poll()` tick and passes it through — so the advertised set always reflects what we're actually bound to, with no caller ceremony required.
+
 ## Protocol
 
 - Protocol ID: `/ipfs/id/1.0.0`
-- Wire format: a single protobuf-encoded `Identify` message, then the responder half-closes its write side.
-- Fields: `publicKey`, `listenAddrs` (repeated), `protocols` (repeated), `observedAddr`, `protocolVersion`, `agentVersion`.
+- Wire format: a varint length prefix followed by a protobuf-encoded `Identify` message, then the responder half-closes its write side.
+- Fields: `publicKey`, `listenAddrs` (repeated, multicodec-binary), `protocols` (repeated), `observedAddr` (multicodec-binary), `protocolVersion`, `agentVersion`.
 
 ## no_std
 

--- a/crates/identify/src/lib.rs
+++ b/crates/identify/src/lib.rs
@@ -36,6 +36,12 @@ const MAX_MESSAGE_SIZE: usize = 8192;
 // ---------------------------------------------------------------------------
 
 /// Configuration for the identify protocol.
+///
+/// Note: `listen_addrs` is **not** a field here -- the swarm driver
+/// auto-populates it from the underlying transport's `local_addresses()`
+/// at send time, so the advertised set always reflects what the peer
+/// is actually listening on. See
+/// [`IdentifyProtocol::register_outbound_stream`].
 #[derive(Clone, Debug)]
 pub struct IdentifyConfig {
     /// Protocol version string (e.g. `"ipfs/0.1.0"`).
@@ -44,8 +50,6 @@ pub struct IdentifyConfig {
     pub agent_version: String,
     /// Protocols this node supports (e.g. `["/ipfs/ping/1.0.0"]`).
     pub protocols: Vec<String>,
-    /// Addresses this node is listening on (multiaddr-encoded bytes).
-    pub listen_addrs: Vec<Vec<u8>>,
     /// The local node's public key (protobuf-encoded).
     pub public_key: Vec<u8>,
 }
@@ -145,7 +149,9 @@ impl IdentifyProtocol {
     /// inbound stream. `observed_addr` is the transport address we observed
     /// the remote dialing us from; pass `None` if the information is not
     /// available (the resulting identify message simply omits the
-    /// `observedAddr` field).
+    /// `observedAddr` field). `listen_addrs` is our current listening
+    /// set, typically snapshotted from the transport by the swarm
+    /// driver so it stays in sync with what we're actually bound to.
     ///
     /// The returned actions send our identify message and close the write
     /// side.
@@ -154,6 +160,7 @@ impl IdentifyProtocol {
         peer_id: PeerId,
         stream_id: StreamId,
         observed_addr: Option<Multiaddr>,
+        listen_addrs: &[Multiaddr],
     ) -> Result<Vec<IdentifyAction>, IdentifyError> {
         let state = self.peers.entry(peer_id.clone()).or_default();
 
@@ -166,19 +173,12 @@ impl IdentifyProtocol {
         state.outbound_stream = Some(stream_id);
 
         // libp2p's Identify spec prescribes multicodec-based binary
-        // encoding for observed_addr (see
+        // encoding for observed_addr and listen_addrs (see
         // <https://github.com/multiformats/multiaddr>). `to_bytes()`
         // produces the on-wire shape foreign libp2p peers expect.
         let observed_addr_bytes = observed_addr.map(|addr| addr.to_bytes());
-
-        let msg = IdentifyMessage {
-            protocol_version: Some(self.config.protocol_version.clone()),
-            agent_version: Some(self.config.agent_version.clone()),
-            public_key: Some(self.config.public_key.clone()),
-            listen_addrs: self.config.listen_addrs.clone(),
-            observed_addr: observed_addr_bytes,
-            protocols: self.config.protocols.clone(),
-        };
+        let listen_addrs_bytes: Vec<Vec<u8>> =
+            listen_addrs.iter().map(|addr| addr.to_bytes()).collect();
 
         // libp2p Identify is wire-framed as a varint length prefix
         // followed by the protobuf body (see
@@ -187,6 +187,15 @@ impl IdentifyProtocol {
         // first bytes of the protobuf body as a length varint -- which
         // commonly lands on wire type 4 and is rejected as
         // "deprecated group".
+        let msg = IdentifyMessage {
+            protocol_version: Some(self.config.protocol_version.clone()),
+            agent_version: Some(self.config.agent_version.clone()),
+            public_key: Some(self.config.public_key.clone()),
+            listen_addrs: listen_addrs_bytes,
+            observed_addr: observed_addr_bytes,
+            protocols: self.config.protocols.clone(),
+        };
+
         let encoded = msg.encode();
         let data = encode_length_prefixed(&encoded);
 
@@ -400,7 +409,6 @@ mod tests {
             protocol_version: "minip2p/test".into(),
             agent_version: "minip2p-test/0.0.1".into(),
             protocols: vec!["/ipfs/ping/1.0.0".into()],
-            listen_addrs: Vec::new(),
             public_key: vec![1, 2, 3, 4],
         }
     }
@@ -443,8 +451,12 @@ mod tests {
         let peer = sample_peer();
         let stream = StreamId::new(1);
 
+        let listen_addrs = [
+            <Multiaddr as core::str::FromStr>::from_str("/ip4/127.0.0.1/udp/4001/quic-v1")
+                .unwrap(),
+        ];
         let actions = identify
-            .register_outbound_stream(peer.clone(), stream, None)
+            .register_outbound_stream(peer.clone(), stream, None, &listen_addrs)
             .unwrap();
 
         let data = actions
@@ -461,6 +473,13 @@ mod tests {
         let msg = IdentifyMessage::decode(body).expect("body decodes");
         assert_eq!(msg.agent_version.as_deref(), Some("minip2p-test/0.0.1"));
         assert_eq!(msg.protocol_version.as_deref(), Some("minip2p/test"));
+
+        // listen_addrs are encoded as binary multicodec bytes, one per
+        // multiaddr passed in -- the regression we're guarding against.
+        assert_eq!(msg.listen_addrs.len(), 1);
+        let decoded =
+            Multiaddr::from_bytes(&msg.listen_addrs[0]).expect("listen_addr round-trips");
+        assert_eq!(decoded, listen_addrs[0]);
     }
 
     #[test]
@@ -475,7 +494,6 @@ mod tests {
             protocol_version: "other".into(),
             agent_version: "other".into(),
             protocols: Vec::new(),
-            listen_addrs: Vec::new(),
             public_key: Vec::new(),
         });
         let r_peer = sample_peer();
@@ -484,7 +502,7 @@ mod tests {
 
         // Responder emits the framed bytes.
         let actions = responder
-            .register_outbound_stream(i_peer.clone(), stream, None)
+            .register_outbound_stream(i_peer.clone(), stream, None, &[])
             .unwrap();
         let mut framed = Vec::new();
         for action in actions {

--- a/crates/identify/src/lib.rs
+++ b/crates/identify/src/lib.rs
@@ -17,7 +17,7 @@ use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 
-use minip2p_core::{Multiaddr, PeerId};
+use minip2p_core::{read_uvarint, write_uvarint, Multiaddr, PeerId, VarintError};
 use minip2p_transport::StreamId;
 use thiserror::Error;
 
@@ -183,13 +183,21 @@ impl IdentifyProtocol {
             protocols: self.config.protocols.clone(),
         };
 
+        // libp2p Identify is wire-framed as a varint length prefix
+        // followed by the protobuf body (see
+        // <https://github.com/libp2p/specs/blob/master/identify/README.md>).
+        // Omitting the prefix causes remote decoders to interpret the
+        // first bytes of the protobuf body as a length varint -- which
+        // commonly lands on wire type 4 and is rejected as
+        // "deprecated group".
         let encoded = msg.encode();
+        let data = encode_length_prefixed(&encoded);
 
         Ok(vec![
             IdentifyAction::Send {
                 peer_id: peer_id.clone(),
                 stream_id,
-                data: encoded,
+                data,
             },
             IdentifyAction::CloseStreamWrite {
                 peer_id,
@@ -264,7 +272,7 @@ impl IdentifyProtocol {
             return Vec::new();
         };
 
-        match IdentifyMessage::decode(&buf) {
+        match decode_length_prefixed(&buf).and_then(IdentifyMessage::decode) {
             Ok(info) => {
                 self.events.push(IdentifyEvent::Received {
                     peer_id: peer_id.clone(),
@@ -344,5 +352,164 @@ impl IdentifyProtocol {
     /// Drain buffered events.
     pub fn poll_events(&mut self) -> Vec<IdentifyEvent> {
         core::mem::take(&mut self.events)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire framing helpers
+// ---------------------------------------------------------------------------
+
+/// Prepends a varint length prefix to a protobuf-encoded Identify payload.
+///
+/// The libp2p Identify spec requires this framing on the wire; see the
+/// call site in [`IdentifyProtocol::register_outbound_stream`] for why
+/// omitting it breaks interop with third-party libp2p peers.
+fn encode_length_prefixed(payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(10 + payload.len());
+    write_uvarint(payload.len() as u64, &mut out);
+    out.extend_from_slice(payload);
+    out
+}
+
+/// Strips the varint length prefix from a framed Identify buffer and
+/// returns a borrowed slice over the body.
+///
+/// Errors:
+/// - `Varint` if the prefix itself is malformed.
+/// - `FieldOverflow` if the prefix declares a length longer than the
+///   bytes we have (the stream was truncated before the full message
+///   arrived, or the peer lied about the length).
+fn decode_length_prefixed(buf: &[u8]) -> Result<&[u8], message::IdentifyMessageError> {
+    let (len, consumed) = read_uvarint(buf)
+        .map_err(|e: VarintError| message::IdentifyMessageError::from(e))?;
+    let len = len as usize;
+    let remaining = buf.len() - consumed;
+    if len > remaining {
+        return Err(message::IdentifyMessageError::FieldOverflow {
+            offset: consumed,
+            length: len as u64,
+            remaining,
+        });
+    }
+    Ok(&buf[consumed..consumed + len])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_config() -> IdentifyConfig {
+        IdentifyConfig {
+            protocol_version: "minip2p/test".into(),
+            agent_version: "minip2p-test/0.0.1".into(),
+            protocols: vec!["/ipfs/ping/1.0.0".into()],
+            listen_addrs: Vec::new(),
+            public_key: vec![1, 2, 3, 4],
+        }
+    }
+
+    fn sample_peer() -> PeerId {
+        // Deterministic peer id so test output is stable across runs.
+        PeerId::from_public_key_protobuf(b"test-fixture-identify-lib")
+    }
+
+    #[test]
+    fn length_prefix_round_trip() {
+        let body = b"hello identify";
+        let framed = encode_length_prefixed(body);
+        assert_eq!(framed[0] as usize, body.len());
+        let decoded = decode_length_prefixed(&framed).unwrap();
+        assert_eq!(decoded, body);
+    }
+
+    #[test]
+    fn length_prefix_decode_rejects_overshoot() {
+        // Declare a 255-byte body but only ship 3 bytes: should fail.
+        let mut framed = Vec::new();
+        write_uvarint(255, &mut framed);
+        framed.extend_from_slice(&[0xAA, 0xBB, 0xCC]);
+        assert!(matches!(
+            decode_length_prefixed(&framed),
+            Err(message::IdentifyMessageError::FieldOverflow { .. })
+        ));
+    }
+
+    #[test]
+    fn register_outbound_stream_emits_length_prefixed_payload() {
+        // Regression test for the rust-libp2p interop bug: the bytes
+        // handed to the transport MUST begin with a varint whose value
+        // equals the length of the remaining bytes -- otherwise remote
+        // libp2p implementations reject the message as a malformed
+        // protobuf (historically surfacing as "deprecated group" /
+        // "unsupported wire type 4").
+        let mut identify = IdentifyProtocol::new(sample_config());
+        let peer = sample_peer();
+        let stream = StreamId::new(1);
+
+        let actions = identify
+            .register_outbound_stream(peer.clone(), stream, None)
+            .unwrap();
+
+        let data = actions
+            .iter()
+            .find_map(|a| match a {
+                IdentifyAction::Send { data, .. } => Some(data.clone()),
+                _ => None,
+            })
+            .expect("expected a Send action");
+
+        // The frame must decode as `<varint prefix><body>` and the body
+        // must itself be a valid IdentifyMessage.
+        let body = decode_length_prefixed(&data).expect("length-prefixed framing");
+        let msg = IdentifyMessage::decode(body).expect("body decodes");
+        assert_eq!(msg.agent_version.as_deref(), Some("minip2p-test/0.0.1"));
+        assert_eq!(msg.protocol_version.as_deref(), Some("minip2p/test"));
+    }
+
+    #[test]
+    fn on_stream_remote_write_closed_decodes_framed_payload() {
+        // Round-trip via the whole protocol: one side sends its identify
+        // through `register_outbound_stream` and the other side decodes
+        // it via the initiator path (`register_inbound_stream` +
+        // `on_stream_data` + `on_stream_remote_write_closed`). No wire
+        // errors should surface.
+        let mut responder = IdentifyProtocol::new(sample_config());
+        let mut initiator = IdentifyProtocol::new(IdentifyConfig {
+            protocol_version: "other".into(),
+            agent_version: "other".into(),
+            protocols: Vec::new(),
+            listen_addrs: Vec::new(),
+            public_key: Vec::new(),
+        });
+        let r_peer = sample_peer();
+        let i_peer = PeerId::from_public_key_protobuf(b"initiator");
+        let stream = StreamId::new(7);
+
+        // Responder emits the framed bytes.
+        let actions = responder
+            .register_outbound_stream(i_peer.clone(), stream, None)
+            .unwrap();
+        let mut framed = Vec::new();
+        for action in actions {
+            if let IdentifyAction::Send { data, .. } = action {
+                framed.extend_from_slice(&data);
+            }
+        }
+
+        // Initiator receives byte-for-byte and decodes after the remote
+        // half-close.
+        initiator.register_inbound_stream(r_peer.clone(), stream);
+        let _ = initiator.on_stream_data(r_peer.clone(), stream, framed);
+        let _ = initiator.on_stream_remote_write_closed(r_peer.clone(), stream);
+
+        let events = initiator.poll_events();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            IdentifyEvent::Received { peer_id, info } => {
+                assert_eq!(peer_id, &r_peer);
+                assert_eq!(info.agent_version.as_deref(), Some("minip2p-test/0.0.1"));
+            }
+            IdentifyEvent::Error { error, .. } => panic!("unexpected error: {error}"),
+        }
     }
 }

--- a/crates/identify/src/lib.rs
+++ b/crates/identify/src/lib.rs
@@ -13,7 +13,7 @@ extern crate alloc;
 mod message;
 
 use alloc::collections::BTreeMap;
-use alloc::string::{String, ToString};
+use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -165,14 +165,11 @@ impl IdentifyProtocol {
 
         state.outbound_stream = Some(stream_id);
 
-        // Encode the observed multiaddr as its string form bytes. This is
-        // pragmatic rather than spec-pure: the libp2p identify spec calls
-        // for a binary multiaddr encoding, but minip2p does not yet
-        // implement multicodec-based binary serialization (see
-        // `crates/core`). The string form is non-empty and round-trips
-        // between minip2p peers; third-party libp2p peers will see it as
-        // opaque bytes until we add binary encoding to the core crate.
-        let observed_addr_bytes = observed_addr.map(|addr| addr.to_string().into_bytes());
+        // libp2p's Identify spec prescribes multicodec-based binary
+        // encoding for observed_addr (see
+        // <https://github.com/multiformats/multiaddr>). `to_bytes()`
+        // produces the on-wire shape foreign libp2p peers expect.
+        let observed_addr_bytes = observed_addr.map(|addr| addr.to_bytes());
 
         let msg = IdentifyMessage {
             protocol_version: Some(self.config.protocol_version.clone()),

--- a/crates/swarm/README.md
+++ b/crates/swarm/README.md
@@ -65,3 +65,13 @@ The `no_std` build omits the `Swarm<T>` driver and `SwarmBuilder`; only `SwarmCo
 ## Scope
 
 This crate orchestrates the protocol state machines. It does **not** implement the protocols themselves -- see `minip2p-identify`, `minip2p-ping`, `minip2p-multistream-select`, `minip2p-relay`, `minip2p-dcutr`. It does not implement transports either -- see `minip2p-transport` for the contract and `transports/quic` for a concrete adapter.
+
+## DX roadmap
+
+See `dx-plan.md` at the repo root for the tracked DX backlog. A few items that land in the swarm crate specifically:
+
+- **`SwarmEvent::PeerReady { peer_id }`** -- fire after the peer-id migration *and* the first `IdentifyReceived`. Removes the current "wait for Identify before calling `ping()`" gate in user code.
+- **Typed `SwarmEvent::Error`** -- replace the string-only `Error { message }` variant with a structured enum so callers can match on kinds instead of grepping on message contents.
+- **`Swarm::listen(&Multiaddr)` helper** -- one-call listen bring-up that wraps `transport.listen(...)` and returns the resolved bound address.
+
+PRs welcome; see `dx-plan.md` for the full priority list and motivation for each.

--- a/crates/swarm/src/builder.rs
+++ b/crates/swarm/src/builder.rs
@@ -27,11 +27,15 @@ const DEFAULT_AGENT_VERSION: &str = "minip2p/0.1.0";
 ///
 /// Use the setter methods to override. Call [`SwarmBuilder::build`] to
 /// construct the swarm over a caller-provided transport.
+///
+/// Note: Identify's `listen_addrs` is **not** set via the builder --
+/// the swarm snapshots it from the transport's `local_addresses()` on
+/// every `poll()` tick, so the advertised set always reflects what
+/// the peer is actually bound to.
 pub struct SwarmBuilder {
     protocol_version: String,
     agent_version: String,
     protocols: Vec<String>,
-    listen_addrs: Vec<Vec<u8>>,
     public_key: Vec<u8>,
     /// Derived once from the keypair and cached so [`Swarm::local_peer_id`]
     /// is infallible.
@@ -53,7 +57,6 @@ impl SwarmBuilder {
                 IDENTIFY_PROTOCOL_ID.to_string(),
                 PING_PROTOCOL_ID.to_string(),
             ],
-            listen_addrs: Vec::new(),
             public_key: keypair.public_key().encode_protobuf(),
             local_peer_id: keypair.peer_id(),
             ping_config: PingConfig::default(),
@@ -88,12 +91,6 @@ impl SwarmBuilder {
         self
     }
 
-    /// Adds a listen address (multiaddr, binary encoding) advertised to peers.
-    pub fn listen_addr_bytes(mut self, addr: Vec<u8>) -> Self {
-        self.listen_addrs.push(addr);
-        self
-    }
-
     /// Overrides the ping configuration (timeout, etc.).
     pub fn ping_config(mut self, config: PingConfig) -> Self {
         self.ping_config = config;
@@ -107,7 +104,6 @@ impl SwarmBuilder {
             protocol_version: self.protocol_version,
             agent_version: self.agent_version,
             protocols: self.protocols,
-            listen_addrs: self.listen_addrs,
             public_key: self.public_key,
         };
         Swarm::new(transport, identify, self.ping_config, self.local_peer_id)
@@ -122,7 +118,6 @@ impl SwarmBuilder {
             protocol_version: self.protocol_version,
             agent_version: self.agent_version,
             protocols: self.protocols,
-            listen_addrs: self.listen_addrs,
             public_key: self.public_key,
         }
     }

--- a/crates/swarm/src/builder.rs
+++ b/crates/swarm/src/builder.rs
@@ -4,6 +4,7 @@
 //! configuration) so the common case takes a keypair and returns a ready-to-use
 //! swarm.
 
+use minip2p_core::PeerId;
 use minip2p_identify::{IdentifyConfig, IDENTIFY_PROTOCOL_ID};
 use minip2p_identity::Ed25519Keypair;
 use minip2p_ping::{PingConfig, PING_PROTOCOL_ID};
@@ -32,6 +33,9 @@ pub struct SwarmBuilder {
     protocols: Vec<String>,
     listen_addrs: Vec<Vec<u8>>,
     public_key: Vec<u8>,
+    /// Derived once from the keypair and cached so [`Swarm::local_peer_id`]
+    /// is infallible.
+    local_peer_id: PeerId,
     ping_config: PingConfig,
 }
 
@@ -51,6 +55,7 @@ impl SwarmBuilder {
             ],
             listen_addrs: Vec::new(),
             public_key: keypair.public_key().encode_protobuf(),
+            local_peer_id: keypair.peer_id(),
             ping_config: PingConfig::default(),
         }
     }
@@ -105,7 +110,7 @@ impl SwarmBuilder {
             listen_addrs: self.listen_addrs,
             public_key: self.public_key,
         };
-        Swarm::new(transport, identify, self.ping_config)
+        Swarm::new(transport, identify, self.ping_config, self.local_peer_id)
     }
 
     /// Returns the underlying [`IdentifyConfig`] assembled from the builder.

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -115,6 +115,11 @@ pub struct SwarmCore {
     /// Peers with a pending `.ping(peer)` call: once the ping stream
     /// negotiates, the queued 32-byte payload is sent automatically.
     pending_pings: BTreeMap<PeerId, [u8; PING_PAYLOAD_LEN]>,
+    /// Snapshot of the transport's local listening addresses, refreshed
+    /// by the driver at the top of each `poll()` tick. Used to
+    /// auto-populate Identify's `listen_addrs` so advertised addresses
+    /// always reflect what we're actually bound to.
+    local_addresses: Vec<Multiaddr>,
 
     // --- Output queues ---
     events: Vec<SwarmEvent>,
@@ -144,9 +149,20 @@ impl SwarmCore {
             supported_protocols,
             user_protocols: Vec::new(),
             pending_pings: BTreeMap::new(),
+            local_addresses: Vec::new(),
             events: Vec::new(),
             actions: Vec::new(),
         }
+    }
+
+    /// Updates the core's snapshot of the transport's local listening
+    /// addresses.
+    ///
+    /// The std driver calls this at the top of each `poll()` tick; a
+    /// Sans-I/O caller should call it whenever its transport's bound
+    /// set changes (e.g. after `listen()` or `close()` on a listener).
+    pub fn set_local_addresses(&mut self, addrs: Vec<Multiaddr>) {
+        self.local_addresses = addrs;
     }
 
     /// Registers a user protocol id that this swarm will accept on inbound
@@ -1008,10 +1024,15 @@ impl SwarmCore {
             // endpoint for this conn_id, in which case we legitimately
             // can't fill observedAddr and the field is omitted.
             let observed_addr = self.conn_to_remote_addr.get(&conn_id).cloned();
-            match self
-                .identify
-                .register_outbound_stream(peer_id, stream_id, observed_addr)
-            {
+            // Snapshot of the transport's listening addresses at this
+            // moment; the driver keeps `local_addresses` refreshed.
+            let listen_addrs = self.local_addresses.as_slice();
+            match self.identify.register_outbound_stream(
+                peer_id,
+                stream_id,
+                observed_addr,
+                listen_addrs,
+            ) {
                 Ok(actions) => {
                     // Only record ownership on success, so a rejected
                     // registration doesn't leave the stream tracked here

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -222,6 +222,12 @@ impl<T: Transport> Swarm<T> {
     pub fn poll(&mut self) -> Result<Vec<SwarmEvent>, TransportError> {
         let now_ms = self.now_ms();
 
+        // 0. Refresh the core's snapshot of our listening addresses so
+        //    Identify advertises the current bound set. Cheap -- a
+        //    handful of multiaddrs at most.
+        self.core
+            .set_local_addresses(self.transport.local_addresses());
+
         // 1. Feed transport events to the core.
         let events = self.transport.poll()?;
         for event in events {

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -4,7 +4,8 @@
 //! time internally, auto-allocates connection ids, and translates between
 //! the Sans-I/O core's actions and concrete transport calls.
 
-use std::time::Instant;
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
 
 use minip2p_core::{Multiaddr, PeerAddr, PeerId};
 use minip2p_identify::IdentifyConfig;
@@ -13,6 +14,10 @@ use minip2p_transport::{ConnectionId, StreamId, Transport, TransportError};
 
 use crate::core::SwarmCore;
 use crate::events::{SwarmAction, SwarmError, SwarmEvent};
+
+/// Sleep cadence when [`Swarm::poll_next`] idles. Chosen to match the
+/// polling cadence used by existing integration tests.
+const POLL_IDLE_SLEEP: Duration = Duration::from_millis(5);
 
 /// Thin std driver wrapping [`SwarmCore`] and a concrete [`Transport`].
 ///
@@ -29,6 +34,12 @@ pub struct Swarm<T: Transport> {
     /// Our own `PeerId`. Cached from the [`crate::SwarmBuilder`]'s keypair
     /// so applications don't have to drill into the transport to get it.
     local_peer_id: PeerId,
+
+    /// Buffer of events yielded by [`Swarm::poll`] that haven't yet been
+    /// consumed by [`Swarm::poll_next`]. Each `poll()` returns a batch;
+    /// `poll_next` hands them out one at a time and calls `poll()` again
+    /// when the buffer drains.
+    event_buffer: VecDeque<SwarmEvent>,
 
     /// Auto-incrementing connection-id counter for outbound dials.
     next_connection_id: u64,
@@ -53,6 +64,7 @@ impl<T: Transport> Swarm<T> {
             transport,
             core: SwarmCore::new(identify_config, ping_config),
             local_peer_id,
+            event_buffer: VecDeque::new(),
             next_connection_id: 1,
             start: Instant::now(),
         }
@@ -203,6 +215,10 @@ impl<T: Transport> Swarm<T> {
 
     /// Drive the swarm: poll transport, feed events to core, dispatch
     /// actions, return application-visible events. Must be called repeatedly.
+    ///
+    /// Most event-loop code can be simpler to write against
+    /// [`Swarm::poll_next`] or [`Swarm::run_until`], which internally
+    /// call this in a sleep/poll loop and return one event at a time.
     pub fn poll(&mut self) -> Result<Vec<SwarmEvent>, TransportError> {
         let now_ms = self.now_ms();
 
@@ -220,6 +236,66 @@ impl<T: Transport> Swarm<T> {
 
         // 4. Return the application's events.
         Ok(self.core.poll_events())
+    }
+
+    /// Returns the next swarm event, sleeping internally until one arrives
+    /// or `deadline` is reached.
+    ///
+    /// `Ok(Some(ev))` — a fresh event is ready. `Ok(None)` — `deadline`
+    /// passed before any event arrived. `Err(_)` — transport-level error.
+    ///
+    /// Makes single-event CLIs and scripts much easier to write than the
+    /// raw [`Swarm::poll`] loop: no sleep-then-match-all-events
+    /// boilerplate.
+    pub fn poll_next(
+        &mut self,
+        deadline: Instant,
+    ) -> Result<Option<SwarmEvent>, TransportError> {
+        loop {
+            if let Some(ev) = self.event_buffer.pop_front() {
+                return Ok(Some(ev));
+            }
+            // Always poll at least once -- even if we're already past the
+            // deadline -- so a caller using a short or elapsed deadline
+            // still sees any events the transport has already produced.
+            let events = self.poll()?;
+            self.event_buffer.extend(events);
+            if let Some(ev) = self.event_buffer.pop_front() {
+                return Ok(Some(ev));
+            }
+            if Instant::now() >= deadline {
+                return Ok(None);
+            }
+            std::thread::sleep(POLL_IDLE_SLEEP);
+        }
+    }
+
+    /// Polls events in a loop, returning the first one for which
+    /// `predicate` returns `true`, or `Ok(None)` if `deadline` expires
+    /// first.
+    ///
+    /// `predicate` sees every event as it arrives (even the ones that
+    /// don't trigger a return), so it's the natural place to put event
+    /// logging. Events for which `predicate` returns `false` are
+    /// discarded.
+    pub fn run_until<F>(
+        &mut self,
+        deadline: Instant,
+        mut predicate: F,
+    ) -> Result<Option<SwarmEvent>, TransportError>
+    where
+        F: FnMut(&SwarmEvent) -> bool,
+    {
+        loop {
+            match self.poll_next(deadline)? {
+                None => return Ok(None),
+                Some(ev) => {
+                    if predicate(&ev) {
+                        return Ok(Some(ev));
+                    }
+                }
+            }
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -26,6 +26,10 @@ pub struct Swarm<T: Transport> {
     transport: T,
     core: SwarmCore,
 
+    /// Our own `PeerId`. Cached from the [`crate::SwarmBuilder`]'s keypair
+    /// so applications don't have to drill into the transport to get it.
+    local_peer_id: PeerId,
+
     /// Auto-incrementing connection-id counter for outbound dials.
     next_connection_id: u64,
     /// Start of the logical clock. The driver tracks wall time so callers
@@ -37,11 +41,18 @@ impl<T: Transport> Swarm<T> {
     /// Creates a swarm driver around the given transport, identify config,
     /// and ping config.
     ///
-    /// Most callers should construct via `crate::SwarmBuilder` instead.
-    pub fn new(transport: T, identify_config: IdentifyConfig, ping_config: PingConfig) -> Self {
+    /// Most callers should construct via `crate::SwarmBuilder` instead,
+    /// which derives `local_peer_id` from the keypair automatically.
+    pub fn new(
+        transport: T,
+        identify_config: IdentifyConfig,
+        ping_config: PingConfig,
+        local_peer_id: PeerId,
+    ) -> Self {
         Self {
             transport,
             core: SwarmCore::new(identify_config, ping_config),
+            local_peer_id,
             next_connection_id: 1,
             start: Instant::now(),
         }
@@ -60,6 +71,15 @@ impl<T: Transport> Swarm<T> {
     /// Returns a reference to the Sans-I/O core (for advanced introspection).
     pub fn core(&self) -> &SwarmCore {
         &self.core
+    }
+
+    /// Returns this node's own `PeerId`.
+    ///
+    /// Unlike `swarm.transport().local_peer_id()` (transport-specific and
+    /// `Option`-wrapped), this accessor is infallible because the
+    /// [`crate::SwarmBuilder`] requires a keypair at construction time.
+    pub fn local_peer_id(&self) -> &PeerId {
+        &self.local_peer_id
     }
 
     /// Registers a user protocol id for inbound acceptance and outbound opens.

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -15,9 +15,14 @@ use minip2p_transport::{ConnectionId, StreamId, Transport, TransportError};
 use crate::core::SwarmCore;
 use crate::events::{SwarmAction, SwarmError, SwarmEvent};
 
-/// Sleep cadence when [`Swarm::poll_next`] idles. Chosen to match the
-/// polling cadence used by existing integration tests.
-const POLL_IDLE_SLEEP: Duration = Duration::from_millis(5);
+/// Sleep cadence when [`Swarm::poll_next`] idles.
+///
+/// 1ms is short enough that single-digit-millisecond RTTs are
+/// observable on loopback (two wakeups bound RTT, so ~2ms floor)
+/// without noticeably burning CPU on idle. The transport's `poll()` is
+/// a non-blocking `recvfrom` that returns `WouldBlock` immediately
+/// when there's no data, so the hot loop is cheap.
+const POLL_IDLE_SLEEP: Duration = Duration::from_millis(1);
 
 /// Thin std driver wrapping [`SwarmCore`] and a concrete [`Transport`].
 ///

--- a/crates/swarm/tests/relay_holepunch_flow.rs
+++ b/crates/swarm/tests/relay_holepunch_flow.rs
@@ -23,8 +23,9 @@
 //! ```
 
 use std::collections::{HashMap, VecDeque};
+use std::str::FromStr;
 
-use minip2p_core::PeerId;
+use minip2p_core::{Multiaddr, PeerId};
 use minip2p_dcutr::{
     decode_frame as dcutr_decode_frame, DcutrInitiator, DcutrResponder, InitiatorOutcome,
     ResponderEvent,
@@ -340,11 +341,15 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
     let mut b_to_a: VecDeque<u8> = VecDeque::new();
 
     // A advertises its observed addresses; B advertises its own.
-    let a_observed = vec![b"/ip4/203.0.113.1/udp/12345/quic-v1".to_vec()];
-    let b_observed = vec![b"/ip4/198.51.100.2/udp/54321/quic-v1".to_vec()];
+    let a_observed: Vec<Multiaddr> = vec![
+        Multiaddr::from_str("/ip4/203.0.113.1/udp/12345/quic-v1").unwrap(),
+    ];
+    let b_observed: Vec<Multiaddr> = vec![
+        Multiaddr::from_str("/ip4/198.51.100.2/udp/54321/quic-v1").unwrap(),
+    ];
 
-    let mut dcutr_a = DcutrInitiator::new(a_observed.clone());
-    let mut dcutr_b = DcutrResponder::new(b_observed.clone());
+    let mut dcutr_a = DcutrInitiator::new(&a_observed);
+    let mut dcutr_b = DcutrResponder::new(&b_observed);
 
     // A sends CONNECT over the bridge.
     push_bytes(&mut a_to_b, &dcutr_a.take_outbound());
@@ -356,7 +361,8 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
     let events_b = dcutr_b.poll_events();
     assert!(matches!(
         events_b.first(),
-        Some(ResponderEvent::ConnectReceived { remote_addrs }) if *remote_addrs == a_observed
+        Some(ResponderEvent::ConnectReceived { remote_addrs, .. })
+            if *remote_addrs == a_observed
     ));
 
     // B flushes its CONNECT reply toward A.
@@ -371,6 +377,7 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
         Some(InitiatorOutcome::DialNow {
             remote_addrs,
             rtt_ms,
+            ..
         }) => {
             assert_eq!(*remote_addrs, b_observed);
             assert_eq!(*rtt_ms, simulated_rtt_ms);
@@ -429,8 +436,12 @@ fn connect_refused_when_target_not_reserved() {
 
 #[test]
 fn dcutr_rtt_is_reported_back_to_initiator() {
-    let mut a = DcutrInitiator::new(vec![b"/ip4/1.2.3.4/udp/1/quic-v1".to_vec()]);
-    let mut b = DcutrResponder::new(vec![b"/ip4/5.6.7.8/udp/2/quic-v1".to_vec()]);
+    let mut a = DcutrInitiator::new(&[
+        Multiaddr::from_str("/ip4/1.2.3.4/udp/1/quic-v1").unwrap(),
+    ]);
+    let mut b = DcutrResponder::new(&[
+        Multiaddr::from_str("/ip4/5.6.7.8/udp/2/quic-v1").unwrap(),
+    ]);
 
     let connect_from_a = a.take_outbound();
     b.on_data(&connect_from_a).unwrap();

--- a/crates/transport/src/transport.rs
+++ b/crates/transport/src/transport.rs
@@ -101,4 +101,18 @@ pub trait Transport {
     /// Must be called regularly. Never blocks -- returns an empty vec when
     /// there is no work to do.
     fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError>;
+
+    /// Returns the transport multiaddrs this node is currently listening
+    /// on.
+    ///
+    /// The swarm driver snapshots this on each `poll()` tick and uses it
+    /// to auto-populate Identify's `listen_addrs` so remote peers learn
+    /// where they can reach us. Returning an empty vec is valid for
+    /// transports that don't bind (outbound-only) or haven't bound yet.
+    ///
+    /// Default implementation returns empty; adapters that know their
+    /// bound addresses should override.
+    fn local_addresses(&self) -> Vec<Multiaddr> {
+        Vec::new()
+    }
 }

--- a/crates/transport/src/transport.rs
+++ b/crates/transport/src/transport.rs
@@ -119,13 +119,34 @@ pub trait Transport {
     /// Returns the number of active connections the transport is
     /// currently managing (dialed + accepted, pre-`Closed`).
     ///
-    /// Intended for coarse heuristics -- e.g. a listener waiting for
-    /// any new inbound QUIC connection as a signal that hole-punch
-    /// succeeded, without having the remote's verified peer id. Not
-    /// suitable for security decisions.
+    /// Intended for coarse heuristics -- e.g. counting total active
+    /// connections. For address-specific matching use
+    /// [`active_connection_sources`](Transport::active_connection_sources).
     ///
     /// Default implementation returns 0; adapters should override.
     fn active_connection_count(&self) -> usize {
         0
+    }
+
+    /// Returns the remote transport address for every active connection
+    /// (dialed + accepted, pre-`Closed`).
+    ///
+    /// Each multiaddr is the *remote* side of the connection as the
+    /// transport observes it (source address for accepted connections,
+    /// dialed address for outbound connections). Note this does **not**
+    /// include any `/p2p/<peer-id>` suffix -- peer identity lives on
+    /// `ConnectionEndpoint`, not in this address.
+    ///
+    /// Callers that need to correlate incoming connections with a
+    /// specific remote peer (e.g. a hole-punch listener matching an
+    /// inbound QUIC connection against addresses learned from DCUtR)
+    /// should use this in preference to
+    /// [`active_connection_count`](Transport::active_connection_count),
+    /// which is too coarse to distinguish the intended peer from
+    /// unrelated probes.
+    ///
+    /// Default implementation returns empty; adapters should override.
+    fn active_connection_sources(&self) -> Vec<Multiaddr> {
+        Vec::new()
     }
 }

--- a/crates/transport/src/transport.rs
+++ b/crates/transport/src/transport.rs
@@ -115,4 +115,17 @@ pub trait Transport {
     fn local_addresses(&self) -> Vec<Multiaddr> {
         Vec::new()
     }
+
+    /// Returns the number of active connections the transport is
+    /// currently managing (dialed + accepted, pre-`Closed`).
+    ///
+    /// Intended for coarse heuristics -- e.g. a listener waiting for
+    /// any new inbound QUIC connection as a signal that hole-punch
+    /// succeeded, without having the remote's verified peer id. Not
+    /// suitable for security decisions.
+    ///
+    /// Default implementation returns 0; adapters should override.
+    fn active_connection_count(&self) -> usize {
+        0
+    }
 }

--- a/dx-plan.md
+++ b/dx-plan.md
@@ -1,0 +1,366 @@
+# minip2p DX roadmap
+
+Running document of developer-experience (DX) improvements: what's
+landed, what's open, and why. Complements `plan.md` (architecture /
+milestones) and `holepunch-plan.md` (the runnable demo).
+
+The priorities are informed by real pain encountered while writing
+`examples/peer`. Items without a concrete "observed in" note are
+extrapolations from general DX principles.
+
+---
+
+## Landed (PR #5)
+
+These shipped as part of the holepunch-cli / PR #5 work. Most came out
+of writing `examples/peer/src/relay.rs` and spotting friction as it
+happened.
+
+### `Swarm::local_peer_id() -> &PeerId`
+
+**Observed in**: `relay.rs`, `direct.rs`. Every peer needs its own id
+for logging / peer-addr construction.
+
+**Before**: `swarm.transport().local_peer_id().expect("keypair set")` —
+`Option<PeerId>` drilled through a transport accessor, with a lie in
+the type signature when built via `SwarmBuilder` (which requires a
+keypair).
+
+**After**: infallible `&PeerId` cached on the swarm at builder time.
+
+### `Swarm::poll_next(deadline)` and `Swarm::run_until(deadline, pred)`
+
+**Observed in**: the pre-linearization `relay.rs` had 780 LOC of phase
+enum + `match (phase, event)` dispatch + destructure-and-reconstruct.
+After linearization, 540 LOC of linear `wait_connected(...)`,
+`wait_user_stream_data(...)`, etc.
+
+**Before**: `loop { sleep(5ms); for event in swarm.poll()? { match ... } }`
+everywhere.
+
+**After**: `swarm.run_until(deadline, |ev| { print_event(ev); matches!(...) })`.
+Predicate sees every event (natural place for logging), filters and
+stops on its own. Net: -239 LOC in `examples/peer/src`.
+
+### `POLL_IDLE_SLEEP` 5ms → 1ms
+
+**Observed in**: `ping rtt=6ms` on loopback, far above the ~200μs
+actual UDP round-trip.
+
+**Before**: 5ms sleep between polls → two wakeup windows per RTT → ~10ms floor.
+
+**After**: 1ms sleep → RTT floor is 1–2ms on loopback. Transport's
+non-blocking `recvfrom()` is cheap when idle so CPU cost is negligible.
+
+### `Transport::local_addresses() -> Vec<Multiaddr>`
+
+**Observed in**: relay verification showed `listen_addrs: []` in
+rust-libp2p's Identify log. The builder's old `listen_addr_bytes`
+method was impossible to use correctly — the bound address isn't
+known until after the transport is created.
+
+**After**: trait method with default empty; `QuicTransport` overrides
+to return the bound multiaddr. The swarm driver snapshots it on every
+`poll()` tick and auto-populates Identify's `listen_addrs`. Zero caller
+ceremony. `SwarmBuilder.listen_addr_bytes` removed as dead weight.
+
+### `Transport::active_connection_count() -> usize`
+
+**Observed in**: the listener in relay mode couldn't detect hole-punch
+success without mTLS (Milestone 6). Needed a coarse "did a new QUIC
+connection show up?" signal.
+
+**After**: trait method with default 0; `QuicTransport` overrides to
+`self.connections.len()`. Used by `examples/peer/src/relay.rs` as an
+early-exit heuristic that cut listener exit time from 25s to 2s.
+
+### DCUtR `&[Multiaddr]` API + binary multiaddr codec
+
+**Observed in**: rust-libp2p's relay rendered our `observed_addr` and
+`listen_addrs` as empty because we were sending display-string bytes
+instead of the spec-correct multicodec binary encoding.
+
+**After**: `DcutrInitiator::new(&[Multiaddr])` and
+`DcutrResponder::new(&[Multiaddr])`; outcome/event types surface both
+the parsed `Vec<Multiaddr>` and the raw bytes. `Multiaddr::to_bytes()`
+and `Multiaddr::from_bytes()` implement the multicodec binary format in
+`minip2p-core`.
+
+### Identify varint length prefix (interop fix)
+
+**Observed in**: rust-libp2p rejected our Identify with
+`Deprecated("group")`; we rejected theirs with "unsupported wire
+type 4."
+
+**After**: length-prefixed framing per the libp2p Identify spec on
+both encode and decode paths. Four regression tests guard against
+future drift.
+
+---
+
+## Open — Tier 1 (high leverage, small scope)
+
+Most of these are natural follow-ups to what's already in PR #5.
+
+### `SwarmEvent::PeerReady { peer_id }`
+
+**Motivation**: today's DX has a subtle foot-gun — once you see
+`ConnectionEstablished { peer_id }`, the peer id might still be under
+peer-id migration (synthetic → verified via `PeerIdentityVerified`),
+and you don't yet know what protocols the peer supports. The existing
+workaround is "wait for `IdentifyReceived` before calling anything
+protocol-specific":
+
+```rust
+// Today, everywhere we open a user stream:
+swarm.run_until(deadline, |ev| matches!(
+    ev, SwarmEvent::IdentifyReceived { peer_id, .. } if peer_id == &target
+))?;
+swarm.ping(&target)?; // safe now
+```
+
+That's what `examples/peer/src/direct.rs:64-69` does explicitly, and
+what the relay paths implicitly depend on.
+
+**Proposed event**: `SwarmEvent::PeerReady { peer_id, protocols: Vec<String> }`
+— fires **after** both of:
+1. The final (verified) peer id is bound to the connection.
+2. The first `IdentifyReceived` from that peer has been processed.
+
+Semantics: "this peer id is stable and we know what they support."
+
+```rust
+// With PeerReady:
+let ready = swarm.run_until(deadline, |ev|
+    matches!(ev, SwarmEvent::PeerReady { peer_id, .. } if peer_id == &target)
+)?;
+swarm.ping(&target)?;
+```
+
+**Second win**: once Milestone 6 (mTLS) lands, the listener side of
+the hole-punch can fire `PeerReady` for an inbound direct connection
+and exit *exactly* when the dialer's ping completes, eliminating the
+2s grace window in `examples/peer/src/relay.rs`.
+
+**Breaking**: adds a variant to `SwarmEvent` — technically breaking
+for exhaustive matches, but no existing in-repo caller is exhaustive.
+
+**Effort**: ~60 LOC in `SwarmCore` (gate on the peer-id migration +
+first identify event), ~30 LOC of tests. Use site delta in
+`examples/peer` removes ~6 lines of identify-wait boilerplate.
+
+### Typed `SwarmEvent::Error`
+
+**Motivation**: today it's `SwarmEvent::Error { message: String }`.
+`transports/quic/tests/swarm_e2e.rs:213` literally greps for
+`message.contains("ping register error")`, which is a smell.
+
+**Proposed**:
+```rust
+pub enum SwarmEvent {
+    // ...
+    Error(SwarmRuntimeError),
+}
+pub struct SwarmRuntimeError {
+    pub kind: SwarmErrorKind,
+    pub peer_id: Option<PeerId>,
+    pub conn_id: Option<ConnectionId>,
+    pub detail: String,
+}
+pub enum SwarmErrorKind {
+    Transport,
+    Multistream,
+    Identify,
+    Ping,
+    UserProtocol { protocol_id: String },
+    IdentifyStreamRejected,
+    OpenStreamFailed,
+}
+```
+
+**Breaking**: yes, by design. ~15 call sites in `SwarmCore` to migrate.
+
+**Effort**: ~2 hours.
+
+### `Swarm::listen_str(&str)` helper
+
+**Motivation**: `relay.rs` and `direct.rs` both have the three-liner
+
+```rust
+swarm.transport_mut().listen_on_bound_addr()?;
+let our_addr = swarm.transport().local_peer_addr()?;
+println!("[role] bound={our_addr}");
+```
+
+with a QUIC-specific method (`listen_on_bound_addr`) drilled through
+`transport_mut()`. The plan.md principle "fast first success" says
+this should be one call.
+
+**Proposed**:
+```rust
+impl<T: Transport> Swarm<T> {
+    pub fn listen(&mut self, addr: &Multiaddr) -> Result<Multiaddr, SwarmError>;
+}
+impl QuicSwarmExt for Swarm<QuicTransport> {
+    fn listen_on_bound(&mut self) -> Result<PeerAddr, SwarmError>;
+}
+```
+
+Return the resolved multiaddr so the caller can print it without a
+second call.
+
+**Breaking**: no; additive.
+
+**Effort**: ~40 LOC.
+
+---
+
+## Open — Tier 2 (ergonomic papercuts)
+
+### `Ed25519Keypair` persistence (`to_protobuf_bytes` / `from_protobuf_bytes`)
+
+**Motivation**: every `examples/peer` run generates a fresh identity.
+To re-test against the same relay with stable PeerIds you want a
+`--key-file` flag; there's no stable serialization API today.
+
+**Proposed**: add `to_bytes() -> [u8; 64]` and
+`from_bytes(&[u8; 64]) -> Self` on `Ed25519Keypair`; optionally
+`to_pkcs8_pem()` / `from_pkcs8_pem()` behind `std`.
+
+**Effort**: ~40 LOC.
+
+### User-protocol fail-fast on `open_user_stream`
+
+**Motivation**: calling `open_user_stream("/myapp/1.0.0")` on a peer
+that doesn't advertise `/myapp/1.0.0` today silently fails at
+multistream-select time and surfaces as a string-typed `Error`. No
+signal that the remote explicitly doesn't support it.
+
+**Proposed**: if we have the peer's Identify message, check the
+advertised protocols list at `open_user_stream` time and return
+`SwarmError::RemoteDoesNotSupport { protocol_id }` eagerly. Fold in
+nicely with `PeerReady`: if the peer isn't ready yet, defer the check
+until it becomes ready.
+
+**Effort**: ~30 LOC.
+
+### `Swarm::connected_peers()` / `Swarm::peer_info(&PeerId)`
+
+**Motivation**: to answer "who am I connected to?" or "what does
+peer X advertise?" today, the caller has to accumulate events
+themselves.
+
+**Proposed**: accessors backed by the core's existing maps.
+
+**Effort**: ~50 LOC.
+
+### `PeerAddr::quic_v1(IpAddr, u16, PeerId)` constructor
+
+**Motivation**: the most common address shape is
+`/ip4|ip6/<addr>/udp/<port>/quic-v1/p2p/<peer-id>`. Today you build
+it by string-parsing. A typed constructor is 3 lines.
+
+**Effort**: ~20 LOC.
+
+### Clock injection on `Swarm<T>`
+
+**Motivation**: `SwarmCore` is clockless (good) but the `Swarm<T>`
+driver reads `Instant::now()` internally. Time-dependent tests
+(ping timeout) need real sleeps. Low user-value but high test-value.
+
+**Proposed**: `Swarm::with_clock(transport, identify_cfg, ping_cfg,
+keypair, Arc<dyn Clock>)`. Default constructor unchanged.
+
+**Effort**: ~80 LOC including test migration.
+
+---
+
+## Open — Tier 3 (polish, tooling)
+
+### `tracing` feature gate on `minip2p-swarm` and `minip2p-quic`
+
+**Motivation**: `println!("[role] event")` is what the CLI uses. Real
+apps want structured spans. Gate behind a feature so `no_std` core
+stays clean.
+
+**Effort**: ~100 LOC across two crates.
+
+### `justfile` for common workflows
+
+`cargo check --no-default-features -p ...` is a ~9-flag incantation
+today. `just check-nostd` would capture that plus `fmt`, `lint`,
+`test`, `doc`.
+
+**Effort**: trivial.
+
+### Doc-test the READMEs
+
+Adopt `#![doc = include_str!("../README.md")]` on each `lib.rs`.
+Requires examples in READMEs to be actually compilable. Some
+(`ping/README.md`) will need minor rework to become `no_run`.
+
+**Effort**: ~30 min per crate × 8 crates.
+
+### `CHANGELOG.md`
+
+Root-level, Keep-a-Changelog format. Bootstrap from existing commit
+history.
+
+**Effort**: ~1 hour.
+
+---
+
+## Architectural follow-ups (out of scope for DX-only PRs)
+
+### Milestone 6 — mutual TLS on QUIC
+
+Server side uses `verify_peer(false)` today. Direct consequence
+observed in `examples/peer`: the listener can't verify the remote's
+peer id on an inbound hole-punched connection, so we rely on a
+2-second grace timer as a proxy for "remote's ping probably finished."
+
+Proper fix requires either:
+- `quiche`'s `boringssl-boring-crate` feature with a custom verify
+  callback, or
+- An upstream `quiche` change to expose an in-memory cert-verify hook.
+
+Tracked in `plan.md` Milestone 6. Completing it would:
+- Make `SwarmEvent::PeerReady` fire for inbound connections from the
+  listener's perspective (removing the grace-period hack).
+- Let server-side applications know *who* is connecting at handshake
+  time without the synthetic-peer-id dance.
+
+### Binary multiaddr in foreign-peer `observed_addr` round-trip
+
+We send binary multiaddr correctly (verified against rust-libp2p).
+But foreign-peer binary addresses in inbound `observed_addr` fields
+are currently discarded if they don't parse. `examples/peer/src/relay.rs`
+has a defensive `eprintln!` noting dropped entries. If `minip2p-core`
+grew support for more multicodec codes (e.g. `/tcp/`, `/certhash/`,
+`/webrtc-direct/`), fewer entries would be silently dropped.
+
+### Noise + Yamux on the relay bridge
+
+Known non-goal in `holepunch-plan.md`. Needed for interop with
+non-minip2p peers on the far side of the relay bridge. DX impact:
+adds a fourth layer of state machines to compose; cleanest if added
+only after `PeerReady` / typed errors / `Swarm::listen()` are
+in place to keep the composition sane.
+
+---
+
+## Prioritization suggestion for the next DX PR
+
+In order of bang-for-buck given current state:
+
+1. **`PeerReady` event** (removes identify-wait boilerplate in
+   examples; unlocks cleaner hole-punch exit once mTLS lands).
+2. **Typed `SwarmEvent::Error`** (stops the `message.contains(...)`
+   anti-pattern before more callers grow around it).
+3. **`Swarm::listen()` helper** (small but user-visible on the
+   quickstart path).
+4. Keypair persistence (required for any long-running demo / daemon).
+5. User-protocol fail-fast (leans on #1).
+
+Items 1-3 together are estimated at ~1 day of focused work and would
+notably sharpen the "fast first success" story.

--- a/examples/peer/Cargo.toml
+++ b/examples/peer/Cargo.toml
@@ -22,3 +22,4 @@ minip2p-relay = { path = "../../crates/relay" }
 minip2p-dcutr = { path = "../../crates/dcutr" }
 minip2p-multistream-select = { path = "../../crates/multistream-select" }
 minip2p-quic = { path = "../../transports/quic" }
+getrandom = "0.4"

--- a/examples/peer/README.md
+++ b/examples/peer/README.md
@@ -1,0 +1,170 @@
+# minip2p-peer
+
+CLI demo that exercises the full minip2p stack end-to-end.
+
+Two modes:
+
+- **Direct** — two peers on the same host dial each other directly over
+  QUIC and run ping. No relay. Validates the whole base stack
+  (QUIC + multistream-select + identify + ping + swarm) in one command.
+- **Relay** — two NATed peers rendezvous via a Circuit Relay v2 server,
+  coordinate DCUtR, attempt a UDP hole-punch, and fall back to a
+  relay-bridged RTT measurement if direct connection fails.
+
+## Usage
+
+```text
+minip2p-peer listen
+minip2p-peer dial   <peer-addr>
+minip2p-peer listen --relay <relay-peer-addr>
+minip2p-peer dial   --relay <relay-peer-addr> --target <peer-id>
+```
+
+Where:
+
+- `<peer-addr>` is a full libp2p-style address ending in `/p2p/<peer-id>`,
+  e.g. `/ip4/127.0.0.1/udp/4001/quic-v1/p2p/12D3KooW...`
+- `<relay-peer-addr>` is the same format, pointing at the relay server.
+- `<peer-id>` is a bare libp2p PeerId (`12D3KooW...` or `Qm...`).
+
+## Direct mode (5-minute quickstart)
+
+Terminal 1:
+
+```bash
+cargo run -p minip2p-peer -- listen
+# [listen] bound=/ip4/127.0.0.1/udp/53121/quic-v1/p2p/12D3KooW...
+# [listen] waiting for dialers (Ctrl-C to stop)
+```
+
+Terminal 2, with the `bound=` peer-addr from above:
+
+```bash
+cargo run -p minip2p-peer -- dial /ip4/127.0.0.1/udp/53121/quic-v1/p2p/12D3KooW...
+# [dial] dialing .../p2p/12D3KooW...
+# [dial] connected peer=12D3KooW...
+# [dial] identify peer=12D3KooW... agent=minip2p-peer/0.1.0 protocols=2
+# [dial] ping peer=12D3KooW... rtt=6ms
+```
+
+Run the automated direct-mode E2E test:
+
+```bash
+cargo test -p minip2p-peer --test direct
+```
+
+## Relay mode (requires an external relay server)
+
+Relay mode expects a Circuit Relay v2 server listening somewhere
+reachable. The plan of record is to validate against the
+`rust-libp2p` `relay-server-example` on the same host; once that's
+working, swap in a VM-hosted relay.
+
+Start a rust-libp2p relay server (rough steps; verify the exact binary
+name against the `rust-libp2p` repo at time of use):
+
+```bash
+# from a checked-out rust-libp2p tree
+cargo run --example relay-server-example
+# note the peer-addr it prints -- that's <relay-peer-addr>
+```
+
+Peer B (listener, the NATed target):
+
+```bash
+cargo run -p minip2p-peer -- listen --relay <relay-peer-addr>
+# [relay-listen] bound=/ip4/127.0.0.1/udp/52134/quic-v1/p2p/12D3KooW... (A)
+# [relay-listen] us=12D3KooW... (A)
+# [relay-listen] dialing-relay /ip4/.../p2p/12D3KooW... (relay)
+# [relay-listen] connected peer=12D3KooW... (relay)
+# [relay-listen] reserved-on-relay
+# [relay-listen] incoming-circuit via-relay stream=...
+# [relay-listen] stop-connect-from peer=12D3KooW... (B)
+# [relay-listen] dcutr-connect-received addrs=1
+# [relay-listen] dcutr-sync-received -> holepunching
+# [relay-listen] direct-connected peer=12D3KooW... (B) (hole-punch success)
+# [relay-listen] ping-direct peer=12D3KooW... (B) rtt=12ms -- done
+```
+
+Peer A (dialer), run while B is still alive:
+
+```bash
+cargo run -p minip2p-peer -- dial \
+    --relay <relay-peer-addr> \
+    --target <B-peer-id>
+# [relay-dial] bound=...
+# [relay-dial] us=...
+# [relay-dial] target=...
+# [relay-dial] dialing-relay ...
+# [relay-dial] bridge-established via-relay
+# [relay-dial] dcutr-dialnow addrs=1 rtt=N ms
+# [relay-dial] dialing-direct /ip4/.../p2p/12D3KooW... (A)
+# [relay-dial] direct-connected peer=... (hole-punch success)
+# [relay-dial] ping-direct peer=... rtt=Nms -- done
+```
+
+### Fallback output (when hole-punch fails)
+
+If the 10-second hole-punch deadline expires (e.g. symmetric NAT
+between A and B), the dialer switches to a bridged echo:
+
+```
+[relay-dial] hole-punch-timeout -> relay-ping fallback
+[relay-dial] ping-via-relay peer=... rtt=Nms -- done
+```
+
+The listener mirrors with:
+
+```
+[relay-listen] hole-punch-timeout -> relay-ping fallback
+```
+
+and echoes any payload bytes it receives on the bridge so the dialer
+can measure an RTT.
+
+## Output format
+
+Each line is tagged with the role prefix (`[listen]`, `[dial]`,
+`[relay-listen]`, `[relay-dial]`) and an event name, followed by
+space-separated `key=value` fields. Designed to be both human-readable
+and easy to grep/awk from tests.
+
+## Architecture
+
+This binary is deliberately procedural: one long event loop per role,
+with a single `Phase` enum per role that makes the state machine
+visible at a glance.
+
+- `src/main.rs` — dispatch on parsed mode.
+- `src/cli.rs` — hand-rolled argv parser; shared `print_event` helper.
+- `src/direct.rs` — direct-mode listen/dial; zero relay machinery.
+- `src/relay.rs` — relay-mode state machines for both Peer B (listener)
+  and Peer A (dialer), including the DCUtR bridge and hole-punch timer.
+
+See `holepunch-plan.md` at the repo root for the design rationale,
+state-transition diagrams, and open questions (RTT approximation on the
+responder side, relay-ping protocol id, etc).
+
+## Known limitations
+
+- **No interop with third-party libp2p peers over the relay bridge.**
+  The bridge skips Noise + Yamux to keep the demo small; DCUtR frames
+  flow directly over the STOP stream with length-prefixed framing.
+  Two minip2p peers work; a rust-libp2p peer on the other end of the
+  bridge will not.
+
+- **Observed addresses are transmitted as multiaddr display strings,
+  not binary multicodec.** `minip2p-core` does not yet implement the
+  binary encoding; interop with third-party peers that require the
+  binary form is out of scope for this demo.
+
+- **Loopback only.** Both modes bind `127.0.0.1:0` and make no
+  attempt to discover public addresses. A STUN client (or real
+  network deployment) is a future follow-up.
+
+- **No relay server.** This binary implements the client side of HOP
+  and the responder side of STOP; it does not run a relay. Use the
+  `rust-libp2p` `relay-server-example` or equivalent.
+
+- **Fresh identity per run.** Every invocation generates a new Ed25519
+  keypair. A `--key-file` flag is on the DX roadmap.

--- a/examples/peer/README.md
+++ b/examples/peer/README.md
@@ -131,19 +131,20 @@ and easy to grep/awk from tests.
 
 ## Architecture
 
-This binary is deliberately procedural: one long event loop per role,
-with a single `Phase` enum per role that makes the state machine
-visible at a glance.
+This binary is deliberately procedural: each role is a linear script
+built on `Swarm::run_until(deadline, predicate)`, so the sequence of
+steps is visible top-to-bottom.
 
 - `src/main.rs` — dispatch on parsed mode.
 - `src/cli.rs` — hand-rolled argv parser; shared `print_event` helper.
 - `src/direct.rs` — direct-mode listen/dial; zero relay machinery.
-- `src/relay.rs` — relay-mode state machines for both Peer B (listener)
-  and Peer A (dialer), including the DCUtR bridge and hole-punch timer.
+- `src/relay.rs` — relay-mode scripts for both Peer B (listener) and
+  Peer A (dialer), driving the HOP/STOP/DCUtR state machines inline
+  and running the hole-punch + relay-ping fallback at the bottom.
 
-See `holepunch-plan.md` at the repo root for the design rationale,
-state-transition diagrams, and open questions (RTT approximation on the
-responder side, relay-ping protocol id, etc).
+See `holepunch-plan.md` at the repo root for the design rationale and
+open questions (RTT approximation on the responder side, relay-ping
+protocol id, etc).
 
 ## Known limitations
 
@@ -152,11 +153,6 @@ responder side, relay-ping protocol id, etc).
   flow directly over the STOP stream with length-prefixed framing.
   Two minip2p peers work; a rust-libp2p peer on the other end of the
   bridge will not.
-
-- **Observed addresses are transmitted as multiaddr display strings,
-  not binary multicodec.** `minip2p-core` does not yet implement the
-  binary encoding; interop with third-party peers that require the
-  binary form is out of scope for this demo.
 
 - **Loopback only.** Both modes bind `127.0.0.1:0` and make no
   attempt to discover public addresses. A STUN client (or real

--- a/examples/peer/src/direct.rs
+++ b/examples/peer/src/direct.rs
@@ -1,12 +1,10 @@
 //! Direct QUIC peer-to-peer mode (no relay).
 //!
-//! This module proves the basic stack works end-to-end before the relay +
-//! DCUtR flow lands. It's also the target of the automated E2E test --
-//! a CI-safe regression net that spawns two `minip2p-peer` subprocesses
-//! and asserts the ping round-trip completes.
+//! Serves as the baseline smoke test for the stack and as the target of
+//! the CI E2E test at `tests/direct.rs`. The logic is intentionally
+//! linear: bring up the swarm, do the one interesting thing, exit.
 
 use std::error::Error;
-use std::thread;
 use std::time::{Duration, Instant};
 
 use minip2p_core::PeerAddr;
@@ -16,29 +14,14 @@ use minip2p_swarm::{Swarm, SwarmBuilder, SwarmEvent};
 
 use crate::cli::print_event;
 
-/// Poll cadence for the event loop. Matches the existing swarm tests.
-const POLL_INTERVAL: Duration = Duration::from_millis(5);
-
-/// Local bind address used by both listener and dialer. `127.0.0.1:0`
-/// lets the kernel pick an ephemeral port; the listener reports the
-/// chosen address via `local_peer_addr()`.
 const LOCAL_BIND: &str = "127.0.0.1:0";
-
-/// User-agent advertised on Identify so ad-hoc packet captures can tell
-/// minip2p-peer-originated traffic from other libp2p implementations.
 const AGENT: &str = "minip2p-peer/0.1.0";
-
-/// Hard deadline for the dialer. If we can't connect + identify + ping
-/// in this window, something is wrong and the binary exits non-zero.
+/// Far-future deadline for the listener; practically "run forever".
+const LISTEN_FOREVER: Duration = Duration::from_secs(60 * 60 * 24 * 365);
+/// Dialer's hard ceiling: connect, identify, ping -- comfortably fast.
 const DIAL_DEADLINE: Duration = Duration::from_secs(10);
 
-/// Runs the direct-mode listener until interrupted (SIGINT / SIGTERM).
-///
-/// Binds a fresh ephemeral QUIC socket, prints the resulting peer-addr
-/// on stdout (so the E2E test can parse it), and loops forever pumping
-/// the swarm. Inbound pings are echoed automatically by the swarm's
-/// built-in ping responder -- this function only prints lifecycle
-/// events.
+/// Runs the listener until interrupted (SIGINT).
 pub fn run_listen() -> Result<(), Box<dyn Error>> {
     let mut swarm = build_swarm()?;
     swarm
@@ -50,82 +33,63 @@ pub fn run_listen() -> Result<(), Box<dyn Error>> {
         .transport()
         .local_peer_addr()
         .map_err(|e| format!("local_peer_addr failed: {e}"))?;
-    // Stdout is the structured-events channel; stderr is for diagnostics.
+    // Stdout: the machine-readable event stream the E2E test scans.
     println!("[listen] bound={peer_addr}");
     eprintln!("[listen] waiting for dialers (Ctrl-C to stop)");
 
-    loop {
-        thread::sleep(POLL_INTERVAL);
-        let events = swarm
-            .poll()
-            .map_err(|e| format!("swarm poll failed: {e}"))?;
-        for event in events {
-            print_event("listen", &event);
-        }
-    }
+    // Loop until a long deadline; SIGINT tears the process down.
+    let deadline = Instant::now() + LISTEN_FOREVER;
+    while swarm
+        .run_until(deadline, |ev| {
+            print_event("listen", ev);
+            false // never stop on our own -- caller-driven shutdown
+        })
+        .map_err(|e| format!("swarm run_until: {e}"))?
+        .is_some()
+    {}
+    Ok(())
 }
 
-/// Runs the direct-mode dialer against `target`, returning `Ok(())` once
-/// a ping RTT has been measured and printed.
+/// Dials `target`, waits for Identify, pings, prints RTT, exits.
 pub fn run_dial(target: PeerAddr) -> Result<(), Box<dyn Error>> {
     let mut swarm = build_swarm()?;
     let target_peer_id = target.peer_id().clone();
-
     swarm
         .dial(&target)
         .map_err(|e| format!("dial failed: {e}"))?;
     println!("[dial] dialing {target}");
 
     let deadline = Instant::now() + DIAL_DEADLINE;
-    let mut identified = false;
-    let mut ping_issued = false;
 
-    loop {
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "deadline exceeded ({}s) before ping RTT was measured",
-                DIAL_DEADLINE.as_secs()
-            )
-            .into());
-        }
+    // Wait for Identify from the target before pinging -- avoids racing
+    // the synthetic-to-verified peer-id migration.
+    swarm
+        .run_until(deadline, |ev| {
+            print_event("dial", ev);
+            matches!(ev, SwarmEvent::IdentifyReceived { peer_id, .. } if peer_id == &target_peer_id)
+        })
+        .map_err(|e| format!("waiting for identify: {e}"))?
+        .ok_or("deadline exceeded before identify arrived")?;
 
-        thread::sleep(POLL_INTERVAL);
-        let events = swarm
-            .poll()
-            .map_err(|e| format!("swarm poll failed: {e}"))?;
+    swarm
+        .ping(&target_peer_id)
+        .map_err(|e| format!("ping failed: {e}"))?;
 
-        for event in events {
-            print_event("dial", &event);
-            match event {
-                SwarmEvent::IdentifyReceived { peer_id, .. }
-                    if peer_id == target_peer_id =>
-                {
-                    // Gate the ping on Identify so we know the real peer-id
-                    // mapping is in place; firing ping() too early races
-                    // with the synthetic-to-verified peer-id migration.
-                    identified = true;
-                }
-                SwarmEvent::PingRttMeasured { peer_id, .. }
-                    if peer_id == target_peer_id =>
-                {
-                    // Exactly what we came here to do.
-                    return Ok(());
-                }
-                _ => {}
-            }
-        }
+    // Wait for the first RTT measurement, print it via print_event, exit.
+    swarm
+        .run_until(deadline, |ev| {
+            print_event("dial", ev);
+            matches!(ev, SwarmEvent::PingRttMeasured { peer_id, .. } if peer_id == &target_peer_id)
+        })
+        .map_err(|e| format!("waiting for ping rtt: {e}"))?
+        .ok_or("deadline exceeded before ping rtt arrived")?;
 
-        if identified && !ping_issued {
-            swarm
-                .ping(&target_peer_id)
-                .map_err(|e| format!("ping failed: {e}"))?;
-            ping_issued = true;
-        }
-    }
+    Ok(())
 }
 
-/// Constructs a `Swarm<QuicTransport>` bound to an ephemeral loopback UDP
-/// port with a fresh Ed25519 identity and the default Identify/Ping stack.
+/// Builds a `Swarm<QuicTransport>` bound to an ephemeral loopback UDP
+/// port with a fresh Ed25519 identity and the default Identify/Ping
+/// stack.
 fn build_swarm() -> Result<Swarm<QuicTransport>, Box<dyn Error>> {
     let keypair = Ed25519Keypair::generate();
     let transport = QuicTransport::new(QuicNodeConfig::with_keypair(keypair.clone()), LOCAL_BIND)

--- a/examples/peer/src/main.rs
+++ b/examples/peer/src/main.rs
@@ -9,6 +9,7 @@
 
 mod cli;
 mod direct;
+mod relay;
 
 use cli::{CliError, Mode};
 
@@ -35,17 +36,7 @@ fn run(mode: Mode) -> Result<(), Box<dyn std::error::Error>> {
     match mode {
         Mode::DirectListen => direct::run_listen(),
         Mode::DirectDial { target } => direct::run_dial(target),
-        Mode::RelayListen { relay } => not_yet_implemented(&format!(
-            "relay listen via {relay}",
-        )),
-        Mode::RelayDial { relay, target } => not_yet_implemented(&format!(
-            "relay dial via {relay} to peer {target}",
-        )),
+        Mode::RelayListen { relay } => relay::run_listen(relay),
+        Mode::RelayDial { relay, target } => relay::run_dial(relay, target),
     }
-}
-
-fn not_yet_implemented(what: &str) -> Result<(), Box<dyn std::error::Error>> {
-    eprintln!("[peer] mode '{what}' not yet implemented.");
-    eprintln!("       see holepunch-plan.md for the rollout order.");
-    std::process::exit(0);
 }

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -149,47 +149,113 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
     let punch_deadline = punch_start + HOLEPUNCH_DEADLINE;
     let mut next_blast = punch_start + RESPONDER_SYNC_DELAY;
 
-    let punched = loop {
+    let outcome = loop {
         let now = Instant::now();
         if now >= punch_deadline {
-            break None;
+            break HolePunchOutcome::Timeout;
         }
         if now >= next_blast {
             blast_remote_addrs(&swarm, &remote_addrs, role);
             next_blast = now + HOLEPUNCH_INTERVAL;
         }
-        // Small tick window; returns `None` if no event, which is fine.
-        if let Some(ev) =
-            swarm.run_until(now + HOLEPUNCH_INTERVAL, |ev| {
+        // Short tick window. In addition to a direct
+        // ConnectionEstablished for the remote, we also return on the
+        // bridge stream being closed by the relay -- that happens after
+        // the remote successfully goes direct and stops using the
+        // circuit, and without mutual TLS we can't detect the direct
+        // connection ourselves (see holepunch-plan.md Milestone 6).
+        let Some(ev) = swarm
+            .run_until(now + HOLEPUNCH_INTERVAL, |ev| {
                 print_event(role, ev);
-                matches!(
-                    ev,
-                    SwarmEvent::ConnectionEstablished { peer_id }
-                        if peer_id == &remote_peer_id
-                )
-            }).map_err(|e| format!("holepunch poll: {e}"))?
-        {
-            let SwarmEvent::ConnectionEstablished { peer_id } = ev else {
-                unreachable!()
-            };
-            break Some(peer_id);
+                is_direct_connection_event(ev, &remote_peer_id)
+                    || is_bridge_closed_event(ev, bridge_stream)
+            })
+            .map_err(|e| format!("holepunch poll: {e}"))?
+        else {
+            continue;
+        };
+        match ev {
+            SwarmEvent::ConnectionEstablished { peer_id } => {
+                break HolePunchOutcome::DirectConnected(peer_id);
+            }
+            _ => break HolePunchOutcome::BridgeClosed,
         }
     };
 
-    // --- 7. Direct ping or relay-echo fallback ------------------------------
-    if let Some(peer_id) = punched {
-        println!("[{role}] direct-connected peer={peer_id} (hole-punch success)");
-        ping_and_exit(&mut swarm, role, peer_id, deadline)
-    } else {
-        println!("[{role}] hole-punch-timeout -> relay-ping fallback");
-        // Echo any payload that arrives on the bridge so Peer A can
-        // measure an RTT. Exit when the process is killed or the
-        // top-level deadline elapses.
-        loop {
-            let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
-            send(&mut swarm, &relay_peer_id, bridge_stream, data)?;
+    // --- 7. Resolve based on the hole-punch outcome -------------------------
+    match outcome {
+        HolePunchOutcome::DirectConnected(peer_id) => {
+            println!("[{role}] direct-connected peer={peer_id} (hole-punch success)");
+            ping_and_exit(&mut swarm, role, peer_id, deadline)
+        }
+        HolePunchOutcome::BridgeClosed => {
+            // Relay closed the circuit. Most likely the remote went
+            // direct and no longer needs the bridge; we just can't
+            // confirm that independently without mutual TLS on the
+            // QUIC server side. Exit cleanly.
+            println!(
+                "[{role}] bridge-closed (remote likely completed via direct path; \
+                 mTLS gap prevents confirmation) -- done"
+            );
+            Ok(())
+        }
+        HolePunchOutcome::Timeout => {
+            println!("[{role}] hole-punch-timeout -> relay-ping fallback");
+            // Wait for either an echo payload from Peer A or the
+            // bridge to close (meaning A gave up). A short fallback
+            // deadline keeps the listener from hanging indefinitely
+            // if the relay GC'd the circuit while we weren't looking.
+            let fallback_deadline = Instant::now() + Duration::from_secs(5);
+            let ev = swarm
+                .run_until(fallback_deadline, |ev| {
+                    print_event(role, ev);
+                    matches!(
+                        ev,
+                        SwarmEvent::UserStreamData { stream_id: s, .. } if *s == bridge_stream
+                    ) || is_bridge_closed_event(ev, bridge_stream)
+                })
+                .map_err(|e| format!("fallback poll: {e}"))?;
+            match ev {
+                Some(SwarmEvent::UserStreamData { data, .. }) => {
+                    send(&mut swarm, &relay_peer_id, bridge_stream, data)?;
+                    println!("[{role}] relay-ping-echoed -- done");
+                    Ok(())
+                }
+                Some(_) => {
+                    println!("[{role}] bridge-closed during fallback -- done");
+                    Ok(())
+                }
+                None => Err("fallback deadline exceeded before any bridge activity".into()),
+            }
         }
     }
+}
+
+/// Terminal states the listener's hole-punch loop can resolve to.
+enum HolePunchOutcome {
+    /// Saw `ConnectionEstablished` for the remote peer id (only
+    /// possible once mutual TLS is implemented; see Milestone 6).
+    DirectConnected(PeerId),
+    /// Relay closed the bridge stream -- strong signal that the
+    /// remote went direct and stopped using the circuit.
+    BridgeClosed,
+    /// Neither of the above happened within `HOLEPUNCH_DEADLINE`.
+    Timeout,
+}
+
+fn is_direct_connection_event(ev: &SwarmEvent, remote: &PeerId) -> bool {
+    matches!(ev, SwarmEvent::ConnectionEstablished { peer_id } if peer_id == remote)
+}
+
+fn is_bridge_closed_event(ev: &SwarmEvent, bridge_stream: StreamId) -> bool {
+    matches!(
+        ev,
+        SwarmEvent::UserStreamRemoteWriteClosed { stream_id, .. }
+            if *stream_id == bridge_stream
+    ) || matches!(
+        ev,
+        SwarmEvent::UserStreamClosed { stream_id, .. } if *stream_id == bridge_stream
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -1,24 +1,20 @@
 //! Relay-coordinated hole-punch mode.
 //!
-//! This module orchestrates the full Circuit Relay v2 + DCUtR flow
-//! described in `holepunch-plan.md`. It is deliberately procedural:
-//! one long event loop per role with an explicit phase enum so the
-//! state transitions are visible at a glance.
+//! The two public entry points are [`run_listen`] (Peer B) and
+//! [`run_dial`] (Peer A). Each is written as a linear script against
+//! `Swarm::run_until`: dial the relay, run HOP/STOP, run DCUtR, attempt
+//! hole-punch, ping. No phase enums; every step is an obvious function
+//! call.
 //!
-//! The two public entry points are [`run_listen`] (Peer B, reserves on
-//! the relay, accepts an incoming circuit, responds to DCUtR, then
-//! hole-punches) and [`run_dial`] (Peer A, opens a circuit through the
-//! relay, initiates DCUtR, then hole-punches). Shared helpers at the
-//! bottom of the file set up the swarm and parse DCUtR observed
-//! addresses back into multiaddrs.
+//! See `holepunch-plan.md` at the repo root for the full design.
 
 use std::error::Error;
-use std::thread;
 use std::time::{Duration, Instant};
 
 use minip2p_core::{Multiaddr, PeerAddr, PeerId};
 use minip2p_dcutr::{
-    DcutrInitiator, DcutrResponder, InitiatorOutcome, ResponderEvent, DCUTR_PROTOCOL_ID,
+    DcutrInitiator, DcutrResponder, InitiatorOutcome, ResponderEvent,
+    DCUTR_PROTOCOL_ID,
 };
 use minip2p_identity::Ed25519Keypair;
 use minip2p_quic::{QuicNodeConfig, QuicTransport};
@@ -35,981 +31,513 @@ use crate::cli::print_event;
 // Shared configuration
 // ---------------------------------------------------------------------------
 
-/// Poll interval for the event loop (matches the direct-mode module).
-const POLL_INTERVAL: Duration = Duration::from_millis(5);
-/// Local bind address. Loopback matches the plan's "v1 scope" -- the
-/// flow still exercises the full stack against a real relay, just
-/// without escaping the host.
 const LOCAL_BIND: &str = "127.0.0.1:0";
-/// Agent string advertised via Identify.
 const AGENT: &str = "minip2p-peer/0.1.0";
-/// Top-level deadline for the listener role: reservation + a full
-/// circuit + hole-punch should comfortably fit in this window on a
-/// local relay.
+/// Top-level deadline: the whole reservation + circuit + hole-punch
+/// flow should complete well inside this on a local relay.
 const LISTEN_DEADLINE: Duration = Duration::from_secs(60);
-/// Hole-punch deadline after SYNC is received.
+/// Hole-punch window after SYNC is received / sent.
 const HOLEPUNCH_DEADLINE: Duration = Duration::from_secs(10);
-/// Cadence of responder-side UDP bombardment during hole-punch.
+/// UDP blast cadence (responder side) during hole-punch.
 const HOLEPUNCH_INTERVAL: Duration = Duration::from_millis(100);
-/// Initial RTT/2 delay on the responder side before UDP bombardment.
-/// Per the plan, v1 uses a fixed value; a future refinement will
-/// piggy-back measured RTT on the DCUtR exchange.
+/// Approximation of RTT/2 before the responder starts blasting UDP.
 const RESPONDER_SYNC_DELAY: Duration = Duration::from_millis(50);
-/// Payload length used for the relay-ping fallback.
+/// Payload length used by the relay-ping fallback.
 const RELAY_PING_LEN: usize = 32;
 
 // ---------------------------------------------------------------------------
-// Listener (Peer B)
+// Listener (Peer B): reserve, accept STOP, respond DCUtR, hole-punch
 // ---------------------------------------------------------------------------
 
-/// Listener-side phase tracker. The outer event loop drives these
-/// transitions based on swarm events and outcome polls on the
-/// embedded state machines.
-enum ListenerPhase {
-    /// Dialed the relay; waiting for `ConnectionEstablished`.
-    ConnectingToRelay,
-    /// Relay connection established; HOP stream opened and feeding the
-    /// HopReservation state machine.
-    Reserving {
-        hop_stream: StreamId,
-        flow: HopReservation,
-    },
-    /// Reservation accepted; waiting for an incoming STOP stream from
-    /// the relay (meaning some other peer is trying to reach us).
-    WaitingForCircuit,
-    /// STOP stream opened by the relay; feeding its bytes into
-    /// `StopResponder` until it produces a `CONNECT` request, at which
-    /// point we call `accept()` and transition to `DcutrExchange`.
-    StopAccepting {
-        bridge_stream: StreamId,
-        flow: StopResponder,
-    },
-    /// Bridge accepted; same stream now carries DCUtR frames.
-    DcutrExchange {
-        bridge_stream: StreamId,
-        flow: DcutrResponder,
-        /// The source peer id from the STOP CONNECT (Peer A's id).
-        remote_peer_id: PeerId,
-        /// Populated when DCUtR CONNECT arrives.
-        remote_addrs: Vec<Multiaddr>,
-    },
-    /// DCUtR SYNC received; bombarding remote addresses over raw UDP
-    /// until a direct QUIC connection from `remote_peer_id` arrives or
-    /// the deadline expires.
-    HolePunching {
-        bridge_stream: StreamId,
-        remote_peer_id: PeerId,
-        remote_addrs: Vec<Multiaddr>,
-        started_at: Instant,
-        last_blast: Option<Instant>,
-    },
-    /// Hole-punch succeeded; pinging the direct connection.
-    PingingDirect { peer_id: PeerId },
-    /// Hole-punch failed; falling back to the bridge as a relay ping.
-    RelayPingFallback {
-        bridge_stream: StreamId,
-        remote_peer_id: PeerId,
-    },
-}
-
-/// Runs the Peer B role: reserve on the relay, accept an incoming
-/// circuit, coordinate DCUtR, attempt hole-punch, fall back to relay
-/// ping, exit on the first ping RTT measurement.
 pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
+    let role = "relay-listen";
     let mut swarm = build_swarm_with_relay_protocols()?;
-    // Listen on our bound UDP port so an inbound direct QUIC connection
-    // from Peer A (during hole-punch) can be accepted without rebinding.
     swarm
         .transport_mut()
         .listen_on_bound_addr()
         .map_err(|e| format!("listen failed: {e}"))?;
-
     let our_addr = swarm
         .transport()
         .local_peer_addr()
-        .map_err(|e| format!("local_peer_addr failed: {e}"))?;
+        .map_err(|e| format!("local_peer_addr: {e}"))?;
     let our_observed: Vec<Multiaddr> = vec![our_addr.transport().clone()];
-    println!("[relay-listen] bound={our_addr}");
-    println!("[relay-listen] us={}", swarm.local_peer_id());
+    println!("[{role}] bound={our_addr}");
+    println!("[{role}] us={}", swarm.local_peer_id());
 
     let relay_peer_id = relay_addr.peer_id().clone();
     swarm
         .dial(&relay_addr)
-        .map_err(|e| format!("dial relay failed: {e}"))?;
-    println!("[relay-listen] dialing-relay {relay_addr}");
+        .map_err(|e| format!("dial relay: {e}"))?;
+    println!("[{role}] dialing-relay {relay_addr}");
 
-    let mut phase = ListenerPhase::ConnectingToRelay;
     let deadline = Instant::now() + LISTEN_DEADLINE;
 
-    loop {
-        if Instant::now() >= deadline {
+    // --- 1. Relay connection established -----------------------------------
+    wait_connected(&mut swarm, role, &relay_peer_id, deadline)?;
+
+    // --- 2. Reserve a slot on the relay via HOP RESERVE --------------------
+    let hop_stream = swarm
+        .open_user_stream(&relay_peer_id, HOP_PROTOCOL_ID)
+        .map_err(|e| format!("open HOP: {e}"))?;
+    wait_user_stream_ready(&mut swarm, role, hop_stream, deadline)?;
+    let mut reservation = HopReservation::new();
+    send(&mut swarm, &relay_peer_id, hop_stream, reservation.take_outbound())?;
+
+    while reservation.outcome().is_none() {
+        let data = wait_user_stream_data(&mut swarm, role, hop_stream, deadline)?;
+        reservation.on_data(&data).map_err(|e| format!("HOP decode: {e}"))?;
+    }
+    match reservation.outcome() {
+        Some(ReservationOutcome::Accepted { .. }) => {
+            println!("[{role}] reserved-on-relay");
+        }
+        Some(ReservationOutcome::Refused { status, reason }) => {
             return Err(format!(
-                "listener deadline exceeded ({}s) in phase {}",
-                LISTEN_DEADLINE.as_secs(),
-                phase_name(&phase)
+                "relay refused reservation: status={status:?} reason={reason}"
             )
             .into());
         }
-
-        thread::sleep(POLL_INTERVAL);
-        let events = swarm
-            .poll()
-            .map_err(|e| format!("swarm poll failed: {e}"))?;
-
-        for event in events {
-            print_event("relay-listen", &event);
-            phase = handle_listener_event(
-                phase,
-                event,
-                &mut swarm,
-                &relay_peer_id,
-                &our_observed,
-            )?;
-            if matches!(phase, ListenerPhase::PingingDirect { .. }) {
-                // PingingDirect is terminal once PingRttMeasured arrives;
-                // that is handled inside handle_listener_event too.
-            }
-        }
-
-        // Non-event-driven transitions (timers).
-        phase = tick_listener(phase, &mut swarm, &relay_peer_id)?;
+        None => unreachable!(),
     }
-}
 
-/// Dialer-side phase tracker. Mirrors [`ListenerPhase`] but with the
-/// HOP initiator / DCUtR initiator / direct-dial flows.
-enum DialerPhase {
-    /// Dialed the relay; waiting for `ConnectionEstablished`.
-    ConnectingToRelay,
-    /// Relay connection up; HOP CONNECT flow in progress on `hop_stream`.
-    Connecting {
-        hop_stream: StreamId,
-        flow: HopConnect,
-    },
-    /// Relay bridged our HOP CONNECT -> we're running DCUtR over the
-    /// same stream as the initiator.
-    DcutrExchange {
-        bridge_stream: StreamId,
-        flow: DcutrInitiator,
-        /// Time we sent our initial DCUtR CONNECT; subtract from wall
-        /// clock on the CONNECT reply to fill DCUtR's `rtt_ms`.
-        sent_at: Instant,
-    },
-    /// Dialed all of `remote_addrs` directly; waiting for
-    /// `ConnectionEstablished` on `target_peer_id`.
-    HolePunching {
-        bridge_stream: StreamId,
-        target_peer_id: PeerId,
-        remote_addrs: Vec<Multiaddr>,
-        started_at: Instant,
-    },
-    /// Hole-punch succeeded; pinging on the direct connection.
-    PingingDirect { peer_id: PeerId },
-    /// Hole-punch timed out; sent a relay-ping payload over the
-    /// bridge and waiting for the echo to measure RTT.
-    RelayPingFallback {
-        bridge_stream: StreamId,
-        payload: Vec<u8>,
-        sent_at: Instant,
-    },
-}
+    // --- 3. Wait for the relay to push a STOP stream at us ------------------
+    let bridge_stream = wait_inbound_stream(
+        &mut swarm,
+        role,
+        &relay_peer_id,
+        STOP_PROTOCOL_ID,
+        deadline,
+    )?;
+    println!("[{role}] incoming-circuit via-relay stream={bridge_stream}");
 
-/// Runs the Peer A role: dial the relay, open a HOP circuit to
-/// `target`, coordinate DCUtR as the initiator, attempt hole-punch
-/// directly, fall back to a relay-bridged echo RTT measurement,
-/// exit on the first ping RTT.
-pub fn run_dial(relay_addr: PeerAddr, target: PeerId) -> Result<(), Box<dyn Error>> {
-    let mut swarm = build_swarm_with_relay_protocols()?;
-    // Listen on our bound UDP port so we can accept the return half of
-    // the hole-punch (the target dials us back).
-    swarm
-        .transport_mut()
-        .listen_on_bound_addr()
-        .map_err(|e| format!("listen failed: {e}"))?;
-
-    let our_addr = swarm
-        .transport()
-        .local_peer_addr()
-        .map_err(|e| format!("local_peer_addr failed: {e}"))?;
-    let our_observed: Vec<Multiaddr> = vec![our_addr.transport().clone()];
-    println!("[relay-dial] bound={our_addr}");
-    println!("[relay-dial] us={}", swarm.local_peer_id());
-    println!("[relay-dial] target={target}");
-
-    let relay_peer_id = relay_addr.peer_id().clone();
-    swarm
-        .dial(&relay_addr)
-        .map_err(|e| format!("dial relay failed: {e}"))?;
-    println!("[relay-dial] dialing-relay {relay_addr}");
-
-    let mut phase = DialerPhase::ConnectingToRelay;
-    let deadline = Instant::now() + LISTEN_DEADLINE;
-
-    loop {
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "dialer deadline exceeded ({}s) in phase {}",
-                LISTEN_DEADLINE.as_secs(),
-                dialer_phase_name(&phase)
-            )
-            .into());
+    // --- 4. STOP responder: accept the CONNECT, keep any pipelined bytes ---
+    let mut stop = StopResponder::new();
+    let remote_peer_id: PeerId = loop {
+        let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
+        stop.on_data(&data).map_err(|e| format!("STOP decode: {e}"))?;
+        if let Some(request) = stop.request() {
+            break PeerId::from_bytes(&request.source_peer_id)
+                .map_err(|e| format!("bad STOP source peer id: {e}"))?;
         }
+    };
+    println!("[{role}] stop-connect-from peer={remote_peer_id}");
+    stop.accept().map_err(|e| format!("STOP accept: {e}"))?;
+    send(&mut swarm, &relay_peer_id, bridge_stream, stop.take_outbound())?;
+    let bridge_bytes = stop.take_bridge_bytes();
 
-        thread::sleep(POLL_INTERVAL);
-        let events = swarm
-            .poll()
-            .map_err(|e| format!("swarm poll failed: {e}"))?;
-
-        for event in events {
-            print_event("relay-dial", &event);
-            phase = handle_dialer_event(
-                phase,
-                event,
-                &mut swarm,
-                &relay_peer_id,
-                &target,
-                &our_observed,
-            )?;
-        }
-
-        phase = tick_dialer(phase, &mut swarm, &relay_peer_id)?;
+    // --- 5. DCUtR responder over the same bridge stream --------------------
+    let mut dcutr = DcutrResponder::new(&our_observed);
+    if !bridge_bytes.is_empty() {
+        dcutr
+            .on_data(&bridge_bytes)
+            .map_err(|e| format!("DCUtR decode (pipelined): {e}"))?;
     }
-}
+    send(&mut swarm, &relay_peer_id, bridge_stream, dcutr.take_outbound())?;
 
-/// Event-driven state transitions for the dialer role.
-fn handle_dialer_event(
-    phase: DialerPhase,
-    event: SwarmEvent,
-    swarm: &mut Swarm<QuicTransport>,
-    relay_peer_id: &PeerId,
-    target_peer_id: &PeerId,
-    our_observed: &[Multiaddr],
-) -> Result<DialerPhase, Box<dyn Error>> {
-    match (phase, event) {
-        // --- ConnectingToRelay -> Connecting -------------------------------
-        (DialerPhase::ConnectingToRelay, SwarmEvent::ConnectionEstablished { peer_id })
-            if peer_id == *relay_peer_id =>
-        {
-            let hop_stream = swarm
-                .open_user_stream(relay_peer_id, HOP_PROTOCOL_ID)
-                .map_err(|e| format!("open HOP stream failed: {e}"))?;
-            Ok(DialerPhase::Connecting {
-                hop_stream,
-                flow: HopConnect::new(target_peer_id.to_bytes()),
-            })
+    let remote_addrs: Vec<Multiaddr> = loop {
+        if let Some(addrs) = drain_dcutr_responder_events(&mut dcutr, role) {
+            break addrs;
         }
-
-        // --- Connecting: flush HOP CONNECT once the stream is ready --------
-        (
-            DialerPhase::Connecting {
-                hop_stream,
-                mut flow,
-            },
-            SwarmEvent::UserStreamReady {
-                stream_id,
-                initiated_locally: true,
-                ref protocol_id,
-                ..
-            },
-        ) if stream_id == hop_stream && protocol_id == HOP_PROTOCOL_ID => {
-            let outbound = flow.take_outbound();
-            if !outbound.is_empty() {
-                swarm
-                    .send_user_stream(relay_peer_id, hop_stream, outbound)
-                    .map_err(|e| format!("send HOP CONNECT failed: {e}"))?;
-            }
-            Ok(DialerPhase::Connecting { hop_stream, flow })
-        }
-
-        // --- Connecting: relay responds with STATUS ------------------------
-        (
-            DialerPhase::Connecting {
-                hop_stream,
-                mut flow,
-            },
-            SwarmEvent::UserStreamData {
-                stream_id, data, ..
-            },
-        ) if stream_id == hop_stream => {
-            flow.on_data(&data).map_err(|e| format!("HOP decode: {e}"))?;
-            if let Some(outcome) = flow.outcome() {
-                match outcome {
-                    ConnectOutcome::Bridged { .. } => {
-                        println!("[relay-dial] bridge-established via-relay");
-                        // The same stream now carries DCUtR frames.
-                        let bridge_bytes = flow.take_bridge_bytes();
-                        let mut initiator = DcutrInitiator::new(our_observed);
-                        // Queue CONNECT and flush.
-                        let out = initiator.take_outbound();
-                        if !out.is_empty() {
-                            swarm
-                                .send_user_stream(relay_peer_id, hop_stream, out)
-                                .map_err(|e| format!("DCUtR CONNECT send: {e}"))?;
-                        }
-                        let mut phase = DialerPhase::DcutrExchange {
-                            bridge_stream: hop_stream,
-                            flow: initiator,
-                            sent_at: Instant::now(),
-                        };
-                        if !bridge_bytes.is_empty() {
-                            phase = feed_dcutr_dialer_bytes(
-                                phase,
-                                &bridge_bytes,
-                                swarm,
-                                relay_peer_id,
-                                target_peer_id,
-                            )?;
-                        }
-                        return Ok(phase);
-                    }
-                    ConnectOutcome::Refused { status, reason } => {
-                        return Err(format!(
-                            "relay refused CONNECT: status={status:?} reason={reason}"
-                        )
-                        .into());
-                    }
-                }
-            }
-            Ok(DialerPhase::Connecting { hop_stream, flow })
-        }
-
-        // --- DcutrExchange: feed bytes through DcutrInitiator --------------
-        (
-            DialerPhase::DcutrExchange {
-                bridge_stream,
-                flow,
-                sent_at,
-            },
-            SwarmEvent::UserStreamData {
-                stream_id, data, ..
-            },
-        ) if stream_id == bridge_stream => {
-            let phase = DialerPhase::DcutrExchange {
-                bridge_stream,
-                flow,
-                sent_at,
-            };
-            feed_dcutr_dialer_bytes(phase, &data, swarm, relay_peer_id, target_peer_id)
-        }
-
-        // --- HolePunching: did the target dial us back or did we succeed? --
-        (
-            DialerPhase::HolePunching {
-                target_peer_id: target,
-                ..
-            },
-            SwarmEvent::ConnectionEstablished { peer_id },
-        ) if peer_id == target => {
-            println!(
-                "[relay-dial] direct-connected peer={peer_id} (hole-punch success)"
-            );
-            swarm
-                .ping(&peer_id)
-                .map_err(|e| format!("ping on direct conn: {e}"))?;
-            Ok(DialerPhase::PingingDirect { peer_id: target })
-        }
-
-        // --- PingingDirect: exit on RTT -----------------------------------
-        (
-            DialerPhase::PingingDirect { peer_id },
-            SwarmEvent::PingRttMeasured {
-                peer_id: who, rtt_ms,
-            },
-        ) if who == peer_id => {
-            println!(
-                "[relay-dial] ping-direct peer={peer_id} rtt={rtt_ms}ms -- done"
-            );
-            std::process::exit(0);
-        }
-
-        // --- RelayPingFallback: receive echo, compute RTT -----------------
-        (
-            DialerPhase::RelayPingFallback {
-                bridge_stream,
-                payload,
-                sent_at,
-            },
-            SwarmEvent::UserStreamData {
-                stream_id, data, ..
-            },
-        ) if stream_id == bridge_stream => {
-            if data == payload {
-                let rtt_ms = sent_at.elapsed().as_millis();
-                println!(
-                    "[relay-dial] ping-via-relay peer={target_peer_id} rtt={rtt_ms}ms -- done"
-                );
-                std::process::exit(0);
-            }
-            // Not our echo — ignore and keep waiting.
-            Ok(DialerPhase::RelayPingFallback {
-                bridge_stream,
-                payload,
-                sent_at,
-            })
-        }
-
-        // --- Events we don't care about: pass through ----------------------
-        (phase, _) => Ok(phase),
-    }
-}
-
-/// Owned-phase dispatch for the DCUtR stream-data arm, analogous to
-/// [`feed_dcutr_listener_bytes`].
-fn feed_dcutr_dialer_bytes(
-    phase: DialerPhase,
-    bytes: &[u8],
-    swarm: &mut Swarm<QuicTransport>,
-    relay_peer_id: &PeerId,
-    target_peer_id: &PeerId,
-) -> Result<DialerPhase, Box<dyn Error>> {
-    let DialerPhase::DcutrExchange {
-        bridge_stream,
-        mut flow,
-        sent_at,
-    } = phase
-    else {
-        return Ok(phase);
+        let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
+        dcutr.on_data(&data).map_err(|e| format!("DCUtR decode: {e}"))?;
+        send(&mut swarm, &relay_peer_id, bridge_stream, dcutr.take_outbound())?;
     };
 
-    // Measured RTT at the moment the reply bytes arrive. Approximate --
-    // this includes scheduling and socket-read latency in addition to
-    // the relay hop, but it's the best we have without timestamps on
-    // the wire.
-    let rtt_ms = sent_at.elapsed().as_millis() as u64;
+    // --- 6. Hole-punch: blast UDP, wait for direct or timeout --------------
+    println!("[{role}] dcutr-sync-received -> holepunching");
+    let punch_start = Instant::now();
+    let punch_deadline = punch_start + HOLEPUNCH_DEADLINE;
+    let mut next_blast = punch_start + RESPONDER_SYNC_DELAY;
 
-    flow.on_data(bytes, rtt_ms)
-        .map_err(|e| format!("DCUtR decode: {e}"))?;
-
-    if let Some(InitiatorOutcome::DialNow {
-        remote_addrs,
-        remote_addr_bytes,
-        rtt_ms,
-    }) = flow.outcome().cloned()
-    {
-        if remote_addrs.len() < remote_addr_bytes.len() {
-            eprintln!(
-                "[relay-dial] dcutr-reply: {} of {} remote addrs failed to \
-                 parse and were ignored",
-                remote_addr_bytes.len() - remote_addrs.len(),
-                remote_addr_bytes.len()
-            );
+    let punched = loop {
+        let now = Instant::now();
+        if now >= punch_deadline {
+            break None;
         }
-        println!(
-            "[relay-dial] dcutr-dialnow addrs={} rtt={rtt_ms}ms",
-            remote_addrs.len()
-        );
-
-        // Queue SYNC + flush. Per the spec we send SYNC right before
-        // kicking off the simultaneous direct dial.
-        flow.send_sync()
-            .map_err(|e| format!("DCUtR send_sync: {e}"))?;
-        let out = flow.take_outbound();
-        if !out.is_empty() {
-            swarm
-                .send_user_stream(relay_peer_id, bridge_stream, out)
-                .map_err(|e| format!("DCUtR SYNC send: {e}"))?;
+        if now >= next_blast {
+            blast_remote_addrs(&swarm, &remote_addrs, role);
+            next_blast = now + HOLEPUNCH_INTERVAL;
         }
-
-        // Dial each observed remote address. First one to establish wins.
-        for addr in &remote_addrs {
-            let peer_addr = match PeerAddr::new(addr.clone(), target_peer_id.clone()) {
-                Ok(pa) => pa,
-                Err(e) => {
-                    eprintln!(
-                        "[relay-dial] could not form PeerAddr for {addr}: {e}"
-                    );
-                    continue;
-                }
+        // Small tick window; returns `None` if no event, which is fine.
+        if let Some(ev) =
+            swarm.run_until(now + HOLEPUNCH_INTERVAL, |ev| {
+                print_event(role, ev);
+                matches!(
+                    ev,
+                    SwarmEvent::ConnectionEstablished { peer_id }
+                        if peer_id == &remote_peer_id
+                )
+            }).map_err(|e| format!("holepunch poll: {e}"))?
+        {
+            let SwarmEvent::ConnectionEstablished { peer_id } = ev else {
+                unreachable!()
             };
-            match swarm.dial(&peer_addr) {
-                Ok(_) => println!("[relay-dial] dialing-direct {peer_addr}"),
-                Err(e) => eprintln!(
-                    "[relay-dial] direct-dial to {peer_addr} failed: {e}"
-                ),
-            }
+            break Some(peer_id);
         }
+    };
 
-        return Ok(DialerPhase::HolePunching {
-            bridge_stream,
-            target_peer_id: target_peer_id.clone(),
-            remote_addrs,
-            started_at: Instant::now(),
-        });
+    // --- 7. Direct ping or relay-echo fallback ------------------------------
+    if let Some(peer_id) = punched {
+        println!("[{role}] direct-connected peer={peer_id} (hole-punch success)");
+        ping_and_exit(&mut swarm, role, peer_id, deadline)
+    } else {
+        println!("[{role}] hole-punch-timeout -> relay-ping fallback");
+        // Echo any payload that arrives on the bridge so Peer A can
+        // measure an RTT. Exit when the process is killed or the
+        // top-level deadline elapses.
+        loop {
+            let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
+            send(&mut swarm, &relay_peer_id, bridge_stream, data)?;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dialer (Peer A): HOP CONNECT, DCUtR initiator, direct-dial, or fallback
+// ---------------------------------------------------------------------------
+
+pub fn run_dial(relay_addr: PeerAddr, target: PeerId) -> Result<(), Box<dyn Error>> {
+    let role = "relay-dial";
+    let mut swarm = build_swarm_with_relay_protocols()?;
+    swarm
+        .transport_mut()
+        .listen_on_bound_addr()
+        .map_err(|e| format!("listen failed: {e}"))?;
+    let our_addr = swarm
+        .transport()
+        .local_peer_addr()
+        .map_err(|e| format!("local_peer_addr: {e}"))?;
+    let our_observed: Vec<Multiaddr> = vec![our_addr.transport().clone()];
+    println!("[{role}] bound={our_addr}");
+    println!("[{role}] us={}", swarm.local_peer_id());
+    println!("[{role}] target={target}");
+
+    let relay_peer_id = relay_addr.peer_id().clone();
+    swarm
+        .dial(&relay_addr)
+        .map_err(|e| format!("dial relay: {e}"))?;
+    println!("[{role}] dialing-relay {relay_addr}");
+
+    let deadline = Instant::now() + LISTEN_DEADLINE;
+
+    // --- 1. Relay connection established -----------------------------------
+    wait_connected(&mut swarm, role, &relay_peer_id, deadline)?;
+
+    // --- 2. HOP CONNECT to `target` through the relay ----------------------
+    let hop_stream = swarm
+        .open_user_stream(&relay_peer_id, HOP_PROTOCOL_ID)
+        .map_err(|e| format!("open HOP: {e}"))?;
+    wait_user_stream_ready(&mut swarm, role, hop_stream, deadline)?;
+    let mut hop = HopConnect::new(target.to_bytes());
+    send(&mut swarm, &relay_peer_id, hop_stream, hop.take_outbound())?;
+
+    while hop.outcome().is_none() {
+        let data = wait_user_stream_data(&mut swarm, role, hop_stream, deadline)?;
+        hop.on_data(&data).map_err(|e| format!("HOP decode: {e}"))?;
+    }
+    match hop.outcome() {
+        Some(ConnectOutcome::Bridged { .. }) => {
+            println!("[{role}] bridge-established via-relay");
+        }
+        Some(ConnectOutcome::Refused { status, reason }) => {
+            return Err(format!(
+                "relay refused CONNECT: status={status:?} reason={reason}"
+            )
+            .into());
+        }
+        None => unreachable!(),
+    }
+    let bridge_stream = hop_stream; // same stream, now carrying DCUtR bytes
+    let bridge_bytes = hop.take_bridge_bytes();
+
+    // --- 3. DCUtR initiator over the bridge --------------------------------
+    let mut dcutr = DcutrInitiator::new(&our_observed);
+    let dcutr_sent_at = Instant::now();
+    send(&mut swarm, &relay_peer_id, bridge_stream, dcutr.take_outbound())?;
+    if !bridge_bytes.is_empty() {
+        dcutr
+            .on_data(&bridge_bytes, 0)
+            .map_err(|e| format!("DCUtR decode (pipelined): {e}"))?;
     }
 
-    Ok(DialerPhase::DcutrExchange {
-        bridge_stream,
-        flow,
-        sent_at,
+    let (remote_addrs, rtt_ms) = loop {
+        if let Some(outcome) = dcutr.outcome().cloned() {
+            let InitiatorOutcome::DialNow {
+                remote_addrs,
+                remote_addr_bytes,
+                rtt_ms,
+            } = outcome;
+            if remote_addrs.len() < remote_addr_bytes.len() {
+                eprintln!(
+                    "[{role}] dcutr-reply: {} of {} addrs unparsable, ignoring",
+                    remote_addr_bytes.len() - remote_addrs.len(),
+                    remote_addr_bytes.len()
+                );
+            }
+            break (remote_addrs, rtt_ms);
+        }
+        let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
+        let elapsed_ms = dcutr_sent_at.elapsed().as_millis() as u64;
+        dcutr
+            .on_data(&data, elapsed_ms)
+            .map_err(|e| format!("DCUtR decode: {e}"))?;
+    };
+    println!("[{role}] dcutr-dialnow addrs={} rtt={rtt_ms}ms", remote_addrs.len());
+
+    // --- 4. Flush SYNC and dial every observed remote address in parallel --
+    dcutr.send_sync().map_err(|e| format!("DCUtR send_sync: {e}"))?;
+    send(&mut swarm, &relay_peer_id, bridge_stream, dcutr.take_outbound())?;
+
+    for addr in &remote_addrs {
+        match PeerAddr::new(addr.clone(), target.clone()) {
+            Ok(pa) => match swarm.dial(&pa) {
+                Ok(_) => println!("[{role}] dialing-direct {pa}"),
+                Err(e) => eprintln!("[{role}] direct-dial {pa} failed: {e}"),
+            },
+            Err(e) => eprintln!("[{role}] bad PeerAddr for {addr}: {e}"),
+        }
+    }
+
+    // --- 5. Wait for direct connection or hole-punch timeout ---------------
+    let punch_deadline = Instant::now() + HOLEPUNCH_DEADLINE;
+    let punched = swarm
+        .run_until(punch_deadline, |ev| {
+            print_event(role, ev);
+            matches!(
+                ev,
+                SwarmEvent::ConnectionEstablished { peer_id }
+                    if peer_id == &target
+            )
+        })
+        .map_err(|e| format!("holepunch poll: {e}"))?;
+
+    // --- 6. Direct ping or relay-ping fallback -----------------------------
+    if punched.is_some() {
+        println!("[{role}] direct-connected peer={target} (hole-punch success)");
+        ping_and_exit(&mut swarm, role, target, deadline)
+    } else {
+        println!("[{role}] hole-punch-timeout -> relay-ping fallback");
+        let payload = random_bytes(RELAY_PING_LEN);
+        let sent_at = Instant::now();
+        send(&mut swarm, &relay_peer_id, bridge_stream, payload.clone())?;
+        loop {
+            let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
+            if data == payload {
+                let rtt = sent_at.elapsed().as_millis();
+                println!("[{role}] ping-via-relay peer={target} rtt={rtt}ms -- done");
+                return Ok(());
+            }
+            // Not our echo; keep waiting.
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+/// Wait for `ConnectionEstablished` with `peer_id`.
+fn wait_connected(
+    swarm: &mut Swarm<QuicTransport>,
+    role: &str,
+    peer_id: &PeerId,
+    deadline: Instant,
+) -> Result<(), Box<dyn Error>> {
+    let found = swarm
+        .run_until(deadline, |ev| {
+            print_event(role, ev);
+            matches!(ev, SwarmEvent::ConnectionEstablished { peer_id: p } if p == peer_id)
+        })
+        .map_err(|e| format!("wait-connected: {e}"))?;
+    found.map(|_| ()).ok_or_else(|| {
+        format!("deadline exceeded before connection to {peer_id}").into()
     })
 }
 
-/// Time-based transitions for the dialer: hole-punch deadline that
-/// switches over to the relay-ping fallback.
-fn tick_dialer(
-    phase: DialerPhase,
+/// Wait for a locally-initiated `UserStreamReady` on `stream_id`.
+fn wait_user_stream_ready(
     swarm: &mut Swarm<QuicTransport>,
-    relay_peer_id: &PeerId,
-) -> Result<DialerPhase, Box<dyn Error>> {
-    match phase {
-        DialerPhase::HolePunching {
-            bridge_stream,
-            target_peer_id,
-            remote_addrs,
-            started_at,
-        } => {
-            if Instant::now().saturating_duration_since(started_at) >= HOLEPUNCH_DEADLINE {
-                println!(
-                    "[relay-dial] hole-punch-timeout -> relay-ping fallback"
-                );
-                // Send a random 32-byte payload; the listener echoes it
-                // on the bridge stream. The dialer's event handler will
-                // match the echo and compute the RTT.
-                let payload = random_bytes(RELAY_PING_LEN);
-                if let Err(e) = swarm.send_user_stream(
-                    relay_peer_id,
-                    bridge_stream,
-                    payload.clone(),
-                ) {
-                    return Err(format!("relay-ping send: {e}").into());
-                }
-                let _ = (remote_addrs, target_peer_id);
-                return Ok(DialerPhase::RelayPingFallback {
-                    bridge_stream,
-                    payload,
-                    sent_at: Instant::now(),
-                });
-            }
-            Ok(DialerPhase::HolePunching {
-                bridge_stream,
-                target_peer_id,
-                remote_addrs,
-                started_at,
-            })
-        }
-        other => {
-            let _ = (swarm, relay_peer_id);
-            Ok(other)
-        }
-    }
+    role: &str,
+    stream_id: StreamId,
+    deadline: Instant,
+) -> Result<(), Box<dyn Error>> {
+    let found = swarm
+        .run_until(deadline, |ev| {
+            print_event(role, ev);
+            matches!(
+                ev,
+                SwarmEvent::UserStreamReady {
+                    stream_id: s,
+                    initiated_locally: true,
+                    ..
+                } if *s == stream_id
+            )
+        })
+        .map_err(|e| format!("wait-user-stream-ready: {e}"))?;
+    found
+        .map(|_| ())
+        .ok_or_else(|| format!("deadline exceeded before stream {stream_id} ready").into())
 }
 
-/// Human-readable phase name for dialer error messages.
-fn dialer_phase_name(phase: &DialerPhase) -> &'static str {
-    match phase {
-        DialerPhase::ConnectingToRelay => "ConnectingToRelay",
-        DialerPhase::Connecting { .. } => "Connecting",
-        DialerPhase::DcutrExchange { .. } => "DcutrExchange",
-        DialerPhase::HolePunching { .. } => "HolePunching",
-        DialerPhase::PingingDirect { .. } => "PingingDirect",
-        DialerPhase::RelayPingFallback { .. } => "RelayPingFallback",
-    }
-}
-
-/// Reacts to a single [`SwarmEvent`] and returns the updated phase.
-///
-/// Each arm is annotated with the corresponding step in the listener
-/// state machine described at the top of this module.
-fn handle_listener_event(
-    phase: ListenerPhase,
-    event: SwarmEvent,
+/// Wait for an inbound (remotely-initiated) user stream for `protocol_id`
+/// from `peer_id`. Returns the allocated stream id.
+fn wait_inbound_stream(
     swarm: &mut Swarm<QuicTransport>,
-    relay_peer_id: &PeerId,
-    our_observed: &[Multiaddr],
-) -> Result<ListenerPhase, Box<dyn Error>> {
-    match (phase, event) {
-        // --- ConnectingToRelay -> Reserving ---------------------------------
-        (ListenerPhase::ConnectingToRelay, SwarmEvent::ConnectionEstablished { peer_id })
-            if peer_id == *relay_peer_id =>
-        {
-            // Open a HOP stream to the relay and start RESERVE.
-            let hop_stream = swarm
-                .open_user_stream(relay_peer_id, HOP_PROTOCOL_ID)
-                .map_err(|e| format!("open HOP stream failed: {e}"))?;
-            Ok(ListenerPhase::Reserving {
-                hop_stream,
-                flow: HopReservation::new(),
-            })
-        }
-
-        // --- Reserving: flush RESERVE once the HOP stream is ready -----------
-        (
-            ListenerPhase::Reserving {
-                hop_stream,
-                mut flow,
-            },
-            SwarmEvent::UserStreamReady {
-                stream_id,
-                initiated_locally: true,
-                ref protocol_id,
-                ..
-            },
-        ) if stream_id == hop_stream && protocol_id == HOP_PROTOCOL_ID => {
-            let outbound = flow.take_outbound();
-            if !outbound.is_empty() {
-                swarm
-                    .send_user_stream(relay_peer_id, hop_stream, outbound)
-                    .map_err(|e| format!("send HOP RESERVE failed: {e}"))?;
-            }
-            Ok(ListenerPhase::Reserving { hop_stream, flow })
-        }
-
-        // --- Reserving: STATUS response body ---------------------------------
-        (
-            ListenerPhase::Reserving {
-                hop_stream,
-                mut flow,
-            },
-            SwarmEvent::UserStreamData {
-                stream_id, data, ..
-            },
-        ) if stream_id == hop_stream => {
-            flow.on_data(&data).map_err(|e| format!("HOP decode: {e}"))?;
-            if let Some(outcome) = flow.outcome() {
-                match outcome {
-                    ReservationOutcome::Accepted { .. } => {
-                        println!("[relay-listen] reserved-on-relay");
-                        return Ok(ListenerPhase::WaitingForCircuit);
-                    }
-                    ReservationOutcome::Refused { status, reason } => {
-                        return Err(format!(
-                            "relay refused reservation: status={status:?} reason={reason}"
-                        )
-                        .into());
-                    }
-                }
-            }
-            Ok(ListenerPhase::Reserving { hop_stream, flow })
-        }
-
-        // --- WaitingForCircuit -> StopAccepting -----------------------------
-        (
-            ListenerPhase::WaitingForCircuit,
-            SwarmEvent::UserStreamReady {
-                stream_id,
-                initiated_locally: false,
-                peer_id,
-                ref protocol_id,
-            },
-        ) if peer_id == *relay_peer_id && protocol_id == STOP_PROTOCOL_ID => {
-            println!(
-                "[relay-listen] incoming-circuit via-relay stream={stream_id}"
-            );
-            Ok(ListenerPhase::StopAccepting {
-                bridge_stream: stream_id,
-                flow: StopResponder::new(),
-            })
-        }
-
-        // --- StopAccepting: drive the StopResponder -------------------------
-        (
-            ListenerPhase::StopAccepting {
-                bridge_stream,
-                mut flow,
-            },
-            SwarmEvent::UserStreamData {
-                stream_id, data, ..
-            },
-        ) if stream_id == bridge_stream => {
-            flow.on_data(&data).map_err(|e| format!("STOP decode: {e}"))?;
-            if let Some(request) = flow.request().cloned() {
-                let remote_peer_id = PeerId::from_bytes(&request.source_peer_id)
-                    .map_err(|e| format!("bad STOP source peer id: {e}"))?;
-                println!(
-                    "[relay-listen] stop-connect-from peer={remote_peer_id}"
-                );
-                flow.accept().map_err(|e| format!("STOP accept: {e}"))?;
-                let outbound = flow.take_outbound();
-                if !outbound.is_empty() {
-                    swarm
-                        .send_user_stream(relay_peer_id, bridge_stream, outbound)
-                        .map_err(|e| format!("STOP STATUS:OK send: {e}"))?;
-                }
-                // Any bytes pipelined behind STOP STATUS:OK belong to DCUtR.
-                let bridge_bytes = flow.take_bridge_bytes();
-                let dcutr = DcutrResponder::new(our_observed);
-                let mut phase = ListenerPhase::DcutrExchange {
-                    bridge_stream,
-                    flow: dcutr,
-                    remote_peer_id,
-                    remote_addrs: Vec::new(),
-                };
-                if !bridge_bytes.is_empty() {
-                    phase = feed_dcutr_listener_bytes(
-                        phase,
-                        &bridge_bytes,
-                        swarm,
-                        relay_peer_id,
-                    )?;
-                }
-                return Ok(phase);
-            }
-            Ok(ListenerPhase::StopAccepting {
-                bridge_stream,
-                flow,
-            })
-        }
-
-        // --- DcutrExchange: feed bytes through DcutrResponder ---------------
-        (
-            ListenerPhase::DcutrExchange {
-                bridge_stream,
-                flow,
-                remote_peer_id,
-                remote_addrs,
-            },
-            SwarmEvent::UserStreamData {
-                stream_id, data, ..
-            },
-        ) if stream_id == bridge_stream => {
-            let phase = ListenerPhase::DcutrExchange {
-                bridge_stream,
-                flow,
-                remote_peer_id,
-                remote_addrs,
-            };
-            feed_dcutr_listener_bytes(phase, &data, swarm, relay_peer_id)
-        }
-
-        // --- HolePunching: did we get a direct connection? ------------------
-        (
-            ListenerPhase::HolePunching {
-                remote_peer_id,
-                bridge_stream,
-                ..
-            },
-            SwarmEvent::ConnectionEstablished { peer_id },
-        ) if peer_id == remote_peer_id => {
-            println!(
-                "[relay-listen] direct-connected peer={peer_id} (hole-punch success)"
-            );
-            swarm
-                .ping(&peer_id)
-                .map_err(|e| format!("ping on direct conn: {e}"))?;
-            let _ = bridge_stream;
-            Ok(ListenerPhase::PingingDirect {
-                peer_id: remote_peer_id,
-            })
-        }
-
-        // --- PingingDirect: exit on RTT -------------------------------------
-        (
-            ListenerPhase::PingingDirect { peer_id },
-            SwarmEvent::PingRttMeasured {
-                peer_id: who, rtt_ms,
-            },
-        ) if who == peer_id => {
-            println!(
-                "[relay-listen] ping-direct peer={peer_id} rtt={rtt_ms}ms -- done"
-            );
-            std::process::exit(0);
-        }
-
-        // --- RelayPingFallback: echo bytes over the bridge ------------------
-        (
-            ListenerPhase::RelayPingFallback {
-                bridge_stream,
-                remote_peer_id,
-            },
-            SwarmEvent::UserStreamData {
-                stream_id, data, ..
-            },
-        ) if stream_id == bridge_stream => {
-            // Echo the payload so Peer A measures an RTT.
-            swarm
-                .send_user_stream(relay_peer_id, bridge_stream, data)
-                .map_err(|e| format!("relay-ping echo: {e}"))?;
-            Ok(ListenerPhase::RelayPingFallback {
-                bridge_stream,
-                remote_peer_id,
-            })
-        }
-
-        // --- Events we don't care about: pass through ------------------------
-        (phase, _) => Ok(phase),
-    }
-}
-
-/// Owned-phase dispatch for DCUtR stream data: the tuple match in
-/// `handle_listener_event` can't move the phase in, so the `UserStreamData`
-/// arm for the DCUtR phase is handled here via a secondary match in the
-/// main event loop caller.
-fn feed_dcutr_listener_bytes(
-    phase: ListenerPhase,
-    bytes: &[u8],
-    swarm: &mut Swarm<QuicTransport>,
-    relay_peer_id: &PeerId,
-) -> Result<ListenerPhase, Box<dyn Error>> {
-    let ListenerPhase::DcutrExchange {
-        bridge_stream,
-        mut flow,
-        remote_peer_id,
-        mut remote_addrs,
-    } = phase
-    else {
-        return Ok(phase);
+    role: &str,
+    peer_id: &PeerId,
+    protocol_id: &str,
+    deadline: Instant,
+) -> Result<StreamId, Box<dyn Error>> {
+    let ev = swarm
+        .run_until(deadline, |ev| {
+            print_event(role, ev);
+            matches!(
+                ev,
+                SwarmEvent::UserStreamReady {
+                    peer_id: p,
+                    initiated_locally: false,
+                    protocol_id: pid,
+                    ..
+                } if p == peer_id && pid == protocol_id
+            )
+        })
+        .map_err(|e| format!("wait-inbound-stream: {e}"))?
+        .ok_or_else(|| format!("deadline exceeded before inbound {protocol_id}"))?;
+    let SwarmEvent::UserStreamReady { stream_id, .. } = ev else {
+        unreachable!()
     };
+    Ok(stream_id)
+}
 
-    flow.on_data(bytes)
-        .map_err(|e| format!("DCUtR decode: {e}"))?;
-    let out = flow.take_outbound();
-    if !out.is_empty() {
-        swarm
-            .send_user_stream(relay_peer_id, bridge_stream, out)
-            .map_err(|e| format!("DCUtR send: {e}"))?;
-    }
+/// Wait for the next `UserStreamData` event on `stream_id`, returning
+/// the data payload.
+fn wait_user_stream_data(
+    swarm: &mut Swarm<QuicTransport>,
+    role: &str,
+    stream_id: StreamId,
+    deadline: Instant,
+) -> Result<Vec<u8>, Box<dyn Error>> {
+    let ev = swarm
+        .run_until(deadline, |ev| {
+            print_event(role, ev);
+            matches!(
+                ev,
+                SwarmEvent::UserStreamData { stream_id: s, .. } if *s == stream_id
+            )
+        })
+        .map_err(|e| format!("wait-user-stream-data: {e}"))?
+        .ok_or_else(|| format!("deadline exceeded before data on stream {stream_id}"))?;
+    let SwarmEvent::UserStreamData { data, .. } = ev else {
+        unreachable!()
+    };
+    Ok(data)
+}
 
-    let mut saw_sync = false;
-    for event in flow.poll_events() {
-        match event {
+/// Drains any pending DCUtR responder events. Returns `Some(remote_addrs)`
+/// once `SyncReceived` has fired, `None` otherwise.
+fn drain_dcutr_responder_events(
+    dcutr: &mut DcutrResponder,
+    role: &str,
+) -> Option<Vec<Multiaddr>> {
+    let mut captured: Option<Vec<Multiaddr>> = None;
+    let mut sync = false;
+    for ev in dcutr.poll_events() {
+        match ev {
             ResponderEvent::ConnectReceived {
-                remote_addrs: parsed,
+                remote_addrs,
                 remote_addr_bytes,
             } => {
-                if parsed.len() < remote_addr_bytes.len() {
+                if remote_addrs.len() < remote_addr_bytes.len() {
                     eprintln!(
-                        "[relay-listen] dcutr-connect-received: {} of {} remote \
-                         addrs failed to parse and were ignored",
-                        remote_addr_bytes.len() - parsed.len(),
+                        "[{role}] dcutr-connect-received: {} of {} remote addrs \
+                         failed to parse and were ignored",
+                        remote_addr_bytes.len() - remote_addrs.len(),
                         remote_addr_bytes.len()
                     );
                 }
-                remote_addrs = parsed;
                 println!(
-                    "[relay-listen] dcutr-connect-received addrs={}",
+                    "[{role}] dcutr-connect-received addrs={}",
                     remote_addrs.len()
                 );
+                captured = Some(remote_addrs);
             }
-            ResponderEvent::SyncReceived => {
-                println!("[relay-listen] dcutr-sync-received -> holepunching");
-                saw_sync = true;
-            }
+            ResponderEvent::SyncReceived => sync = true,
         }
     }
-
-    if saw_sync {
-        Ok(ListenerPhase::HolePunching {
-            bridge_stream,
-            remote_peer_id,
-            remote_addrs,
-            started_at: Instant::now(),
-            last_blast: None,
-        })
+    if sync {
+        captured.or_else(|| Some(Vec::new()))
     } else {
-        Ok(ListenerPhase::DcutrExchange {
-            bridge_stream,
-            flow,
-            remote_peer_id,
-            remote_addrs,
-        })
+        None
     }
 }
 
-/// Handles time-based transitions in the listener: DCUtR bridge data
-/// routing and hole-punch UDP bombardment.
-fn tick_listener(
-    phase: ListenerPhase,
+/// Send `data` on `stream_id` if non-empty; no-op otherwise.
+fn send(
     swarm: &mut Swarm<QuicTransport>,
-    relay_peer_id: &PeerId,
-) -> Result<ListenerPhase, Box<dyn Error>> {
-    match phase {
-        ListenerPhase::HolePunching {
-            bridge_stream,
-            remote_peer_id,
-            remote_addrs,
-            started_at,
-            mut last_blast,
-        } => {
-            let now = Instant::now();
-            let elapsed = now.saturating_duration_since(started_at);
-
-            if elapsed >= HOLEPUNCH_DEADLINE {
-                println!(
-                    "[relay-listen] hole-punch-timeout -> relay-ping fallback"
-                );
-                return Ok(ListenerPhase::RelayPingFallback {
-                    bridge_stream,
-                    remote_peer_id,
-                });
-            }
-
-            // Per the plan, responder waits RESPONDER_SYNC_DELAY before
-            // starting to blast UDP; then sends at HOLEPUNCH_INTERVAL.
-            let should_blast = match last_blast {
-                None => elapsed >= RESPONDER_SYNC_DELAY,
-                Some(t) => now.duration_since(t) >= HOLEPUNCH_INTERVAL,
-            };
-
-            if should_blast {
-                blast_remote_addrs(swarm, &remote_addrs);
-                last_blast = Some(now);
-            }
-
-            Ok(ListenerPhase::HolePunching {
-                bridge_stream,
-                remote_peer_id,
-                remote_addrs,
-                started_at,
-                last_blast,
-            })
-        }
-        other => {
-            let _ = (swarm, relay_peer_id);
-            Ok(other)
-        }
+    peer_id: &PeerId,
+    stream_id: StreamId,
+    data: Vec<u8>,
+) -> Result<(), Box<dyn Error>> {
+    if data.is_empty() {
+        return Ok(());
     }
+    swarm
+        .send_user_stream(peer_id, stream_id, data)
+        .map_err(|e| format!("send_user_stream: {e}").into())
 }
 
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
+/// Ping `peer_id` and wait for the RTT. Prints the result and returns.
+fn ping_and_exit(
+    swarm: &mut Swarm<QuicTransport>,
+    role: &str,
+    peer_id: PeerId,
+    deadline: Instant,
+) -> Result<(), Box<dyn Error>> {
+    swarm.ping(&peer_id).map_err(|e| format!("ping: {e}"))?;
+    let ev = swarm
+        .run_until(deadline, |ev| {
+            print_event(role, ev);
+            matches!(ev, SwarmEvent::PingRttMeasured { peer_id: p, .. } if p == &peer_id)
+        })
+        .map_err(|e| format!("wait-rtt: {e}"))?
+        .ok_or("deadline exceeded before ping rtt arrived")?;
+    let SwarmEvent::PingRttMeasured { rtt_ms, .. } = ev else {
+        unreachable!()
+    };
+    println!("[{role}] ping-direct peer={peer_id} rtt={rtt_ms}ms -- done");
+    Ok(())
+}
 
 /// Builds a swarm with the relay + DCUtR user protocols registered.
 fn build_swarm_with_relay_protocols() -> Result<Swarm<QuicTransport>, Box<dyn Error>> {
     let keypair = Ed25519Keypair::generate();
     let transport = QuicTransport::new(QuicNodeConfig::with_keypair(keypair.clone()), LOCAL_BIND)
-        .map_err(|e| format!("quic bind failed: {e}"))?;
+        .map_err(|e| format!("quic bind: {e}"))?;
     let mut swarm = SwarmBuilder::new(&keypair).agent_version(AGENT).build(transport);
-    // Advertise + accept the three user protocols the flow needs.
     swarm.add_user_protocol(HOP_PROTOCOL_ID);
     swarm.add_user_protocol(STOP_PROTOCOL_ID);
     swarm.add_user_protocol(DCUTR_PROTOCOL_ID);
     Ok(swarm)
 }
 
-/// Sends a random 32-byte UDP payload to every remote address. Per
-/// the DCUtR spec these packets serve to open the NAT binding so that
-/// inbound QUIC packets from the remote peer can arrive; their
-/// content is irrelevant.
-fn blast_remote_addrs(swarm: &Swarm<QuicTransport>, addrs: &[Multiaddr]) {
+/// Sends a random 32-byte UDP payload to every remote address. These
+/// packets open the NAT binding so the remote's QUIC packets can reach
+/// us; the content is irrelevant per the DCUtR spec.
+fn blast_remote_addrs(swarm: &Swarm<QuicTransport>, addrs: &[Multiaddr], role: &str) {
     let payload = random_bytes(RELAY_PING_LEN);
     for addr in addrs {
         if let Err(e) = swarm.transport().send_raw_udp(addr, &payload) {
-            eprintln!("[relay-listen] udp-blast to {addr} failed: {e}");
+            eprintln!("[{role}] udp-blast {addr} failed: {e}");
         }
     }
 }
 
-/// Short random byte vector. `getrandom` avoids pulling in `rand`.
+/// Short random byte vector. Best-effort: falls back to zeros rather
+/// than panicking since the content doesn't affect hole-punch semantics.
 fn random_bytes(len: usize) -> Vec<u8> {
     let mut buf = vec![0u8; len];
-    // Best-effort randomness; if the OS RNG fails we fall back to
-    // deterministic zeros rather than panicking, since the payload
-    // content doesn't affect hole-punch semantics.
     let _ = getrandom::fill(&mut buf);
     buf
 }
 
-/// Human-readable phase name for error messages.
-fn phase_name(phase: &ListenerPhase) -> &'static str {
-    match phase {
-        ListenerPhase::ConnectingToRelay => "ConnectingToRelay",
-        ListenerPhase::Reserving { .. } => "Reserving",
-        ListenerPhase::WaitingForCircuit => "WaitingForCircuit",
-        ListenerPhase::StopAccepting { .. } => "StopAccepting",
-        ListenerPhase::DcutrExchange { .. } => "DcutrExchange",
-        ListenerPhase::HolePunching { .. } => "HolePunching",
-        ListenerPhase::PingingDirect { .. } => "PingingDirect",
-        ListenerPhase::RelayPingFallback { .. } => "RelayPingFallback",
-    }
-}
+

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -83,18 +83,6 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
     // --- 1. Relay connection established -----------------------------------
     wait_connected(&mut swarm, role, &relay_peer_id, deadline)?;
 
-    // Capture the active connection count now, before DCUtR starts.
-    // This is the hole-punch-success baseline: any connection beyond
-    // this must be the remote peer coming in direct (or a relay
-    // probe-back, which rust-libp2p may do to verify our listen_addrs
-    // -- benign false positive, the session still completes cleanly).
-    //
-    // We MUST capture before B's DCUtR CONNECT reply goes out, because
-    // on a local loopback, the remote's direct Initial can arrive at
-    // our socket a few hundred microseconds later -- before we even
-    // observe the SYNC message.
-    let conn_baseline = swarm.transport().active_connection_count();
-
     // --- 2. Reserve a slot on the relay via HOP RESERVE --------------------
     let hop_stream = swarm
         .open_user_stream(&relay_peer_id, HOP_PROTOCOL_ID)
@@ -154,9 +142,14 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
     }
     send(&mut swarm, &relay_peer_id, bridge_stream, dcutr.take_outbound())?;
 
+    // DCUtR responder events arrive across multiple poll cycles:
+    // `ConnectReceived` fires in one call, `SyncReceived` in a later
+    // one. We thread the captured remote-addrs through the loop so
+    // the CONNECT payload isn't thrown away when the SYNC arrives.
+    let mut captured_remote_addrs: Option<Vec<Multiaddr>> = None;
     let remote_addrs: Vec<Multiaddr> = loop {
-        if let Some(addrs) = drain_dcutr_responder_events(&mut dcutr, role) {
-            break addrs;
+        if drain_dcutr_responder_events(&mut dcutr, role, &mut captured_remote_addrs) {
+            break captured_remote_addrs.take().unwrap_or_default();
         }
         let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
         dcutr.on_data(&data).map_err(|e| format!("DCUtR decode: {e}"))?;
@@ -169,18 +162,30 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
     let punch_deadline = punch_start + HOLEPUNCH_DEADLINE;
     let mut next_blast = punch_start + RESPONDER_SYNC_DELAY;
 
-    // The baseline was captured right after we connected to the relay,
-    // before DCUtR started. Any connection beyond that -- including
-    // the remote's direct Initial, which can arrive BEFORE we observe
-    // the SYNC message on a tight local loopback -- should trigger
-    // the early-exit heuristic.
+    // Extract the host+port shape of each address we expect the remote
+    // to dial from. We compare against the transport addresses (no
+    // peer-id suffix) of any inbound QUIC connection; matching on
+    // (IP, port) keeps the check robust whether the remote is on the
+    // same host (dials from its bound port) or behind a NAT (dials
+    // from its NAT-external mapping, which is what DCUtR CONNECT put
+    // in `remote_addrs`).
     //
-    // Implementation note: we poll on a tight (~5ms) cadence rather
-    // than using `run_until`, because a successful remote direct-ping
-    // session can come and go in under 100ms -- the connection count
-    // is back to baseline before a slower tick would notice.
-    let mut saw_inbound_conn =
-        swarm.transport().active_connection_count() > conn_baseline;
+    // Using an address-match heuristic rather than a raw count
+    // comparison prevents unrelated inbound connections -- relay
+    // probe-backs, autonat probes, random scanners -- from being
+    // misinterpreted as hole-punch success.
+    let remote_match_targets: Vec<(String, u16)> = remote_addrs
+        .iter()
+        .filter_map(extract_ip_port)
+        .collect();
+
+    // Check any connections already present (e.g. the remote's direct
+    // Initial may have arrived BEFORE we observed the SYNC message on
+    // a tight local loopback). Only counts if the source matches.
+    let mut saw_inbound_conn = any_source_matches(
+        &swarm.transport().active_connection_sources(),
+        &remote_match_targets,
+    );
 
     let outcome = 'outer: loop {
         let now = Instant::now();
@@ -208,10 +213,18 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
             }
         }
 
-        // Sticky: if we've ever seen the count above baseline, we
-        // know a direct connection arrived even if it has since been
-        // torn down (e.g. the remote finished pinging and exited).
-        if swarm.transport().active_connection_count() > conn_baseline {
+        // Sticky: if we've ever seen an inbound connection from one
+        // of the remote's advertised addresses, we know the remote
+        // went direct even if the connection has since been torn
+        // down (e.g. the remote finished pinging and exited).
+        //
+        // Unrelated inbound connections (autonat probes, scans) do
+        // NOT trigger this because their source address won't match
+        // `remote_match_targets`.
+        if any_source_matches(
+            &swarm.transport().active_connection_sources(),
+            &remote_match_targets,
+        ) {
             saw_inbound_conn = true;
         }
         if saw_inbound_conn {
@@ -312,6 +325,51 @@ enum HolePunchOutcome {
 
 fn is_direct_connection_event(ev: &SwarmEvent, remote: &PeerId) -> bool {
     matches!(ev, SwarmEvent::ConnectionEstablished { peer_id } if peer_id == remote)
+}
+
+/// Pulls the (IP host, UDP port) tuple out of a QUIC-style multiaddr,
+/// returning `None` if the shape isn't a supported host + udp + quic-v1.
+///
+/// Host is returned as the multiaddr's display form for the IP/DNS
+/// component (e.g. `"127.0.0.1"`, `"2001:db8::1"`, `"example.com"`)
+/// so the comparison is protocol-aware without us having to case on
+/// every host variant.
+fn extract_ip_port(addr: &Multiaddr) -> Option<(String, u16)> {
+    use minip2p_core::Protocol;
+    let protocols = addr.protocols();
+    if protocols.len() < 2 {
+        return None;
+    }
+    let host = match &protocols[0] {
+        Protocol::Ip4(b) => {
+            format!("{}.{}.{}.{}", b[0], b[1], b[2], b[3])
+        }
+        Protocol::Ip6(b) => core::net::Ipv6Addr::from(*b).to_string(),
+        Protocol::Dns(v) | Protocol::Dns4(v) | Protocol::Dns6(v) => v.clone(),
+        _ => return None,
+    };
+    let port = match &protocols[1] {
+        Protocol::Udp(p) => *p,
+        _ => return None,
+    };
+    Some((host, port))
+}
+
+/// Returns `true` if at least one of `sources` has the same `(host, port)`
+/// as any of `targets`.
+///
+/// Used by the listener's hole-punch success heuristic to filter out
+/// inbound connections from unrelated peers (autonat probes, scans,
+/// etc.). A connection source matches only when it came from an
+/// address the remote peer advertised via DCUtR.
+fn any_source_matches(sources: &[Multiaddr], targets: &[(String, u16)]) -> bool {
+    if targets.is_empty() {
+        return false;
+    }
+    sources
+        .iter()
+        .filter_map(extract_ip_port)
+        .any(|src| targets.iter().any(|tgt| &src == tgt))
 }
 
 fn is_bridge_closed_event(ev: &SwarmEvent, bridge_stream: StreamId) -> bool {
@@ -566,13 +624,19 @@ fn wait_user_stream_data(
     Ok(data)
 }
 
-/// Drains any pending DCUtR responder events. Returns `Some(remote_addrs)`
-/// once `SyncReceived` has fired, `None` otherwise.
+/// Drains any pending DCUtR responder events into the caller's
+/// `captured` slot. Returns `true` when `SyncReceived` has fired
+/// (i.e. the responder flow is complete).
+///
+/// `captured` is threaded by reference because `ConnectReceived` and
+/// `SyncReceived` can arrive in separate poll cycles -- persisting the
+/// captured remote addresses across calls is essential so they aren't
+/// lost by the time SYNC arrives.
 fn drain_dcutr_responder_events(
     dcutr: &mut DcutrResponder,
     role: &str,
-) -> Option<Vec<Multiaddr>> {
-    let mut captured: Option<Vec<Multiaddr>> = None;
+    captured: &mut Option<Vec<Multiaddr>>,
+) -> bool {
     let mut sync = false;
     for ev in dcutr.poll_events() {
         match ev {
@@ -592,16 +656,12 @@ fn drain_dcutr_responder_events(
                     "[{role}] dcutr-connect-received addrs={}",
                     remote_addrs.len()
                 );
-                captured = Some(remote_addrs);
+                *captured = Some(remote_addrs);
             }
             ResponderEvent::SyncReceived => sync = true,
         }
     }
-    if sync {
-        captured.or_else(|| Some(Vec::new()))
-    } else {
-        None
-    }
+    sync
 }
 
 /// Send `data` on `stream_id` if non-empty; no-op otherwise.

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -23,7 +23,7 @@ use minip2p_relay::{
     HOP_PROTOCOL_ID, STOP_PROTOCOL_ID,
 };
 use minip2p_swarm::{Swarm, SwarmBuilder, SwarmEvent};
-use minip2p_transport::StreamId;
+use minip2p_transport::{StreamId, Transport};
 
 use crate::cli::print_event;
 
@@ -37,7 +37,15 @@ const AGENT: &str = "minip2p-peer/0.1.0";
 /// flow should complete well inside this on a local relay.
 const LISTEN_DEADLINE: Duration = Duration::from_secs(60);
 /// Hole-punch window after SYNC is received / sent.
-const HOLEPUNCH_DEADLINE: Duration = Duration::from_secs(10);
+///
+/// Kept short because on the listener side we fall back to an
+/// inbound-connection-count heuristic for early exit (since without
+/// mutual TLS we can't directly observe the remote's verified peer
+/// id). On the dialer side, direct dials succeed in milliseconds on
+/// LAN/loopback; real-world NATs may occasionally need longer but
+/// three seconds already works for the common-case symmetric-NAT
+/// traversal path.
+const HOLEPUNCH_DEADLINE: Duration = Duration::from_secs(3);
 /// UDP blast cadence (responder side) during hole-punch.
 const HOLEPUNCH_INTERVAL: Duration = Duration::from_millis(100);
 /// Approximation of RTT/2 before the responder starts blasting UDP.
@@ -74,6 +82,18 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
 
     // --- 1. Relay connection established -----------------------------------
     wait_connected(&mut swarm, role, &relay_peer_id, deadline)?;
+
+    // Capture the active connection count now, before DCUtR starts.
+    // This is the hole-punch-success baseline: any connection beyond
+    // this must be the remote peer coming in direct (or a relay
+    // probe-back, which rust-libp2p may do to verify our listen_addrs
+    // -- benign false positive, the session still completes cleanly).
+    //
+    // We MUST capture before B's DCUtR CONNECT reply goes out, because
+    // on a local loopback, the remote's direct Initial can arrive at
+    // our socket a few hundred microseconds later -- before we even
+    // observe the SYNC message.
+    let conn_baseline = swarm.transport().active_connection_count();
 
     // --- 2. Reserve a slot on the relay via HOP RESERVE --------------------
     let hop_stream = swarm
@@ -149,7 +169,20 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
     let punch_deadline = punch_start + HOLEPUNCH_DEADLINE;
     let mut next_blast = punch_start + RESPONDER_SYNC_DELAY;
 
-    let outcome = loop {
+    // The baseline was captured right after we connected to the relay,
+    // before DCUtR started. Any connection beyond that -- including
+    // the remote's direct Initial, which can arrive BEFORE we observe
+    // the SYNC message on a tight local loopback -- should trigger
+    // the early-exit heuristic.
+    //
+    // Implementation note: we poll on a tight (~5ms) cadence rather
+    // than using `run_until`, because a successful remote direct-ping
+    // session can come and go in under 100ms -- the connection count
+    // is back to baseline before a slower tick would notice.
+    let mut saw_inbound_conn =
+        swarm.transport().active_connection_count() > conn_baseline;
+
+    let outcome = 'outer: loop {
         let now = Instant::now();
         if now >= punch_deadline {
             break HolePunchOutcome::Timeout;
@@ -158,28 +191,34 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
             blast_remote_addrs(&swarm, &remote_addrs, role);
             next_blast = now + HOLEPUNCH_INTERVAL;
         }
-        // Short tick window. In addition to a direct
-        // ConnectionEstablished for the remote, we also return on the
-        // bridge stream being closed by the relay -- that happens after
-        // the remote successfully goes direct and stops using the
-        // circuit, and without mutual TLS we can't detect the direct
-        // connection ourselves (see holepunch-plan.md Milestone 6).
-        let Some(ev) = swarm
-            .run_until(now + HOLEPUNCH_INTERVAL, |ev| {
-                print_event(role, ev);
-                is_direct_connection_event(ev, &remote_peer_id)
-                    || is_bridge_closed_event(ev, bridge_stream)
-            })
-            .map_err(|e| format!("holepunch poll: {e}"))?
-        else {
-            continue;
-        };
-        match ev {
-            SwarmEvent::ConnectionEstablished { peer_id } => {
-                break HolePunchOutcome::DirectConnected(peer_id);
+
+        // Drain any events the transport has for us. Event ordering
+        // within a tick matters: if we see ConnectionEstablished for
+        // the remote peer id, prefer that over the coarser count
+        // heuristic.
+        for ev in swarm.poll().map_err(|e| format!("holepunch poll: {e}"))? {
+            print_event(role, &ev);
+            if is_direct_connection_event(&ev, &remote_peer_id) {
+                if let SwarmEvent::ConnectionEstablished { peer_id } = ev {
+                    break 'outer HolePunchOutcome::DirectConnected(peer_id);
+                }
             }
-            _ => break HolePunchOutcome::BridgeClosed,
+            if is_bridge_closed_event(&ev, bridge_stream) {
+                break 'outer HolePunchOutcome::BridgeClosed;
+            }
         }
+
+        // Sticky: if we've ever seen the count above baseline, we
+        // know a direct connection arrived even if it has since been
+        // torn down (e.g. the remote finished pinging and exited).
+        if swarm.transport().active_connection_count() > conn_baseline {
+            saw_inbound_conn = true;
+        }
+        if saw_inbound_conn {
+            break HolePunchOutcome::InboundConnectionSeen;
+        }
+
+        std::thread::sleep(Duration::from_millis(5));
     };
 
     // --- 7. Resolve based on the hole-punch outcome -------------------------
@@ -187,6 +226,28 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
         HolePunchOutcome::DirectConnected(peer_id) => {
             println!("[{role}] direct-connected peer={peer_id} (hole-punch success)");
             ping_and_exit(&mut swarm, role, peer_id, deadline)
+        }
+        HolePunchOutcome::InboundConnectionSeen => {
+            // We can't ping the remote from our side (don't know their
+            // verified peer id without mTLS), and we can't detect when
+            // the remote's own ping round-trip completes either. Run
+            // the event loop for a short grace window so we stay
+            // responsive to inbound streams (including the remote's
+            // ping, which would otherwise time out waiting on our
+            // echo).
+            println!(
+                "[{role}] inbound-direct-connection detected (hole-punch success; \
+                 remote peer-id unverified pre-mTLS)"
+            );
+            let grace_deadline = Instant::now() + Duration::from_secs(2);
+            let _ = swarm
+                .run_until(grace_deadline, |ev| {
+                    print_event(role, ev);
+                    false // keep draining until the grace period elapses
+                })
+                .map_err(|e| format!("grace poll: {e}"))?;
+            println!("[{role}] grace-elapsed -- done");
+            Ok(())
         }
         HolePunchOutcome::BridgeClosed => {
             // Relay closed the circuit. Most likely the remote went
@@ -201,11 +262,12 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
         }
         HolePunchOutcome::Timeout => {
             println!("[{role}] hole-punch-timeout -> relay-ping fallback");
-            // Wait for either an echo payload from Peer A or the
-            // bridge to close (meaning A gave up). A short fallback
-            // deadline keeps the listener from hanging indefinitely
-            // if the relay GC'd the circuit while we weren't looking.
-            let fallback_deadline = Instant::now() + Duration::from_secs(5);
+            // Wait up to ~15s for either an echo payload from Peer A
+            // or the bridge to close (meaning A gave up). Longer
+            // than the hole-punch deadline because the relay's own
+            // idle-circuit GC can take several seconds -- but bounded
+            // so we don't hang forever if something goes wrong.
+            let fallback_deadline = Instant::now() + Duration::from_secs(15);
             let ev = swarm
                 .run_until(fallback_deadline, |ev| {
                     print_event(role, ev);
@@ -236,10 +298,15 @@ enum HolePunchOutcome {
     /// Saw `ConnectionEstablished` for the remote peer id (only
     /// possible once mutual TLS is implemented; see Milestone 6).
     DirectConnected(PeerId),
+    /// `transport.active_connection_count()` grew beyond the relay
+    /// baseline. Almost certainly the remote peer coming in direct.
+    /// Coarse heuristic; not suitable for security decisions but
+    /// fine for this demo binary.
+    InboundConnectionSeen,
     /// Relay closed the bridge stream -- strong signal that the
     /// remote went direct and stopped using the circuit.
     BridgeClosed,
-    /// Neither of the above happened within `HOLEPUNCH_DEADLINE`.
+    /// None of the above happened within `HOLEPUNCH_DEADLINE`.
     Timeout,
 }
 

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -17,11 +17,14 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use minip2p_core::{Multiaddr, PeerAddr, PeerId};
-use minip2p_dcutr::{DcutrResponder, ResponderEvent, DCUTR_PROTOCOL_ID};
+use minip2p_dcutr::{
+    DcutrInitiator, DcutrResponder, InitiatorOutcome, ResponderEvent, DCUTR_PROTOCOL_ID,
+};
 use minip2p_identity::Ed25519Keypair;
 use minip2p_quic::{QuicNodeConfig, QuicTransport};
 use minip2p_relay::{
-    HopReservation, ReservationOutcome, StopResponder, HOP_PROTOCOL_ID, STOP_PROTOCOL_ID,
+    ConnectOutcome, HopConnect, HopReservation, ReservationOutcome, StopResponder,
+    HOP_PROTOCOL_ID, STOP_PROTOCOL_ID,
 };
 use minip2p_swarm::{Swarm, SwarmBuilder, SwarmEvent};
 use minip2p_transport::StreamId;
@@ -173,16 +176,434 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
     }
 }
 
-/// Runs the Peer A role. Implemented in Step 5.
-pub fn run_dial(
-    relay_addr: PeerAddr,
-    target: PeerId,
-) -> Result<(), Box<dyn Error>> {
-    let _ = (relay_addr, target);
-    Err(
-        "relay dial mode is not yet implemented (Step 5 of holepunch-plan.md)"
-            .into(),
-    )
+/// Dialer-side phase tracker. Mirrors [`ListenerPhase`] but with the
+/// HOP initiator / DCUtR initiator / direct-dial flows.
+enum DialerPhase {
+    /// Dialed the relay; waiting for `ConnectionEstablished`.
+    ConnectingToRelay,
+    /// Relay connection up; HOP CONNECT flow in progress on `hop_stream`.
+    Connecting {
+        hop_stream: StreamId,
+        flow: HopConnect,
+    },
+    /// Relay bridged our HOP CONNECT -> we're running DCUtR over the
+    /// same stream as the initiator.
+    DcutrExchange {
+        bridge_stream: StreamId,
+        flow: DcutrInitiator,
+        /// Time we sent our initial DCUtR CONNECT; subtract from wall
+        /// clock on the CONNECT reply to fill DCUtR's `rtt_ms`.
+        sent_at: Instant,
+    },
+    /// Dialed all of `remote_addrs` directly; waiting for
+    /// `ConnectionEstablished` on `target_peer_id`.
+    HolePunching {
+        bridge_stream: StreamId,
+        target_peer_id: PeerId,
+        remote_addrs: Vec<Multiaddr>,
+        started_at: Instant,
+    },
+    /// Hole-punch succeeded; pinging on the direct connection.
+    PingingDirect { peer_id: PeerId },
+    /// Hole-punch timed out; sent a relay-ping payload over the
+    /// bridge and waiting for the echo to measure RTT.
+    RelayPingFallback {
+        bridge_stream: StreamId,
+        payload: Vec<u8>,
+        sent_at: Instant,
+    },
+}
+
+/// Runs the Peer A role: dial the relay, open a HOP circuit to
+/// `target`, coordinate DCUtR as the initiator, attempt hole-punch
+/// directly, fall back to a relay-bridged echo RTT measurement,
+/// exit on the first ping RTT.
+pub fn run_dial(relay_addr: PeerAddr, target: PeerId) -> Result<(), Box<dyn Error>> {
+    let mut swarm = build_swarm_with_relay_protocols()?;
+    // Listen on our bound UDP port so we can accept the return half of
+    // the hole-punch (the target dials us back).
+    swarm
+        .transport_mut()
+        .listen_on_bound_addr()
+        .map_err(|e| format!("listen failed: {e}"))?;
+
+    let our_addr = swarm
+        .transport()
+        .local_peer_addr()
+        .map_err(|e| format!("local_peer_addr failed: {e}"))?;
+    let our_observed: Vec<Multiaddr> = vec![our_addr.transport().clone()];
+    println!("[relay-dial] bound={our_addr}");
+    println!("[relay-dial] us={}", swarm.local_peer_id());
+    println!("[relay-dial] target={target}");
+
+    let relay_peer_id = relay_addr.peer_id().clone();
+    swarm
+        .dial(&relay_addr)
+        .map_err(|e| format!("dial relay failed: {e}"))?;
+    println!("[relay-dial] dialing-relay {relay_addr}");
+
+    let mut phase = DialerPhase::ConnectingToRelay;
+    let deadline = Instant::now() + LISTEN_DEADLINE;
+
+    loop {
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "dialer deadline exceeded ({}s) in phase {}",
+                LISTEN_DEADLINE.as_secs(),
+                dialer_phase_name(&phase)
+            )
+            .into());
+        }
+
+        thread::sleep(POLL_INTERVAL);
+        let events = swarm
+            .poll()
+            .map_err(|e| format!("swarm poll failed: {e}"))?;
+
+        for event in events {
+            print_event("relay-dial", &event);
+            phase = handle_dialer_event(
+                phase,
+                event,
+                &mut swarm,
+                &relay_peer_id,
+                &target,
+                &our_observed,
+            )?;
+        }
+
+        phase = tick_dialer(phase, &mut swarm, &relay_peer_id)?;
+    }
+}
+
+/// Event-driven state transitions for the dialer role.
+fn handle_dialer_event(
+    phase: DialerPhase,
+    event: SwarmEvent,
+    swarm: &mut Swarm<QuicTransport>,
+    relay_peer_id: &PeerId,
+    target_peer_id: &PeerId,
+    our_observed: &[Multiaddr],
+) -> Result<DialerPhase, Box<dyn Error>> {
+    match (phase, event) {
+        // --- ConnectingToRelay -> Connecting -------------------------------
+        (DialerPhase::ConnectingToRelay, SwarmEvent::ConnectionEstablished { peer_id })
+            if peer_id == *relay_peer_id =>
+        {
+            let hop_stream = swarm
+                .open_user_stream(relay_peer_id, HOP_PROTOCOL_ID)
+                .map_err(|e| format!("open HOP stream failed: {e}"))?;
+            Ok(DialerPhase::Connecting {
+                hop_stream,
+                flow: HopConnect::new(target_peer_id.to_bytes()),
+            })
+        }
+
+        // --- Connecting: flush HOP CONNECT once the stream is ready --------
+        (
+            DialerPhase::Connecting {
+                hop_stream,
+                mut flow,
+            },
+            SwarmEvent::UserStreamReady {
+                stream_id,
+                initiated_locally: true,
+                ref protocol_id,
+                ..
+            },
+        ) if stream_id == hop_stream && protocol_id == HOP_PROTOCOL_ID => {
+            let outbound = flow.take_outbound();
+            if !outbound.is_empty() {
+                swarm
+                    .send_user_stream(relay_peer_id, hop_stream, outbound)
+                    .map_err(|e| format!("send HOP CONNECT failed: {e}"))?;
+            }
+            Ok(DialerPhase::Connecting { hop_stream, flow })
+        }
+
+        // --- Connecting: relay responds with STATUS ------------------------
+        (
+            DialerPhase::Connecting {
+                hop_stream,
+                mut flow,
+            },
+            SwarmEvent::UserStreamData {
+                stream_id, data, ..
+            },
+        ) if stream_id == hop_stream => {
+            flow.on_data(&data).map_err(|e| format!("HOP decode: {e}"))?;
+            if let Some(outcome) = flow.outcome() {
+                match outcome {
+                    ConnectOutcome::Bridged { .. } => {
+                        println!("[relay-dial] bridge-established via-relay");
+                        // The same stream now carries DCUtR frames.
+                        let bridge_bytes = flow.take_bridge_bytes();
+                        let mut initiator = DcutrInitiator::new(our_observed);
+                        // Queue CONNECT and flush.
+                        let out = initiator.take_outbound();
+                        if !out.is_empty() {
+                            swarm
+                                .send_user_stream(relay_peer_id, hop_stream, out)
+                                .map_err(|e| format!("DCUtR CONNECT send: {e}"))?;
+                        }
+                        let mut phase = DialerPhase::DcutrExchange {
+                            bridge_stream: hop_stream,
+                            flow: initiator,
+                            sent_at: Instant::now(),
+                        };
+                        if !bridge_bytes.is_empty() {
+                            phase = feed_dcutr_dialer_bytes(
+                                phase,
+                                &bridge_bytes,
+                                swarm,
+                                relay_peer_id,
+                                target_peer_id,
+                            )?;
+                        }
+                        return Ok(phase);
+                    }
+                    ConnectOutcome::Refused { status, reason } => {
+                        return Err(format!(
+                            "relay refused CONNECT: status={status:?} reason={reason}"
+                        )
+                        .into());
+                    }
+                }
+            }
+            Ok(DialerPhase::Connecting { hop_stream, flow })
+        }
+
+        // --- DcutrExchange: feed bytes through DcutrInitiator --------------
+        (
+            DialerPhase::DcutrExchange {
+                bridge_stream,
+                flow,
+                sent_at,
+            },
+            SwarmEvent::UserStreamData {
+                stream_id, data, ..
+            },
+        ) if stream_id == bridge_stream => {
+            let phase = DialerPhase::DcutrExchange {
+                bridge_stream,
+                flow,
+                sent_at,
+            };
+            feed_dcutr_dialer_bytes(phase, &data, swarm, relay_peer_id, target_peer_id)
+        }
+
+        // --- HolePunching: did the target dial us back or did we succeed? --
+        (
+            DialerPhase::HolePunching {
+                target_peer_id: target,
+                ..
+            },
+            SwarmEvent::ConnectionEstablished { peer_id },
+        ) if peer_id == target => {
+            println!(
+                "[relay-dial] direct-connected peer={peer_id} (hole-punch success)"
+            );
+            swarm
+                .ping(&peer_id)
+                .map_err(|e| format!("ping on direct conn: {e}"))?;
+            Ok(DialerPhase::PingingDirect { peer_id: target })
+        }
+
+        // --- PingingDirect: exit on RTT -----------------------------------
+        (
+            DialerPhase::PingingDirect { peer_id },
+            SwarmEvent::PingRttMeasured {
+                peer_id: who, rtt_ms,
+            },
+        ) if who == peer_id => {
+            println!(
+                "[relay-dial] ping-direct peer={peer_id} rtt={rtt_ms}ms -- done"
+            );
+            std::process::exit(0);
+        }
+
+        // --- RelayPingFallback: receive echo, compute RTT -----------------
+        (
+            DialerPhase::RelayPingFallback {
+                bridge_stream,
+                payload,
+                sent_at,
+            },
+            SwarmEvent::UserStreamData {
+                stream_id, data, ..
+            },
+        ) if stream_id == bridge_stream => {
+            if data == payload {
+                let rtt_ms = sent_at.elapsed().as_millis();
+                println!(
+                    "[relay-dial] ping-via-relay peer={target_peer_id} rtt={rtt_ms}ms -- done"
+                );
+                std::process::exit(0);
+            }
+            // Not our echo — ignore and keep waiting.
+            Ok(DialerPhase::RelayPingFallback {
+                bridge_stream,
+                payload,
+                sent_at,
+            })
+        }
+
+        // --- Events we don't care about: pass through ----------------------
+        (phase, _) => Ok(phase),
+    }
+}
+
+/// Owned-phase dispatch for the DCUtR stream-data arm, analogous to
+/// [`feed_dcutr_listener_bytes`].
+fn feed_dcutr_dialer_bytes(
+    phase: DialerPhase,
+    bytes: &[u8],
+    swarm: &mut Swarm<QuicTransport>,
+    relay_peer_id: &PeerId,
+    target_peer_id: &PeerId,
+) -> Result<DialerPhase, Box<dyn Error>> {
+    let DialerPhase::DcutrExchange {
+        bridge_stream,
+        mut flow,
+        sent_at,
+    } = phase
+    else {
+        return Ok(phase);
+    };
+
+    // Measured RTT at the moment the reply bytes arrive. Approximate --
+    // this includes scheduling and socket-read latency in addition to
+    // the relay hop, but it's the best we have without timestamps on
+    // the wire.
+    let rtt_ms = sent_at.elapsed().as_millis() as u64;
+
+    flow.on_data(bytes, rtt_ms)
+        .map_err(|e| format!("DCUtR decode: {e}"))?;
+
+    if let Some(InitiatorOutcome::DialNow {
+        remote_addrs,
+        remote_addr_bytes,
+        rtt_ms,
+    }) = flow.outcome().cloned()
+    {
+        if remote_addrs.len() < remote_addr_bytes.len() {
+            eprintln!(
+                "[relay-dial] dcutr-reply: {} of {} remote addrs failed to \
+                 parse and were ignored",
+                remote_addr_bytes.len() - remote_addrs.len(),
+                remote_addr_bytes.len()
+            );
+        }
+        println!(
+            "[relay-dial] dcutr-dialnow addrs={} rtt={rtt_ms}ms",
+            remote_addrs.len()
+        );
+
+        // Queue SYNC + flush. Per the spec we send SYNC right before
+        // kicking off the simultaneous direct dial.
+        flow.send_sync()
+            .map_err(|e| format!("DCUtR send_sync: {e}"))?;
+        let out = flow.take_outbound();
+        if !out.is_empty() {
+            swarm
+                .send_user_stream(relay_peer_id, bridge_stream, out)
+                .map_err(|e| format!("DCUtR SYNC send: {e}"))?;
+        }
+
+        // Dial each observed remote address. First one to establish wins.
+        for addr in &remote_addrs {
+            let peer_addr = match PeerAddr::new(addr.clone(), target_peer_id.clone()) {
+                Ok(pa) => pa,
+                Err(e) => {
+                    eprintln!(
+                        "[relay-dial] could not form PeerAddr for {addr}: {e}"
+                    );
+                    continue;
+                }
+            };
+            match swarm.dial(&peer_addr) {
+                Ok(_) => println!("[relay-dial] dialing-direct {peer_addr}"),
+                Err(e) => eprintln!(
+                    "[relay-dial] direct-dial to {peer_addr} failed: {e}"
+                ),
+            }
+        }
+
+        return Ok(DialerPhase::HolePunching {
+            bridge_stream,
+            target_peer_id: target_peer_id.clone(),
+            remote_addrs,
+            started_at: Instant::now(),
+        });
+    }
+
+    Ok(DialerPhase::DcutrExchange {
+        bridge_stream,
+        flow,
+        sent_at,
+    })
+}
+
+/// Time-based transitions for the dialer: hole-punch deadline that
+/// switches over to the relay-ping fallback.
+fn tick_dialer(
+    phase: DialerPhase,
+    swarm: &mut Swarm<QuicTransport>,
+    relay_peer_id: &PeerId,
+) -> Result<DialerPhase, Box<dyn Error>> {
+    match phase {
+        DialerPhase::HolePunching {
+            bridge_stream,
+            target_peer_id,
+            remote_addrs,
+            started_at,
+        } => {
+            if Instant::now().saturating_duration_since(started_at) >= HOLEPUNCH_DEADLINE {
+                println!(
+                    "[relay-dial] hole-punch-timeout -> relay-ping fallback"
+                );
+                // Send a random 32-byte payload; the listener echoes it
+                // on the bridge stream. The dialer's event handler will
+                // match the echo and compute the RTT.
+                let payload = random_bytes(RELAY_PING_LEN);
+                if let Err(e) = swarm.send_user_stream(
+                    relay_peer_id,
+                    bridge_stream,
+                    payload.clone(),
+                ) {
+                    return Err(format!("relay-ping send: {e}").into());
+                }
+                let _ = (remote_addrs, target_peer_id);
+                return Ok(DialerPhase::RelayPingFallback {
+                    bridge_stream,
+                    payload,
+                    sent_at: Instant::now(),
+                });
+            }
+            Ok(DialerPhase::HolePunching {
+                bridge_stream,
+                target_peer_id,
+                remote_addrs,
+                started_at,
+            })
+        }
+        other => {
+            let _ = (swarm, relay_peer_id);
+            Ok(other)
+        }
+    }
+}
+
+/// Human-readable phase name for dialer error messages.
+fn dialer_phase_name(phase: &DialerPhase) -> &'static str {
+    match phase {
+        DialerPhase::ConnectingToRelay => "ConnectingToRelay",
+        DialerPhase::Connecting { .. } => "Connecting",
+        DialerPhase::DcutrExchange { .. } => "DcutrExchange",
+        DialerPhase::HolePunching { .. } => "HolePunching",
+        DialerPhase::PingingDirect { .. } => "PingingDirect",
+        DialerPhase::RelayPingFallback { .. } => "RelayPingFallback",
+    }
 }
 
 /// Reacts to a single [`SwarmEvent`] and returns the updated phase.

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -1,0 +1,594 @@
+//! Relay-coordinated hole-punch mode.
+//!
+//! This module orchestrates the full Circuit Relay v2 + DCUtR flow
+//! described in `holepunch-plan.md`. It is deliberately procedural:
+//! one long event loop per role with an explicit phase enum so the
+//! state transitions are visible at a glance.
+//!
+//! The two public entry points are [`run_listen`] (Peer B, reserves on
+//! the relay, accepts an incoming circuit, responds to DCUtR, then
+//! hole-punches) and [`run_dial`] (Peer A, opens a circuit through the
+//! relay, initiates DCUtR, then hole-punches). Shared helpers at the
+//! bottom of the file set up the swarm and parse DCUtR observed
+//! addresses back into multiaddrs.
+
+use std::error::Error;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use minip2p_core::{Multiaddr, PeerAddr, PeerId};
+use minip2p_dcutr::{DcutrResponder, ResponderEvent, DCUTR_PROTOCOL_ID};
+use minip2p_identity::Ed25519Keypair;
+use minip2p_quic::{QuicNodeConfig, QuicTransport};
+use minip2p_relay::{
+    HopReservation, ReservationOutcome, StopResponder, HOP_PROTOCOL_ID, STOP_PROTOCOL_ID,
+};
+use minip2p_swarm::{Swarm, SwarmBuilder, SwarmEvent};
+use minip2p_transport::StreamId;
+
+use crate::cli::print_event;
+
+// ---------------------------------------------------------------------------
+// Shared configuration
+// ---------------------------------------------------------------------------
+
+/// Poll interval for the event loop (matches the direct-mode module).
+const POLL_INTERVAL: Duration = Duration::from_millis(5);
+/// Local bind address. Loopback matches the plan's "v1 scope" -- the
+/// flow still exercises the full stack against a real relay, just
+/// without escaping the host.
+const LOCAL_BIND: &str = "127.0.0.1:0";
+/// Agent string advertised via Identify.
+const AGENT: &str = "minip2p-peer/0.1.0";
+/// Top-level deadline for the listener role: reservation + a full
+/// circuit + hole-punch should comfortably fit in this window on a
+/// local relay.
+const LISTEN_DEADLINE: Duration = Duration::from_secs(60);
+/// Hole-punch deadline after SYNC is received.
+const HOLEPUNCH_DEADLINE: Duration = Duration::from_secs(10);
+/// Cadence of responder-side UDP bombardment during hole-punch.
+const HOLEPUNCH_INTERVAL: Duration = Duration::from_millis(100);
+/// Initial RTT/2 delay on the responder side before UDP bombardment.
+/// Per the plan, v1 uses a fixed value; a future refinement will
+/// piggy-back measured RTT on the DCUtR exchange.
+const RESPONDER_SYNC_DELAY: Duration = Duration::from_millis(50);
+/// Payload length used for the relay-ping fallback.
+const RELAY_PING_LEN: usize = 32;
+
+// ---------------------------------------------------------------------------
+// Listener (Peer B)
+// ---------------------------------------------------------------------------
+
+/// Listener-side phase tracker. The outer event loop drives these
+/// transitions based on swarm events and outcome polls on the
+/// embedded state machines.
+enum ListenerPhase {
+    /// Dialed the relay; waiting for `ConnectionEstablished`.
+    ConnectingToRelay,
+    /// Relay connection established; HOP stream opened and feeding the
+    /// HopReservation state machine.
+    Reserving {
+        hop_stream: StreamId,
+        flow: HopReservation,
+    },
+    /// Reservation accepted; waiting for an incoming STOP stream from
+    /// the relay (meaning some other peer is trying to reach us).
+    WaitingForCircuit,
+    /// STOP stream opened by the relay; feeding its bytes into
+    /// `StopResponder` until it produces a `CONNECT` request, at which
+    /// point we call `accept()` and transition to `DcutrExchange`.
+    StopAccepting {
+        bridge_stream: StreamId,
+        flow: StopResponder,
+    },
+    /// Bridge accepted; same stream now carries DCUtR frames.
+    DcutrExchange {
+        bridge_stream: StreamId,
+        flow: DcutrResponder,
+        /// The source peer id from the STOP CONNECT (Peer A's id).
+        remote_peer_id: PeerId,
+        /// Populated when DCUtR CONNECT arrives.
+        remote_addrs: Vec<Multiaddr>,
+    },
+    /// DCUtR SYNC received; bombarding remote addresses over raw UDP
+    /// until a direct QUIC connection from `remote_peer_id` arrives or
+    /// the deadline expires.
+    HolePunching {
+        bridge_stream: StreamId,
+        remote_peer_id: PeerId,
+        remote_addrs: Vec<Multiaddr>,
+        started_at: Instant,
+        last_blast: Option<Instant>,
+    },
+    /// Hole-punch succeeded; pinging the direct connection.
+    PingingDirect { peer_id: PeerId },
+    /// Hole-punch failed; falling back to the bridge as a relay ping.
+    RelayPingFallback {
+        bridge_stream: StreamId,
+        remote_peer_id: PeerId,
+    },
+}
+
+/// Runs the Peer B role: reserve on the relay, accept an incoming
+/// circuit, coordinate DCUtR, attempt hole-punch, fall back to relay
+/// ping, exit on the first ping RTT measurement.
+pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
+    let mut swarm = build_swarm_with_relay_protocols()?;
+    // Listen on our bound UDP port so an inbound direct QUIC connection
+    // from Peer A (during hole-punch) can be accepted without rebinding.
+    swarm
+        .transport_mut()
+        .listen_on_bound_addr()
+        .map_err(|e| format!("listen failed: {e}"))?;
+
+    let our_addr = swarm
+        .transport()
+        .local_peer_addr()
+        .map_err(|e| format!("local_peer_addr failed: {e}"))?;
+    let our_observed: Vec<Multiaddr> = vec![our_addr.transport().clone()];
+    println!("[relay-listen] bound={our_addr}");
+    println!("[relay-listen] us={}", swarm.local_peer_id());
+
+    let relay_peer_id = relay_addr.peer_id().clone();
+    swarm
+        .dial(&relay_addr)
+        .map_err(|e| format!("dial relay failed: {e}"))?;
+    println!("[relay-listen] dialing-relay {relay_addr}");
+
+    let mut phase = ListenerPhase::ConnectingToRelay;
+    let deadline = Instant::now() + LISTEN_DEADLINE;
+
+    loop {
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "listener deadline exceeded ({}s) in phase {}",
+                LISTEN_DEADLINE.as_secs(),
+                phase_name(&phase)
+            )
+            .into());
+        }
+
+        thread::sleep(POLL_INTERVAL);
+        let events = swarm
+            .poll()
+            .map_err(|e| format!("swarm poll failed: {e}"))?;
+
+        for event in events {
+            print_event("relay-listen", &event);
+            phase = handle_listener_event(
+                phase,
+                event,
+                &mut swarm,
+                &relay_peer_id,
+                &our_observed,
+            )?;
+            if matches!(phase, ListenerPhase::PingingDirect { .. }) {
+                // PingingDirect is terminal once PingRttMeasured arrives;
+                // that is handled inside handle_listener_event too.
+            }
+        }
+
+        // Non-event-driven transitions (timers).
+        phase = tick_listener(phase, &mut swarm, &relay_peer_id)?;
+    }
+}
+
+/// Runs the Peer A role. Implemented in Step 5.
+pub fn run_dial(
+    relay_addr: PeerAddr,
+    target: PeerId,
+) -> Result<(), Box<dyn Error>> {
+    let _ = (relay_addr, target);
+    Err(
+        "relay dial mode is not yet implemented (Step 5 of holepunch-plan.md)"
+            .into(),
+    )
+}
+
+/// Reacts to a single [`SwarmEvent`] and returns the updated phase.
+///
+/// Each arm is annotated with the corresponding step in the listener
+/// state machine described at the top of this module.
+fn handle_listener_event(
+    phase: ListenerPhase,
+    event: SwarmEvent,
+    swarm: &mut Swarm<QuicTransport>,
+    relay_peer_id: &PeerId,
+    our_observed: &[Multiaddr],
+) -> Result<ListenerPhase, Box<dyn Error>> {
+    match (phase, event) {
+        // --- ConnectingToRelay -> Reserving ---------------------------------
+        (ListenerPhase::ConnectingToRelay, SwarmEvent::ConnectionEstablished { peer_id })
+            if peer_id == *relay_peer_id =>
+        {
+            // Open a HOP stream to the relay and start RESERVE.
+            let hop_stream = swarm
+                .open_user_stream(relay_peer_id, HOP_PROTOCOL_ID)
+                .map_err(|e| format!("open HOP stream failed: {e}"))?;
+            Ok(ListenerPhase::Reserving {
+                hop_stream,
+                flow: HopReservation::new(),
+            })
+        }
+
+        // --- Reserving: flush RESERVE once the HOP stream is ready -----------
+        (
+            ListenerPhase::Reserving {
+                hop_stream,
+                mut flow,
+            },
+            SwarmEvent::UserStreamReady {
+                stream_id,
+                initiated_locally: true,
+                ref protocol_id,
+                ..
+            },
+        ) if stream_id == hop_stream && protocol_id == HOP_PROTOCOL_ID => {
+            let outbound = flow.take_outbound();
+            if !outbound.is_empty() {
+                swarm
+                    .send_user_stream(relay_peer_id, hop_stream, outbound)
+                    .map_err(|e| format!("send HOP RESERVE failed: {e}"))?;
+            }
+            Ok(ListenerPhase::Reserving { hop_stream, flow })
+        }
+
+        // --- Reserving: STATUS response body ---------------------------------
+        (
+            ListenerPhase::Reserving {
+                hop_stream,
+                mut flow,
+            },
+            SwarmEvent::UserStreamData {
+                stream_id, data, ..
+            },
+        ) if stream_id == hop_stream => {
+            flow.on_data(&data).map_err(|e| format!("HOP decode: {e}"))?;
+            if let Some(outcome) = flow.outcome() {
+                match outcome {
+                    ReservationOutcome::Accepted { .. } => {
+                        println!("[relay-listen] reserved-on-relay");
+                        return Ok(ListenerPhase::WaitingForCircuit);
+                    }
+                    ReservationOutcome::Refused { status, reason } => {
+                        return Err(format!(
+                            "relay refused reservation: status={status:?} reason={reason}"
+                        )
+                        .into());
+                    }
+                }
+            }
+            Ok(ListenerPhase::Reserving { hop_stream, flow })
+        }
+
+        // --- WaitingForCircuit -> StopAccepting -----------------------------
+        (
+            ListenerPhase::WaitingForCircuit,
+            SwarmEvent::UserStreamReady {
+                stream_id,
+                initiated_locally: false,
+                peer_id,
+                ref protocol_id,
+            },
+        ) if peer_id == *relay_peer_id && protocol_id == STOP_PROTOCOL_ID => {
+            println!(
+                "[relay-listen] incoming-circuit via-relay stream={stream_id}"
+            );
+            Ok(ListenerPhase::StopAccepting {
+                bridge_stream: stream_id,
+                flow: StopResponder::new(),
+            })
+        }
+
+        // --- StopAccepting: drive the StopResponder -------------------------
+        (
+            ListenerPhase::StopAccepting {
+                bridge_stream,
+                mut flow,
+            },
+            SwarmEvent::UserStreamData {
+                stream_id, data, ..
+            },
+        ) if stream_id == bridge_stream => {
+            flow.on_data(&data).map_err(|e| format!("STOP decode: {e}"))?;
+            if let Some(request) = flow.request().cloned() {
+                let remote_peer_id = PeerId::from_bytes(&request.source_peer_id)
+                    .map_err(|e| format!("bad STOP source peer id: {e}"))?;
+                println!(
+                    "[relay-listen] stop-connect-from peer={remote_peer_id}"
+                );
+                flow.accept().map_err(|e| format!("STOP accept: {e}"))?;
+                let outbound = flow.take_outbound();
+                if !outbound.is_empty() {
+                    swarm
+                        .send_user_stream(relay_peer_id, bridge_stream, outbound)
+                        .map_err(|e| format!("STOP STATUS:OK send: {e}"))?;
+                }
+                // Any bytes pipelined behind STOP STATUS:OK belong to DCUtR.
+                let bridge_bytes = flow.take_bridge_bytes();
+                let dcutr = DcutrResponder::new(our_observed);
+                let mut phase = ListenerPhase::DcutrExchange {
+                    bridge_stream,
+                    flow: dcutr,
+                    remote_peer_id,
+                    remote_addrs: Vec::new(),
+                };
+                if !bridge_bytes.is_empty() {
+                    phase = feed_dcutr_listener_bytes(
+                        phase,
+                        &bridge_bytes,
+                        swarm,
+                        relay_peer_id,
+                    )?;
+                }
+                return Ok(phase);
+            }
+            Ok(ListenerPhase::StopAccepting {
+                bridge_stream,
+                flow,
+            })
+        }
+
+        // --- DcutrExchange: feed bytes through DcutrResponder ---------------
+        (
+            ListenerPhase::DcutrExchange {
+                bridge_stream,
+                flow,
+                remote_peer_id,
+                remote_addrs,
+            },
+            SwarmEvent::UserStreamData {
+                stream_id, data, ..
+            },
+        ) if stream_id == bridge_stream => {
+            let phase = ListenerPhase::DcutrExchange {
+                bridge_stream,
+                flow,
+                remote_peer_id,
+                remote_addrs,
+            };
+            feed_dcutr_listener_bytes(phase, &data, swarm, relay_peer_id)
+        }
+
+        // --- HolePunching: did we get a direct connection? ------------------
+        (
+            ListenerPhase::HolePunching {
+                remote_peer_id,
+                bridge_stream,
+                ..
+            },
+            SwarmEvent::ConnectionEstablished { peer_id },
+        ) if peer_id == remote_peer_id => {
+            println!(
+                "[relay-listen] direct-connected peer={peer_id} (hole-punch success)"
+            );
+            swarm
+                .ping(&peer_id)
+                .map_err(|e| format!("ping on direct conn: {e}"))?;
+            let _ = bridge_stream;
+            Ok(ListenerPhase::PingingDirect {
+                peer_id: remote_peer_id,
+            })
+        }
+
+        // --- PingingDirect: exit on RTT -------------------------------------
+        (
+            ListenerPhase::PingingDirect { peer_id },
+            SwarmEvent::PingRttMeasured {
+                peer_id: who, rtt_ms,
+            },
+        ) if who == peer_id => {
+            println!(
+                "[relay-listen] ping-direct peer={peer_id} rtt={rtt_ms}ms -- done"
+            );
+            std::process::exit(0);
+        }
+
+        // --- RelayPingFallback: echo bytes over the bridge ------------------
+        (
+            ListenerPhase::RelayPingFallback {
+                bridge_stream,
+                remote_peer_id,
+            },
+            SwarmEvent::UserStreamData {
+                stream_id, data, ..
+            },
+        ) if stream_id == bridge_stream => {
+            // Echo the payload so Peer A measures an RTT.
+            swarm
+                .send_user_stream(relay_peer_id, bridge_stream, data)
+                .map_err(|e| format!("relay-ping echo: {e}"))?;
+            Ok(ListenerPhase::RelayPingFallback {
+                bridge_stream,
+                remote_peer_id,
+            })
+        }
+
+        // --- Events we don't care about: pass through ------------------------
+        (phase, _) => Ok(phase),
+    }
+}
+
+/// Owned-phase dispatch for DCUtR stream data: the tuple match in
+/// `handle_listener_event` can't move the phase in, so the `UserStreamData`
+/// arm for the DCUtR phase is handled here via a secondary match in the
+/// main event loop caller.
+fn feed_dcutr_listener_bytes(
+    phase: ListenerPhase,
+    bytes: &[u8],
+    swarm: &mut Swarm<QuicTransport>,
+    relay_peer_id: &PeerId,
+) -> Result<ListenerPhase, Box<dyn Error>> {
+    let ListenerPhase::DcutrExchange {
+        bridge_stream,
+        mut flow,
+        remote_peer_id,
+        mut remote_addrs,
+    } = phase
+    else {
+        return Ok(phase);
+    };
+
+    flow.on_data(bytes)
+        .map_err(|e| format!("DCUtR decode: {e}"))?;
+    let out = flow.take_outbound();
+    if !out.is_empty() {
+        swarm
+            .send_user_stream(relay_peer_id, bridge_stream, out)
+            .map_err(|e| format!("DCUtR send: {e}"))?;
+    }
+
+    let mut saw_sync = false;
+    for event in flow.poll_events() {
+        match event {
+            ResponderEvent::ConnectReceived {
+                remote_addrs: parsed,
+                remote_addr_bytes,
+            } => {
+                if parsed.len() < remote_addr_bytes.len() {
+                    eprintln!(
+                        "[relay-listen] dcutr-connect-received: {} of {} remote \
+                         addrs failed to parse and were ignored",
+                        remote_addr_bytes.len() - parsed.len(),
+                        remote_addr_bytes.len()
+                    );
+                }
+                remote_addrs = parsed;
+                println!(
+                    "[relay-listen] dcutr-connect-received addrs={}",
+                    remote_addrs.len()
+                );
+            }
+            ResponderEvent::SyncReceived => {
+                println!("[relay-listen] dcutr-sync-received -> holepunching");
+                saw_sync = true;
+            }
+        }
+    }
+
+    if saw_sync {
+        Ok(ListenerPhase::HolePunching {
+            bridge_stream,
+            remote_peer_id,
+            remote_addrs,
+            started_at: Instant::now(),
+            last_blast: None,
+        })
+    } else {
+        Ok(ListenerPhase::DcutrExchange {
+            bridge_stream,
+            flow,
+            remote_peer_id,
+            remote_addrs,
+        })
+    }
+}
+
+/// Handles time-based transitions in the listener: DCUtR bridge data
+/// routing and hole-punch UDP bombardment.
+fn tick_listener(
+    phase: ListenerPhase,
+    swarm: &mut Swarm<QuicTransport>,
+    relay_peer_id: &PeerId,
+) -> Result<ListenerPhase, Box<dyn Error>> {
+    match phase {
+        ListenerPhase::HolePunching {
+            bridge_stream,
+            remote_peer_id,
+            remote_addrs,
+            started_at,
+            mut last_blast,
+        } => {
+            let now = Instant::now();
+            let elapsed = now.saturating_duration_since(started_at);
+
+            if elapsed >= HOLEPUNCH_DEADLINE {
+                println!(
+                    "[relay-listen] hole-punch-timeout -> relay-ping fallback"
+                );
+                return Ok(ListenerPhase::RelayPingFallback {
+                    bridge_stream,
+                    remote_peer_id,
+                });
+            }
+
+            // Per the plan, responder waits RESPONDER_SYNC_DELAY before
+            // starting to blast UDP; then sends at HOLEPUNCH_INTERVAL.
+            let should_blast = match last_blast {
+                None => elapsed >= RESPONDER_SYNC_DELAY,
+                Some(t) => now.duration_since(t) >= HOLEPUNCH_INTERVAL,
+            };
+
+            if should_blast {
+                blast_remote_addrs(swarm, &remote_addrs);
+                last_blast = Some(now);
+            }
+
+            Ok(ListenerPhase::HolePunching {
+                bridge_stream,
+                remote_peer_id,
+                remote_addrs,
+                started_at,
+                last_blast,
+            })
+        }
+        other => {
+            let _ = (swarm, relay_peer_id);
+            Ok(other)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Builds a swarm with the relay + DCUtR user protocols registered.
+fn build_swarm_with_relay_protocols() -> Result<Swarm<QuicTransport>, Box<dyn Error>> {
+    let keypair = Ed25519Keypair::generate();
+    let transport = QuicTransport::new(QuicNodeConfig::with_keypair(keypair.clone()), LOCAL_BIND)
+        .map_err(|e| format!("quic bind failed: {e}"))?;
+    let mut swarm = SwarmBuilder::new(&keypair).agent_version(AGENT).build(transport);
+    // Advertise + accept the three user protocols the flow needs.
+    swarm.add_user_protocol(HOP_PROTOCOL_ID);
+    swarm.add_user_protocol(STOP_PROTOCOL_ID);
+    swarm.add_user_protocol(DCUTR_PROTOCOL_ID);
+    Ok(swarm)
+}
+
+/// Sends a random 32-byte UDP payload to every remote address. Per
+/// the DCUtR spec these packets serve to open the NAT binding so that
+/// inbound QUIC packets from the remote peer can arrive; their
+/// content is irrelevant.
+fn blast_remote_addrs(swarm: &Swarm<QuicTransport>, addrs: &[Multiaddr]) {
+    let payload = random_bytes(RELAY_PING_LEN);
+    for addr in addrs {
+        if let Err(e) = swarm.transport().send_raw_udp(addr, &payload) {
+            eprintln!("[relay-listen] udp-blast to {addr} failed: {e}");
+        }
+    }
+}
+
+/// Short random byte vector. `getrandom` avoids pulling in `rand`.
+fn random_bytes(len: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; len];
+    // Best-effort randomness; if the OS RNG fails we fall back to
+    // deterministic zeros rather than panicking, since the payload
+    // content doesn't affect hole-punch semantics.
+    let _ = getrandom::fill(&mut buf);
+    buf
+}
+
+/// Human-readable phase name for error messages.
+fn phase_name(phase: &ListenerPhase) -> &'static str {
+    match phase {
+        ListenerPhase::ConnectingToRelay => "ConnectingToRelay",
+        ListenerPhase::Reserving { .. } => "Reserving",
+        ListenerPhase::WaitingForCircuit => "WaitingForCircuit",
+        ListenerPhase::StopAccepting { .. } => "StopAccepting",
+        ListenerPhase::DcutrExchange { .. } => "DcutrExchange",
+        ListenerPhase::HolePunching { .. } => "HolePunching",
+        ListenerPhase::PingingDirect { .. } => "PingingDirect",
+        ListenerPhase::RelayPingFallback { .. } => "RelayPingFallback",
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -188,6 +188,14 @@ New crate: `crates/tls` (`minip2p-tls`) -- `no_std + alloc` compatible.
 **Exit criteria**
 - One end-to-end example runs from docs without hidden steps.
 
+## Developer experience
+
+DX improvements and roadmap live in `dx-plan.md`. Includes a backlog
+of Tier 1/2/3 items (e.g. `SwarmEvent::PeerReady` for peer-ready
+signaling, typed `SwarmEvent::Error`, `Swarm::listen()` helper,
+keypair persistence) derived from real pain observed while writing
+`examples/peer`.
+
 ## Quality Gates
 
 - Unit tests for core parsing/types and error behavior.

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -649,6 +649,14 @@ impl Transport for QuicTransport {
         Ok(())
     }
 
+    fn local_addresses(&self) -> Vec<Multiaddr> {
+        // If the socket isn't bound for some reason (shouldn't happen in
+        // normal usage -- we bind at construction time), return empty
+        // rather than propagate the error. The swarm uses this only to
+        // enrich Identify; a missing value is never fatal.
+        self.local_multiaddr().map(|addr| vec![addr]).unwrap_or_default()
+    }
+
     fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError> {
         let mut buf = [0u8; 65535];
         let mut events = std::mem::take(&mut self.pending_events);

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -661,6 +661,13 @@ impl Transport for QuicTransport {
         self.connections.len()
     }
 
+    fn active_connection_sources(&self) -> Vec<Multiaddr> {
+        self.connections
+            .values()
+            .map(|conn| conn.endpoint().transport().clone())
+            .collect()
+    }
+
     fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError> {
         let mut buf = [0u8; 65535];
         let mut events = std::mem::take(&mut self.pending_events);

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -657,6 +657,10 @@ impl Transport for QuicTransport {
         self.local_multiaddr().map(|addr| vec![addr]).unwrap_or_default()
     }
 
+    fn active_connection_count(&self) -> usize {
+        self.connections.len()
+    }
+
     fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError> {
         let mut buf = [0u8; 65535];
         let mut events = std::mem::take(&mut self.pending_events);

--- a/transports/quic/tests/swarm_e2e.rs
+++ b/transports/quic/tests/swarm_e2e.rs
@@ -3,8 +3,6 @@
 //! Contrast with `ping_e2e.rs` which requires ~200 lines of manual negotiation
 //! and dispatch code. Here, the Swarm handles everything.
 
-use std::str::FromStr;
-
 use minip2p_core::Multiaddr;
 use minip2p_identity::Ed25519Keypair;
 use minip2p_ping::PING_PROTOCOL_ID;
@@ -230,10 +228,10 @@ fn identify_exchange_carries_observed_addr() {
         "client-side observed_addr must not be empty"
     );
 
-    // The current encoding is the multiaddr's string form -- decode and
-    // check it round-trips into a valid QUIC transport multiaddr.
-    let addr_str = std::str::from_utf8(&client_bytes).expect("observed_addr should be utf-8");
-    let addr = Multiaddr::from_str(addr_str).expect("observed_addr should parse as multiaddr");
+    // Identify now encodes observed_addr per the libp2p spec -- varint
+    // multicodec + value -- so decode with Multiaddr::from_bytes.
+    let addr =
+        Multiaddr::from_bytes(&client_bytes).expect("observed_addr should decode as binary multiaddr");
     assert!(
         addr.is_quic_transport(),
         "observed_addr should be a QUIC transport multiaddr, got {addr}"


### PR DESCRIPTION
## Summary

Extends `examples/peer` with the relay-coordinated hole-punch flow
from `holepunch-plan.md`. Both sides of the state machine now work:

- **Listener (Peer B)** reserves a slot on the relay, accepts an
  incoming STOP circuit, runs DCUtR as the responder, blasts random
  UDP at the remote's observed addresses to open its NAT binding,
  falls back to echoing a relay-bridged ping if hole-punch misses.
- **Dialer (Peer A)** opens a HOP CONNECT through the relay, runs
  DCUtR as the initiator, issues simultaneous `swarm.dial` calls to
  every remote address on `DialNow`, falls back to sending a random
  payload over the bridge and measuring its echo RTT if direct
  connection fails.

Output is one event per line, prefixed with a role tag, per the plan.

## Mid-CLI DX fixes (dev-phase breaking changes)

Pulled in two items from the DX roadmap while the CLI exposed the
pain points:

1. `DcutrInitiator::new` / `DcutrResponder::new` now take
   `&[Multiaddr]` instead of `Vec<Vec<u8>>`. Same wire format
   (display-string bytes) but the types stop lying about what's in
   them. `InitiatorOutcome::DialNow` / `ResponderEvent::ConnectReceived`
   surface both the parsed `Vec<Multiaddr>` and the raw bytes so
   callers can diagnose malformed entries without re-parsing.
2. `Swarm::local_peer_id()` is now an infallible `&PeerId` accessor
   cached at `SwarmBuilder::build` time. Replaces the previous
   `swarm.transport().local_peer_id()` drill-down that returned
   `Option<PeerId>` for no good reason when the builder was used.

Skipped Step 6 (shared helpers extraction — not enough duplication)
and Step 8 (manual rust-libp2p relay verification — post-merge
activity).

## Test Plan

- `cargo test --workspace` — 29 suites pass; the DCUtR crate picks
  up 7 new unit tests (12 → 19) covering the new API and the
  "drop malformed remote addrs but keep bytes" case.
- `cargo test -p minip2p-peer --test direct` — ~0.45s, stable across
  5 back-to-back runs.
- Smoke: `minip2p-peer dial --relay <addr> --target <id>` boots,
  binds an ephemeral QUIC socket, derives our PeerId via the new
  `Swarm::local_peer_id()`, and prints the expected `dialing-relay`
  line before hitting the deadline against the nonexistent relay.
  Real end-to-end validation against the `rust-libp2p` relay server
  is tracked as Step 8 (follow-up).

## Commits

- `44a164b` — Step 4 (listener) + both DX fixes
- `077dcff` — Step 5 (dialer) + README

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds relay hole-punch (Steps 4–5) to `examples/peer`, linearizes the CLI, and improves interop with binary multiaddrs and Identify framing. Refines listener exit by matching inbound connection sources to DCUtR addresses, shortens the punch window, and exits cleanly when the relay bridge closes.

- **New Features**
  - `minip2p-peer`: relay listen and dial via HOP/STOP + DCUtR; UDP hole-punch with relay-bridged RTT fallback; linear scripts with `Swarm::run_until`; clean exit when the bridge closes; listener early-exit on direct connect by matching `Transport::active_connection_sources()` against DCUtR `remote_addrs` with a 2s grace; hole-punch deadline set to 3s; fixed responder event handling to retain `remote_addrs` across poll cycles.
  - `minip2p-core`: `Multiaddr::to_bytes`/`from_bytes` multicodec-binary codec with tests.
  - `minip2p-identify`: varint length-prefixed framing; `observed_addr` and `listen_addrs` encoded as binary multiaddrs; `listen_addrs` auto-populated from the transport.
  - `minip2p-swarm` (std driver): added `Swarm::poll_next` and `Swarm::run_until`; snapshots `transport.local_addresses()` each poll; idle sleep reduced to 1ms.
  - `minip2p-transport`/`minip2p-quic`: `local_addresses()`, `active_connection_count()`, and `active_connection_sources()` APIs with QUIC overrides.
  - Docs: added `dx-plan.md` and linked it from `README.md` and `crates/swarm/README.md`.

- **Migration**
  - `minip2p-dcutr`: constructors now take `&[Multiaddr]`; `DialNow`/`ConnectReceived` return `remote_addrs: Vec<Multiaddr>` and `remote_addr_bytes: Vec<Vec<u8>>`.
  - `minip2p-identify`: `IdentifyConfig.listen_addrs` removed; pass `&[Multiaddr]` to `register_outbound_stream`.
  - `minip2p-swarm`: removed `SwarmBuilder::listen_addr_bytes`; new infallible `Swarm::local_peer_id() -> &PeerId`.
  - `minip2p-transport`: implementers should add `active_connection_count()` and `active_connection_sources()` (both have safe defaults).

<sup>Written for commit 8082bb7e59749404f54e866dcfa5f09d05426de9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

