### PR TITLE
quic: enable mutual TLS identity verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +34,24 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -51,6 +78,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "boring"
+version = "4.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a732fa30cc654efcca7d4b39cc0e0b0a22df43a188fa8221ea9a24ddca718caf"
+dependencies = [
+ "bitflags",
+ "boring-sys",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+]
+
+[[package]]
+name = "boring-sys"
+version = "4.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f922afb52d05239f8d4042ca1df15da9d340c2b58bfb5b8daf15acbf8d6e195e"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,10 +119,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "cmake"
@@ -328,22 +400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +424,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,29 +489,23 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -483,6 +576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,16 +603,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -532,6 +638,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minip2p-core"
@@ -607,6 +719,7 @@ dependencies = [
 name = "minip2p-quic"
 version = "0.1.0"
 dependencies = [
+ "boring",
  "getrandom 0.4.2",
  "minip2p-core",
  "minip2p-identify",
@@ -617,7 +730,6 @@ dependencies = [
  "minip2p-tls",
  "minip2p-transport",
  "quiche",
- "tempfile",
 ]
 
 [[package]]
@@ -681,6 +793,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +822,17 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "p256"
@@ -781,10 +914,12 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882f4a3c27bedb806b4944a82700fc5ab3c0f1bd57ba98155b103e6d61dc7e25"
 dependencies = [
+ "boring",
  "bytes",
  "cmake",
  "either",
  "enum_dispatch",
+ "foreign-types-shared",
  "intrusive-collections",
  "libc",
  "libm",
@@ -803,12 +938,6 @@ checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -832,6 +961,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rfc6979"
 version = "0.5.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +998,12 @@ dependencies = [
  "hmac",
  "subtle",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -869,19 +1033,6 @@ dependencies = [
  "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
 ]
 
 [[package]]
@@ -1041,19 +1192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.3.4",
- "once_cell",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1319,34 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Runtime adapters (`std`):
 
 Current validated behavior:
 
-- Two local peers connect over QUIC in integration tests, with libp2p TLS peer authentication.
+- Two local peers connect over QUIC in integration tests, with mutual libp2p TLS peer authentication.
 - Bidirectional stream data exchange with half-close propagation.
 - Multistream-select negotiation with spec-compliant varint framing.
 - Ping protocol round-trips with RTT measurement over negotiated streams.
@@ -100,7 +100,7 @@ cargo doc --workspace --no-deps --open
 - [x] Circuit Relay v2 client state machines.
 - [x] DCUtR hole-punching state machines.
 - [ ] Runnable hole-punch CLI against a real relay (see `holepunch-plan.md`).
-- [ ] Mutual TLS on the QUIC transport so the listener learns the client PeerId at handshake time.
+- [x] Mutual TLS on the QUIC transport so the listener learns the client PeerId at handshake time.
 - [ ] Additional transport adapters (TCP, WebSocket, WebRTC).
 
 See `plan.md` for the detailed execution plan and milestones, and `holepunch-plan.md` for the runnable relay/DCUtR demo work.

--- a/crates/ping/src/lib.rs
+++ b/crates/ping/src/lib.rs
@@ -195,6 +195,13 @@ impl PingProtocol {
         Ok(())
     }
 
+    /// Returns the negotiated outbound ping stream for `peer_id`, if any.
+    pub fn outbound_stream(&self, peer_id: &PeerId) -> Option<StreamId> {
+        self.peers
+            .get(peer_id)
+            .and_then(|peer| peer.outbound_stream)
+    }
+
     /// Registers a negotiated inbound stream from a peer.
     pub fn register_inbound_stream(
         &mut self,
@@ -831,6 +838,19 @@ mod tests {
             .expect("re-register outbound stream after remove_peer");
         let actions = ping.register_inbound_stream(peer.clone(), StreamId::new(11));
         assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn outbound_stream_ignores_inbound_streams() {
+        let mut ping = PingProtocol::default();
+        let peer = test_peer();
+
+        ping.register_inbound_stream(peer.clone(), StreamId::new(1));
+        assert_eq!(ping.outbound_stream(&peer), None);
+
+        ping.register_outbound_stream(peer.clone(), StreamId::new(2))
+            .expect("register outbound stream");
+        assert_eq!(ping.outbound_stream(&peer), Some(StreamId::new(2)));
     }
 
     #[test]

--- a/crates/ping/src/lib.rs
+++ b/crates/ping/src/lib.rs
@@ -468,9 +468,8 @@ impl PingProtocol {
     /// Re-keys all state for `old_peer_id` to `new_peer_id`.
     ///
     /// Used when the swarm discovers a connection's real peer identity after
-    /// initially registering the connection under a placeholder (e.g. the
-    /// listener side of a one-way TLS handshake creates a synthetic PeerId
-    /// that is upgraded once the real identity is verified).
+    /// initially registering the connection under a placeholder that is
+    /// upgraded once the real identity is verified.
     ///
     /// Also rewrites any buffered events still referencing `old_peer_id` so
     /// the application only ever sees events under the real PeerId.

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -607,14 +607,7 @@ impl SwarmCore {
     }
 
     fn find_negotiated_ping_stream(&self, peer_id: &PeerId) -> Option<StreamId> {
-        let conn = *self.peer_to_conn.get(peer_id)?;
-        self.stream_owner.iter().find_map(|((c, s), owner)| {
-            if *c == conn && matches!(owner, ProtocolKind::Ping) {
-                Some(*s)
-            } else {
-                None
-            }
-        })
+        self.ping.outbound_stream(peer_id)
     }
 
     fn has_pending_ping_stream(&self, peer_id: &PeerId) -> bool {

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -397,8 +397,7 @@ impl SwarmCore {
                 if let Some(peer_id) = endpoint.peer_id() {
                     self.register_connection(id, peer_id.clone());
                 } else {
-                    // Peer identity is not yet known (e.g. server side with
-                    // verify_peer(false)). Synthesize a placeholder PeerId
+                    // Peer identity is not yet known. Synthesize a placeholder PeerId
                     // for internal bookkeeping so protocol handlers can still
                     // operate. No ConnectionEstablished event yet -- we emit
                     // one when the real identity arrives via

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -635,6 +635,11 @@ impl SwarmCore {
         target: ProtocolKind,
     ) -> Result<(), SwarmError> {
         let conn_id = self.require_conn(peer_id)?;
+        debug_assert_eq!(
+            self.conn_to_peer.get(&conn_id),
+            Some(peer_id),
+            "protocol opens must use a connection mapped to the requested peer"
+        );
         let token = self.next_open_token();
         self.pending_opens.insert(
             token,

--- a/crates/tls/src/lib.rs
+++ b/crates/tls/src/lib.rs
@@ -7,6 +7,10 @@
 //! Both verification and generation are `no_std + alloc` compatible. The
 //! `std` feature adds a convenience wrapper ([`generate_certificate`]) that
 //! uses OS randomness and a default validity window, plus PEM encoding helpers.
+//!
+//! Certificate generation currently uses Ed25519 host identities. Verification
+//! parses other libp2p public-key extensions for test-vector coverage, but only
+//! Ed25519 host-key signatures are accepted today.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/transport/src/event.rs
+++ b/crates/transport/src/event.rs
@@ -49,6 +49,12 @@ pub enum TransportEvent {
         endpoint: ConnectionEndpoint,
     },
     /// A peer identity was bound to a connection.
+    ///
+    /// Transports may emit this after `Connected` when identity is learned as a
+    /// post-handshake upgrade. Transports that verify identity during the
+    /// handshake may also emit both `Connected` with the verified endpoint and
+    /// this event so consumers that track identity-upgrade events have one
+    /// consistent signal to observe.
     PeerIdentityVerified {
         id: ConnectionId,
         endpoint: ConnectionEndpoint,

--- a/examples/peer/README.md
+++ b/examples/peer/README.md
@@ -5,11 +5,13 @@ CLI demo that exercises the full minip2p stack end-to-end.
 Two modes:
 
 - **Direct** — two peers on the same host dial each other directly over
-  QUIC and run ping. No relay. Validates the whole base stack
-  (QUIC + multistream-select + identify + ping + swarm) in one command.
+  QUIC, verify each other with libp2p mTLS, and run ping. No relay.
+  Validates the whole base stack (QUIC + mTLS + multistream-select +
+  identify + ping + swarm) in one command.
 - **Relay** — two NATed peers rendezvous via a Circuit Relay v2 server,
-  coordinate DCUtR, attempt a UDP hole-punch, and fall back to a
-  relay-bridged RTT measurement if direct connection fails.
+  coordinate DCUtR, attempt a UDP hole-punch, verify direct QUIC identities
+  with mTLS, and fall back to a relay-bridged RTT measurement if direct
+  connection fails.
 
 ## Usage
 
@@ -44,8 +46,13 @@ cargo run -p minip2p-peer -- dial /ip4/127.0.0.1/udp/53121/quic-v1/p2p/12D3KooW.
 # [dial] dialing .../p2p/12D3KooW...
 # [dial] connected peer=12D3KooW...
 # [dial] identify peer=12D3KooW... agent=minip2p-peer/0.1.0 protocols=2
+# [dial] peer-ready peer=12D3KooW... protocols=2
 # [dial] ping peer=12D3KooW... rtt=6ms
 ```
+
+Both sides authenticate during the QUIC TLS handshake. The listener learns the
+dialer's `PeerId` from the client certificate; no post-hoc manual binding is
+needed.
 
 Run the automated direct-mode E2E test:
 
@@ -140,7 +147,7 @@ steps is visible top-to-bottom.
 - `src/direct.rs` — direct-mode listen/dial; zero relay machinery.
 - `src/relay.rs` — relay-mode scripts for both Peer B (listener) and
   Peer A (dialer), driving the HOP/STOP/DCUtR state machines inline
-  and running the hole-punch + relay-ping fallback at the bottom.
+  and running mTLS-verified hole-punch + relay-ping fallback at the bottom.
 
 See `holepunch-plan.md` at the repo root for the design rationale and
 open questions (RTT approximation on the responder side, relay-ping

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -37,13 +37,9 @@ const AGENT: &str = "minip2p-peer/0.1.0";
 const LISTEN_DEADLINE: Duration = Duration::from_secs(60);
 /// Hole-punch window after SYNC is received / sent.
 ///
-/// Kept short because on the listener side we fall back to an
-/// inbound-connection-count heuristic for early exit (since without
-/// mutual TLS we can't directly observe the remote's verified peer
-/// id). On the dialer side, direct dials succeed in milliseconds on
-/// LAN/loopback; real-world NATs may occasionally need longer but
-/// three seconds already works for the common-case symmetric-NAT
-/// traversal path.
+/// Direct dials succeed in milliseconds on LAN/loopback; real-world NATs may
+/// occasionally need longer but three seconds already works for the common-case
+/// symmetric-NAT traversal path.
 const HOLEPUNCH_DEADLINE: Duration = Duration::from_secs(3);
 /// UDP blast cadence (responder side) during hole-punch.
 const HOLEPUNCH_INTERVAL: Duration = Duration::from_millis(100);
@@ -252,22 +248,30 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
             ping_and_exit(&mut swarm, role, peer_id, deadline)
         }
         HolePunchOutcome::InboundConnectionSeen => {
-            // We saw an inbound direct path but this CLI flow has not mapped it
-            // back to the remote relay peer yet. Run the event loop for a short
-            // grace window so we stay responsive to inbound streams.
+            // The address heuristic fired before Swarm surfaced the verified
+            // mTLS identity. Give QUIC one short grace window to complete the
+            // identity event so this side can direct-ping too.
             println!(
                 "[{role}] inbound-direct-connection detected (hole-punch success; \
-                 waiting for peer mapping)"
+                 waiting for verified mTLS identity)"
             );
             let grace_deadline = Instant::now() + Duration::from_secs(2);
-            let _ = swarm
+            let verified = swarm
                 .run_until(grace_deadline, |ev| {
                     print_event(role, ev);
-                    false // keep draining until the grace period elapses
+                    matches!(ev, SwarmEvent::ConnectionEstablished { peer_id } if peer_id == &remote_peer_id)
                 })
                 .map_err(|e| format!("grace poll: {e}"))?;
-            println!("[{role}] grace-elapsed -- done");
-            Ok(())
+            match verified {
+                Some(SwarmEvent::ConnectionEstablished { peer_id }) => {
+                    println!("[{role}] direct-connected peer={peer_id} (mTLS verified)");
+                    ping_and_exit(&mut swarm, role, peer_id, deadline)
+                }
+                _ => {
+                    println!("[{role}] grace-elapsed before mTLS identity -- done");
+                    Ok(())
+                }
+            }
         }
         HolePunchOutcome::BridgeClosed => {
             // Relay closed the circuit. Most likely the remote went
@@ -314,13 +318,11 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
 
 /// Terminal states the listener's hole-punch loop can resolve to.
 enum HolePunchOutcome {
-    /// Saw `ConnectionEstablished` for the remote peer id (only
-    /// possible once mutual TLS is implemented; see Milestone 6).
+    /// Saw `ConnectionEstablished` for the remote peer id from mTLS.
     DirectConnected(PeerId),
-    /// `transport.active_connection_count()` grew beyond the relay
-    /// baseline. Almost certainly the remote peer coming in direct.
-    /// Coarse heuristic; not suitable for security decisions but
-    /// fine for this demo binary.
+    /// Saw an inbound QUIC source matching the remote's DCUtR address before
+    /// the verified identity reached Swarm. Coarse trigger only; the listener
+    /// waits for mTLS identity before direct-pinging.
     InboundConnectionSeen,
     /// Relay closed the bridge stream -- strong signal that the
     /// remote went direct and stopped using the circuit.

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -252,16 +252,12 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
             ping_and_exit(&mut swarm, role, peer_id, deadline)
         }
         HolePunchOutcome::InboundConnectionSeen => {
-            // We can't ping the remote from our side (don't know their
-            // verified peer id without mTLS), and we can't detect when
-            // the remote's own ping round-trip completes either. Run
-            // the event loop for a short grace window so we stay
-            // responsive to inbound streams (including the remote's
-            // ping, which would otherwise time out waiting on our
-            // echo).
+            // We saw an inbound direct path but this CLI flow has not mapped it
+            // back to the remote relay peer yet. Run the event loop for a short
+            // grace window so we stay responsive to inbound streams.
             println!(
                 "[{role}] inbound-direct-connection detected (hole-punch success; \
-                 remote peer-id unverified pre-mTLS)"
+                 waiting for peer mapping)"
             );
             let grace_deadline = Instant::now() + Duration::from_secs(2);
             let _ = swarm
@@ -275,12 +271,11 @@ pub fn run_listen(relay_addr: PeerAddr) -> Result<(), Box<dyn Error>> {
         }
         HolePunchOutcome::BridgeClosed => {
             // Relay closed the circuit. Most likely the remote went
-            // direct and no longer needs the bridge; we just can't
-            // confirm that independently without mutual TLS on the
-            // QUIC server side. Exit cleanly.
+            // direct and no longer needs the bridge; this CLI treats
+            // that as a clean terminal state.
             println!(
                 "[{role}] bridge-closed (remote likely completed via direct path; \
-                 mTLS gap prevents confirmation) -- done"
+                 relay no longer needed) -- done"
             );
             Ok(())
         }

--- a/examples/peer/tests/direct.rs
+++ b/examples/peer/tests/direct.rs
@@ -86,16 +86,19 @@ fn read_bound_line<R: std::io::Read + Send + 'static>(
     thread::spawn(move || {
         let mut buf = BufReader::new(reader);
         let mut line = String::new();
+        let mut sent_bound = false;
         loop {
             line.clear();
             if buf.read_line(&mut line).unwrap_or(0) == 0 {
                 // EOF: listener died before printing its bound line.
-                let _ = tx.send(None);
+                if !sent_bound {
+                    let _ = tx.send(None);
+                }
                 return;
             }
-            if let Some(rest) = line.strip_prefix("[listen] bound=") {
+            if !sent_bound && let Some(rest) = line.strip_prefix("[listen] bound=") {
                 let _ = tx.send(Some(rest.trim_end().to_string()));
-                return;
+                sent_bound = true;
             }
         }
     });

--- a/holepunch-plan.md
+++ b/holepunch-plan.md
@@ -299,9 +299,5 @@ frame delivery without needing a separate poll round.
   the CLI to know the right abstraction.
 - Noise + Yamux over the relay bridge for interop with third-party
   libp2p peers.
-- Mutual TLS on the QUIC transport so the server side gets the client's
-  verified PeerId without relying on a post-hoc Identify or the synthetic
-  placeholder. Requires quiche custom verify callback (boringssl feature)
-  or upstream change.
 - Relay discovery (e.g. through DHT or a bootstrap list) instead of
   requiring the user to supply the relay multiaddr.

--- a/plan.md
+++ b/plan.md
@@ -171,9 +171,9 @@ New crate: `crates/tls` (`minip2p-tls`) -- `no_std + alloc` compatible.
 - Two minip2p peers connect via a real relay server, negotiate DCUtR, attempt hole punch, and succeed (direct ping) or fall back to relay ping.
 - Deferred (larger scope): STUN client for address discovery, relay server binary, production-grade refusal handling.
 
-### Milestone 6: Architectural cleanup
+### Milestone 6: Architectural cleanup -- DONE
 
-- [ ] Mutual TLS on the QUIC transport so the listener side learns the real client PeerId without the synthetic-placeholder dance. Requires either `quiche`'s `boringssl-boring-crate` feature with a custom verify callback, or an upstream change.
+- [x] Mutual TLS on the QUIC transport so the listener side learns the real client PeerId without the synthetic-placeholder dance. Uses `quiche`'s `boringssl-boring-crate` feature with a permissive TLS verify callback; libp2p certificate identity verification remains in `minip2p-tls` after the QUIC handshake.
 
 **Exit criteria**
 - `TransportEvent::PeerIdentityVerified` fires on the server side of a mutual-TLS QUIC handshake; the synthetic PeerId path in Swarm is exercised only as a fallback, not as the default.

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -8,9 +8,9 @@ minip2p-transport = { path = "../../crates/transport" }
 minip2p-identity = { path = "../../crates/identity" }
 minip2p-core = { path = "../../crates/core" }
 minip2p-tls = { path = "../../crates/tls" }
-quiche = "0.28"
+boring = "4"
+quiche = { version = "0.28", features = ["boringssl-boring-crate"] }
 getrandom = "0.4"
-tempfile = "3"
 
 [dev-dependencies]
 minip2p-multistream-select = { path = "../../crates/multistream-select" }

--- a/transports/quic/README.md
+++ b/transports/quic/README.md
@@ -15,19 +15,20 @@ No async runtime required. The host drives the transport by calling `poll()`.
   - `close_stream_write`
   - `reset_stream`
 - Stream events (`StreamOpened`, `IncomingStream`, `StreamData`, `StreamRemoteWriteClosed`, `StreamClosed`).
-- Optional peer-id binding with `verify_connection_peer_id(...)`.
+- Mutual libp2p TLS peer authentication. Dialing and listening require a configured Ed25519 keypair.
+- Automatic peer-id verification from libp2p TLS certificates. `Connected` carries the verified endpoint; `PeerIdentityVerified` is also emitted when the peer index is bound or updated.
 - Dial supports `/ip4`, `/ip6`, `/dns`, `/dns4`, `/dns6` QUIC transport addresses.
 
 ## Basic usage
 
 ```rust
 use minip2p_core::{Multiaddr, PeerAddr, Protocol};
-use minip2p_identity::PeerId;
+use minip2p_identity::Ed25519Keypair;
 use minip2p_quic::{QuicNodeConfig, QuicTransport};
 use minip2p_transport::{ConnectionId, Transport};
-use std::str::FromStr;
 
-let listener_cfg = QuicNodeConfig::dev_listener_with_tls("cert.pem", "key.pem");
+let listener_key = Ed25519Keypair::generate();
+let listener_cfg = QuicNodeConfig::with_keypair(listener_key.clone());
 let mut listener = QuicTransport::new(listener_cfg, "127.0.0.1:0")?;
 
 let local = listener.local_addr()?;
@@ -41,8 +42,7 @@ listener.listen(&listen_addr)?;
 let dialer_cfg = QuicNodeConfig::dev_dialer();
 let mut dialer = QuicTransport::new(dialer_cfg, "127.0.0.1:0")?;
 
-let peer_id = PeerId::from_str("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N")?;
-let peer_addr = PeerAddr::new(listen_addr, peer_id)?;
+let peer_addr = PeerAddr::new(listen_addr, listener_key.peer_id())?;
 
 let conn_id = ConnectionId::new(1);
 dialer.dial(conn_id, &peer_addr)?;
@@ -55,3 +55,10 @@ dialer.send_stream(conn_id, stream_id, b"hello".to_vec())?;
 
 This crate is a concrete transport adapter and depends on `std`.
 For Sans-I/O contracts and shared types, use `minip2p-transport`.
+
+## Authentication Notes
+
+- QUIC handshakes require mutual TLS. A peer that omits a certificate or presents a certificate without the libp2p public-key extension is rejected before `Connected` is emitted.
+- The TLS backend only handles the wire handshake. libp2p identity verification is performed by `minip2p-tls` after quiche exposes the peer certificate.
+- `minip2p-tls` currently accepts Ed25519 host-key signatures for verified peers.
+- `IncomingConnection` is pre-auth and may be emitted before certificate verification finishes. Treat `Connected` or `PeerIdentityVerified` as the authenticated connection signal.

--- a/transports/quic/src/connection.rs
+++ b/transports/quic/src/connection.rs
@@ -157,40 +157,49 @@ impl QuicConnection {
             self.flush(socket)?;
 
             // Auto-verify the remote peer's identity from their TLS certificate.
-            if let Some(peer_cert_der) = self.conn.peer_cert() {
-                match minip2p_tls::verify_libp2p_certificate(peer_cert_der) {
-                    Ok(verified_peer_id) => {
-                        // If the dialer specified an expected PeerId (via PeerAddr),
-                        // reject the connection if the verified identity doesn't match.
-                        if let Some(expected) = self.endpoint.peer_id() {
-                            if *expected != verified_peer_id {
-                                events.push(TransportEvent::Error {
-                                    id: self.id,
-                                    message: format!(
-                                        "peer id mismatch: dialed {expected} but server certificate proves {verified_peer_id}"
-                                    ),
-                                });
-                                // Close the connection — the peer is not who we expected.
-                                let _ = self.conn.close(true, 0x01, b"peer id mismatch");
-                                self.state = ConnectionState::Closing;
-                                self.flush(socket)?;
-                                return Ok(());
-                            }
+            let Some(peer_cert_der) = self.conn.peer_cert() else {
+                events.push(TransportEvent::Error {
+                    id: self.id,
+                    message: "peer TLS certificate missing".into(),
+                });
+                let _ = self.conn.close(true, 0x03, b"peer certificate missing");
+                self.state = ConnectionState::Closing;
+                self.flush(socket)?;
+                return Ok(());
+            };
+
+            match minip2p_tls::verify_libp2p_certificate(peer_cert_der) {
+                Ok(verified_peer_id) => {
+                    // If the dialer specified an expected PeerId (via PeerAddr),
+                    // reject the connection if the verified identity doesn't match.
+                    if let Some(expected) = self.endpoint.peer_id() {
+                        if *expected != verified_peer_id {
+                            events.push(TransportEvent::Error {
+                                id: self.id,
+                                message: format!(
+                                    "peer id mismatch: dialed {expected} but server certificate proves {verified_peer_id}"
+                                ),
+                            });
+                            // Close the connection — the peer is not who we expected.
+                            let _ = self.conn.close(true, 0x01, b"peer id mismatch");
+                            self.state = ConnectionState::Closing;
+                            self.flush(socket)?;
+                            return Ok(());
                         }
-                        self.endpoint.set_peer_id(verified_peer_id);
                     }
-                    Err(e) => {
-                        events.push(TransportEvent::Error {
-                            id: self.id,
-                            message: format!("peer TLS certificate verification failed: {e}"),
-                        });
-                        let _ = self
-                            .conn
-                            .close(true, 0x02, b"certificate verification failed");
-                        self.state = ConnectionState::Closing;
-                        self.flush(socket)?;
-                        return Ok(());
-                    }
+                    self.endpoint.set_peer_id(verified_peer_id);
+                }
+                Err(e) => {
+                    events.push(TransportEvent::Error {
+                        id: self.id,
+                        message: format!("peer TLS certificate verification failed: {e}"),
+                    });
+                    let _ = self
+                        .conn
+                        .close(true, 0x02, b"certificate verification failed");
+                    self.state = ConnectionState::Closing;
+                    self.flush(socket)?;
+                    return Ok(());
                 }
             }
 

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -6,6 +6,9 @@
 use std::collections::{BTreeSet, HashMap};
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs, UdpSocket};
 
+use boring::pkey::PKey;
+use boring::ssl::{SslContextBuilder, SslMethod, SslVerifyMode};
+use boring::x509::X509;
 use minip2p_core::{Multiaddr, PeerAddr, PeerId, Protocol};
 use minip2p_transport::{
     ConnectionEndpoint, ConnectionId, StreamId, Transport, TransportError, TransportEvent,
@@ -181,6 +184,73 @@ fn socket_addr_to_multiaddr(addr: SocketAddr) -> Multiaddr {
     }
 }
 
+/// Builds the shared QUIC TLS configuration.
+fn build_quiche_config(node_config: &QuicNodeConfig) -> Result<quiche::Config, TransportError> {
+    let mut tls_builder =
+        SslContextBuilder::new(SslMethod::tls()).map_err(|e| TransportError::ListenFailed {
+            reason: format!("failed to create BoringSSL context: {e}"),
+        })?;
+
+    // Request peer certificates on both client and server handshakes. BoringSSL's
+    // chain validation is intentionally bypassed here because libp2p TLS uses
+    // self-signed certificates with identity proof in a custom extension; the
+    // transport verifies that extension after QUIC reports the peer certificate.
+    tls_builder.set_verify_callback(SslVerifyMode::PEER, |_preverify_ok, _ctx| true);
+
+    if let Some(keypair) = node_config.keypair() {
+        let (cert_der, key_der) = minip2p_tls::generate_certificate(keypair).map_err(|e| {
+            TransportError::InvalidConfig {
+                reason: format!("failed to generate libp2p TLS certificate: {e}"),
+            }
+        })?;
+
+        let cert = X509::from_der(&cert_der).map_err(|e| TransportError::InvalidConfig {
+            reason: format!("failed to parse generated TLS certificate: {e}"),
+        })?;
+        tls_builder
+            .set_certificate(&cert)
+            .map_err(|e| TransportError::InvalidConfig {
+                reason: format!("failed to load generated cert into BoringSSL: {e}"),
+            })?;
+
+        let private_key =
+            PKey::private_key_from_der(&key_der).map_err(|e| TransportError::InvalidConfig {
+                reason: format!("failed to parse generated TLS private key: {e}"),
+            })?;
+        tls_builder
+            .set_private_key(&private_key)
+            .map_err(|e| TransportError::InvalidConfig {
+                reason: format!("failed to load generated key into BoringSSL: {e}"),
+            })?;
+        tls_builder
+            .check_private_key()
+            .map_err(|e| TransportError::InvalidConfig {
+                reason: format!("generated TLS private key does not match certificate: {e}"),
+            })?;
+    }
+
+    let mut quiche_config =
+        quiche::Config::with_boring_ssl_ctx_builder(quiche::PROTOCOL_VERSION, tls_builder)
+            .map_err(|e| TransportError::ListenFailed {
+                reason: format!("failed to create quiche config: {e}"),
+            })?;
+
+    quiche_config
+        .set_application_protos(&[b"libp2p"])
+        .map_err(|e| TransportError::ListenFailed {
+            reason: format!("failed to set alpn: {e}"),
+        })?;
+
+    quiche_config.set_initial_max_data(10_000_000);
+    quiche_config.set_initial_max_stream_data_bidi_local(1_000_000);
+    quiche_config.set_initial_max_stream_data_bidi_remote(1_000_000);
+    quiche_config.set_initial_max_streams_bidi(100);
+    quiche_config.set_max_recv_udp_payload_size(1350);
+    quiche_config.set_max_send_udp_payload_size(1350);
+
+    Ok(quiche_config)
+}
+
 /// QUIC transport backed by a non-blocking UDP socket and `quiche`.
 pub struct QuicTransport {
     /// Non-blocking UDP socket for all QUIC traffic.
@@ -201,16 +271,11 @@ pub struct QuicTransport {
     next_connection_id: u64,
     /// Retained node configuration.
     node_config: QuicNodeConfig,
-    /// Temp files for the auto-generated TLS cert/key. Held here to keep them
-    /// alive for the lifetime of the transport (quiche reads from file paths).
-    _tls_temp_files: Option<(tempfile::NamedTempFile, tempfile::NamedTempFile)>,
 }
 
 impl QuicTransport {
     /// Creates a new QUIC transport bound to the given address.
     pub fn new(node_config: QuicNodeConfig, bind_addr: &str) -> Result<Self, TransportError> {
-        use std::io::Write;
-
         let socket = UdpSocket::bind(bind_addr).map_err(|e| TransportError::ListenFailed {
             reason: format!("failed to bind udp socket: {e}"),
         })?;
@@ -221,91 +286,7 @@ impl QuicTransport {
                 reason: format!("failed to set nonblocking: {e}"),
             })?;
 
-        let mut quiche_config = quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|e| {
-            TransportError::ListenFailed {
-                reason: format!("failed to create quiche config: {e}"),
-            }
-        })?;
-
-        quiche_config
-            .set_application_protos(&[b"libp2p"])
-            .map_err(|e| TransportError::ListenFailed {
-                reason: format!("failed to set alpn: {e}"),
-            })?;
-
-        quiche_config.set_initial_max_data(10_000_000);
-        quiche_config.set_initial_max_stream_data_bidi_local(1_000_000);
-        quiche_config.set_initial_max_stream_data_bidi_remote(1_000_000);
-        quiche_config.set_initial_max_streams_bidi(100);
-        quiche_config.set_max_recv_udp_payload_size(1350);
-        quiche_config.set_max_send_udp_payload_size(1350);
-        quiche_config.verify_peer(false);
-
-        // Auto-generate libp2p TLS cert from Ed25519 keypair.
-        //
-        // NOTE: quiche only supports loading certs/keys from PEM file paths
-        // (no in-memory API in the default build). We write to temp files as a
-        // workaround. The files are auto-deleted when the transport is dropped.
-        // To avoid this, quiche would need the `boringssl-boring-crate` feature
-        // for in-memory cert loading via `SslContextBuilder`.
-        let tls_temp_files = if let Some(keypair) = node_config.keypair() {
-            let (cert_der, key_der) = minip2p_tls::generate_certificate(keypair).map_err(|e| {
-                TransportError::InvalidConfig {
-                    reason: format!("failed to generate libp2p TLS certificate: {e}"),
-                }
-            })?;
-
-            let cert_pem = minip2p_tls::cert_to_pem(&cert_der);
-            let key_pem = minip2p_tls::private_key_to_pem(&key_der);
-
-            let mut cert_file =
-                tempfile::NamedTempFile::new().map_err(|e| TransportError::InvalidConfig {
-                    reason: format!("failed to create temp cert file: {e}"),
-                })?;
-            cert_file.write_all(cert_pem.as_bytes()).map_err(|e| {
-                TransportError::InvalidConfig {
-                    reason: format!("failed to write temp cert file: {e}"),
-                }
-            })?;
-
-            let mut key_file =
-                tempfile::NamedTempFile::new().map_err(|e| TransportError::InvalidConfig {
-                    reason: format!("failed to create temp key file: {e}"),
-                })?;
-            key_file
-                .write_all(key_pem.as_bytes())
-                .map_err(|e| TransportError::InvalidConfig {
-                    reason: format!("failed to write temp key file: {e}"),
-                })?;
-
-            let cert_path = cert_file
-                .path()
-                .to_str()
-                .ok_or(TransportError::InvalidConfig {
-                    reason: "temp cert file path is not valid UTF-8".into(),
-                })?;
-            quiche_config
-                .load_cert_chain_from_pem_file(cert_path)
-                .map_err(|e| TransportError::InvalidConfig {
-                    reason: format!("failed to load generated cert into quiche: {e}"),
-                })?;
-
-            let key_path = key_file
-                .path()
-                .to_str()
-                .ok_or(TransportError::InvalidConfig {
-                    reason: "temp key file path is not valid UTF-8".into(),
-                })?;
-            quiche_config
-                .load_priv_key_from_pem_file(key_path)
-                .map_err(|e| TransportError::InvalidConfig {
-                    reason: format!("failed to load generated key into quiche: {e}"),
-                })?;
-
-            Some((cert_file, key_file))
-        } else {
-            None
-        };
+        let quiche_config = build_quiche_config(&node_config)?;
 
         Ok(Self {
             socket,
@@ -317,7 +298,6 @@ impl QuicTransport {
             listen_addr: None,
             next_connection_id: 1,
             node_config,
-            _tls_temp_files: tls_temp_files,
         })
     }
 
@@ -762,13 +742,34 @@ impl Transport for QuicTransport {
 
             if let Some(id) = target_conn_id {
                 let mut source_cid: Option<Vec<u8>> = None;
+                let mut identity_update: Option<(Option<PeerId>, ConnectionEndpoint)> = None;
                 if let Some(conn) = self.connections.get_mut(&id) {
+                    let previous_peer_id = conn.endpoint().peer_id().cloned();
                     conn.recv_packet(packet, from, local_addr, &self.socket, &mut events)?;
                     source_cid = Some(conn.source_cid_bytes());
+                    if conn.endpoint().peer_id() != previous_peer_id.as_ref() {
+                        identity_update = Some((previous_peer_id, conn.endpoint().clone()));
+                    }
                 }
 
                 if let Some(source_cid) = source_cid {
                     self.cid_to_connection.insert(source_cid, id);
+                }
+
+                if let Some((previous_peer_id, endpoint)) = identity_update {
+                    if let Some(previous) = previous_peer_id.as_ref() {
+                        self.remove_peer_connection(previous, id);
+                    }
+
+                    if let Some(peer_id) = endpoint.peer_id() {
+                        self.index_peer_connection(peer_id.clone(), id);
+                    }
+
+                    events.push(TransportEvent::PeerIdentityVerified {
+                        id,
+                        endpoint,
+                        previous_peer_id,
+                    });
                 }
             }
         }

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -191,11 +191,15 @@ fn build_quiche_config(node_config: &QuicNodeConfig) -> Result<quiche::Config, T
             reason: format!("failed to create BoringSSL context: {e}"),
         })?;
 
-    // Request peer certificates on both client and server handshakes. BoringSSL's
-    // chain validation is intentionally bypassed here because libp2p TLS uses
-    // self-signed certificates with identity proof in a custom extension; the
-    // transport verifies that extension after QUIC reports the peer certificate.
-    tls_builder.set_verify_callback(SslVerifyMode::PEER, |_preverify_ok, _ctx| true);
+    // Require peer certificates on server handshakes and request them on client
+    // handshakes. BoringSSL's chain validation is intentionally bypassed here
+    // because libp2p TLS uses self-signed certificates with identity proof in a
+    // custom extension; the transport verifies that extension after QUIC reports
+    // the peer certificate.
+    tls_builder.set_verify_callback(
+        SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT,
+        |_preverify_ok, _ctx| true,
+    );
 
     if let Some(keypair) = node_config.keypair() {
         let (cert_der, key_der) = minip2p_tls::generate_certificate(keypair).map_err(|e| {
@@ -482,6 +486,12 @@ impl Transport for QuicTransport {
     fn dial(&mut self, id: ConnectionId, addr: &PeerAddr) -> Result<(), TransportError> {
         if self.connections.contains_key(&id) {
             return Err(TransportError::ConnectionExists { id });
+        }
+
+        if self.node_config.keypair().is_none() {
+            return Err(TransportError::InvalidConfig {
+                reason: "dialer role requires an Ed25519 keypair for mutual TLS; use QuicNodeConfig::with_keypair(...) or QuicNodeConfig::dev_dialer()".into(),
+            });
         }
 
         let peer_socket = resolve_dial_socket_addr(addr.transport(), "dial target")?;

--- a/transports/quic/tests/two_peer.rs
+++ b/transports/quic/tests/two_peer.rs
@@ -236,6 +236,33 @@ fn listen_without_tls_returns_config_error_and_no_listening_event() {
 }
 
 #[test]
+fn listener_rejects_dialer_without_mtls_identity() {
+    let mut server =
+        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("server bind");
+    let mut anonymous_client =
+        QuicTransport::new(QuicNodeConfig::new(), "127.0.0.1:0").expect("client bind");
+
+    server.listen_on_bound_addr().expect("server listen");
+    let peer_addr = server.local_peer_addr().expect("peer addr");
+
+    let err = anonymous_client
+        .dial(ConnectionId::new(77), &peer_addr)
+        .expect_err("anonymous client must not start mTLS dial");
+    assert!(matches!(err, TransportError::InvalidConfig { .. }));
+
+    let server_events = server.poll().expect("server poll");
+    assert!(
+        server_events.iter().all(|event| !matches!(
+            event,
+            TransportEvent::IncomingConnection { .. }
+                | TransportEvent::Connected { .. }
+                | TransportEvent::PeerIdentityVerified { .. }
+        )),
+        "anonymous dial must not reach the listener"
+    );
+}
+
+#[test]
 fn mtls_verifies_listener_side_client_identity_and_updates_peer_index() {
     let (mut server, mut client, peer_addr) = setup_pair();
     let client_peer_id = client.local_peer_id().expect("client peer id");

--- a/transports/quic/tests/two_peer.rs
+++ b/transports/quic/tests/two_peer.rs
@@ -1,6 +1,9 @@
+use std::net::UdpSocket;
+
 use minip2p_core::PeerAddr;
 use minip2p_quic::{QuicNodeConfig, QuicTransport};
 use minip2p_transport::{ConnectionId, StreamId, Transport, TransportError, TransportEvent};
+use quiche::ConnectionId as QuicConnectionId;
 
 fn setup_pair() -> (QuicTransport, QuicTransport, PeerAddr) {
     let mut server =
@@ -263,6 +266,112 @@ fn listener_rejects_dialer_without_mtls_identity() {
 }
 
 #[test]
+fn dialer_rejects_listener_with_unexpected_peer_id() {
+    let mut listener_a =
+        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("listener a");
+    let mut listener_b =
+        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("listener b");
+    let mut dialer =
+        QuicTransport::new(QuicNodeConfig::dev_dialer(), "127.0.0.1:0").expect("dialer");
+
+    listener_a.listen_on_bound_addr().expect("listen a");
+    listener_b.listen_on_bound_addr().expect("listen b");
+
+    let listener_a_addr = listener_a.local_peer_addr().expect("listener a addr");
+    let listener_b_peer = listener_b.local_peer_id().expect("listener b peer id");
+    let wrong_peer_addr =
+        PeerAddr::new(listener_a_addr.transport().clone(), listener_b_peer).expect("peer addr");
+
+    let conn_id = ConnectionId::new(88);
+    dialer.dial(conn_id, &wrong_peer_addr).expect("dial starts");
+
+    let mut saw_mismatch = false;
+    let mut saw_connected = false;
+
+    for _ in 0..100 {
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let _ = listener_a.poll().expect("listener a poll");
+        let events = dialer.poll().expect("dialer poll");
+
+        saw_mismatch |= events.iter().any(|event| {
+            matches!(event, TransportEvent::Error { message, .. } if message.contains("peer id mismatch"))
+        });
+        saw_connected |= events
+            .iter()
+            .any(|event| matches!(event, TransportEvent::Connected { .. }));
+
+        if saw_mismatch {
+            break;
+        }
+    }
+
+    assert!(saw_mismatch, "dialer must report peer id mismatch");
+    assert!(!saw_connected, "dialer must not connect wrong peer id");
+}
+
+#[test]
+fn listener_rejects_dialer_with_invalid_libp2p_cert() {
+    let mut server =
+        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("server bind");
+    server.listen_on_bound_addr().expect("server listen");
+    let server_addr = server.local_addr().expect("server socket addr");
+
+    let client_socket = UdpSocket::bind("127.0.0.1:0").expect("client socket");
+    client_socket
+        .set_nonblocking(true)
+        .expect("client socket nonblocking");
+    let client_addr = client_socket.local_addr().expect("client local addr");
+
+    let mut config = vanilla_tls_quiche_config();
+    let scid = QuicConnectionId::from_vec(vec![0x42; quiche::MAX_CONN_ID_LEN]);
+    let mut conn = quiche::connect(None, &scid, client_addr, server_addr, &mut config)
+        .expect("raw quiche connect");
+
+    flush_raw_quiche_client(&mut conn, &client_socket);
+
+    let mut saw_incoming = false;
+    let mut saw_cert_error = false;
+    let mut saw_connected = false;
+    let mut saw_verified = false;
+
+    for _ in 0..100 {
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        for event in server.poll().expect("server poll") {
+            saw_incoming |= matches!(event, TransportEvent::IncomingConnection { .. });
+            saw_cert_error |= matches!(
+                event,
+                TransportEvent::Error { ref message, .. }
+                    if message.contains("peer TLS certificate verification failed")
+            );
+            saw_connected |= matches!(event, TransportEvent::Connected { .. });
+            saw_verified |= matches!(event, TransportEvent::PeerIdentityVerified { .. });
+        }
+
+        drain_raw_quiche_client(&mut conn, &client_socket, client_addr);
+        flush_raw_quiche_client(&mut conn, &client_socket);
+
+        if saw_cert_error || conn.is_closed() {
+            break;
+        }
+    }
+
+    assert!(
+        saw_incoming,
+        "listener may surface pre-auth incoming connection"
+    );
+    assert!(saw_cert_error, "listener must reject invalid libp2p cert");
+    assert!(
+        !saw_connected,
+        "listener must not connect invalid libp2p cert"
+    );
+    assert!(
+        !saw_verified,
+        "listener must not verify invalid libp2p cert"
+    );
+}
+
+#[test]
 fn mtls_verifies_listener_side_client_identity_and_updates_peer_index() {
     let (mut server, mut client, peer_addr) = setup_pair();
     let client_peer_id = client.local_peer_id().expect("client peer id");
@@ -391,4 +500,90 @@ fn open_stream_before_connected_returns_invalid_state() {
 fn stream_id_round_trips_as_u64() {
     let id = StreamId::new(1234);
     assert_eq!(id.as_u64(), 1234);
+}
+
+fn vanilla_tls_quiche_config() -> quiche::Config {
+    use boring::asn1::Asn1Time;
+    use boring::hash::MessageDigest;
+    use boring::nid::Nid;
+    use boring::pkey::PKey;
+    use boring::rsa::Rsa;
+    use boring::ssl::{SslContextBuilder, SslMethod, SslVerifyMode};
+    use boring::x509::{X509, X509Name};
+
+    let rsa = Rsa::generate(2048).expect("rsa key");
+    let pkey = PKey::from_rsa(rsa).expect("pkey");
+
+    let mut name = X509Name::builder().expect("name builder");
+    name.append_entry_by_nid(Nid::COMMONNAME, "invalid-libp2p-cert")
+        .expect("common name");
+    let name = name.build();
+
+    let mut cert = X509::builder().expect("x509 builder");
+    cert.set_version(2).expect("version");
+    cert.set_subject_name(&name).expect("subject");
+    cert.set_issuer_name(&name).expect("issuer");
+    cert.set_not_before(&Asn1Time::days_from_now(0).expect("not before"))
+        .expect("set not before");
+    cert.set_not_after(&Asn1Time::days_from_now(365).expect("not after"))
+        .expect("set not after");
+    cert.set_pubkey(&pkey).expect("pubkey");
+    cert.sign(&pkey, MessageDigest::sha256())
+        .expect("sign cert");
+    let cert = cert.build();
+
+    let mut tls = SslContextBuilder::new(SslMethod::tls()).expect("tls context");
+    tls.set_verify_callback(
+        SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT,
+        |_preverify_ok, _ctx| true,
+    );
+    tls.set_certificate(&cert).expect("set cert");
+    tls.set_private_key(&pkey).expect("set key");
+    tls.check_private_key().expect("check key");
+
+    let mut config = quiche::Config::with_boring_ssl_ctx_builder(quiche::PROTOCOL_VERSION, tls)
+        .expect("quiche config");
+    config.set_application_protos(&[b"libp2p"]).expect("alpn");
+    config.set_initial_max_data(10_000_000);
+    config.set_initial_max_stream_data_bidi_local(1_000_000);
+    config.set_initial_max_stream_data_bidi_remote(1_000_000);
+    config.set_initial_max_streams_bidi(100);
+    config.set_max_recv_udp_payload_size(1350);
+    config.set_max_send_udp_payload_size(1350);
+    config
+}
+
+fn flush_raw_quiche_client(conn: &mut quiche::Connection, socket: &UdpSocket) {
+    let mut out = [0u8; 1350];
+    loop {
+        match conn.send(&mut out) {
+            Ok((written, send_info)) => {
+                socket
+                    .send_to(&out[..written], send_info.to)
+                    .expect("raw client send");
+            }
+            Err(quiche::Error::Done) => break,
+            Err(e) => panic!("raw client send failed: {e}"),
+        }
+    }
+}
+
+fn drain_raw_quiche_client(
+    conn: &mut quiche::Connection,
+    socket: &UdpSocket,
+    local: std::net::SocketAddr,
+) {
+    let mut buf = [0u8; 65535];
+    loop {
+        let (len, from) = match socket.recv_from(&mut buf) {
+            Ok(v) => v,
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(e) => panic!("raw client recv failed: {e}"),
+        };
+        let recv_info = quiche::RecvInfo { from, to: local };
+        match conn.recv(&mut buf[..len], recv_info) {
+            Ok(_) | Err(quiche::Error::Done) => {}
+            Err(e) => panic!("raw client quiche recv failed: {e}"),
+        }
+    }
 }

--- a/transports/quic/tests/two_peer.rs
+++ b/transports/quic/tests/two_peer.rs
@@ -1,6 +1,4 @@
-use std::str::FromStr;
-
-use minip2p_core::{PeerAddr, PeerId};
+use minip2p_core::PeerAddr;
 use minip2p_quic::{QuicNodeConfig, QuicTransport};
 use minip2p_transport::{ConnectionId, StreamId, Transport, TransportError, TransportEvent};
 
@@ -238,52 +236,47 @@ fn listen_without_tls_returns_config_error_and_no_listening_event() {
 }
 
 #[test]
-fn identity_upgrade_emits_verified_event_and_updates_peer_index() {
+fn mtls_verifies_listener_side_client_identity_and_updates_peer_index() {
     let (mut server, mut client, peer_addr) = setup_pair();
+    let client_peer_id = client.local_peer_id().expect("client peer id");
 
     let client_conn_id = ConnectionId::new(42);
     client
         .dial(client_conn_id, &peer_addr)
         .expect("client dial");
 
-    let server_conn_id =
-        wait_for_connection(&mut server, &mut client, client_conn_id, &peer_addr, 250)
-            .expect("server connection");
+    let mut verified_event = None;
 
-    // On the server side, the client cert is not available (quiche with
-    // verify_peer(false) does not request client certs). So the server
-    // endpoint has no auto-verified peer id. Manual binding still works.
-    let override_peer_id =
-        PeerId::from_str("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N").expect("peer id");
-    server
-        .verify_connection_peer_id(server_conn_id, override_peer_id.clone())
-        .expect("verify peer id");
+    for _ in 0..250 {
+        let (server_events, client_events) = drive_pair_once(&mut server, &mut client);
 
-    let events = server.poll().expect("server poll");
-    let verified_event = events
-        .iter()
-        .find_map(|event| {
+        for event in server_events {
             if let TransportEvent::PeerIdentityVerified {
                 id,
                 endpoint,
                 previous_peer_id,
             } = event
             {
-                Some((*id, endpoint.clone(), previous_peer_id.clone()))
-            } else {
-                None
+                verified_event = Some((id, endpoint, previous_peer_id));
             }
-        })
-        .expect("peer identity verified event");
+        }
 
-    assert_eq!(verified_event.0, server_conn_id);
-    assert_eq!(verified_event.1.peer_id(), Some(&override_peer_id));
-    // No previous_peer_id: server can't auto-verify client identity since
-    // quiche doesn't request client certs with verify_peer(false).
+        let client_connected = client_events.iter().any(
+            |event| matches!(event, TransportEvent::Connected { id, .. } if *id == client_conn_id),
+        );
+
+        if verified_event.is_some() && client_connected {
+            break;
+        }
+    }
+
+    let verified_event = verified_event.expect("peer identity verified event");
+
+    assert_eq!(verified_event.1.peer_id(), Some(&client_peer_id));
     assert!(verified_event.2.is_none());
 
-    let indexed = server.connection_ids_for_peer(&override_peer_id);
-    assert_eq!(indexed, vec![server_conn_id]);
+    let indexed = server.connection_ids_for_peer(&client_peer_id);
+    assert_eq!(indexed, vec![verified_event.0]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Switch the QUIC adapter to quiche's BoringSSL context path so peer certificates are requested in both handshake directions.
- Keep libp2p certificate identity validation in minip2p-tls and emit server-side PeerIdentityVerified automatically.
- Update mTLS docs/tests and fix the direct CLI harness to keep listener stdout drained.

## Verification
- cargo test -p minip2p-quic
- cargo check --no-default-features -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-identify -p minip2p-ping -p minip2p-relay -p minip2p-dcutr -p minip2p-swarm
- cargo test --workspace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables and enforces mutual TLS on QUIC so both sides present libp2p certificates and the listener learns the client PeerId during the handshake. Adds coverage for identity failures: anonymous clients, invalid libp2p certs, and peer-id mismatches are rejected.

- **New Features**
  - Switched to `quiche`’s BoringSSL context; request peer certificates on both client and server, bypass chain validation via a verify callback, and verify libp2p identity in `minip2p-tls` after the handshake.
  - Enforced mTLS: dialers must provide an Ed25519 keypair (else `dial` errors), the listener rejects missing/invalid peer certificates, and mismatched expected PeerId closes the connection.
  - Transport emits `TransportEvent::PeerIdentityVerified` on identity bind/update and reindexes the connection; Swarm uses the negotiated outbound ping stream; examples updated to wait for verified identity; tests expanded to cover anonymous dialers, invalid libp2p certs, and peer-id mismatches; docs clarify pre-auth `IncomingConnection` vs authenticated `Connected`/`PeerIdentityVerified`.

- **Dependencies**
  - Added `boring` and enabled `quiche` feature `boringssl-boring-crate`; removed `tempfile`.

<sup>Written for commit 2c4d2ae2137256527c7f5c5a800b166f298cf234. Summary will update on new commits. <a href="https://cubic.dev/pr/deepso7/minip2p/pull/7?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

