### PR TITLE
quic: make identity configuration mandatory

### DIFF
--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -156,9 +156,8 @@ impl<T: Transport> Swarm<T> {
 
     /// Returns this node's own `PeerId`.
     ///
-    /// Unlike `swarm.transport().local_peer_id()` (transport-specific and
-    /// `Option`-wrapped), this accessor is infallible because the
-    /// [`crate::SwarmBuilder`] requires a keypair at construction time.
+    /// This accessor is infallible because the [`crate::SwarmBuilder`] requires
+    /// a keypair at construction time.
     pub fn local_peer_id(&self) -> &PeerId {
         &self.local_peer_id
     }

--- a/examples/peer/src/direct.rs
+++ b/examples/peer/src/direct.rs
@@ -85,7 +85,7 @@ pub fn run_dial(target: PeerAddr) -> Result<(), Box<dyn Error>> {
 /// stack.
 fn build_swarm() -> Result<Swarm<QuicTransport>, Box<dyn Error>> {
     let keypair = Ed25519Keypair::generate();
-    let transport = QuicTransport::new(QuicNodeConfig::with_keypair(keypair.clone()), LOCAL_BIND)
+    let transport = QuicTransport::new(QuicNodeConfig::new(keypair.clone()), LOCAL_BIND)
         .map_err(|e| format!("quic bind failed: {e}"))?;
     Ok(SwarmBuilder::new(&keypair)
         .agent_version(AGENT)

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -719,7 +719,7 @@ fn ping_and_exit(
 /// Builds a swarm with the relay + DCUtR user protocols registered.
 fn build_swarm_with_relay_protocols() -> Result<Swarm<QuicTransport>, Box<dyn Error>> {
     let keypair = Ed25519Keypair::generate();
-    let transport = QuicTransport::new(QuicNodeConfig::with_keypair(keypair.clone()), LOCAL_BIND)
+    let transport = QuicTransport::new(QuicNodeConfig::new(keypair.clone()), LOCAL_BIND)
         .map_err(|e| format!("quic bind: {e}"))?;
     let mut swarm = SwarmBuilder::new(&keypair)
         .agent_version(AGENT)

--- a/transports/quic/README.md
+++ b/transports/quic/README.md
@@ -17,6 +17,7 @@ No async runtime required. The host drives the transport by calling `poll()`.
 - Stream events (`StreamOpened`, `IncomingStream`, `StreamData`, `StreamRemoteWriteClosed`, `StreamClosed`).
 - Mutual libp2p TLS peer authentication. Dialing and listening require a configured Ed25519 keypair.
 - Automatic peer-id verification from libp2p TLS certificates. `Connected` carries the verified endpoint; `PeerIdentityVerified` is also emitted when the peer index is bound or updated.
+- `QuicNodeConfig` is identity-first: constructing a transport requires an Ed25519 host keypair.
 - Dial supports `/ip4`, `/ip6`, `/dns`, `/dns4`, `/dns6` QUIC transport addresses.
 
 ## Basic usage
@@ -28,7 +29,7 @@ use minip2p_quic::{QuicNodeConfig, QuicTransport};
 use minip2p_transport::{ConnectionId, Transport};
 
 let listener_key = Ed25519Keypair::generate();
-let listener_cfg = QuicNodeConfig::with_keypair(listener_key.clone());
+let listener_cfg = QuicNodeConfig::new(listener_key.clone());
 let mut listener = QuicTransport::new(listener_cfg, "127.0.0.1:0")?;
 
 let local = listener.local_addr()?;

--- a/transports/quic/src/config.rs
+++ b/transports/quic/src/config.rs
@@ -3,62 +3,42 @@ use minip2p_identity::Ed25519Keypair;
 
 /// Configuration for a QUIC transport node.
 ///
-/// Use [`with_keypair`](Self::with_keypair) to create a node with a libp2p
-/// identity. A TLS certificate is auto-generated from the keypair, and the
+/// QUIC always uses mutual libp2p TLS in minip2p, so a node identity is
+/// mandatory. A TLS certificate is auto-generated from the keypair, and the
 /// remote peer's identity is verified automatically after each QUIC handshake.
 #[derive(Clone, Debug)]
 pub struct QuicNodeConfig {
     /// Ed25519 host keypair for libp2p TLS identity.
-    pub(crate) keypair: Option<Ed25519Keypair>,
-}
-
-impl Default for QuicNodeConfig {
-    fn default() -> Self {
-        Self { keypair: None }
-    }
+    pub(crate) keypair: Ed25519Keypair,
 }
 
 impl QuicNodeConfig {
-    /// Creates an empty configuration (no identity, cannot listen).
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Creates a configuration from an Ed25519 host keypair.
     ///
     /// A libp2p-spec TLS certificate is auto-generated from the keypair. Both
     /// dialing and listening are enabled. Peer identity is verified
     /// automatically after each QUIC handshake.
-    pub fn with_keypair(keypair: Ed25519Keypair) -> Self {
-        Self {
-            keypair: Some(keypair),
-        }
+    pub fn new(keypair: Ed25519Keypair) -> Self {
+        Self { keypair }
     }
 
     /// Convenience: generates a fresh keypair for a dev/test dialer.
     pub fn dev_dialer() -> Self {
-        Self::with_keypair(Ed25519Keypair::generate())
+        Self::new(Ed25519Keypair::generate())
     }
 
     /// Convenience: generates a fresh keypair for a dev/test listener.
     pub fn dev_listener() -> Self {
-        Self::with_keypair(Ed25519Keypair::generate())
+        Self::new(Ed25519Keypair::generate())
     }
 
     /// Returns this node's `PeerId`, derived from the configured keypair.
-    ///
-    /// Returns `None` if no keypair is configured.
-    pub fn peer_id(&self) -> Option<PeerId> {
-        self.keypair.as_ref().map(|kp| kp.peer_id())
+    pub fn peer_id(&self) -> PeerId {
+        self.keypair.peer_id()
     }
 
-    /// Returns `true` if TLS is configured (required for listening).
-    pub fn can_listen(&self) -> bool {
-        self.keypair.is_some()
-    }
-
-    /// Returns the Ed25519 host keypair, if configured.
-    pub(crate) fn keypair(&self) -> Option<&Ed25519Keypair> {
-        self.keypair.as_ref()
+    /// Returns the Ed25519 host keypair.
+    pub(crate) fn keypair(&self) -> &Ed25519Keypair {
+        &self.keypair
     }
 }

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -201,37 +201,36 @@ fn build_quiche_config(node_config: &QuicNodeConfig) -> Result<quiche::Config, T
         |_preverify_ok, _ctx| true,
     );
 
-    if let Some(keypair) = node_config.keypair() {
-        let (cert_der, key_der) = minip2p_tls::generate_certificate(keypair).map_err(|e| {
+    let (cert_der, key_der) =
+        minip2p_tls::generate_certificate(node_config.keypair()).map_err(|e| {
             TransportError::InvalidConfig {
                 reason: format!("failed to generate libp2p TLS certificate: {e}"),
             }
         })?;
 
-        let cert = X509::from_der(&cert_der).map_err(|e| TransportError::InvalidConfig {
-            reason: format!("failed to parse generated TLS certificate: {e}"),
+    let cert = X509::from_der(&cert_der).map_err(|e| TransportError::InvalidConfig {
+        reason: format!("failed to parse generated TLS certificate: {e}"),
+    })?;
+    tls_builder
+        .set_certificate(&cert)
+        .map_err(|e| TransportError::InvalidConfig {
+            reason: format!("failed to load generated cert into BoringSSL: {e}"),
         })?;
-        tls_builder
-            .set_certificate(&cert)
-            .map_err(|e| TransportError::InvalidConfig {
-                reason: format!("failed to load generated cert into BoringSSL: {e}"),
-            })?;
 
-        let private_key =
-            PKey::private_key_from_der(&key_der).map_err(|e| TransportError::InvalidConfig {
-                reason: format!("failed to parse generated TLS private key: {e}"),
-            })?;
-        tls_builder
-            .set_private_key(&private_key)
-            .map_err(|e| TransportError::InvalidConfig {
-                reason: format!("failed to load generated key into BoringSSL: {e}"),
-            })?;
-        tls_builder
-            .check_private_key()
-            .map_err(|e| TransportError::InvalidConfig {
-                reason: format!("generated TLS private key does not match certificate: {e}"),
-            })?;
-    }
+    let private_key =
+        PKey::private_key_from_der(&key_der).map_err(|e| TransportError::InvalidConfig {
+            reason: format!("failed to parse generated TLS private key: {e}"),
+        })?;
+    tls_builder
+        .set_private_key(&private_key)
+        .map_err(|e| TransportError::InvalidConfig {
+            reason: format!("failed to load generated key into BoringSSL: {e}"),
+        })?;
+    tls_builder
+        .check_private_key()
+        .map_err(|e| TransportError::InvalidConfig {
+            reason: format!("generated TLS private key does not match certificate: {e}"),
+        })?;
 
     let mut quiche_config =
         quiche::Config::with_boring_ssl_ctx_builder(quiche::PROTOCOL_VERSION, tls_builder)
@@ -338,21 +337,16 @@ impl QuicTransport {
     }
 
     /// Returns this node's `PeerId`, derived from the configured keypair.
-    ///
-    /// Returns `None` if no keypair was configured.
-    pub fn local_peer_id(&self) -> Option<PeerId> {
+    pub fn local_peer_id(&self) -> PeerId {
         self.node_config.peer_id()
     }
 
     /// Returns a `PeerAddr` that other nodes can use to dial this transport.
     ///
-    /// Combines the bound socket address with this node's `PeerId`. Only
-    /// available after the transport has a keypair configured.
+    /// Combines the bound socket address with this node's `PeerId`.
     pub fn local_peer_addr(&self) -> Result<PeerAddr, TransportError> {
         let addr = self.local_addr()?;
-        let peer_id = self.local_peer_id().ok_or(TransportError::InvalidConfig {
-            reason: "no keypair configured; cannot derive local PeerAddr".into(),
-        })?;
+        let peer_id = self.local_peer_id();
         let multiaddr = socket_addr_to_multiaddr(addr);
         PeerAddr::new(multiaddr, peer_id).map_err(|e| TransportError::InvalidConfig {
             reason: format!("failed to build local PeerAddr: {e}"),
@@ -488,12 +482,6 @@ impl Transport for QuicTransport {
             return Err(TransportError::ConnectionExists { id });
         }
 
-        if self.node_config.keypair().is_none() {
-            return Err(TransportError::InvalidConfig {
-                reason: "dialer role requires an Ed25519 keypair for mutual TLS; use QuicNodeConfig::with_keypair(...) or QuicNodeConfig::dev_dialer()".into(),
-            });
-        }
-
         let peer_socket = resolve_dial_socket_addr(addr.transport(), "dial target")?;
         let local_socket = self.local_addr()?;
 
@@ -555,12 +543,6 @@ impl Transport for QuicTransport {
 
     fn listen(&mut self, addr: &Multiaddr) -> Result<Multiaddr, TransportError> {
         let socket_addr = extract_listen_socket_addr(addr, "listen address")?;
-
-        if !self.node_config.can_listen() {
-            return Err(TransportError::InvalidConfig {
-                reason: "listener role requires an Ed25519 keypair; use QuicNodeConfig::with_keypair(...) or QuicNodeConfig::dev_listener()".into(),
-            });
-        }
 
         let local_addr = self.local_addr()?;
         ensure_listen_matches_bound_socket(socket_addr, local_addr)?;

--- a/transports/quic/tests/swarm_e2e.rs
+++ b/transports/quic/tests/swarm_e2e.rs
@@ -12,8 +12,7 @@ use minip2p_transport::{StreamId, TransportError};
 
 fn make_swarm(keypair: Ed25519Keypair) -> Swarm<QuicTransport> {
     let transport =
-        QuicTransport::new(QuicNodeConfig::with_keypair(keypair.clone()), "127.0.0.1:0")
-            .expect("bind");
+        QuicTransport::new(QuicNodeConfig::new(keypair.clone()), "127.0.0.1:0").expect("bind");
     SwarmBuilder::new(&keypair)
         .agent_version("minip2p-test/0.1.0")
         .build(transport)

--- a/transports/quic/tests/two_peer.rs
+++ b/transports/quic/tests/two_peer.rs
@@ -220,49 +220,49 @@ fn close_stream_write_emits_remote_write_closed() {
 }
 
 #[test]
-fn listen_without_tls_returns_config_error_and_no_listening_event() {
-    let config = QuicNodeConfig::new();
-    let mut transport = QuicTransport::new(config, "127.0.0.1:0").expect("bind");
-
-    let err = transport
-        .listen_on_bound_addr()
-        .expect_err("listen should fail");
-    assert!(matches!(err, TransportError::InvalidConfig { .. }));
-
-    let events = transport.poll().expect("poll should still work");
-    assert!(
-        !events
-            .iter()
-            .any(|event| matches!(event, TransportEvent::Listening { .. })),
-        "listening event must not be emitted on failed listen"
-    );
-}
-
-#[test]
 fn listener_rejects_dialer_without_mtls_identity() {
     let mut server =
         QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("server bind");
-    let mut anonymous_client =
-        QuicTransport::new(QuicNodeConfig::new(), "127.0.0.1:0").expect("client bind");
-
     server.listen_on_bound_addr().expect("server listen");
-    let peer_addr = server.local_peer_addr().expect("peer addr");
+    let server_addr = server.local_addr().expect("server socket addr");
 
-    let err = anonymous_client
-        .dial(ConnectionId::new(77), &peer_addr)
-        .expect_err("anonymous client must not start mTLS dial");
-    assert!(matches!(err, TransportError::InvalidConfig { .. }));
+    let client_socket = UdpSocket::bind("127.0.0.1:0").expect("client socket");
+    client_socket
+        .set_nonblocking(true)
+        .expect("client socket nonblocking");
+    let client_addr = client_socket.local_addr().expect("client local addr");
 
-    let server_events = server.poll().expect("server poll");
+    let mut config = raw_quiche_config(None);
+    let scid = QuicConnectionId::from_vec(vec![0x24; quiche::MAX_CONN_ID_LEN]);
+    let mut conn = quiche::connect(None, &scid, client_addr, server_addr, &mut config)
+        .expect("raw quiche connect");
+
+    flush_raw_quiche_client(&mut conn, &client_socket);
+
+    let mut saw_connected = false;
+    let mut saw_verified = false;
+
+    for _ in 0..100 {
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        for event in server.poll().expect("server poll") {
+            saw_connected |= matches!(event, TransportEvent::Connected { .. });
+            saw_verified |= matches!(event, TransportEvent::PeerIdentityVerified { .. });
+        }
+
+        drain_raw_quiche_client(&mut conn, &client_socket, client_addr);
+        flush_raw_quiche_client(&mut conn, &client_socket);
+
+        if conn.is_closed() {
+            break;
+        }
+    }
+
     assert!(
-        server_events.iter().all(|event| !matches!(
-            event,
-            TransportEvent::IncomingConnection { .. }
-                | TransportEvent::Connected { .. }
-                | TransportEvent::PeerIdentityVerified { .. }
-        )),
-        "anonymous dial must not reach the listener"
+        !saw_connected,
+        "listener must not connect anonymous clients"
     );
+    assert!(!saw_verified, "anonymous clients must not verify identity");
 }
 
 #[test]
@@ -278,7 +278,7 @@ fn dialer_rejects_listener_with_unexpected_peer_id() {
     listener_b.listen_on_bound_addr().expect("listen b");
 
     let listener_a_addr = listener_a.local_peer_addr().expect("listener a addr");
-    let listener_b_peer = listener_b.local_peer_id().expect("listener b peer id");
+    let listener_b_peer = listener_b.local_peer_id();
     let wrong_peer_addr =
         PeerAddr::new(listener_a_addr.transport().clone(), listener_b_peer).expect("peer addr");
 
@@ -322,7 +322,8 @@ fn listener_rejects_dialer_with_invalid_libp2p_cert() {
         .expect("client socket nonblocking");
     let client_addr = client_socket.local_addr().expect("client local addr");
 
-    let mut config = vanilla_tls_quiche_config();
+    let (cert, key) = vanilla_tls_identity();
+    let mut config = raw_quiche_config(Some((&cert, &key)));
     let scid = QuicConnectionId::from_vec(vec![0x42; quiche::MAX_CONN_ID_LEN]);
     let mut conn = quiche::connect(None, &scid, client_addr, server_addr, &mut config)
         .expect("raw quiche connect");
@@ -374,7 +375,7 @@ fn listener_rejects_dialer_with_invalid_libp2p_cert() {
 #[test]
 fn mtls_verifies_listener_side_client_identity_and_updates_peer_index() {
     let (mut server, mut client, peer_addr) = setup_pair();
-    let client_peer_id = client.local_peer_id().expect("client peer id");
+    let client_peer_id = client.local_peer_id();
 
     let client_conn_id = ConnectionId::new(42);
     client
@@ -502,13 +503,15 @@ fn stream_id_round_trips_as_u64() {
     assert_eq!(id.as_u64(), 1234);
 }
 
-fn vanilla_tls_quiche_config() -> quiche::Config {
+fn vanilla_tls_identity() -> (
+    boring::x509::X509,
+    boring::pkey::PKey<boring::pkey::Private>,
+) {
     use boring::asn1::Asn1Time;
     use boring::hash::MessageDigest;
     use boring::nid::Nid;
     use boring::pkey::PKey;
     use boring::rsa::Rsa;
-    use boring::ssl::{SslContextBuilder, SslMethod, SslVerifyMode};
     use boring::x509::{X509, X509Name};
 
     let rsa = Rsa::generate(2048).expect("rsa key");
@@ -532,14 +535,27 @@ fn vanilla_tls_quiche_config() -> quiche::Config {
         .expect("sign cert");
     let cert = cert.build();
 
+    (cert, pkey)
+}
+
+fn raw_quiche_config(
+    identity: Option<(
+        &boring::x509::X509,
+        &boring::pkey::PKey<boring::pkey::Private>,
+    )>,
+) -> quiche::Config {
+    use boring::ssl::{SslContextBuilder, SslMethod, SslVerifyMode};
+
     let mut tls = SslContextBuilder::new(SslMethod::tls()).expect("tls context");
     tls.set_verify_callback(
         SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT,
         |_preverify_ok, _ctx| true,
     );
-    tls.set_certificate(&cert).expect("set cert");
-    tls.set_private_key(&pkey).expect("set key");
-    tls.check_private_key().expect("check key");
+    if let Some((cert, pkey)) = identity {
+        tls.set_certificate(cert).expect("set cert");
+        tls.set_private_key(pkey).expect("set key");
+        tls.check_private_key().expect("check key");
+    }
 
     let mut config = quiche::Config::with_boring_ssl_ctx_builder(quiche::PROTOCOL_VERSION, tls)
         .expect("quiche config");


### PR DESCRIPTION
## Summary
- Make `QuicNodeConfig` identity-first by requiring an `Ed25519Keypair` at construction time.
- Remove the anonymous/empty QUIC config path and the redundant `with_keypair` alias.
- Update examples, docs, and QUIC tests to use `QuicNodeConfig::new(keypair)` while preserving dev/test helpers.

## Verification
- cargo test -p minip2p-quic --test two_peer
- cargo check --no-default-features -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-identify -p minip2p-ping -p minip2p-relay -p minip2p-dcutr -p minip2p-swarm
- cargo test --workspace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make QUIC identity mandatory by requiring an Ed25519 keypair when creating `QuicNodeConfig`, removing the anonymous config path. This simplifies TLS setup and makes peer ID access infallible.

- **Refactors**
  - `QuicNodeConfig` now requires a keypair: use `QuicNodeConfig::new(keypair)`. Removed no-arg `new()` and `with_keypair`.
  - Transport always configures mTLS; removed runtime "no identity" checks for dial/listen.
  - `QuicTransport::local_peer_id()` returns `PeerId` (not `Option`); `local_peer_addr()` simplified accordingly.
  - Updated examples, docs, and tests to the new constructor; README notes identity-first behavior.

- **Migration**
  - Replace `QuicNodeConfig::with_keypair(kp)` and no-arg `QuicNodeConfig::new()` with `QuicNodeConfig::new(kp)`.
  - Update code expecting `Option<PeerId>` to use `PeerId` directly (e.g., `transport.local_peer_id()`).
  - Dev/test helpers unchanged: use `QuicNodeConfig::dev_dialer()` and `QuicNodeConfig::dev_listener()`.

<sup>Written for commit cfa2a66088218735617632ee7e3992ebaed2a43c. Summary will update on new commits. <a href="https://cubic.dev/pr/deepso7/minip2p/pull/8?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

