### PR TITLE
move candidate selection into core

### DIFF
--- a/crates/autonat/src/lib.rs
+++ b/crates/autonat/src/lib.rs
@@ -13,7 +13,7 @@ extern crate alloc;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use minip2p_core::{Multiaddr, PeerId, VarintError, read_uvarint, write_uvarint};
+use minip2p_core::{Multiaddr, PeerId, VarintError, read_uvarint, uvarint_len, write_uvarint};
 
 /// Protocol id for AutoNAT v1.
 pub const AUTONAT_PROTOCOL_ID: &str = "/libp2p/autonat/1.0.0";
@@ -258,15 +258,17 @@ impl AutoNatClient {
 
     fn try_decode_response(&mut self) -> Result<(), AutoNatError> {
         enforce_max_size(&self.recv_buf)?;
-        let (payload, consumed) = match decode_frame(&self.recv_buf) {
-            FrameDecode::Complete { payload, consumed } => (payload.to_vec(), consumed),
+        let (msg, consumed) = match decode_frame(&self.recv_buf) {
+            FrameDecode::Complete { payload, consumed } => {
+                let msg = Message::decode(payload)?;
+                (msg, consumed)
+            }
             FrameDecode::Incomplete => return Ok(()),
             FrameDecode::TooLarge { len } => return Err(AutoNatError::FrameTooLarge { len }),
             FrameDecode::Error(e) => return Err(AutoNatError::Varint(e)),
         };
         self.recv_buf.drain(..consumed);
 
-        let msg = Message::decode(&payload)?;
         if msg.kind != MessageType::DialResponse {
             self.state = FlowState::Done;
             return Err(AutoNatError::UnexpectedMessage(
@@ -359,15 +361,17 @@ impl AutoNatServer {
 
     fn try_decode_request(&mut self) -> Result<(), AutoNatError> {
         enforce_max_size(&self.recv_buf)?;
-        let (payload, consumed) = match decode_frame(&self.recv_buf) {
-            FrameDecode::Complete { payload, consumed } => (payload.to_vec(), consumed),
+        let (msg, consumed) = match decode_frame(&self.recv_buf) {
+            FrameDecode::Complete { payload, consumed } => {
+                let msg = Message::decode(payload)?;
+                (msg, consumed)
+            }
             FrameDecode::Incomplete => return Ok(()),
             FrameDecode::TooLarge { len } => return Err(AutoNatError::FrameTooLarge { len }),
             FrameDecode::Error(e) => return Err(AutoNatError::Varint(e)),
         };
         self.recv_buf.drain(..consumed);
 
-        let msg = Message::decode(&payload)?;
         if msg.kind != MessageType::Dial {
             self.state = ServerState::Done;
             return Err(AutoNatError::UnexpectedMessage("expected DIAL".into()));
@@ -408,7 +412,7 @@ pub enum FrameDecode<'a> {
 
 /// Encodes a protobuf message body with a varint length prefix.
 pub fn encode_frame(payload: &[u8]) -> Vec<u8> {
-    let mut out = Vec::new();
+    let mut out = Vec::with_capacity(uvarint_len(payload.len() as u64) + payload.len());
     write_uvarint(payload.len() as u64, &mut out);
     out.extend_from_slice(payload);
     out

--- a/crates/autonat/src/lib.rs
+++ b/crates/autonat/src/lib.rs
@@ -258,16 +258,14 @@ impl AutoNatClient {
 
     fn try_decode_response(&mut self) -> Result<(), AutoNatError> {
         enforce_max_size(&self.recv_buf)?;
-        let (msg, consumed) = match decode_frame(&self.recv_buf) {
-            FrameDecode::Complete { payload, consumed } => {
-                let msg = Message::decode(payload)?;
-                (msg, consumed)
-            }
+        let (decoded, consumed) = match decode_frame(&self.recv_buf) {
+            FrameDecode::Complete { payload, consumed } => (Message::decode(payload), consumed),
             FrameDecode::Incomplete => return Ok(()),
             FrameDecode::TooLarge { len } => return Err(AutoNatError::FrameTooLarge { len }),
             FrameDecode::Error(e) => return Err(AutoNatError::Varint(e)),
         };
         self.recv_buf.drain(..consumed);
+        let msg = decoded?;
 
         if msg.kind != MessageType::DialResponse {
             self.state = FlowState::Done;
@@ -361,16 +359,14 @@ impl AutoNatServer {
 
     fn try_decode_request(&mut self) -> Result<(), AutoNatError> {
         enforce_max_size(&self.recv_buf)?;
-        let (msg, consumed) = match decode_frame(&self.recv_buf) {
-            FrameDecode::Complete { payload, consumed } => {
-                let msg = Message::decode(payload)?;
-                (msg, consumed)
-            }
+        let (decoded, consumed) = match decode_frame(&self.recv_buf) {
+            FrameDecode::Complete { payload, consumed } => (Message::decode(payload), consumed),
             FrameDecode::Incomplete => return Ok(()),
             FrameDecode::TooLarge { len } => return Err(AutoNatError::FrameTooLarge { len }),
             FrameDecode::Error(e) => return Err(AutoNatError::Varint(e)),
         };
         self.recv_buf.drain(..consumed);
+        let msg = decoded?;
 
         if msg.kind != MessageType::Dial {
             self.state = ServerState::Done;
@@ -718,6 +714,49 @@ mod tests {
         assert!(
             matches!(client.outcome(), Some(Reachability::Private { status: ResponseStatus::DialError, reason }) if reason == "all dialbacks failed")
         );
+    }
+
+    #[test]
+    fn client_consumes_bad_frame_before_decode_error() {
+        let peer_id = PeerId::from_str(PEER_ID).unwrap();
+        let mut client = AutoNatClient::new(&peer_id, &[]);
+        let _ = client.take_outbound();
+
+        let bad_frame = encode_frame(&[TAG_TYPE, 99]);
+        assert!(matches!(
+            client.on_data(&bad_frame),
+            Err(AutoNatError::InvalidMessageType { value: 99 })
+        ));
+
+        let mut server = AutoNatServer::new();
+        server.respond_error(ResponseStatus::DialError, "after bad frame");
+        client.on_data(&server.take_outbound()).unwrap();
+
+        assert!(
+            matches!(client.outcome(), Some(Reachability::Private { status: ResponseStatus::DialError, reason }) if reason == "after bad frame")
+        );
+    }
+
+    #[test]
+    fn server_consumes_bad_frame_before_decode_error() {
+        let mut server = AutoNatServer::new();
+
+        let bad_frame = encode_frame(&[TAG_TYPE, 99]);
+        assert!(matches!(
+            server.on_data(&bad_frame),
+            Err(AutoNatError::InvalidMessageType { value: 99 })
+        ));
+
+        let peer_id = PeerId::from_str(PEER_ID).unwrap();
+        let addr = Multiaddr::from_str("/ip4/203.0.113.7/udp/4001/quic-v1").unwrap();
+        let mut client = AutoNatClient::new(&peer_id, core::slice::from_ref(&addr));
+        server.on_data(&client.take_outbound()).unwrap();
+
+        let request = server
+            .request()
+            .expect("request should decode after bad frame");
+        assert_eq!(request.peer_id, peer_id);
+        assert_eq!(request.addrs, vec![addr]);
     }
 
     #[test]

--- a/crates/core/src/candidates.rs
+++ b/crates/core/src/candidates.rs
@@ -65,8 +65,22 @@ pub struct DirectCandidate {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DirectCandidateSelection {
     pub accepted: Vec<DirectCandidate>,
-    pub candidates: Vec<Multiaddr>,
     pub rejected: Vec<DirectCandidateRejection>,
+}
+
+impl DirectCandidateSelection {
+    /// Returns true when no dialable candidates were accepted.
+    pub fn is_empty(&self) -> bool {
+        self.accepted.is_empty()
+    }
+
+    /// Consumes the selection and returns accepted candidate addresses in order.
+    pub fn into_addrs(self) -> Vec<Multiaddr> {
+        self.accepted
+            .into_iter()
+            .map(|candidate| candidate.addr)
+            .collect()
+    }
 }
 
 /// Selects dialable direct-connect candidates in deterministic priority order.
@@ -84,13 +98,9 @@ pub fn select_direct_candidates(
     identify_observed: Option<Multiaddr>,
     listen: Option<Multiaddr>,
 ) -> DirectCandidateSelection {
+    let capacity = manual.len() + identify_observed.is_some() as usize + listen.is_some() as usize;
     let mut selection = DirectCandidateSelection {
-        candidates: Vec::with_capacity(
-            manual.len() + identify_observed.is_some() as usize + listen.is_some() as usize,
-        ),
-        accepted: Vec::with_capacity(
-            manual.len() + identify_observed.is_some() as usize + listen.is_some() as usize,
-        ),
+        accepted: Vec::with_capacity(capacity),
         rejected: Vec::new(),
     };
 
@@ -135,9 +145,9 @@ fn push_candidate(
         return;
     }
     if selection
-        .candidates
+        .accepted
         .iter()
-        .any(|existing| existing == &addr)
+        .any(|candidate| candidate.addr == addr)
     {
         reject(
             selection,
@@ -148,11 +158,7 @@ fn push_candidate(
         return;
     }
 
-    selection.accepted.push(DirectCandidate {
-        source,
-        addr: addr.clone(),
-    });
-    selection.candidates.push(addr);
+    selection.accepted.push(DirectCandidate { source, addr });
 }
 
 fn reject(
@@ -169,7 +175,7 @@ fn reject(
 }
 
 /// Returns true when the multiaddr starts with a wildcard IP host.
-pub fn is_wildcard_addr(addr: &Multiaddr) -> bool {
+fn is_wildcard_addr(addr: &Multiaddr) -> bool {
     match addr.protocols().first() {
         Some(Protocol::Ip4(bytes)) => *bytes == [0, 0, 0, 0],
         Some(Protocol::Ip6(bytes)) => *bytes == [0; 16],
@@ -199,32 +205,37 @@ mod tests {
             Some(listen.clone()),
         );
 
-        assert_eq!(selected.candidates, vec![manual, observed, listen]);
         assert_eq!(selected.accepted.len(), 3);
         assert_eq!(selected.accepted[0].source, DirectCandidateSource::Manual);
+        assert_eq!(selected.accepted[0].addr, manual);
         assert_eq!(
             selected.accepted[1].source,
             DirectCandidateSource::IdentifyObserved
         );
+        assert_eq!(selected.accepted[1].addr, observed);
         assert_eq!(selected.accepted[2].source, DirectCandidateSource::Listen);
+        assert_eq!(selected.accepted[2].addr, listen);
         assert!(selected.rejected.is_empty());
     }
 
     #[test]
     fn rejects_wildcard_listen_addresses() {
-        let listen = addr("/ip4/0.0.0.0/udp/4001/quic-v1");
+        for listen in [
+            addr("/ip4/0.0.0.0/udp/4001/quic-v1"),
+            addr("/ip6/::/udp/4001/quic-v1"),
+        ] {
+            let selected = select_direct_candidates(&[], None, Some(listen.clone()));
 
-        let selected = select_direct_candidates(&[], None, Some(listen.clone()));
-
-        assert!(selected.candidates.is_empty());
-        assert_eq!(
-            selected.rejected,
-            vec![DirectCandidateRejection {
-                source: DirectCandidateSource::Listen,
-                addr: listen,
-                reason: DirectCandidateRejectReason::WildcardBindAddress,
-            }]
-        );
+            assert!(selected.is_empty());
+            assert_eq!(
+                selected.rejected,
+                vec![DirectCandidateRejection {
+                    source: DirectCandidateSource::Listen,
+                    addr: listen,
+                    reason: DirectCandidateRejectReason::WildcardBindAddress,
+                }]
+            );
+        }
     }
 
     #[test]
@@ -233,7 +244,7 @@ mod tests {
 
         let selected = select_direct_candidates(core::slice::from_ref(&bad), None, None);
 
-        assert!(selected.candidates.is_empty());
+        assert!(selected.is_empty());
         assert_eq!(
             selected.rejected[0].reason,
             DirectCandidateRejectReason::NotQuicV1Transport
@@ -250,7 +261,7 @@ mod tests {
             Some(manual.clone()),
         );
 
-        assert_eq!(selected.candidates, vec![manual.clone()]);
+        assert_eq!(selected.clone().into_addrs(), vec![manual.clone()]);
         assert_eq!(selected.rejected.len(), 2);
         assert_eq!(
             selected.rejected[0].source,
@@ -265,11 +276,5 @@ mod tests {
             selected.rejected[1].reason,
             DirectCandidateRejectReason::Duplicate
         );
-    }
-
-    #[test]
-    fn detects_ipv6_wildcard() {
-        assert!(is_wildcard_addr(&addr("/ip6/::/udp/4001/quic-v1")));
-        assert!(!is_wildcard_addr(&addr("/ip6/::1/udp/4001/quic-v1")));
     }
 }

--- a/crates/core/src/candidates.rs
+++ b/crates/core/src/candidates.rs
@@ -1,0 +1,275 @@
+use alloc::vec::Vec;
+
+use crate::{Multiaddr, Protocol};
+
+/// Where a direct-connect candidate came from.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DirectCandidateSource {
+    /// User-supplied explicit public address.
+    Manual,
+    /// Address observed by a public peer through Identify.
+    IdentifyObserved,
+    /// Local non-wildcard listen address.
+    Listen,
+}
+
+impl DirectCandidateSource {
+    /// Stable text for logs and diagnostics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::IdentifyObserved => "identify-observed",
+            Self::Listen => "listen",
+        }
+    }
+}
+
+/// Why a direct-connect candidate was rejected.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DirectCandidateRejectReason {
+    /// The address starts with `0.0.0.0` or `::` and is not remotely dialable.
+    WildcardBindAddress,
+    /// The address is not exactly host + udp + quic-v1.
+    NotQuicV1Transport,
+    /// The address was already accepted from a higher-priority source.
+    Duplicate,
+}
+
+impl DirectCandidateRejectReason {
+    /// Stable text for logs and diagnostics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WildcardBindAddress => "wildcard-bind-address",
+            Self::NotQuicV1Transport => "not-quic-v1-transport",
+            Self::Duplicate => "duplicate",
+        }
+    }
+}
+
+/// A candidate skipped by [`select_direct_candidates`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DirectCandidateRejection {
+    pub source: DirectCandidateSource,
+    pub addr: Multiaddr,
+    pub reason: DirectCandidateRejectReason,
+}
+
+/// A candidate accepted by [`select_direct_candidates`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DirectCandidate {
+    pub source: DirectCandidateSource,
+    pub addr: Multiaddr,
+}
+
+/// Ordered direct-connect candidates plus skipped candidates for diagnostics.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DirectCandidateSelection {
+    pub accepted: Vec<DirectCandidate>,
+    pub candidates: Vec<Multiaddr>,
+    pub rejected: Vec<DirectCandidateRejection>,
+}
+
+/// Selects dialable direct-connect candidates in deterministic priority order.
+///
+/// Priority is:
+/// 1. manual external addresses,
+/// 2. Identify observed address,
+/// 3. local non-wildcard listen address.
+///
+/// The selector is pure Sans-I/O policy: no DNS resolution, socket access,
+/// logging, timing, or transport side effects. It intentionally accepts only
+/// strict QUIC-v1 transport addresses (`/<host>/udp/<port>/quic-v1`).
+pub fn select_direct_candidates(
+    manual: &[Multiaddr],
+    identify_observed: Option<Multiaddr>,
+    listen: Option<Multiaddr>,
+) -> DirectCandidateSelection {
+    let mut selection = DirectCandidateSelection {
+        candidates: Vec::with_capacity(
+            manual.len() + identify_observed.is_some() as usize + listen.is_some() as usize,
+        ),
+        accepted: Vec::with_capacity(
+            manual.len() + identify_observed.is_some() as usize + listen.is_some() as usize,
+        ),
+        rejected: Vec::new(),
+    };
+
+    for addr in manual {
+        push_candidate(&mut selection, DirectCandidateSource::Manual, addr.clone());
+    }
+    if let Some(addr) = identify_observed {
+        push_candidate(
+            &mut selection,
+            DirectCandidateSource::IdentifyObserved,
+            addr,
+        );
+    }
+    if let Some(addr) = listen {
+        push_candidate(&mut selection, DirectCandidateSource::Listen, addr);
+    }
+
+    selection
+}
+
+fn push_candidate(
+    selection: &mut DirectCandidateSelection,
+    source: DirectCandidateSource,
+    addr: Multiaddr,
+) {
+    if is_wildcard_addr(&addr) {
+        reject(
+            selection,
+            source,
+            addr,
+            DirectCandidateRejectReason::WildcardBindAddress,
+        );
+        return;
+    }
+    if !addr.is_quic_transport() {
+        reject(
+            selection,
+            source,
+            addr,
+            DirectCandidateRejectReason::NotQuicV1Transport,
+        );
+        return;
+    }
+    if selection
+        .candidates
+        .iter()
+        .any(|existing| existing == &addr)
+    {
+        reject(
+            selection,
+            source,
+            addr,
+            DirectCandidateRejectReason::Duplicate,
+        );
+        return;
+    }
+
+    selection.accepted.push(DirectCandidate {
+        source,
+        addr: addr.clone(),
+    });
+    selection.candidates.push(addr);
+}
+
+fn reject(
+    selection: &mut DirectCandidateSelection,
+    source: DirectCandidateSource,
+    addr: Multiaddr,
+    reason: DirectCandidateRejectReason,
+) {
+    selection.rejected.push(DirectCandidateRejection {
+        source,
+        addr,
+        reason,
+    });
+}
+
+/// Returns true when the multiaddr starts with a wildcard IP host.
+pub fn is_wildcard_addr(addr: &Multiaddr) -> bool {
+    match addr.protocols().first() {
+        Some(Protocol::Ip4(bytes)) => *bytes == [0, 0, 0, 0],
+        Some(Protocol::Ip6(bytes)) => *bytes == [0; 16],
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use super::*;
+
+    fn addr(value: &str) -> Multiaddr {
+        Multiaddr::from_str(value).unwrap()
+    }
+
+    #[test]
+    fn selects_candidates_in_priority_order() {
+        let manual = addr("/ip4/203.0.113.7/udp/4001/quic-v1");
+        let observed = addr("/ip4/198.51.100.9/udp/5001/quic-v1");
+        let listen = addr("/ip4/127.0.0.1/udp/6001/quic-v1");
+
+        let selected = select_direct_candidates(
+            core::slice::from_ref(&manual),
+            Some(observed.clone()),
+            Some(listen.clone()),
+        );
+
+        assert_eq!(selected.candidates, vec![manual, observed, listen]);
+        assert_eq!(selected.accepted.len(), 3);
+        assert_eq!(selected.accepted[0].source, DirectCandidateSource::Manual);
+        assert_eq!(
+            selected.accepted[1].source,
+            DirectCandidateSource::IdentifyObserved
+        );
+        assert_eq!(selected.accepted[2].source, DirectCandidateSource::Listen);
+        assert!(selected.rejected.is_empty());
+    }
+
+    #[test]
+    fn rejects_wildcard_listen_addresses() {
+        let listen = addr("/ip4/0.0.0.0/udp/4001/quic-v1");
+
+        let selected = select_direct_candidates(&[], None, Some(listen.clone()));
+
+        assert!(selected.candidates.is_empty());
+        assert_eq!(
+            selected.rejected,
+            vec![DirectCandidateRejection {
+                source: DirectCandidateSource::Listen,
+                addr: listen,
+                reason: DirectCandidateRejectReason::WildcardBindAddress,
+            }]
+        );
+    }
+
+    #[test]
+    fn rejects_non_quic_v1_transport_shapes() {
+        let bad = addr("/ip4/203.0.113.7/udp/4001");
+
+        let selected = select_direct_candidates(core::slice::from_ref(&bad), None, None);
+
+        assert!(selected.candidates.is_empty());
+        assert_eq!(
+            selected.rejected[0].reason,
+            DirectCandidateRejectReason::NotQuicV1Transport
+        );
+    }
+
+    #[test]
+    fn removes_duplicates_deterministically() {
+        let manual = addr("/ip4/203.0.113.7/udp/4001/quic-v1");
+
+        let selected = select_direct_candidates(
+            core::slice::from_ref(&manual),
+            Some(manual.clone()),
+            Some(manual.clone()),
+        );
+
+        assert_eq!(selected.candidates, vec![manual.clone()]);
+        assert_eq!(selected.rejected.len(), 2);
+        assert_eq!(
+            selected.rejected[0].source,
+            DirectCandidateSource::IdentifyObserved
+        );
+        assert_eq!(
+            selected.rejected[0].reason,
+            DirectCandidateRejectReason::Duplicate
+        );
+        assert_eq!(selected.rejected[1].source, DirectCandidateSource::Listen);
+        assert_eq!(
+            selected.rejected[1].reason,
+            DirectCandidateRejectReason::Duplicate
+        );
+    }
+
+    #[test]
+    fn detects_ipv6_wildcard() {
+        assert!(is_wildcard_addr(&addr("/ip6/::/udp/4001/quic-v1")));
+        assert!(!is_wildcard_addr(&addr("/ip6/::1/udp/4001/quic-v1")));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,7 +16,7 @@ mod protocol;
 
 pub use candidates::{
     DirectCandidate, DirectCandidateRejectReason, DirectCandidateRejection,
-    DirectCandidateSelection, DirectCandidateSource, is_wildcard_addr, select_direct_candidates,
+    DirectCandidateSelection, DirectCandidateSource, select_direct_candidates,
 };
 pub use error::{MultiaddrError, PeerAddrError};
 pub use minip2p_identity::PeerId;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,11 +8,16 @@
 
 extern crate alloc;
 
+mod candidates;
 mod error;
 mod multiaddr;
 mod peer_addr;
 mod protocol;
 
+pub use candidates::{
+    DirectCandidate, DirectCandidateRejectReason, DirectCandidateRejection,
+    DirectCandidateSelection, DirectCandidateSource, is_wildcard_addr, select_direct_candidates,
+};
 pub use error::{MultiaddrError, PeerAddrError};
 pub use minip2p_identity::PeerId;
 pub use minip2p_identity::{VarintError, read_uvarint, uvarint_len, write_uvarint};

--- a/crates/core/src/multiaddr.rs
+++ b/crates/core/src/multiaddr.rs
@@ -403,7 +403,10 @@ mod tests {
             0xCC, 0x03, // quic
         ])
         .unwrap_err();
-        assert!(matches!(err, MultiaddrError::UnknownProtocolCode { code: 0x01cc }));
+        assert!(matches!(
+            err,
+            MultiaddrError::UnknownProtocolCode { code: 0x01cc }
+        ));
     }
 
     #[test]

--- a/crates/dcutr/src/lib.rs
+++ b/crates/dcutr/src/lib.rs
@@ -214,8 +214,14 @@ impl DcutrInitiator {
             e
         })?;
 
-        let (payload, consumed) = match decode_frame(&self.recv_buf) {
-            FrameDecode::Complete { payload, consumed } => (payload.to_vec(), consumed),
+        let (reply, consumed) = match decode_frame(&self.recv_buf) {
+            FrameDecode::Complete { payload, consumed } => {
+                let reply = HolePunch::decode(payload).map_err(|e| {
+                    self.state = InitiatorState::Done;
+                    DcutrError::Malformed(e)
+                })?;
+                (reply, consumed)
+            }
             FrameDecode::Incomplete => return Ok(()),
             FrameDecode::Error(e) => {
                 self.state = InitiatorState::Done;
@@ -223,11 +229,6 @@ impl DcutrInitiator {
             }
         };
         self.recv_buf.drain(..consumed);
-
-        let reply = HolePunch::decode(&payload).map_err(|e| {
-            self.state = InitiatorState::Done;
-            DcutrError::Malformed(e)
-        })?;
 
         if reply.kind != HolePunchType::Connect {
             self.state = InitiatorState::Done;
@@ -357,8 +358,14 @@ impl DcutrResponder {
                 e
             })?;
 
-            let (payload, consumed) = match decode_frame(&self.recv_buf) {
-                FrameDecode::Complete { payload, consumed } => (payload.to_vec(), consumed),
+            let (msg, consumed) = match decode_frame(&self.recv_buf) {
+                FrameDecode::Complete { payload, consumed } => {
+                    let msg = HolePunch::decode(payload).map_err(|e| {
+                        self.state = ResponderState::Done;
+                        DcutrError::Malformed(e)
+                    })?;
+                    (msg, consumed)
+                }
                 FrameDecode::Incomplete => return Ok(()),
                 FrameDecode::Error(e) => {
                     self.state = ResponderState::Done;
@@ -366,11 +373,6 @@ impl DcutrResponder {
                 }
             };
             self.recv_buf.drain(..consumed);
-
-            let msg = HolePunch::decode(&payload).map_err(|e| {
-                self.state = ResponderState::Done;
-                DcutrError::Malformed(e)
-            })?;
 
             match (self.state, msg.kind) {
                 (ResponderState::AwaitingConnect, HolePunchType::Connect) => {

--- a/crates/multistream-select/src/lib.rs
+++ b/crates/multistream-select/src/lib.rs
@@ -150,94 +150,112 @@ impl MultistreamSelect {
                 break;
             }
 
-            let (payload, consumed) = match decode_message(&self.recv_buf) {
-                DecodeResult::Complete { payload, consumed } => (payload.to_string(), consumed),
+            let (next_state, produced, consumed) = match decode_message(&self.recv_buf) {
+                DecodeResult::Complete { payload, consumed } => {
+                    let (next_state, produced) = handle_message(
+                        self.role,
+                        self.state,
+                        self.desired_protocol.as_deref(),
+                        &self.supported_protocols,
+                        payload,
+                    );
+                    (next_state, produced, consumed)
+                }
                 DecodeResult::Incomplete => break,
                 DecodeResult::Error(err) => {
-                    outputs.extend(self.protocol_error(err));
+                    self.state = State::Done;
+                    outputs.push(MultistreamOutput::ProtocolError {
+                        reason: err.to_string(),
+                    });
                     break;
                 }
             };
             self.recv_buf.drain(..consumed);
-            outputs.extend(self.on_message(&payload));
+            self.state = next_state;
+            outputs.extend(produced);
         }
 
         outputs
     }
+}
 
-    /// Processes a single decoded protocol line and advances the state machine.
-    fn on_message(&mut self, line: &str) -> Vec<MultistreamOutput> {
-        match self.state {
-            State::WaitingForRemoteHeader => {
-                if line != MULTISTREAM_PROTOCOL_ID {
-                    return self.protocol_error(MultistreamError::UnexpectedHeader {
-                        actual: line.to_string(),
-                    });
-                }
-
-                match self.role {
-                    Role::Dialer => {
-                        let desired = self
-                            .desired_protocol
-                            .as_ref()
-                            .expect("dialer must have desired protocol");
-                        self.state = State::WaitingForProtocolResponse;
-                        vec![MultistreamOutput::OutboundData(encode_message(desired))]
-                    }
-                    Role::Listener => {
-                        self.state = State::WaitingForProtocolRequest;
-                        Vec::new()
-                    }
-                }
+/// Processes a single decoded protocol line.
+fn handle_message(
+    role: Role,
+    state: State,
+    desired_protocol: Option<&str>,
+    supported_protocols: &BTreeSet<String>,
+    line: &str,
+) -> (State, Vec<MultistreamOutput>) {
+    match state {
+        State::WaitingForRemoteHeader => {
+            if line != MULTISTREAM_PROTOCOL_ID {
+                return protocol_error(MultistreamError::UnexpectedHeader {
+                    actual: line.to_string(),
+                });
             }
-            State::WaitingForProtocolRequest => {
-                if self.supported_protocols.contains(line) {
-                    self.state = State::Done;
+
+            match role {
+                Role::Dialer => {
+                    let desired = desired_protocol.expect("dialer must have desired protocol");
+                    (
+                        State::WaitingForProtocolResponse,
+                        vec![MultistreamOutput::OutboundData(encode_message(desired))],
+                    )
+                }
+                Role::Listener => (State::WaitingForProtocolRequest, Vec::new()),
+            }
+        }
+        State::WaitingForProtocolRequest => {
+            if supported_protocols.contains(line) {
+                (
+                    State::Done,
                     vec![
                         MultistreamOutput::OutboundData(encode_message(line)),
                         MultistreamOutput::Negotiated {
                             protocol: line.to_string(),
                         },
-                    ]
-                } else {
-                    self.state = State::Done;
+                    ],
+                )
+            } else {
+                (
+                    State::Done,
                     vec![
                         MultistreamOutput::OutboundData(encode_message(NOT_AVAILABLE)),
                         MultistreamOutput::NotAvailable,
-                    ]
-                }
+                    ],
+                )
             }
-            State::WaitingForProtocolResponse => {
-                let desired = self
-                    .desired_protocol
-                    .as_ref()
-                    .expect("dialer must have desired protocol");
-
-                if line == desired {
-                    self.state = State::Done;
-                    vec![MultistreamOutput::Negotiated {
-                        protocol: desired.clone(),
-                    }]
-                } else if line == NOT_AVAILABLE {
-                    self.state = State::Done;
-                    vec![MultistreamOutput::NotAvailable]
-                } else {
-                    self.protocol_error(MultistreamError::UnexpectedProtocolResponse {
-                        actual: line.to_string(),
-                    })
-                }
-            }
-            State::Done => Vec::new(),
         }
-    }
+        State::WaitingForProtocolResponse => {
+            let desired = desired_protocol.expect("dialer must have desired protocol");
 
-    /// Transitions to Done and returns a ProtocolError output.
-    fn protocol_error(&mut self, error: MultistreamError) -> Vec<MultistreamOutput> {
-        self.state = State::Done;
+            if line == desired {
+                (
+                    State::Done,
+                    vec![MultistreamOutput::Negotiated {
+                        protocol: desired.to_string(),
+                    }],
+                )
+            } else if line == NOT_AVAILABLE {
+                (State::Done, vec![MultistreamOutput::NotAvailable])
+            } else {
+                protocol_error(MultistreamError::UnexpectedProtocolResponse {
+                    actual: line.to_string(),
+                })
+            }
+        }
+        State::Done => (State::Done, Vec::new()),
+    }
+}
+
+fn protocol_error(error: MultistreamError) -> (State, Vec<MultistreamOutput>) {
+    (
+        State::Done,
         vec![MultistreamOutput::ProtocolError {
             reason: error.to_string(),
-        }]
-    }
+        }],
+    )
 }
 
 /// Encodes a protocol string as a varint-length-prefixed message.

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -175,8 +175,14 @@ impl HopReservation {
             e
         })?;
 
-        let (payload, consumed) = match decode_frame(&self.recv_buf) {
-            FrameDecode::Complete { payload, consumed } => (payload.to_vec(), consumed),
+        let (msg, consumed) = match decode_frame(&self.recv_buf) {
+            FrameDecode::Complete { payload, consumed } => {
+                let msg = HopMessage::decode(payload).map_err(|e| {
+                    self.state = FlowState::Done;
+                    RelayError::Malformed(e)
+                })?;
+                (msg, consumed)
+            }
             FrameDecode::Incomplete => return Ok(()),
             FrameDecode::Error(e) => {
                 self.state = FlowState::Done;
@@ -184,11 +190,6 @@ impl HopReservation {
             }
         };
         self.recv_buf.drain(..consumed);
-
-        let msg = HopMessage::decode(&payload).map_err(|e| {
-            self.state = FlowState::Done;
-            RelayError::Malformed(e)
-        })?;
 
         if msg.kind != HopMessageType::Status {
             self.state = FlowState::Done;
@@ -346,8 +347,14 @@ impl HopConnect {
             e
         })?;
 
-        let (payload, consumed) = match decode_frame(&self.recv_buf) {
-            FrameDecode::Complete { payload, consumed } => (payload.to_vec(), consumed),
+        let (msg, consumed) = match decode_frame(&self.recv_buf) {
+            FrameDecode::Complete { payload, consumed } => {
+                let msg = HopMessage::decode(payload).map_err(|e| {
+                    self.state = FlowState::Done;
+                    RelayError::Malformed(e)
+                })?;
+                (msg, consumed)
+            }
             FrameDecode::Incomplete => return Ok(()),
             FrameDecode::Error(e) => {
                 self.state = FlowState::Done;
@@ -355,11 +362,6 @@ impl HopConnect {
             }
         };
         self.recv_buf.drain(..consumed);
-
-        let msg = HopMessage::decode(&payload).map_err(|e| {
-            self.state = FlowState::Done;
-            RelayError::Malformed(e)
-        })?;
 
         if msg.kind != HopMessageType::Status {
             self.state = FlowState::Done;
@@ -537,8 +539,14 @@ impl StopResponder {
             e
         })?;
 
-        let (payload, consumed) = match decode_frame(&self.recv_buf) {
-            FrameDecode::Complete { payload, consumed } => (payload.to_vec(), consumed),
+        let (msg, consumed) = match decode_frame(&self.recv_buf) {
+            FrameDecode::Complete { payload, consumed } => {
+                let msg = StopMessage::decode(payload).map_err(|e| {
+                    self.state = StopState::Done;
+                    RelayError::Malformed(e)
+                })?;
+                (msg, consumed)
+            }
             FrameDecode::Incomplete => return Ok(()),
             FrameDecode::Error(e) => {
                 self.state = StopState::Done;
@@ -546,11 +554,6 @@ impl StopResponder {
             }
         };
         self.recv_buf.drain(..consumed);
-
-        let msg = StopMessage::decode(&payload).map_err(|e| {
-            self.state = StopState::Done;
-            RelayError::Malformed(e)
-        })?;
 
         if msg.kind != StopMessageType::Connect {
             self.state = StopState::Done;

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -56,7 +56,7 @@ impl Clock for SystemClock {
 /// Thin std driver wrapping [`SwarmCore`] and a concrete [`Transport`].
 ///
 /// Preserves the one-call DX built on top of the core:
-/// - `dial(addr) -> ConnectionId` auto-allocates the connection id.
+/// - `dial(addr) -> ConnectionId` delegates connection-id allocation to the transport.
 /// - `poll()` reads the wall clock internally; callers need not thread
 ///   `now_ms` through every call.
 /// - `ping(peer)` opens a ping stream if needed and fires the payload as
@@ -75,8 +75,6 @@ pub struct Swarm<T: Transport> {
     /// when the buffer drains.
     event_buffer: VecDeque<SwarmEvent>,
 
-    /// Auto-incrementing connection-id counter for outbound dials.
-    next_connection_id: u64,
     /// Logical clock used to drive Sans-I/O timers.
     clock: Arc<dyn Clock>,
 }
@@ -119,7 +117,6 @@ impl<T: Transport> Swarm<T> {
             core: SwarmCore::new(identify_config, ping_config),
             local_peer_id,
             event_buffer: VecDeque::new(),
-            next_connection_id: 1,
             clock,
         }
     }
@@ -194,10 +191,9 @@ impl<T: Transport> Swarm<T> {
         })
     }
 
-    /// Dial a remote peer. Swarm auto-allocates a connection id.
+    /// Dial a remote peer. The transport allocates the connection id.
     pub fn dial(&mut self, addr: &PeerAddr) -> Result<ConnectionId, TransportError> {
-        let id = self.allocate_connection_id();
-        self.transport.dial(id, addr)?;
+        let id = self.transport.dial(addr)?;
         self.core.on_dialed(id);
         Ok(id)
     }
@@ -397,16 +393,6 @@ impl<T: Transport> Swarm<T> {
 
     fn now_ms(&self) -> u64 {
         self.clock.now_ms()
-    }
-
-    fn allocate_connection_id(&mut self) -> ConnectionId {
-        loop {
-            let raw = self.next_connection_id;
-            self.next_connection_id = self.next_connection_id.wrapping_add(1);
-            if raw != 0 {
-                return ConnectionId::new(raw);
-            }
-        }
     }
 
     /// Drains all actions from the core and dispatches each to the

--- a/crates/tls/src/pem.rs
+++ b/crates/tls/src/pem.rs
@@ -92,16 +92,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn base64_encodes_empty() {
-        assert_eq!(base64_encode(b""), "");
-    }
-
-    #[test]
-    fn base64_encodes_hello() {
-        assert_eq!(base64_encode(b"Hello"), "SGVsbG8=");
-    }
-
-    #[test]
     fn base64_encodes_three_byte_boundary() {
         assert_eq!(base64_encode(b"abc"), "YWJj");
     }

--- a/crates/transport/src/error.rs
+++ b/crates/transport/src/error.rs
@@ -18,8 +18,6 @@ pub enum TransportError {
     ResourceExhausted { resource: &'static str },
     #[error("connection {id} not found")]
     ConnectionNotFound { id: ConnectionId },
-    #[error("connection {id} already exists")]
-    ConnectionExists { id: ConnectionId },
     #[error("connection {id} is {state}, expected {expected}")]
     InvalidState {
         id: ConnectionId,

--- a/crates/transport/src/transport.rs
+++ b/crates/transport/src/transport.rs
@@ -152,4 +152,15 @@ pub trait Transport {
     fn active_connection_sources(&self) -> Vec<Multiaddr> {
         Vec::new()
     }
+
+    /// Returns the remote transport address for every active inbound/accepted
+    /// connection (pre-`Closed`).
+    ///
+    /// Unlike [`active_connection_sources`](Transport::active_connection_sources),
+    /// this intentionally excludes outbound dials. Hole-punch responders use it
+    /// to distinguish a real inbound packet from their own simultaneous direct
+    /// dial attempt.
+    fn active_inbound_connection_sources(&self) -> Vec<Multiaddr> {
+        Vec::new()
+    }
 }

--- a/crates/transport/src/transport.rs
+++ b/crates/transport/src/transport.rs
@@ -16,7 +16,8 @@ use crate::{ConnectionId, StreamId, TransportError, TransportEvent};
 ///
 /// ## Connection lifecycle
 ///
-/// - `dial()` returns `Ok` before any events for that connection are emitted.
+/// - `dial()` returns the allocated connection id before any events for that
+///   connection are emitted.
 /// - A dialed connection emits `Connected` exactly once after the handshake
 ///   completes. No stream events may precede `Connected`.
 /// - An incoming connection emits `IncomingConnection` before `Connected`.
@@ -44,12 +45,13 @@ use crate::{ConnectionId, StreamId, TransportError, TransportEvent};
 /// - Events across different connections have no ordering guarantee.
 /// - `poll()` never blocks. It returns an empty vec when idle.
 pub trait Transport {
-    /// Initiate an outbound connection.
+    /// Initiate an outbound connection and return its allocated connection id.
     ///
-    /// The caller provides the `id`; the transport must reject duplicates with
-    /// `ConnectionExists`. The connection is not usable until `Connected` is
-    /// emitted from `poll()`.
-    fn dial(&mut self, id: ConnectionId, addr: &PeerAddr) -> Result<(), TransportError>;
+    /// The transport owns connection-id allocation for both inbound and
+    /// outbound connections, so adapters can avoid collisions between accepted
+    /// connections and later dials. The connection is not usable until
+    /// `Connected` is emitted from `poll()`.
+    fn dial(&mut self, addr: &PeerAddr) -> Result<ConnectionId, TransportError>;
 
     /// Start listening for inbound connections on the given address.
     ///

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -187,9 +187,10 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         )?;
     };
 
-    // --- 6. Hole-punch: blast UDP, wait for direct or timeout --------------
+    // --- 6. Hole-punch: dial + blast UDP, wait for direct or timeout -------
     println!("[{role}] dcutr-sync-received -> holepunching");
     print_remote_candidates(role, &remote_addrs);
+    dial_direct_candidates(&mut swarm, role, &remote_peer_id, &remote_addrs);
     let punch_start = Instant::now();
     let punch_deadline = punch_start + HOLEPUNCH_DEADLINE;
     let mut next_blast = punch_start + RESPONDER_SYNC_DELAY;
@@ -531,15 +532,7 @@ pub fn run_dial(
         dcutr.take_outbound(),
     )?;
 
-    for addr in &remote_addrs {
-        match PeerAddr::new(addr.clone(), target.clone()) {
-            Ok(pa) => match swarm.dial(&pa) {
-                Ok(_) => println!("[{role}] direct-dial-attempt {pa}"),
-                Err(e) => eprintln!("[{role}] direct-dial-failed addr={pa} reason={e}"),
-            },
-            Err(e) => eprintln!("[{role}] bad PeerAddr for {addr}: {e}"),
-        }
-    }
+    dial_direct_candidates(&mut swarm, role, &target, &remote_addrs);
 
     // --- 5. Wait for direct connection or hole-punch timeout ---------------
     let punch_deadline = Instant::now() + HOLEPUNCH_DEADLINE;
@@ -949,6 +942,23 @@ fn drain_dcutr_responder_events(
         }
     }
     sync
+}
+
+fn dial_direct_candidates(
+    swarm: &mut Swarm<QuicTransport>,
+    role: &str,
+    peer_id: &PeerId,
+    addrs: &[Multiaddr],
+) {
+    for addr in addrs {
+        match PeerAddr::new(addr.clone(), peer_id.clone()) {
+            Ok(peer_addr) => match swarm.dial(&peer_addr) {
+                Ok(_) => println!("[{role}] direct-dial-attempt {peer_addr}"),
+                Err(e) => eprintln!("[{role}] direct-dial-failed addr={peer_addr} reason={e}"),
+            },
+            Err(e) => eprintln!("[{role}] bad PeerAddr for {addr}: {e}"),
+        }
+    }
 }
 
 /// Send `data` on `stream_id` if non-empty; no-op otherwise.

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -214,7 +214,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     // Initial may have arrived BEFORE we observed the SYNC message on
     // a tight local loopback). Only counts if the source matches.
     let mut saw_inbound_conn = any_source_matches(
-        &swarm.transport().active_connection_sources(),
+        &swarm.transport().active_inbound_connection_sources(),
         &remote_match_targets,
     );
 
@@ -253,7 +253,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         // NOT trigger this because their source address won't match
         // `remote_match_targets`.
         if any_source_matches(
-            &swarm.transport().active_connection_sources(),
+            &swarm.transport().active_inbound_connection_sources(),
             &remote_match_targets,
         ) {
             saw_inbound_conn = true;
@@ -292,8 +292,8 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
                     ping_and_exit(&mut swarm, role, peer_id, deadline)
                 }
                 _ => {
-                    println!("[{role}] grace-elapsed before mTLS identity -- done");
-                    Ok(())
+                    println!("[{role}] grace-elapsed before mTLS identity -> relay-ping fallback");
+                    relay_ping_fallback(&mut swarm, role, &relay_peer_id, bridge_stream)
                 }
             }
         }
@@ -309,33 +309,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         }
         HolePunchOutcome::Timeout => {
             println!("[{role}] hole-punch-timeout reason=deadline elapsed -> relay-ping fallback");
-            // Wait up to ~15s for either an echo payload from Peer A
-            // or the bridge to close (meaning A gave up). Longer
-            // than the hole-punch deadline because the relay's own
-            // idle-circuit GC can take several seconds -- but bounded
-            // so we don't hang forever if something goes wrong.
-            let fallback_deadline = Instant::now() + Duration::from_secs(15);
-            let ev = swarm
-                .run_until(fallback_deadline, |ev| {
-                    print_event(role, ev);
-                    matches!(
-                        ev,
-                        SwarmEvent::UserStreamData { stream_id: s, .. } if *s == bridge_stream
-                    ) || is_bridge_closed_event(ev, bridge_stream)
-                })
-                .map_err(|e| format!("fallback poll: {e}"))?;
-            match ev {
-                Some(SwarmEvent::UserStreamData { data, .. }) => {
-                    send(&mut swarm, &relay_peer_id, bridge_stream, data)?;
-                    println!("[{role}] relay-ping-echoed -- done");
-                    Ok(())
-                }
-                Some(_) => {
-                    println!("[{role}] bridge-closed during fallback -- done");
-                    Ok(())
-                }
-                None => Err("fallback deadline exceeded before any bridge activity".into()),
-            }
+            relay_ping_fallback(&mut swarm, role, &relay_peer_id, bridge_stream)
         }
     }
 }
@@ -958,6 +932,41 @@ fn dial_direct_candidates(
             },
             Err(e) => eprintln!("[{role}] bad PeerAddr for {addr}: {e}"),
         }
+    }
+}
+
+fn relay_ping_fallback(
+    swarm: &mut Swarm<QuicTransport>,
+    role: &str,
+    relay_peer_id: &PeerId,
+    bridge_stream: StreamId,
+) -> Result<(), Box<dyn Error>> {
+    // Wait up to ~15s for either an echo payload from Peer A or the bridge to
+    // close (meaning A gave up). Longer than the hole-punch deadline because
+    // the relay's own idle-circuit GC can take several seconds -- but bounded
+    // so we don't hang forever if something goes wrong.
+    let fallback_deadline = Instant::now() + Duration::from_secs(15);
+    let ev = swarm
+        .run_until(fallback_deadline, |ev| {
+            print_event(role, ev);
+            matches!(
+                ev,
+                SwarmEvent::UserStreamData { stream_id: s, .. } if *s == bridge_stream
+            ) || is_bridge_closed_event(ev, bridge_stream)
+        })
+        .map_err(|e| format!("fallback poll: {e}"))?;
+
+    match ev {
+        Some(SwarmEvent::UserStreamData { data, .. }) => {
+            send(swarm, relay_peer_id, bridge_stream, data)?;
+            println!("[{role}] relay-ping-echoed -- done");
+            Ok(())
+        }
+        Some(_) => {
+            println!("[{role}] bridge-closed during fallback -- done");
+            Ok(())
+        }
+        None => Err("fallback deadline exceeded before any bridge activity".into()),
     }
 }
 

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -1133,13 +1133,13 @@ fn candidate_addrs(
         );
     }
 
-    if selection.candidates.is_empty() {
+    if selection.is_empty() {
         eprintln!(
             "[{role}] no-dialable-dcutr-candidates; add --external-addr or bind a non-wildcard address"
         );
     }
 
-    selection.candidates
+    selection.into_addrs()
 }
 
 fn relay_observed_addr(
@@ -1223,7 +1223,7 @@ fn successful_candidates_in_original_order(
     let mut ordered = Vec::new();
     for candidate in candidates {
         if successful.iter().any(|addr| addr == candidate) {
-            push_unique(&mut ordered, candidate.clone());
+            ordered.push(candidate.clone());
         }
     }
     ordered
@@ -1297,31 +1297,6 @@ mod tests {
         assert_eq!(dialback_bind_addrs(&dns4), &["0.0.0.0:0"]);
         assert_eq!(dialback_bind_addrs(&ip6), &["[::]:0"]);
         assert_eq!(dialback_bind_addrs(&dns6), &["[::]:0"]);
-    }
-
-    #[test]
-    fn candidate_addrs_filters_wildcard_bind_addresses() {
-        let bound = Multiaddr::from_str("/ip4/0.0.0.0/udp/4001/quic-v1").unwrap();
-        let external = Multiaddr::from_str("/ip4/203.0.113.7/udp/4001/quic-v1").unwrap();
-        let observed = Multiaddr::from_str("/ip4/198.51.100.9/udp/5001/quic-v1").unwrap();
-
-        let candidates = candidate_addrs(
-            "test",
-            &bound,
-            core::slice::from_ref(&external),
-            Some(observed.clone()),
-        );
-
-        assert_eq!(candidates, vec![external, observed]);
-    }
-
-    #[test]
-    fn candidate_addrs_keeps_non_wildcard_listen_address() {
-        let bound = Multiaddr::from_str("/ip4/127.0.0.1/udp/4001/quic-v1").unwrap();
-
-        let candidates = candidate_addrs("test", &bound, &[], None);
-
-        assert_eq!(candidates, vec![bound]);
     }
 
     #[test]

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use minip2p_autonat::{
     AUTONAT_PROTOCOL_ID, AutoNatClient, AutoNatServer, Reachability, ResponseStatus,
 };
-use minip2p_core::{Multiaddr, PeerAddr, PeerId, Protocol};
+use minip2p_core::{Multiaddr, PeerAddr, PeerId, Protocol, select_direct_candidates};
 use minip2p_dcutr::{
     DCUTR_PROTOCOL_ID, DcutrInitiator, DcutrResponder, InitiatorOutcome, ResponderEvent,
 };
@@ -1094,48 +1094,33 @@ fn candidate_addrs(
     external_addrs: &[Multiaddr],
     observed_addr: Option<Multiaddr>,
 ) -> Vec<Multiaddr> {
-    let mut candidates = Vec::with_capacity(external_addrs.len() + 2);
-    for addr in external_addrs {
-        push_candidate(role, &mut candidates, "manual", addr.clone());
+    let selection =
+        select_direct_candidates(external_addrs, observed_addr, Some(bound_addr.clone()));
+
+    for candidate in &selection.accepted {
+        println!(
+            "[{role}] candidate-added source={} addr={}",
+            candidate.source.as_str(),
+            candidate.addr
+        );
     }
-    if let Some(addr) = observed_addr {
-        push_candidate(role, &mut candidates, "identify-observed", addr);
+
+    for rejected in &selection.rejected {
+        println!(
+            "[{role}] candidate-skipped source={} addr={} reason={}",
+            rejected.source.as_str(),
+            rejected.addr,
+            rejected.reason.as_str()
+        );
     }
-    push_candidate(role, &mut candidates, "listen", bound_addr.clone());
-    if candidates.is_empty() {
+
+    if selection.candidates.is_empty() {
         eprintln!(
             "[{role}] no-dialable-dcutr-candidates; add --external-addr or bind a non-wildcard address"
         );
     }
-    candidates
-}
 
-fn push_candidate(role: &str, candidates: &mut Vec<Multiaddr>, source: &str, addr: Multiaddr) {
-    if is_wildcard_addr(&addr) {
-        println!(
-            "[{role}] candidate-skipped source={source} addr={addr} reason=wildcard-bind-address"
-        );
-        return;
-    }
-    if !addr.is_quic_transport() {
-        println!(
-            "[{role}] candidate-skipped source={source} addr={addr} reason=not-quic-transport"
-        );
-        return;
-    }
-    let before = candidates.len();
-    push_unique(candidates, addr.clone());
-    if candidates.len() > before {
-        println!("[{role}] candidate-added source={source} addr={addr}");
-    }
-}
-
-fn is_wildcard_addr(addr: &Multiaddr) -> bool {
-    match addr.protocols().first() {
-        Some(Protocol::Ip4(bytes)) => *bytes == [0, 0, 0, 0],
-        Some(Protocol::Ip6(bytes)) => *bytes == [0; 16],
-        _ => false,
-    }
+    selection.candidates
 }
 
 fn relay_observed_addr(

--- a/holepunch-plan.md
+++ b/holepunch-plan.md
@@ -352,12 +352,13 @@ frame delivery without needing a separate poll round.
    - [x] Confirm DCUtR CONNECT/SYNC exchange succeeds over the relay circuit.
    - [x] Confirm fallback `ping-via-relay` succeeds when direct candidates are not dialable.
 
-7. Direct-candidate discovery -- NEXT
-   - [ ] Do not advertise wildcard bind addresses (`0.0.0.0`, `::`) as DCUtR candidates.
-   - [ ] Add parseable Identify observed addresses as candidates after relay/public-peer Identify.
+7. Direct-candidate discovery -- DONE
+   - [x] Do not advertise wildcard bind addresses (`0.0.0.0`, `::`) as DCUtR candidates.
+   - [x] Add parseable Identify observed addresses as candidates after relay/public-peer Identify.
    - [x] Strictly require `/quic-v1`; legacy `/quic` is intentionally rejected rather than normalized.
-   - [ ] Keep candidate priority deterministic: manual `--external-addr`, then Identify observed address, then non-wildcard listen address.
-   - [ ] Preserve relay fallback as the success path when no dialable direct candidate exists.
+   - [x] Keep candidate priority deterministic: manual `--external-addr`, then Identify observed address, then non-wildcard listen address.
+   - [x] Preserve relay fallback as the success path when no dialable direct candidate exists.
+   - [x] Move reusable candidate selection policy into `minip2p-core` as pure `no_std + alloc` logic.
 
 ## Future follow-ups (not on this branch)
 

--- a/transports/quic/README.md
+++ b/transports/quic/README.md
@@ -40,7 +40,7 @@ let listen_addr = Multiaddr::from_protocols(vec![
 ]);
 listener.listen(&listen_addr)?;
 
-let dialer_cfg = QuicNodeConfig::dev_dialer();
+let dialer_cfg = QuicNodeConfig::generate();
 let mut dialer = QuicTransport::new(dialer_cfg, "127.0.0.1:0")?;
 
 let peer_addr = PeerAddr::new(listen_addr, listener_key.peer_id())?;

--- a/transports/quic/src/config.rs
+++ b/transports/quic/src/config.rs
@@ -22,13 +22,8 @@ impl QuicNodeConfig {
         Self { keypair }
     }
 
-    /// Convenience: generates a fresh keypair for a dev/test dialer.
-    pub fn dev_dialer() -> Self {
-        Self::new(Ed25519Keypair::generate())
-    }
-
-    /// Convenience: generates a fresh keypair for a dev/test listener.
-    pub fn dev_listener() -> Self {
+    /// Generates a configuration with a fresh Ed25519 host keypair.
+    pub fn generate() -> Self {
         Self::new(Ed25519Keypair::generate())
     }
 

--- a/transports/quic/src/connection.rs
+++ b/transports/quic/src/connection.rs
@@ -121,6 +121,10 @@ impl QuicConnection {
         &self.endpoint
     }
 
+    pub fn is_server(&self) -> bool {
+        self.conn.is_server()
+    }
+
     pub fn set_peer_id(&mut self, peer_id: PeerId) {
         self.endpoint.set_peer_id(peer_id);
     }

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -364,11 +364,6 @@ impl QuicTransport {
         self.listen(&multiaddr)
     }
 
-    /// Dials a peer, automatically allocating a connection id.
-    pub fn dial_auto(&mut self, addr: &PeerAddr) -> Result<ConnectionId, TransportError> {
-        self.dial(addr)
-    }
-
     /// Returns all active connection ids for the given peer.
     pub fn connection_ids_for_peer(&self, peer_id: &PeerId) -> Vec<ConnectionId> {
         self.peer_connections
@@ -526,10 +521,7 @@ impl Transport for QuicTransport {
         );
         let source_cid = conn.source_cid_bytes();
 
-        if self.connections.insert(id, conn).is_some() {
-            return Err(TransportError::ConnectionExists { id });
-        }
-
+        self.connections.insert(id, conn);
         self.cid_to_connection.insert(source_cid, id);
         self.index_peer_connection(addr.peer_id().clone(), id);
 

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -641,6 +641,14 @@ impl Transport for QuicTransport {
             .collect()
     }
 
+    fn active_inbound_connection_sources(&self) -> Vec<Multiaddr> {
+        self.connections
+            .values()
+            .filter(|conn| conn.is_server())
+            .map(|conn| conn.endpoint().transport().clone())
+            .collect()
+    }
+
     fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError> {
         let mut buf = [0u8; 65535];
         let mut events = std::mem::take(&mut self.pending_events);

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -366,9 +366,7 @@ impl QuicTransport {
 
     /// Dials a peer, automatically allocating a connection id.
     pub fn dial_auto(&mut self, addr: &PeerAddr) -> Result<ConnectionId, TransportError> {
-        let id = self.allocate_connection_id()?;
-        self.dial(id, addr)?;
-        Ok(id)
+        self.dial(addr)
     }
 
     /// Returns all active connection ids for the given peer.
@@ -477,11 +475,8 @@ impl QuicTransport {
 }
 
 impl Transport for QuicTransport {
-    fn dial(&mut self, id: ConnectionId, addr: &PeerAddr) -> Result<(), TransportError> {
-        if self.connections.contains_key(&id) {
-            return Err(TransportError::ConnectionExists { id });
-        }
-
+    fn dial(&mut self, addr: &PeerAddr) -> Result<ConnectionId, TransportError> {
+        let id = self.allocate_connection_id()?;
         let peer_socket = resolve_dial_socket_addr(addr.transport(), "dial target")?;
         let local_socket = self.local_addr()?;
 
@@ -538,7 +533,7 @@ impl Transport for QuicTransport {
         self.cid_to_connection.insert(source_cid, id);
         self.index_peer_connection(addr.peer_id().clone(), id);
 
-        Ok(())
+        Ok(id)
     }
 
     fn listen(&mut self, addr: &Multiaddr) -> Result<Multiaddr, TransportError> {

--- a/transports/quic/tests/ping_e2e.rs
+++ b/transports/quic/tests/ping_e2e.rs
@@ -89,10 +89,8 @@ impl PingHarness {
         let peer_addr = server.local_peer_addr().expect("peer addr");
 
         // Connect.
-        let client_conn_id = ConnectionId::new(client_conn_id_raw);
-        client
-            .dial(client_conn_id, &peer_addr)
-            .expect("client dial");
+        let _ = client_conn_id_raw;
+        let client_conn_id = client.dial(&peer_addr).expect("client dial");
 
         let server_conn_id =
             Self::wait_for_connection(&mut server, &mut client, client_conn_id, &peer_addr, 250)

--- a/transports/quic/tests/ping_e2e.rs
+++ b/transports/quic/tests/ping_e2e.rs
@@ -81,9 +81,9 @@ impl PingHarness {
     /// Create a connected, verified, and multistream-negotiated ping pair.
     fn new(client_conn_id_raw: u64) -> Self {
         let mut server =
-            QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("server bind");
+            QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("server bind");
         let mut client =
-            QuicTransport::new(QuicNodeConfig::dev_dialer(), "127.0.0.1:0").expect("client bind");
+            QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("client bind");
 
         server.listen_on_bound_addr().expect("server listen");
         let peer_addr = server.local_peer_addr().expect("peer addr");

--- a/transports/quic/tests/swarm_e2e.rs
+++ b/transports/quic/tests/swarm_e2e.rs
@@ -28,6 +28,18 @@ fn drive_pair(
     (server_events, client_events)
 }
 
+fn drive_three(
+    a: &mut Swarm<QuicTransport>,
+    b: &mut Swarm<QuicTransport>,
+    c: &mut Swarm<QuicTransport>,
+) -> (Vec<SwarmEvent>, Vec<SwarmEvent>, Vec<SwarmEvent>) {
+    std::thread::sleep(std::time::Duration::from_millis(5));
+    let a_events = a.poll().expect("a poll");
+    let b_events = b.poll().expect("b poll");
+    let c_events = c.poll().expect("c poll");
+    (a_events, b_events, c_events)
+}
+
 #[test]
 fn swarm_ping_roundtrip_with_auto_identify() {
     // Set up server.
@@ -112,6 +124,61 @@ fn swarm_ping_roundtrip_with_auto_identify() {
     assert!(client_identified, "client should receive identify");
     assert!(client_ready, "client should become ready");
     assert!(rtt_measured, "ping RTT should be measured");
+}
+
+#[test]
+fn inbound_connection_does_not_collide_with_later_outbound_dial() {
+    let mut inbound_peer = make_swarm(Ed25519Keypair::generate());
+    let mut middle = make_swarm(Ed25519Keypair::generate());
+    let mut outbound_peer = make_swarm(Ed25519Keypair::generate());
+
+    let middle_addr = middle.listen_on_bound_addr().expect("middle listen");
+    let middle_peer_id = middle_addr.peer_id().clone();
+    let outbound_addr = outbound_peer
+        .listen_on_bound_addr()
+        .expect("outbound listen");
+    let outbound_peer_id = outbound_addr.peer_id().clone();
+
+    inbound_peer.dial(&middle_addr).expect("inbound dial");
+
+    let mut middle_saw_inbound = false;
+    for _ in 0..500 {
+        let (inbound_events, middle_events, _outbound_events) =
+            drive_three(&mut inbound_peer, &mut middle, &mut outbound_peer);
+
+        let inbound_connected = inbound_events.iter().any(
+            |event| matches!(event, SwarmEvent::ConnectionEstablished { peer_id } if peer_id == &middle_peer_id),
+        );
+        middle_saw_inbound |= middle_events
+            .iter()
+            .any(|event| matches!(event, SwarmEvent::ConnectionEstablished { .. }));
+
+        if inbound_connected && middle_saw_inbound {
+            break;
+        }
+    }
+
+    assert!(
+        middle_saw_inbound,
+        "middle should accept inbound connection"
+    );
+
+    middle
+        .dial(&outbound_addr)
+        .expect("later outbound dial must not collide with inbound connection id");
+
+    for _ in 0..500 {
+        let (_inbound_events, middle_events, _outbound_events) =
+            drive_three(&mut inbound_peer, &mut middle, &mut outbound_peer);
+
+        if middle_events.iter().any(
+            |event| matches!(event, SwarmEvent::ConnectionEstablished { peer_id } if peer_id == &outbound_peer_id),
+        ) {
+            return;
+        }
+    }
+
+    panic!("middle should connect to outbound peer after accepting inbound connection");
 }
 
 const USER_PROTOCOL_ID: &str = "/minip2p/test/echo/1.0.0";

--- a/transports/quic/tests/transport_contract.rs
+++ b/transports/quic/tests/transport_contract.rs
@@ -44,8 +44,7 @@ fn connect_pair(
     Vec<TransportEvent>,
     Vec<TransportEvent>,
 ) {
-    let client_conn = ConnectionId::new(1);
-    client.dial(client_conn, peer_addr).expect("dial");
+    let client_conn = client.dial(peer_addr).expect("dial");
 
     let mut all_server_events = Vec::new();
     let mut all_client_events = Vec::new();
@@ -180,17 +179,14 @@ fn no_stream_events_before_connected() {
 }
 
 #[test]
-fn dial_with_duplicate_id_returns_connection_exists() {
+fn outbound_dial_allocates_unique_ids() {
     let (mut server, mut client, peer_addr) = setup_pair();
-    let id = ConnectionId::new(42);
-    client.dial(id, &peer_addr).expect("first dial");
+    let first = client.dial(&peer_addr).expect("first dial");
+    let second = client.dial(&peer_addr).expect("second dial");
 
-    let err = client
-        .dial(id, &peer_addr)
-        .expect_err("duplicate must fail");
-    assert!(
-        matches!(err, TransportError::ConnectionExists { .. }),
-        "expected ConnectionExists, got {err:?}"
+    assert_ne!(
+        first, second,
+        "transport must allocate unique connection ids"
     );
 
     // Drive to avoid dangling state.

--- a/transports/quic/tests/transport_contract.rs
+++ b/transports/quic/tests/transport_contract.rs
@@ -13,9 +13,8 @@ use minip2p_transport::{ConnectionId, Transport, TransportError, TransportEvent}
 // ---------------------------------------------------------------------------
 
 fn setup_pair() -> (QuicTransport, QuicTransport, PeerAddr) {
-    let mut server =
-        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("server");
-    let client = QuicTransport::new(QuicNodeConfig::dev_dialer(), "127.0.0.1:0").expect("client");
+    let mut server = QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("server");
+    let client = QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("client");
 
     server.listen_on_bound_addr().expect("listen");
     let peer_addr = server.local_peer_addr().expect("peer addr");
@@ -104,7 +103,7 @@ fn connect_pair(
 #[test]
 fn listen_returns_the_resolved_listen_address_and_event_matches() {
     let mut listener =
-        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("listener");
+        QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("listener");
     let requested = listener.local_multiaddr().expect("local multiaddr");
 
     let resolved = listener.listen(&requested).expect("listen");
@@ -353,7 +352,7 @@ fn reset_stream_emits_stream_closed() {
 #[test]
 fn open_stream_on_unknown_connection_returns_not_found() {
     let mut transport =
-        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("bind");
+        QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("bind");
 
     let err = transport
         .open_stream(ConnectionId::new(999))
@@ -364,7 +363,7 @@ fn open_stream_on_unknown_connection_returns_not_found() {
 #[test]
 fn send_on_unknown_connection_returns_not_found() {
     let mut transport =
-        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("bind");
+        QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("bind");
 
     let err = transport
         .send_stream(ConnectionId::new(999), 0.into(), b"data".to_vec())
@@ -375,7 +374,7 @@ fn send_on_unknown_connection_returns_not_found() {
 #[test]
 fn poll_returns_empty_when_idle() {
     let mut transport =
-        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("bind");
+        QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("bind");
 
     let events = transport.poll().expect("poll");
     assert!(events.is_empty(), "idle poll must return empty vec");

--- a/transports/quic/tests/two_peer.rs
+++ b/transports/quic/tests/two_peer.rs
@@ -7,9 +7,9 @@ use quiche::ConnectionId as QuicConnectionId;
 
 fn setup_pair() -> (QuicTransport, QuicTransport, PeerAddr) {
     let mut server =
-        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("server bind");
+        QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("server bind");
     let client =
-        QuicTransport::new(QuicNodeConfig::dev_dialer(), "127.0.0.1:0").expect("client bind");
+        QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("client bind");
 
     server.listen_on_bound_addr().expect("server listen");
     let peer_addr = server.local_peer_addr().expect("peer addr");
@@ -218,7 +218,7 @@ fn close_stream_write_emits_remote_write_closed() {
 #[test]
 fn listener_rejects_dialer_without_mtls_identity() {
     let mut server =
-        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("server bind");
+        QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("server bind");
     server.listen_on_bound_addr().expect("server listen");
     let server_addr = server.local_addr().expect("server socket addr");
 
@@ -264,11 +264,10 @@ fn listener_rejects_dialer_without_mtls_identity() {
 #[test]
 fn dialer_rejects_listener_with_unexpected_peer_id() {
     let mut listener_a =
-        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("listener a");
+        QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("listener a");
     let mut listener_b =
-        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("listener b");
-    let mut dialer =
-        QuicTransport::new(QuicNodeConfig::dev_dialer(), "127.0.0.1:0").expect("dialer");
+        QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("listener b");
+    let mut dialer = QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("dialer");
 
     listener_a.listen_on_bound_addr().expect("listen a");
     listener_b.listen_on_bound_addr().expect("listen b");
@@ -307,7 +306,7 @@ fn dialer_rejects_listener_with_unexpected_peer_id() {
 #[test]
 fn listener_rejects_dialer_with_invalid_libp2p_cert() {
     let mut server =
-        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("server bind");
+        QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("server bind");
     server.listen_on_bound_addr().expect("server listen");
     let server_addr = server.local_addr().expect("server socket addr");
 
@@ -433,7 +432,7 @@ fn dial_supports_dns4_target_for_quic_transport() {
 
 #[test]
 fn listen_rejects_address_mismatch_with_bound_socket() {
-    let config = QuicNodeConfig::dev_listener();
+    let config = QuicNodeConfig::generate();
     let mut transport = QuicTransport::new(config, "127.0.0.1:0").expect("bind");
 
     let local = transport.local_addr().expect("local addr");
@@ -472,12 +471,11 @@ fn listen_rejects_address_mismatch_with_bound_socket() {
 #[test]
 fn open_stream_before_connected_returns_invalid_state() {
     let mut listener =
-        QuicTransport::new(QuicNodeConfig::dev_listener(), "127.0.0.1:0").expect("listener");
+        QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("listener");
     listener.listen_on_bound_addr().expect("listen");
     let peer_addr = listener.local_peer_addr().expect("peer addr");
 
-    let mut dialer =
-        QuicTransport::new(QuicNodeConfig::dev_dialer(), "127.0.0.1:0").expect("dialer");
+    let mut dialer = QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("dialer");
 
     let conn_id = dialer.dial(&peer_addr).expect("dial");
 

--- a/transports/quic/tests/two_peer.rs
+++ b/transports/quic/tests/two_peer.rs
@@ -76,10 +76,7 @@ fn wait_for_connection(
 fn two_peers_open_stream_and_exchange_data() {
     let (mut server, mut client, peer_addr) = setup_pair();
 
-    let client_conn_id = ConnectionId::new(1);
-    client
-        .dial(client_conn_id, &peer_addr)
-        .expect("client dial");
+    let client_conn_id = client.dial(&peer_addr).expect("client dial");
 
     let server_conn_id =
         wait_for_connection(&mut server, &mut client, client_conn_id, &peer_addr, 250)
@@ -154,8 +151,7 @@ fn two_peers_open_stream_and_exchange_data() {
 fn close_stream_write_emits_remote_write_closed() {
     let (mut server, mut client, peer_addr) = setup_pair();
 
-    let client_conn_id = ConnectionId::new(5);
-    client.dial(client_conn_id, &peer_addr).expect("dial");
+    let client_conn_id = client.dial(&peer_addr).expect("dial");
 
     let server_conn_id =
         wait_for_connection(&mut server, &mut client, client_conn_id, &peer_addr, 250)
@@ -282,8 +278,7 @@ fn dialer_rejects_listener_with_unexpected_peer_id() {
     let wrong_peer_addr =
         PeerAddr::new(listener_a_addr.transport().clone(), listener_b_peer).expect("peer addr");
 
-    let conn_id = ConnectionId::new(88);
-    dialer.dial(conn_id, &wrong_peer_addr).expect("dial starts");
+    let _conn_id = dialer.dial(&wrong_peer_addr).expect("dial starts");
 
     let mut saw_mismatch = false;
     let mut saw_connected = false;
@@ -377,10 +372,7 @@ fn mtls_verifies_listener_side_client_identity_and_updates_peer_index() {
     let (mut server, mut client, peer_addr) = setup_pair();
     let client_peer_id = client.local_peer_id();
 
-    let client_conn_id = ConnectionId::new(42);
-    client
-        .dial(client_conn_id, &peer_addr)
-        .expect("client dial");
+    let client_conn_id = client.dial(&peer_addr).expect("client dial");
 
     let mut verified_event = None;
 
@@ -433,8 +425,7 @@ fn dial_supports_dns4_target_for_quic_transport() {
     let dns_peer_addr =
         PeerAddr::new(dns_transport, peer_addr.peer_id().clone()).expect("dns peer addr");
 
-    let conn_id = ConnectionId::new(77);
-    client.dial(conn_id, &dns_peer_addr).expect("dial via dns4");
+    let conn_id = client.dial(&dns_peer_addr).expect("dial via dns4");
 
     let connected = wait_for_connection(&mut server, &mut client, conn_id, &dns_peer_addr, 250);
     assert!(connected.is_some(), "client should connect via dns4 target");
@@ -488,8 +479,7 @@ fn open_stream_before_connected_returns_invalid_state() {
     let mut dialer =
         QuicTransport::new(QuicNodeConfig::dev_dialer(), "127.0.0.1:0").expect("dialer");
 
-    let conn_id = ConnectionId::new(999);
-    dialer.dial(conn_id, &peer_addr).expect("dial");
+    let conn_id = dialer.dial(&peer_addr).expect("dial");
 
     let err = dialer
         .open_stream(conn_id)


### PR DESCRIPTION
## Summary
- Move direct-candidate selection policy into `minip2p-core` as pure `no_std + alloc` logic.
- Preserve CLI diagnostics by returning accepted candidates and structured rejection reasons.
- Mark direct-candidate discovery complete in `holepunch-plan.md`.

## Verification
- `cargo fmt`
- `cargo test -p minip2p-core`
- `cargo check -p minip2p-core --no-default-features`
- `cargo check --workspace`
- `cargo test -p minip2p-peer`
- `cargo test -p minip2p-swarm`
- `cargo check --no-default-features` for transport, multistream-select, ping, identify, relay, dcutr, autonat, swarm

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves direct-connect candidate selection into `minip2p-core` as pure `no_std + alloc` policy and shifts connection-id allocation into transports to prevent inbound/outbound id collisions. Also dials direct candidates from the DCUtR responder, fixes hole-punch detection to ignore our own dials, reduces allocations in protocol decoding, and makes AutoNAT consume invalid frames before reporting decode errors.

- New Features
  - Added `candidates` module exporting `select_direct_candidates`, `DirectCandidate{,Rejection,RejectReason,Source}` with stable `as_str()` messages. Policy: priority manual → identify-observed → listen; rejects wildcard binds; requires `/<host>/udp/<port>/quic-v1`; de-duplicates.
  - Added `active_inbound_connection_sources()` for hole-punch responders; examples log adds/skips, dial selected candidates on both roles, and fall back to relay when needed.

- Refactors
  - `Transport::dial` now allocates and returns `ConnectionId`; `Swarm` delegates. QUIC transport updated (including inbound-only source reporting). Tests ensure unique ids and no inbound/outbound id collisions.
  - Reduced protocol decode allocations across `autonat`, `dcutr`, `relay`, and `multistream-select` by decoding directly from framed payloads and preallocating frames with `uvarint_len`.
  - AutoNAT: now consumes invalid frames before raising decode errors, so sessions recover; added tests.

<sup>Written for commit 7f983c9101d6aef59a912de9574b958ce89516a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

