### PR TITLE
Direct candidate discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,7 @@ name = "minip2p-peer"
 version = "0.1.0"
 dependencies = [
  "getrandom",
+ "libc",
  "minip2p-autonat",
  "minip2p-core",
  "minip2p-dcutr",

--- a/crates/core/src/candidates.rs
+++ b/crates/core/src/candidates.rs
@@ -5,8 +5,8 @@ use crate::{Multiaddr, Protocol};
 /// Where a direct-connect candidate came from.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DirectCandidateSource {
-    /// User-supplied explicit public address.
-    Manual,
+    /// Confirmed local external address.
+    ConfirmedExternal,
     /// Address observed by a public peer through Identify.
     IdentifyObserved,
     /// Local non-wildcard listen address.
@@ -17,7 +17,7 @@ impl DirectCandidateSource {
     /// Stable text for logs and diagnostics.
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Manual => "manual",
+            Self::ConfirmedExternal => "confirmed-external",
             Self::IdentifyObserved => "identify-observed",
             Self::Listen => "listen",
         }
@@ -86,7 +86,7 @@ impl DirectCandidateSelection {
 /// Selects dialable direct-connect candidates in deterministic priority order.
 ///
 /// Priority is:
-/// 1. manual external addresses,
+/// 1. confirmed external addresses,
 /// 2. Identify observed address,
 /// 3. local non-wildcard listen address.
 ///
@@ -94,18 +94,23 @@ impl DirectCandidateSelection {
 /// logging, timing, or transport side effects. It intentionally accepts only
 /// strict QUIC-v1 transport addresses (`/<host>/udp/<port>/quic-v1`).
 pub fn select_direct_candidates(
-    manual: &[Multiaddr],
+    external: &[Multiaddr],
     identify_observed: Option<Multiaddr>,
     listen: Option<Multiaddr>,
 ) -> DirectCandidateSelection {
-    let capacity = manual.len() + identify_observed.is_some() as usize + listen.is_some() as usize;
+    let capacity =
+        external.len() + identify_observed.is_some() as usize + listen.is_some() as usize;
     let mut selection = DirectCandidateSelection {
         accepted: Vec::with_capacity(capacity),
         rejected: Vec::new(),
     };
 
-    for addr in manual {
-        push_candidate(&mut selection, DirectCandidateSource::Manual, addr.clone());
+    for addr in external {
+        push_candidate(
+            &mut selection,
+            DirectCandidateSource::ConfirmedExternal,
+            addr.clone(),
+        );
     }
     if let Some(addr) = identify_observed {
         push_candidate(
@@ -206,7 +211,10 @@ mod tests {
         );
 
         assert_eq!(selected.accepted.len(), 3);
-        assert_eq!(selected.accepted[0].source, DirectCandidateSource::Manual);
+        assert_eq!(
+            selected.accepted[0].source,
+            DirectCandidateSource::ConfirmedExternal
+        );
         assert_eq!(selected.accepted[0].addr, manual);
         assert_eq!(
             selected.accepted[1].source,

--- a/crates/core/src/direct_paths.rs
+++ b/crates/core/src/direct_paths.rs
@@ -1,0 +1,343 @@
+use alloc::vec::Vec;
+
+use crate::{ExternalAddressSource, Multiaddr};
+
+/// Maximum number of direct paths tracked for one peer.
+pub const MAX_DIRECT_PATHS: usize = 30;
+
+/// Default delay before retrying a failed direct path.
+pub const DEFAULT_DIRECT_PATH_RETRY_MS: u64 = 5_000;
+
+/// Where a direct path candidate came from.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DirectPathSource {
+    /// User-supplied explicit public address.
+    Manual,
+    /// Confirmed external address, when the original source no longer matters.
+    ConfirmedExternal,
+    /// Address reported by a remote peer through Identify's observed address.
+    IdentifyObserved,
+    /// Address confirmed by AutoNAT dial-back.
+    AutoNat,
+    /// Address discovered through NAT-PMP, PCP, or UPnP port mapping.
+    PortMapped,
+    /// Address discovered through a STUN/QAD-like probe.
+    Stun,
+    /// Local non-wildcard listen address.
+    Listen,
+    /// Address exchanged by DCUtR over a relay connection.
+    Dcutr,
+}
+
+impl DirectPathSource {
+    /// Stable text for logs and diagnostics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::ConfirmedExternal => "confirmed-external",
+            Self::IdentifyObserved => "identify-observed",
+            Self::AutoNat => "autonat",
+            Self::PortMapped => "port-mapped",
+            Self::Stun => "stun",
+            Self::Listen => "listen",
+            Self::Dcutr => "dcutr",
+        }
+    }
+}
+
+impl From<ExternalAddressSource> for DirectPathSource {
+    fn from(source: ExternalAddressSource) -> Self {
+        match source {
+            ExternalAddressSource::Manual => Self::Manual,
+            ExternalAddressSource::IdentifyObserved => Self::IdentifyObserved,
+            ExternalAddressSource::AutoNat => Self::AutoNat,
+            ExternalAddressSource::PortMapped => Self::PortMapped,
+            ExternalAddressSource::Stun => Self::Stun,
+        }
+    }
+}
+
+/// Current direct path usability.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DirectPathStatus {
+    /// Path has not been tried yet.
+    Unknown,
+    /// A direct connection attempt is currently in flight.
+    Dialing,
+    /// Path has opened successfully.
+    Open,
+    /// Path opened before but is no longer active.
+    Inactive,
+    /// A recent direct connection attempt failed.
+    Failed,
+}
+
+impl DirectPathStatus {
+    /// Stable text for logs and diagnostics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Dialing => "dialing",
+            Self::Open => "open",
+            Self::Inactive => "inactive",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// A source-tagged direct path candidate.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DirectPath {
+    pub source: DirectPathSource,
+    pub addr: Multiaddr,
+    pub status: DirectPathStatus,
+    pub attempts: u32,
+    pub last_updated_ms: u64,
+    pub next_attempt_ms: u64,
+}
+
+/// Result of inserting or refreshing a direct path candidate.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DirectPathUpdate {
+    pub changed: bool,
+    pub expired: Option<DirectPath>,
+}
+
+/// Sans-I/O direct path lifecycle.
+///
+/// This is intentionally transport-agnostic policy. It records candidates,
+/// path state, and retry timing, but never opens sockets, resolves DNS, sends
+/// packets, sleeps, or reads a clock.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DirectPathBook {
+    paths: Vec<DirectPath>,
+    retry_interval_ms: u64,
+    max_paths: usize,
+}
+
+impl Default for DirectPathBook {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DirectPathBook {
+    /// Creates an empty book with default retry and capacity settings.
+    pub fn new() -> Self {
+        Self {
+            paths: Vec::new(),
+            retry_interval_ms: DEFAULT_DIRECT_PATH_RETRY_MS,
+            max_paths: MAX_DIRECT_PATHS,
+        }
+    }
+
+    /// Overrides the retry interval for failed paths.
+    pub fn with_retry_interval_ms(mut self, retry_interval_ms: u64) -> Self {
+        self.retry_interval_ms = retry_interval_ms;
+        self
+    }
+
+    /// Returns all tracked paths in priority order.
+    pub fn paths(&self) -> &[DirectPath] {
+        &self.paths
+    }
+
+    /// Returns true when no direct paths are tracked.
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+
+    /// Inserts or refreshes a path.
+    ///
+    /// New and refreshed paths move to the front. If capacity is exceeded,
+    /// failed/inactive paths are evicted first, then the oldest path.
+    pub fn insert(
+        &mut self,
+        source: DirectPathSource,
+        addr: Multiaddr,
+        now_ms: u64,
+    ) -> DirectPathUpdate {
+        if let Some(pos) = self.paths.iter().position(|path| path.addr == addr) {
+            let mut path = self.paths.remove(pos);
+            path.source = source;
+            path.last_updated_ms = now_ms;
+            self.paths.insert(0, path);
+            return DirectPathUpdate {
+                changed: false,
+                expired: None,
+            };
+        }
+
+        self.paths.insert(
+            0,
+            DirectPath {
+                source,
+                addr,
+                status: DirectPathStatus::Unknown,
+                attempts: 0,
+                last_updated_ms: now_ms,
+                next_attempt_ms: now_ms,
+            },
+        );
+
+        let expired = self.prune_one();
+        DirectPathUpdate {
+            changed: true,
+            expired,
+        }
+    }
+
+    /// Marks all matching paths as in-flight if they are eligible to be tried.
+    pub fn begin_attempts(&mut self, now_ms: u64) -> Vec<Multiaddr> {
+        let mut attempts = Vec::new();
+        for path in &mut self.paths {
+            if path.status == DirectPathStatus::Open || now_ms < path.next_attempt_ms {
+                continue;
+            }
+            path.status = DirectPathStatus::Dialing;
+            path.attempts = path.attempts.saturating_add(1);
+            path.last_updated_ms = now_ms;
+            attempts.push(path.addr.clone());
+        }
+        attempts
+    }
+
+    /// Marks every tracked path as failed and schedules retry.
+    pub fn fail_attempts(&mut self, now_ms: u64) {
+        for path in &mut self.paths {
+            if path.status == DirectPathStatus::Open {
+                continue;
+            }
+            path.status = DirectPathStatus::Failed;
+            path.last_updated_ms = now_ms;
+            path.next_attempt_ms = now_ms.saturating_add(self.retry_interval_ms);
+        }
+    }
+
+    /// Marks one path as open.
+    pub fn mark_open(&mut self, addr: &Multiaddr, now_ms: u64) -> bool {
+        self.mark(addr, DirectPathStatus::Open, now_ms)
+    }
+
+    /// Marks one path as inactive.
+    pub fn mark_inactive(&mut self, addr: &Multiaddr, now_ms: u64) -> bool {
+        self.mark(addr, DirectPathStatus::Inactive, now_ms)
+    }
+
+    /// Returns all tracked path addresses.
+    pub fn addrs(&self) -> Vec<Multiaddr> {
+        self.paths.iter().map(|path| path.addr.clone()).collect()
+    }
+
+    /// Returns all paths which are not known to be failed.
+    pub fn usable_addrs(&self) -> Vec<Multiaddr> {
+        self.paths
+            .iter()
+            .filter(|path| path.status != DirectPathStatus::Failed)
+            .map(|path| path.addr.clone())
+            .collect()
+    }
+
+    fn mark(&mut self, addr: &Multiaddr, status: DirectPathStatus, now_ms: u64) -> bool {
+        let Some(pos) = self.paths.iter().position(|path| &path.addr == addr) else {
+            return false;
+        };
+        let mut path = self.paths.remove(pos);
+        path.status = status;
+        path.last_updated_ms = now_ms;
+        if status == DirectPathStatus::Open {
+            path.next_attempt_ms = now_ms;
+        }
+        self.paths.insert(0, path);
+        true
+    }
+
+    fn prune_one(&mut self) -> Option<DirectPath> {
+        if self.paths.len() <= self.max_paths {
+            return None;
+        }
+
+        let prune_pos = self
+            .paths
+            .iter()
+            .rposition(|path| {
+                matches!(
+                    path.status,
+                    DirectPathStatus::Failed | DirectPathStatus::Inactive
+                )
+            })
+            .unwrap_or(self.paths.len() - 1);
+
+        Some(self.paths.remove(prune_pos))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use super::*;
+
+    fn addr(value: &str) -> Multiaddr {
+        Multiaddr::from_str(value).unwrap()
+    }
+
+    #[test]
+    fn insert_deduplicates_and_refreshes_priority() {
+        let mut book = DirectPathBook::new();
+        let first = addr("/ip4/203.0.113.1/udp/4001/quic-v1");
+        let second = addr("/ip4/203.0.113.2/udp/4001/quic-v1");
+
+        assert!(
+            book.insert(DirectPathSource::Dcutr, first.clone(), 10)
+                .changed
+        );
+        assert!(
+            book.insert(DirectPathSource::Stun, second.clone(), 20)
+                .changed
+        );
+        assert!(
+            !book
+                .insert(DirectPathSource::AutoNat, first.clone(), 30)
+                .changed
+        );
+
+        assert_eq!(book.paths()[0].addr, first);
+        assert_eq!(book.paths()[0].source, DirectPathSource::AutoNat);
+        assert_eq!(book.paths()[1].addr, second);
+    }
+
+    #[test]
+    fn attempts_are_retry_gated_after_failure() {
+        let mut book = DirectPathBook::new().with_retry_interval_ms(5_000);
+        let first = addr("/ip4/203.0.113.1/udp/4001/quic-v1");
+        book.insert(DirectPathSource::Dcutr, first.clone(), 10);
+
+        assert_eq!(book.begin_attempts(10), vec![first.clone()]);
+        assert_eq!(book.paths()[0].status, DirectPathStatus::Dialing);
+        book.fail_attempts(100);
+        assert_eq!(book.begin_attempts(1_000), Vec::<Multiaddr>::new());
+        assert_eq!(book.begin_attempts(5_100), vec![first]);
+        assert_eq!(book.paths()[0].attempts, 2);
+    }
+
+    #[test]
+    fn failed_paths_are_evicted_before_unknown_paths() {
+        let mut book = DirectPathBook {
+            paths: Vec::new(),
+            retry_interval_ms: DEFAULT_DIRECT_PATH_RETRY_MS,
+            max_paths: 2,
+        };
+        let first = addr("/ip4/203.0.113.1/udp/4001/quic-v1");
+        let second = addr("/ip4/203.0.113.2/udp/4001/quic-v1");
+        let third = addr("/ip4/203.0.113.3/udp/4001/quic-v1");
+
+        book.insert(DirectPathSource::Dcutr, first.clone(), 1);
+        book.insert(DirectPathSource::Dcutr, second.clone(), 2);
+        book.fail_attempts(3);
+        let update = book.insert(DirectPathSource::Dcutr, third.clone(), 4);
+
+        assert_eq!(update.expired.expect("expired").addr, first);
+        assert_eq!(book.addrs(), vec![third, second]);
+    }
+}

--- a/crates/core/src/direct_paths.rs
+++ b/crates/core/src/direct_paths.rs
@@ -191,7 +191,11 @@ impl DirectPathBook {
     pub fn begin_attempts(&mut self, now_ms: u64) -> Vec<Multiaddr> {
         let mut attempts = Vec::new();
         for path in &mut self.paths {
-            if path.status == DirectPathStatus::Open || now_ms < path.next_attempt_ms {
+            if matches!(
+                path.status,
+                DirectPathStatus::Open | DirectPathStatus::Dialing
+            ) || now_ms < path.next_attempt_ms
+            {
                 continue;
             }
             path.status = DirectPathStatus::Dialing;
@@ -202,10 +206,10 @@ impl DirectPathBook {
         attempts
     }
 
-    /// Marks every tracked path as failed and schedules retry.
+    /// Marks every in-flight path as failed and schedules retry.
     pub fn fail_attempts(&mut self, now_ms: u64) {
         for path in &mut self.paths {
-            if path.status == DirectPathStatus::Open {
+            if path.status != DirectPathStatus::Dialing {
                 continue;
             }
             path.status = DirectPathStatus::Failed;
@@ -315,10 +319,33 @@ mod tests {
 
         assert_eq!(book.begin_attempts(10), vec![first.clone()]);
         assert_eq!(book.paths()[0].status, DirectPathStatus::Dialing);
+        assert_eq!(book.begin_attempts(10), Vec::<Multiaddr>::new());
+        assert_eq!(book.paths()[0].attempts, 1);
         book.fail_attempts(100);
         assert_eq!(book.begin_attempts(1_000), Vec::<Multiaddr>::new());
         assert_eq!(book.begin_attempts(5_100), vec![first]);
         assert_eq!(book.paths()[0].attempts, 2);
+    }
+
+    #[test]
+    fn fail_attempts_only_marks_paths_that_were_dialed() {
+        let mut book = DirectPathBook::new().with_retry_interval_ms(5_000);
+        let ready = addr("/ip4/203.0.113.1/udp/4001/quic-v1");
+        let not_ready = addr("/ip4/203.0.113.2/udp/4001/quic-v1");
+        book.insert(DirectPathSource::Dcutr, ready.clone(), 0);
+        book.insert(DirectPathSource::Dcutr, not_ready.clone(), 100);
+
+        assert_eq!(book.begin_attempts(0), vec![ready.clone()]);
+        book.fail_attempts(10);
+
+        let ready_path = book.paths().iter().find(|path| path.addr == ready).unwrap();
+        let not_ready_path = book
+            .paths()
+            .iter()
+            .find(|path| path.addr == not_ready)
+            .unwrap();
+        assert_eq!(ready_path.status, DirectPathStatus::Failed);
+        assert_eq!(not_ready_path.status, DirectPathStatus::Unknown);
     }
 
     #[test]
@@ -334,6 +361,7 @@ mod tests {
 
         book.insert(DirectPathSource::Dcutr, first.clone(), 1);
         book.insert(DirectPathSource::Dcutr, second.clone(), 2);
+        assert_eq!(book.begin_attempts(3), vec![second.clone(), first.clone()]);
         book.fail_attempts(3);
         let update = book.insert(DirectPathSource::Dcutr, third.clone(), 4);
 

--- a/crates/core/src/external_addresses.rs
+++ b/crates/core/src/external_addresses.rs
@@ -1,0 +1,206 @@
+use alloc::vec::Vec;
+
+use crate::Multiaddr;
+
+/// Maximum number of confirmed external addresses kept for one local peer.
+pub const MAX_EXTERNAL_ADDRS: usize = 20;
+
+/// Where an external address came from.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExternalAddressSource {
+    /// User-supplied explicit public address.
+    Manual,
+    /// Address reported by a remote peer through Identify's observed address.
+    IdentifyObserved,
+    /// Address confirmed by AutoNAT dial-back.
+    AutoNat,
+    /// Address discovered through NAT-PMP, PCP, or UPnP port mapping.
+    PortMapped,
+    /// Address discovered through a STUN-like probe.
+    Stun,
+}
+
+impl ExternalAddressSource {
+    /// Stable text for logs and diagnostics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::IdentifyObserved => "identify-observed",
+            Self::AutoNat => "autonat",
+            Self::PortMapped => "port-mapped",
+            Self::Stun => "stun",
+        }
+    }
+}
+
+/// A source-tagged external address.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExternalAddress {
+    pub source: ExternalAddressSource,
+    pub addr: Multiaddr,
+}
+
+/// Result of confirming an external address.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExternalAddressUpdate {
+    /// True when the confirmed set changed, false when an existing address was
+    /// only refreshed or re-sourced.
+    pub changed: bool,
+    /// Address evicted because the confirmed-address limit was exceeded.
+    pub expired: Option<ExternalAddress>,
+}
+
+/// Sans-I/O external address lifecycle.
+///
+/// Candidates are addresses we have heard about but have not proven yet.
+/// Confirmed addresses are the addresses we should advertise through Identify
+/// and prefer for direct-connection candidates.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ExternalAddressBook {
+    candidates: Vec<ExternalAddress>,
+    confirmed: Vec<ExternalAddress>,
+}
+
+impl ExternalAddressBook {
+    /// Returns unconfirmed candidate addresses in discovery order.
+    pub fn candidates(&self) -> &[ExternalAddress] {
+        &self.candidates
+    }
+
+    /// Returns confirmed external addresses in priority order.
+    pub fn confirmed(&self) -> &[ExternalAddress] {
+        &self.confirmed
+    }
+
+    /// Returns true if `addr` is already confirmed.
+    pub fn is_confirmed(&self, addr: &Multiaddr) -> bool {
+        self.confirmed.iter().any(|entry| &entry.addr == addr)
+    }
+
+    /// Records a candidate address.
+    ///
+    /// Returns true when this is a newly observed candidate. Already confirmed
+    /// addresses and duplicate candidates are ignored.
+    pub fn observe_candidate(&mut self, source: ExternalAddressSource, addr: Multiaddr) -> bool {
+        if self.is_confirmed(&addr)
+            || self
+                .candidates
+                .iter()
+                .any(|candidate| candidate.addr == addr)
+        {
+            return false;
+        }
+
+        self.candidates.push(ExternalAddress { source, addr });
+        true
+    }
+
+    /// Promotes an address to confirmed, refreshing it to the front if it was
+    /// already known.
+    pub fn confirm(
+        &mut self,
+        source: ExternalAddressSource,
+        addr: Multiaddr,
+    ) -> ExternalAddressUpdate {
+        self.candidates.retain(|candidate| candidate.addr != addr);
+
+        if let Some(pos) = self
+            .confirmed
+            .iter()
+            .position(|candidate| candidate.addr == addr)
+        {
+            let mut entry = self.confirmed.remove(pos);
+            entry.source = source;
+            self.confirmed.insert(0, entry);
+            return ExternalAddressUpdate {
+                changed: false,
+                expired: None,
+            };
+        }
+
+        self.confirmed.insert(0, ExternalAddress { source, addr });
+        let expired = if self.confirmed.len() > MAX_EXTERNAL_ADDRS {
+            self.confirmed.pop()
+        } else {
+            None
+        };
+
+        ExternalAddressUpdate {
+            changed: true,
+            expired,
+        }
+    }
+
+    /// Removes a confirmed address.
+    pub fn remove(&mut self, addr: &Multiaddr) -> Option<ExternalAddress> {
+        let pos = self
+            .confirmed
+            .iter()
+            .position(|candidate| &candidate.addr == addr)?;
+        Some(self.confirmed.remove(pos))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use super::*;
+
+    fn addr(value: &str) -> Multiaddr {
+        Multiaddr::from_str(value).unwrap()
+    }
+
+    #[test]
+    fn candidate_is_not_duplicated_or_readded_after_confirmation() {
+        let mut book = ExternalAddressBook::default();
+        let observed = addr("/ip4/203.0.113.7/udp/4001/quic-v1");
+
+        assert!(book.observe_candidate(ExternalAddressSource::IdentifyObserved, observed.clone()));
+        assert!(!book.observe_candidate(ExternalAddressSource::IdentifyObserved, observed.clone()));
+
+        let update = book.confirm(ExternalAddressSource::AutoNat, observed.clone());
+        assert!(update.changed);
+        assert!(update.expired.is_none());
+        assert!(book.candidates().is_empty());
+        assert!(!book.observe_candidate(ExternalAddressSource::IdentifyObserved, observed));
+    }
+
+    #[test]
+    fn confirming_existing_address_refreshes_priority_without_counting_change() {
+        let mut book = ExternalAddressBook::default();
+        let first = addr("/ip4/203.0.113.1/udp/4001/quic-v1");
+        let second = addr("/ip4/203.0.113.2/udp/4001/quic-v1");
+
+        assert!(
+            book.confirm(ExternalAddressSource::Manual, first.clone())
+                .changed
+        );
+        assert!(
+            book.confirm(ExternalAddressSource::Manual, second.clone())
+                .changed
+        );
+        let update = book.confirm(ExternalAddressSource::AutoNat, first.clone());
+
+        assert!(!update.changed);
+        assert_eq!(book.confirmed()[0].addr, first);
+        assert_eq!(book.confirmed()[0].source, ExternalAddressSource::AutoNat);
+    }
+
+    #[test]
+    fn confirmed_addresses_are_capped() {
+        let mut book = ExternalAddressBook::default();
+
+        for i in 0..=MAX_EXTERNAL_ADDRS {
+            let addr = addr(&alloc::format!("/ip4/203.0.113.{i}/udp/4001/quic-v1"));
+            let update = book.confirm(ExternalAddressSource::Manual, addr);
+            if i < MAX_EXTERNAL_ADDRS {
+                assert!(update.expired.is_none());
+            } else {
+                assert!(update.expired.is_some());
+            }
+        }
+
+        assert_eq!(book.confirmed().len(), MAX_EXTERNAL_ADDRS);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -9,6 +9,7 @@
 extern crate alloc;
 
 mod candidates;
+mod direct_paths;
 mod error;
 mod external_addresses;
 mod multiaddr;
@@ -18,6 +19,10 @@ mod protocol;
 pub use candidates::{
     DirectCandidate, DirectCandidateRejectReason, DirectCandidateRejection,
     DirectCandidateSelection, DirectCandidateSource, select_direct_candidates,
+};
+pub use direct_paths::{
+    DEFAULT_DIRECT_PATH_RETRY_MS, DirectPath, DirectPathBook, DirectPathSource, DirectPathStatus,
+    DirectPathUpdate, MAX_DIRECT_PATHS,
 };
 pub use error::{MultiaddrError, PeerAddrError};
 pub use external_addresses::{

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 
 mod candidates;
 mod error;
+mod external_addresses;
 mod multiaddr;
 mod peer_addr;
 mod protocol;
@@ -19,6 +20,10 @@ pub use candidates::{
     DirectCandidateSelection, DirectCandidateSource, select_direct_candidates,
 };
 pub use error::{MultiaddrError, PeerAddrError};
+pub use external_addresses::{
+    ExternalAddress, ExternalAddressBook, ExternalAddressSource, ExternalAddressUpdate,
+    MAX_EXTERNAL_ADDRS,
+};
 pub use minip2p_identity::PeerId;
 pub use minip2p_identity::{VarintError, read_uvarint, uvarint_len, write_uvarint};
 pub use multiaddr::Multiaddr;

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -17,7 +17,9 @@ use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 
-use minip2p_core::{Multiaddr, PeerId};
+use minip2p_core::{
+    ExternalAddress, ExternalAddressBook, ExternalAddressSource, Multiaddr, PeerId,
+};
 use minip2p_identify::{
     IDENTIFY_PROTOCOL_ID, IdentifyAction, IdentifyConfig, IdentifyEvent, IdentifyMessage,
     IdentifyProtocol,
@@ -123,6 +125,8 @@ pub struct SwarmCore {
     /// auto-populate Identify's `listen_addrs` so advertised addresses
     /// always reflect what we're actually bound to.
     local_addresses: Vec<Multiaddr>,
+    /// External address lifecycle for this local node.
+    external_addresses: ExternalAddressBook,
     /// Latest Identify payload received for each peer.
     peer_info: BTreeMap<PeerId, IdentifyMessage>,
     /// Peers for which `PeerReady` has already been emitted.
@@ -159,6 +163,7 @@ impl SwarmCore {
             user_protocols: Vec::new(),
             pending_pings: BTreeMap::new(),
             local_addresses: Vec::new(),
+            external_addresses: ExternalAddressBook::default(),
             peer_info: BTreeMap::new(),
             ready_peers: BTreeSet::new(),
             established_peers: BTreeSet::new(),
@@ -175,6 +180,46 @@ impl SwarmCore {
     /// set changes (e.g. after `listen()` or `close()` on a listener).
     pub fn set_local_addresses(&mut self, addrs: Vec<Multiaddr>) {
         self.local_addresses = addrs;
+    }
+
+    /// Returns confirmed external addresses in advertise/dial priority order.
+    pub fn external_addresses(&self) -> &[ExternalAddress] {
+        self.external_addresses.confirmed()
+    }
+
+    /// Returns observed but unconfirmed external-address candidates.
+    pub fn external_address_candidates(&self) -> &[ExternalAddress] {
+        self.external_addresses.candidates()
+    }
+
+    /// Confirms an external address and advertises it in future Identify
+    /// responses.
+    ///
+    /// This is Sans-I/O policy only. Callers are responsible for deciding when
+    /// an address is trustworthy, e.g. because it was supplied manually,
+    /// confirmed by AutoNAT, or discovered through port mapping.
+    pub fn confirm_external_address(&mut self, source: ExternalAddressSource, addr: Multiaddr) {
+        let update = self.external_addresses.confirm(source, addr.clone());
+        self.events.push(SwarmEvent::ExternalAddrConfirmed {
+            source,
+            address: addr,
+        });
+        if let Some(expired) = update.expired {
+            self.events.push(SwarmEvent::ExternalAddrExpired {
+                source: expired.source,
+                address: expired.addr,
+            });
+        }
+    }
+
+    /// Removes a confirmed external address.
+    pub fn remove_external_address(&mut self, addr: &Multiaddr) {
+        if let Some(expired) = self.external_addresses.remove(addr) {
+            self.events.push(SwarmEvent::ExternalAddrExpired {
+                source: expired.source,
+                address: expired.addr,
+            });
+        }
     }
 
     /// Registers a user protocol id that this swarm will accept on inbound
@@ -629,6 +674,31 @@ impl SwarmCore {
         });
     }
 
+    fn observe_external_addr_candidate(&mut self, source: ExternalAddressSource, addr: Multiaddr) {
+        if self
+            .external_addresses
+            .observe_candidate(source, addr.clone())
+        {
+            self.events.push(SwarmEvent::ExternalAddrCandidate {
+                source,
+                address: addr,
+            });
+        }
+    }
+
+    fn identify_advertised_addrs(&self) -> Vec<Multiaddr> {
+        let mut addrs = Vec::with_capacity(
+            self.local_addresses.len() + self.external_addresses.confirmed().len(),
+        );
+        for addr in &self.local_addresses {
+            push_unique_addr(&mut addrs, addr.clone());
+        }
+        for external in self.external_addresses.confirmed() {
+            push_unique_addr(&mut addrs, external.addr.clone());
+        }
+        addrs
+    }
+
     fn find_negotiated_ping_stream(&self, peer_id: &PeerId) -> Option<StreamId> {
         self.ping.outbound_stream(peer_id)
     }
@@ -833,6 +903,9 @@ impl SwarmCore {
                         *peer_id = new.clone();
                     }
                 }
+                SwarmEvent::ExternalAddrCandidate { .. }
+                | SwarmEvent::ExternalAddrConfirmed { .. }
+                | SwarmEvent::ExternalAddrExpired { .. } => {}
                 SwarmEvent::Error(error) => {
                     if error.peer_id.as_ref() == Some(old) {
                         error.peer_id = Some(new.clone());
@@ -1168,15 +1241,17 @@ impl SwarmCore {
             // endpoint for this conn_id, in which case we legitimately
             // can't fill observedAddr and the field is omitted.
             let observed_addr = self.conn_to_remote_addr.get(&conn_id).cloned();
-            // Snapshot of the transport's listening addresses at this
-            // moment; the driver keeps `local_addresses` refreshed.
-            let listen_addrs = self.local_addresses.as_slice();
+            // Snapshot of the addresses we should advertise at this moment:
+            // transport listen addresses plus confirmed external addresses.
+            // The driver keeps `local_addresses` refreshed; this core owns
+            // the external-address book.
+            let listen_addrs = self.identify_advertised_addrs();
             let responder_peer_id = peer_id.clone();
             match self.identify.register_outbound_stream(
                 peer_id,
                 stream_id,
                 observed_addr,
-                listen_addrs,
+                &listen_addrs,
             ) {
                 Ok(actions) => {
                     // Only record ownership on success, so a rejected
@@ -1372,6 +1447,20 @@ impl SwarmCore {
         for event in self.identify.poll_events() {
             match event {
                 IdentifyEvent::Received { peer_id, info } => {
+                    if let Some(bytes) = info.observed_addr.as_deref() {
+                        match Multiaddr::from_bytes(bytes) {
+                            Ok(addr) => self.observe_external_addr_candidate(
+                                ExternalAddressSource::IdentifyObserved,
+                                addr,
+                            ),
+                            Err(e) => self.emit_error(
+                                SwarmErrorKind::Identify,
+                                Some(peer_id.clone()),
+                                self.conn_for(&peer_id),
+                                format!("failed to parse identify observed address: {e}"),
+                            ),
+                        }
+                    }
                     self.peer_info.insert(peer_id.clone(), info.clone());
                     self.events.push(SwarmEvent::IdentifyReceived {
                         peer_id: peer_id.clone(),
@@ -1389,6 +1478,12 @@ impl SwarmCore {
                 }
             }
         }
+    }
+}
+
+fn push_unique_addr(addrs: &mut Vec<Multiaddr>, addr: Multiaddr) {
+    if !addrs.iter().any(|existing| existing == &addr) {
+        addrs.push(addr);
     }
 }
 
@@ -1546,5 +1641,54 @@ mod tests {
             SwarmError::UserStreamNotFound { peer_id: p, stream_id: s }
                 if p == peer_id && s == stream_id
         ));
+    }
+
+    #[test]
+    fn confirmed_external_address_is_advertised_with_listen_addresses() {
+        let mut core = test_core();
+        let listen = loopback_transport();
+        let external = Multiaddr::from_str("/ip4/203.0.113.7/udp/4001/quic-v1").unwrap();
+
+        core.set_local_addresses(vec![listen.clone()]);
+        core.confirm_external_address(ExternalAddressSource::AutoNat, external.clone());
+
+        let addrs = core.identify_advertised_addrs();
+        assert_eq!(addrs, vec![listen, external]);
+    }
+
+    #[test]
+    fn confirming_external_address_emits_confirmed_event() {
+        let mut core = test_core();
+        let external = Multiaddr::from_str("/ip4/203.0.113.7/udp/4001/quic-v1").unwrap();
+
+        core.confirm_external_address(ExternalAddressSource::Manual, external.clone());
+
+        let events = core.poll_events();
+        assert!(matches!(
+            events.as_slice(),
+            [SwarmEvent::ExternalAddrConfirmed { source, address }]
+                if *source == ExternalAddressSource::Manual && address == &external
+        ));
+        assert_eq!(core.external_addresses()[0].addr, external);
+    }
+
+    #[test]
+    fn observed_external_candidate_is_deduplicated_against_confirmed_addresses() {
+        let mut core = test_core();
+        let external = Multiaddr::from_str("/ip4/203.0.113.7/udp/4001/quic-v1").unwrap();
+
+        core.observe_external_addr_candidate(
+            ExternalAddressSource::IdentifyObserved,
+            external.clone(),
+        );
+        core.observe_external_addr_candidate(
+            ExternalAddressSource::IdentifyObserved,
+            external.clone(),
+        );
+        core.confirm_external_address(ExternalAddressSource::AutoNat, external.clone());
+        core.observe_external_addr_candidate(ExternalAddressSource::IdentifyObserved, external);
+
+        assert!(core.external_address_candidates().is_empty());
+        assert_eq!(core.external_addresses().len(), 1);
     }
 }

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -8,7 +8,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use minip2p_core::{Multiaddr, PeerAddr, PeerId};
+use minip2p_core::{ExternalAddress, ExternalAddressSource, Multiaddr, PeerAddr, PeerId};
 use minip2p_identify::{IdentifyConfig, IdentifyMessage};
 use minip2p_ping::{PING_PAYLOAD_LEN, PingConfig};
 use minip2p_transport::{ConnectionId, StreamId, Transport, TransportError};
@@ -151,6 +151,16 @@ impl<T: Transport> Swarm<T> {
         self.core.is_peer_ready(peer_id)
     }
 
+    /// Returns confirmed external addresses in advertise/dial priority order.
+    pub fn external_addresses(&self) -> &[ExternalAddress] {
+        self.core.external_addresses()
+    }
+
+    /// Returns observed but unconfirmed external-address candidates.
+    pub fn external_address_candidates(&self) -> &[ExternalAddress] {
+        self.core.external_address_candidates()
+    }
+
     /// Returns this node's own `PeerId`.
     ///
     /// This accessor is infallible because the [`crate::SwarmBuilder`] requires
@@ -162,6 +172,25 @@ impl<T: Transport> Swarm<T> {
     /// Registers a user protocol id for inbound acceptance and outbound opens.
     pub fn add_user_protocol(&mut self, protocol_id: impl Into<String>) {
         self.core.add_user_protocol(protocol_id);
+    }
+
+    /// Adds a user-confirmed external address.
+    ///
+    /// This is the API equivalent of rust-libp2p's `add_external_address`:
+    /// callers should use it only when an address is known to be reachable,
+    /// such as an explicit public address supplied by the user.
+    pub fn add_external_address(&mut self, addr: Multiaddr) {
+        self.confirm_external_address(ExternalAddressSource::Manual, addr);
+    }
+
+    /// Confirms an external address from a specific discovery source.
+    pub fn confirm_external_address(&mut self, source: ExternalAddressSource, addr: Multiaddr) {
+        self.core.confirm_external_address(source, addr);
+    }
+
+    /// Removes a confirmed external address.
+    pub fn remove_external_address(&mut self, addr: &Multiaddr) {
+        self.core.remove_external_address(addr);
     }
 
     /// Start listening on the given multiaddr and return the resolved local address.

--- a/crates/swarm/src/events.rs
+++ b/crates/swarm/src/events.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use minip2p_core::PeerId;
+use minip2p_core::{ExternalAddressSource, Multiaddr, PeerId};
 use minip2p_identify::IdentifyMessage;
 use minip2p_transport::{ConnectionId, StreamId};
 
@@ -33,6 +33,21 @@ pub enum SwarmEvent {
     PeerReady {
         peer_id: PeerId,
         protocols: Vec<String>,
+    },
+    /// A possible external address was observed but not yet confirmed.
+    ExternalAddrCandidate {
+        source: ExternalAddressSource,
+        address: Multiaddr,
+    },
+    /// A local external address was confirmed and will be advertised.
+    ExternalAddrConfirmed {
+        source: ExternalAddressSource,
+        address: Multiaddr,
+    },
+    /// A previously confirmed local external address expired or was removed.
+    ExternalAddrExpired {
+        source: ExternalAddressSource,
+        address: Multiaddr,
     },
     /// A ping RTT measurement completed.
     PingRttMeasured { peer_id: PeerId, rtt_ms: u64 },

--- a/crates/swarm/src/lib.rs
+++ b/crates/swarm/src/lib.rs
@@ -38,6 +38,7 @@ pub use crate::core::SwarmCore;
 pub use crate::events::{
     OpenStreamToken, SwarmAction, SwarmError, SwarmErrorKind, SwarmEvent, SwarmRuntimeError,
 };
+pub use minip2p_core::{ExternalAddress, ExternalAddressSource};
 
 #[cfg(feature = "std")]
 pub use crate::builder::SwarmBuilder;

--- a/examples/peer/Cargo.toml
+++ b/examples/peer/Cargo.toml
@@ -24,3 +24,4 @@ minip2p-dcutr = { path = "../../crates/dcutr" }
 minip2p-multistream-select = { path = "../../crates/multistream-select" }
 minip2p-quic = { path = "../../transports/quic" }
 getrandom = "0.4.2"
+libc = "0.2.186"

--- a/examples/peer/src/cli.rs
+++ b/examples/peer/src/cli.rs
@@ -336,6 +336,24 @@ pub fn print_event(role: &str, event: &SwarmEvent) {
                 protocol_list
             );
         }
+        SwarmEvent::ExternalAddrCandidate { source, address } => {
+            println!(
+                "[{role}] external-addr-candidate source={} addr={address}",
+                source.as_str()
+            );
+        }
+        SwarmEvent::ExternalAddrConfirmed { source, address } => {
+            println!(
+                "[{role}] external-addr-confirmed source={} addr={address}",
+                source.as_str()
+            );
+        }
+        SwarmEvent::ExternalAddrExpired { source, address } => {
+            println!(
+                "[{role}] external-addr-expired source={} addr={address}",
+                source.as_str()
+            );
+        }
         SwarmEvent::PingRttMeasured { peer_id, rtt_ms } => {
             println!("[{role}] ping peer={peer_id} rtt={rtt_ms}ms");
         }

--- a/examples/peer/src/cli.rs
+++ b/examples/peer/src/cli.rs
@@ -62,6 +62,8 @@ pub struct RunOptions {
     pub external_addrs: Vec<Multiaddr>,
     /// Optional AutoNAT service peer used to validate candidate dialability.
     pub autonat: Option<PeerAddr>,
+    /// STUN servers used to discover extra same-socket DCUtR candidates.
+    pub stun_servers: Vec<String>,
 }
 
 /// Parse error surfaced back to `main` so the binary exits with a readable
@@ -111,7 +113,7 @@ fn parse_listen(args: Vec<String>) -> Result<Mode, CliError> {
     let options = flags.options;
     if flags.relay.is_none() && options.has_relay_mode_only_flags() {
         return Err(CliError(
-            "--autonat and --external-addr are only valid with relay modes".into(),
+            "--autonat, --external-addr, and --stun are only valid with relay modes".into(),
         ));
     }
 
@@ -153,7 +155,7 @@ fn parse_dial(args: Vec<String>) -> Result<Mode, CliError> {
         (1, None, None) => {
             if options.has_relay_mode_only_flags() {
                 return Err(CliError(
-                    "--autonat and --external-addr are only valid with relay modes".into(),
+                    "--autonat, --external-addr, and --stun are only valid with relay modes".into(),
                 ));
             }
             let raw = &positional[0];
@@ -265,6 +267,11 @@ impl Flags {
                         CliError(format!("invalid --autonat peer-addr '{value}': {e}"))
                     })?);
                 }
+                "--stun" => {
+                    let value = flag_value(args, i, key)?;
+                    validate_host_port("--stun", value)?;
+                    options.stun_servers.push(value.clone());
+                }
                 other => {
                     return Err(CliError(format!("unknown flag '{other}'")));
                 }
@@ -282,7 +289,7 @@ impl Flags {
 
 impl RunOptions {
     fn has_relay_mode_only_flags(&self) -> bool {
-        !self.external_addrs.is_empty() || self.autonat.is_some()
+        !self.external_addrs.is_empty() || self.autonat.is_some() || !self.stun_servers.is_empty()
     }
 }
 
@@ -300,6 +307,22 @@ fn parse_quic_multiaddr(flag: &str, value: &str) -> Result<Multiaddr, CliError> 
         )));
     }
     Ok(addr)
+}
+
+fn validate_host_port(flag: &str, value: &str) -> Result<(), CliError> {
+    if value.parse::<std::net::SocketAddr>().is_ok() {
+        return Ok(());
+    }
+
+    if let Some((host, port)) = value.rsplit_once(':') {
+        if !host.is_empty() && !port.is_empty() && port.parse::<u16>().is_ok() {
+            return Ok(());
+        }
+    }
+
+    Err(CliError(format!(
+        "{flag} must be host:port, ip:port, or [ipv6]:port, got '{value}'"
+    )))
 }
 
 /// Prints a [`SwarmEvent`] in the plan's one-event-per-line format.
@@ -410,8 +433,8 @@ USAGE:
     minip2p-peer listen [--key <path>] [--listen <quic-multiaddr>]
     minip2p-peer dial   <peer-addr> [--key <path>] [--listen <quic-multiaddr>]
     minip2p-peer autonat [--key <path>] [--listen <quic-multiaddr>]
-    minip2p-peer listen --relay <relay-peer-addr> [--autonat <peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--external-addr <quic-multiaddr>]...
-    minip2p-peer dial   --relay <relay-peer-addr> --target <peer-id> [--autonat <peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--external-addr <quic-multiaddr>]...
+    minip2p-peer listen --relay <relay-peer-addr> [--autonat <peer-addr>] [--stun <host:port>]... [--key <path>] [--listen <quic-multiaddr>] [--external-addr <quic-multiaddr>]...
+    minip2p-peer dial   --relay <relay-peer-addr> --target <peer-id> [--autonat <peer-addr>] [--stun <host:port>]... [--key <path>] [--listen <quic-multiaddr>] [--external-addr <quic-multiaddr>]...
 
 NOTES:
     <peer-addr>        full libp2p-style address ending in /p2p/<peer-id>
@@ -422,6 +445,7 @@ NOTES:
     --listen           bind multiaddr; default is 127.0.0.1:0
     --external-addr    repeatable relay-mode DCUtR candidate
     --autonat          relay-mode public AutoNAT service for dialability checks
+    --stun             repeatable relay-mode STUN server for same-socket candidates
 
     See holepunch-plan.md at the repo root for full semantics."
         .to_string()
@@ -550,6 +574,49 @@ mod tests {
     }
 
     #[test]
+    fn relay_listen_accepts_repeated_stun_servers() {
+        match parse(v(&[
+            "listen",
+            "--relay",
+            PEER_ADDR,
+            "--stun",
+            "stun.example.com:3478",
+            "--stun",
+            "203.0.113.10:3478",
+        ]))
+        .unwrap()
+        {
+            Mode::RelayListen { options, .. } => {
+                assert_eq!(
+                    options.stun_servers,
+                    vec!["stun.example.com:3478", "203.0.113.10:3478"]
+                );
+            }
+            other => panic!("expected RelayListen, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn relay_dial_accepts_ipv6_stun_server() {
+        match parse(v(&[
+            "dial",
+            "--relay",
+            PEER_ADDR,
+            "--target",
+            PEER_ID,
+            "--stun",
+            "[2001:db8::1]:3478",
+        ]))
+        .unwrap()
+        {
+            Mode::RelayDial { options, .. } => {
+                assert_eq!(options.stun_servers, vec!["[2001:db8::1]:3478"]);
+            }
+            other => panic!("expected RelayDial, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn autonat_server_accepts_key_and_listen_addr() {
         match parse(v(&[
             "autonat",
@@ -578,6 +645,25 @@ mod tests {
     fn direct_mode_rejects_autonat_flag() {
         let err = parse(v(&["listen", "--autonat", PEER_ADDR])).unwrap_err();
         assert!(err.0.contains("--autonat"));
+    }
+
+    #[test]
+    fn direct_mode_rejects_stun_flag() {
+        let err = parse(v(&["listen", "--stun", "stun.example.com:3478"])).unwrap_err();
+        assert!(err.0.contains("--stun"));
+    }
+
+    #[test]
+    fn invalid_stun_server_errors() {
+        let err = parse(v(&[
+            "listen",
+            "--relay",
+            PEER_ADDR,
+            "--stun",
+            "stun.example.com",
+        ]))
+        .unwrap_err();
+        assert!(err.0.contains("--stun"));
     }
 
     #[test]

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -14,7 +14,9 @@ use std::time::{Duration, Instant};
 use minip2p_autonat::{
     AUTONAT_PROTOCOL_ID, AutoNatClient, AutoNatServer, Reachability, ResponseStatus,
 };
-use minip2p_core::{Multiaddr, PeerAddr, PeerId, Protocol, select_direct_candidates};
+use minip2p_core::{
+    ExternalAddressSource, Multiaddr, PeerAddr, PeerId, Protocol, select_direct_candidates,
+};
 use minip2p_dcutr::{
     DCUTR_PROTOCOL_ID, DcutrInitiator, DcutrResponder, InitiatorOutcome, ResponderEvent,
 };
@@ -41,11 +43,13 @@ const LISTEN_DEADLINE: Duration = Duration::from_secs(60);
 /// Hole-punch window after SYNC is received / sent.
 ///
 /// Direct dials succeed in milliseconds on LAN/loopback; real-world NATs may
-/// occasionally need longer but three seconds already works for the common-case
-/// symmetric-NAT traversal path.
-const HOLEPUNCH_DEADLINE: Duration = Duration::from_secs(3);
-/// UDP blast cadence (responder side) during hole-punch.
-const HOLEPUNCH_INTERVAL: Duration = Duration::from_millis(100);
+/// need longer because mapping creation and QUIC handshakes race through two
+/// consumer NATs.
+const HOLEPUNCH_DEADLINE: Duration = Duration::from_secs(10);
+/// Minimum UDP blast cadence during hole-punch.
+const HOLEPUNCH_INTERVAL_MIN_MS: u64 = 10;
+/// Maximum UDP blast cadence during hole-punch.
+const HOLEPUNCH_INTERVAL_MAX_MS: u64 = 200;
 /// Approximation of RTT/2 before the responder starts blasting UDP.
 const RESPONDER_SYNC_DELAY: Duration = Duration::from_millis(50);
 /// Payload length used by the relay-ping fallback.
@@ -68,6 +72,7 @@ const RELAY_READY_RETRY_BACKOFF: Duration = Duration::from_millis(500);
 pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<dyn Error>> {
     let role = "relay-listen";
     let mut swarm = build_swarm_with_relay_protocols(&options, role)?;
+    register_manual_external_addrs(&mut swarm, &options);
     let our_addr = swarm
         .listen_on_bound_addr()
         .map_err(|e| format!("listen failed: {e}"))?;
@@ -83,7 +88,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     let initial_candidates = candidate_addrs(
         role,
         our_addr.transport(),
-        &options.external_addrs,
+        &confirmed_external_addrs(&swarm),
         relay_observed_addr(&swarm, &relay_peer_id, role),
     );
     let our_observed = validate_candidates_with_autonat(
@@ -225,7 +230,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         }
         if now >= next_blast {
             blast_remote_addrs(&swarm, &remote_addrs, role);
-            next_blast = now + HOLEPUNCH_INTERVAL;
+            next_blast = now + next_holepunch_delay();
         }
 
         // Drain any events the transport has for us. Event ordering
@@ -400,6 +405,7 @@ pub fn run_dial(
 ) -> Result<(), Box<dyn Error>> {
     let role = "relay-dial";
     let mut swarm = build_swarm_with_relay_protocols(&options, role)?;
+    register_manual_external_addrs(&mut swarm, &options);
     let our_addr = swarm
         .listen_on_bound_addr()
         .map_err(|e| format!("listen failed: {e}"))?;
@@ -416,7 +422,7 @@ pub fn run_dial(
     let initial_candidates = candidate_addrs(
         role,
         our_addr.transport(),
-        &options.external_addrs,
+        &confirmed_external_addrs(&swarm),
         relay_observed_addr(&swarm, &relay_peer_id, role),
     );
     let our_observed = validate_candidates_with_autonat(
@@ -509,20 +515,16 @@ pub fn run_dial(
     dial_direct_candidates(&mut swarm, role, &target, &remote_addrs);
 
     // --- 5. Wait for direct connection or hole-punch timeout ---------------
-    let punch_deadline = Instant::now() + HOLEPUNCH_DEADLINE;
-    let punched = swarm
-        .run_until(punch_deadline, |ev| {
-            print_event(role, ev);
-            matches!(
-                ev,
-                SwarmEvent::ConnectionEstablished { peer_id }
-                    if peer_id == &target
-            )
-        })
-        .map_err(|e| format!("holepunch poll: {e}"))?;
+    let punched = wait_for_direct_with_udp_blast(
+        &mut swarm,
+        role,
+        &target,
+        &remote_addrs,
+        Instant::now() + HOLEPUNCH_DEADLINE,
+    )?;
 
     // --- 6. Direct ping or relay-ping fallback -----------------------------
-    if punched.is_some() {
+    if punched {
         println!("[{role}] direct-connected peer={target} (hole-punch success)");
         ping_and_exit(&mut swarm, role, target, deadline)
     } else {
@@ -935,6 +937,35 @@ fn dial_direct_candidates(
     }
 }
 
+fn wait_for_direct_with_udp_blast(
+    swarm: &mut Swarm<QuicTransport>,
+    role: &str,
+    peer_id: &PeerId,
+    addrs: &[Multiaddr],
+    deadline: Instant,
+) -> Result<bool, Box<dyn Error>> {
+    let mut next_blast = Instant::now();
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return Ok(false);
+        }
+        if now >= next_blast {
+            blast_remote_addrs(swarm, addrs, role);
+            next_blast = now + next_holepunch_delay();
+        }
+
+        for ev in swarm.poll().map_err(|e| format!("holepunch poll: {e}"))? {
+            print_event(role, &ev);
+            if matches!(&ev, SwarmEvent::ConnectionEstablished { peer_id: p } if p == peer_id) {
+                return Ok(true);
+            }
+        }
+
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
 fn relay_ping_fallback(
     swarm: &mut Swarm<QuicTransport>,
     role: &str,
@@ -1038,6 +1069,20 @@ fn build_autonat_swarm(
         .build(transport);
     swarm.add_user_protocol(AUTONAT_PROTOCOL_ID);
     Ok(swarm)
+}
+
+fn register_manual_external_addrs(swarm: &mut Swarm<QuicTransport>, options: &RunOptions) {
+    for addr in &options.external_addrs {
+        swarm.add_external_address(addr.clone());
+    }
+}
+
+fn confirmed_external_addrs(swarm: &Swarm<QuicTransport>) -> Vec<Multiaddr> {
+    swarm
+        .external_addresses()
+        .iter()
+        .map(|entry| entry.addr.clone())
+        .collect()
 }
 
 fn dialback_candidate(
@@ -1203,7 +1248,11 @@ fn validate_candidates_with_autonat(
                 );
             }
             println!("[{role}] autonat-public addrs={}", addrs.len());
-            Ok(successful_candidates_in_original_order(candidates, &addrs))
+            let successful = successful_candidates_in_original_order(candidates, &addrs);
+            for addr in &successful {
+                swarm.confirm_external_address(ExternalAddressSource::AutoNat, addr.clone());
+            }
+            Ok(successful)
         }
         Reachability::Private { status, reason } => {
             println!("[{role}] autonat-private status={status:?} reason={reason}");
@@ -1263,6 +1312,17 @@ fn blast_remote_addrs(swarm: &Swarm<QuicTransport>, addrs: &[Multiaddr], role: &
             eprintln!("[{role}] udp-blast {addr} failed: {e}");
         }
     }
+}
+
+fn next_holepunch_delay() -> Duration {
+    let range = HOLEPUNCH_INTERVAL_MAX_MS - HOLEPUNCH_INTERVAL_MIN_MS + 1;
+    let mut raw = [0u8; 8];
+    let jitter = if getrandom::fill(&mut raw).is_ok() {
+        u64::from_le_bytes(raw) % range
+    } else {
+        range / 2
+    };
+    Duration::from_millis(HOLEPUNCH_INTERVAL_MIN_MS + jitter)
 }
 
 /// Short random byte vector. Best-effort: falls back to zeros rather

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -31,7 +31,7 @@ use minip2p_swarm::{Swarm, SwarmBuilder, SwarmEvent};
 use minip2p_transport::{StreamId, Transport};
 
 use crate::cli::{RunOptions, print_event};
-use crate::runtime::{bind_addr, load_keypair};
+use crate::runtime::{bind_addr, load_keypair, local_global_ipv6_quic_addrs};
 
 // ---------------------------------------------------------------------------
 // Shared configuration
@@ -100,6 +100,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         &confirmed_external_addrs(&swarm),
         relay_observed_addr(&swarm, &relay_peer_id, role),
     );
+    let initial_candidates = append_interface_ipv6_candidates(role, initial_candidates, &our_addr);
     let initial_candidates = append_stun_candidates(role, initial_candidates, &stun_candidates);
     let mut our_observed = validate_candidates_with_autonat(
         &mut swarm,
@@ -489,6 +490,7 @@ pub fn run_dial(
         &confirmed_external_addrs(&swarm),
         relay_observed_addr(&swarm, &relay_peer_id, role),
     );
+    let initial_candidates = append_interface_ipv6_candidates(role, initial_candidates, &our_addr);
     let initial_candidates = append_stun_candidates(role, initial_candidates, &stun_candidates);
     let mut our_observed = validate_candidates_with_autonat(
         &mut swarm,
@@ -1281,6 +1283,25 @@ fn append_stun_candidates(
             println!("[{role}] candidate-added source=stun addr={addr}");
         } else {
             println!("[{role}] candidate-skipped source=stun addr={addr} reason=duplicate");
+        }
+    }
+    candidates
+}
+
+fn append_interface_ipv6_candidates(
+    role: &str,
+    mut candidates: Vec<Multiaddr>,
+    bound_addr: &PeerAddr,
+) -> Vec<Multiaddr> {
+    for addr in local_global_ipv6_quic_addrs(bound_addr.transport()) {
+        let before = candidates.len();
+        push_unique(&mut candidates, addr.clone());
+        if candidates.len() > before {
+            println!("[{role}] candidate-added source=interface-ipv6 addr={addr}");
+        } else {
+            println!(
+                "[{role}] candidate-skipped source=interface-ipv6 addr={addr} reason=duplicate"
+            );
         }
     }
     candidates

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -52,6 +52,11 @@ const HOLEPUNCH_DEADLINE: Duration = Duration::from_secs(10);
 const HOLEPUNCH_INTERVAL_MIN_MS: u64 = 10;
 /// Maximum UDP blast cadence during hole-punch.
 const HOLEPUNCH_INTERVAL_MAX_MS: u64 = 200;
+/// How often to re-open direct QUIC dials while the hole-punch window is open.
+const HOLEPUNCH_REDIAL_INTERVAL: Duration = Duration::from_millis(250);
+/// DCUtR paths are short-lived and only used during the active punch window,
+/// so the std runner controls retry cadence directly.
+const HOLEPUNCH_DIRECT_PATH_RETRY_MS: u64 = 0;
 /// Approximation of RTT/2 before the responder starts blasting UDP.
 const RESPONDER_SYNC_DELAY: Duration = Duration::from_millis(50);
 /// Payload length used by the relay-ping fallback.
@@ -229,6 +234,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         elapsed_ms(punch_start),
     );
     let mut next_blast = punch_start + RESPONDER_SYNC_DELAY;
+    let mut next_redial = punch_start + HOLEPUNCH_REDIAL_INTERVAL;
 
     // Extract the host+port shape of each address we expect the remote
     // to dial from. We compare against the transport addresses (no
@@ -264,6 +270,17 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         if now >= next_blast {
             blast_remote_paths(&swarm, &remote_paths, role);
             next_blast = now + next_holepunch_delay();
+        }
+        if now >= next_redial {
+            remote_paths.fail_attempts(elapsed_ms(punch_start));
+            dial_direct_candidates(
+                &mut swarm,
+                role,
+                &remote_peer_id,
+                &mut remote_paths,
+                elapsed_ms(punch_start),
+            );
+            next_redial = now + HOLEPUNCH_REDIAL_INTERVAL;
         }
 
         // Drain any events the transport has for us. Event ordering
@@ -1033,7 +1050,7 @@ fn drain_dcutr_responder_events(
 }
 
 fn remote_path_book(addrs: &[Multiaddr]) -> DirectPathBook {
-    let mut book = DirectPathBook::new();
+    let mut book = DirectPathBook::new().with_retry_interval_ms(HOLEPUNCH_DIRECT_PATH_RETRY_MS);
     for addr in addrs.iter().rev() {
         book.insert(DirectPathSource::Dcutr, addr.clone(), 0);
     }
@@ -1076,6 +1093,7 @@ fn wait_for_direct_with_udp_blast(
     deadline: Instant,
 ) -> Result<bool, Box<dyn Error>> {
     let mut next_blast = Instant::now();
+    let mut next_redial = started_at + HOLEPUNCH_REDIAL_INTERVAL;
     loop {
         let now = Instant::now();
         if now >= deadline {
@@ -1086,6 +1104,11 @@ fn wait_for_direct_with_udp_blast(
         if now >= next_blast {
             blast_remote_paths(swarm, paths, role);
             next_blast = now + next_holepunch_delay();
+        }
+        if now >= next_redial {
+            paths.fail_attempts(elapsed_ms(started_at));
+            dial_direct_candidates(swarm, role, peer_id, paths, elapsed_ms(started_at));
+            next_redial = now + HOLEPUNCH_REDIAL_INTERVAL;
         }
 
         for ev in swarm.poll().map_err(|e| format!("holepunch poll: {e}"))? {

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -81,7 +81,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         .map_err(|e| format!("listen failed: {e}"))?;
     println!("[{role}] bound={our_addr}");
     println!("[{role}] us={}", swarm.local_peer_id());
-    let stun_candidates = discover_stun_candidates(&swarm, role, &options);
+    let stun_candidates = discover_stun_candidates(&mut swarm, role, &options);
 
     let relay_peer_id = relay_addr.peer_id().clone();
     let deadline = Instant::now() + LISTEN_DEADLINE;
@@ -288,7 +288,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     // --- 7. Resolve based on the hole-punch outcome -------------------------
     match outcome {
         HolePunchOutcome::DirectConnected(peer_id) => {
-            print_direct_path_summary(role, "hole-punch-open", &remote_paths);
+            print_direct_path_summary(role, "hole-punch-success", &remote_paths);
             println!("[{role}] direct-connected peer={peer_id} (hole-punch success)");
             ping_and_exit(&mut swarm, role, peer_id, deadline)
         }
@@ -430,7 +430,7 @@ pub fn run_dial(
     println!("[{role}] bound={our_addr}");
     println!("[{role}] us={}", swarm.local_peer_id());
     println!("[{role}] target={target}");
-    let stun_candidates = discover_stun_candidates(&swarm, role, &options);
+    let stun_candidates = discover_stun_candidates(&mut swarm, role, &options);
 
     let relay_peer_id = relay_addr.peer_id().clone();
     let deadline = Instant::now() + LISTEN_DEADLINE;
@@ -1008,7 +1008,7 @@ fn wait_for_direct_with_udp_blast(
         for ev in swarm.poll().map_err(|e| format!("holepunch poll: {e}"))? {
             print_event(role, &ev);
             if matches!(&ev, SwarmEvent::ConnectionEstablished { peer_id: p } if p == peer_id) {
-                print_direct_path_summary(role, "hole-punch-open", paths);
+                print_direct_path_summary(role, "hole-punch-success", paths);
                 return Ok(true);
             }
         }
@@ -1137,7 +1137,7 @@ fn confirmed_external_addrs(swarm: &Swarm<QuicTransport>) -> Vec<Multiaddr> {
 }
 
 fn discover_stun_candidates(
-    swarm: &Swarm<QuicTransport>,
+    swarm: &mut Swarm<QuicTransport>,
     role: &str,
     options: &RunOptions,
 ) -> Vec<Multiaddr> {
@@ -1145,7 +1145,7 @@ fn discover_stun_candidates(
     for server in &options.stun_servers {
         println!("[{role}] stun-probing server={server}");
         match swarm
-            .transport()
+            .transport_mut()
             .discover_external_addr_stun(server, STUN_DISCOVERY_TIMEOUT)
         {
             Ok(addr) => {

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -55,6 +55,7 @@ const RESPONDER_SYNC_DELAY: Duration = Duration::from_millis(50);
 /// Payload length used by the relay-ping fallback.
 const RELAY_PING_LEN: usize = 32;
 const AUTONAT_CLIENT_DEADLINE: Duration = Duration::from_secs(20);
+const AUTONAT_IDENTIFY_GRACE: Duration = Duration::from_secs(2);
 const AUTONAT_REQUEST_DEADLINE: Duration = Duration::from_secs(5);
 // Client deadline must absorb candidate_count * binds_per_candidate * dialback
 // deadline. Generic /dns candidates may try two bind families; /ip4, /ip6,
@@ -1192,7 +1193,15 @@ fn relay_observed_addr(
     relay_peer_id: &PeerId,
     role: &str,
 ) -> Option<Multiaddr> {
-    let raw = swarm.peer_info(relay_peer_id)?.observed_addr.as_deref()?;
+    observed_addr_from_peer(swarm, relay_peer_id, role)
+}
+
+fn observed_addr_from_peer(
+    swarm: &Swarm<QuicTransport>,
+    peer_id: &PeerId,
+    role: &str,
+) -> Option<Multiaddr> {
+    let raw = swarm.peer_info(peer_id)?.observed_addr.as_deref()?;
     match Multiaddr::from_bytes(raw) {
         Ok(addr) => Some(addr),
         Err(e) => {
@@ -1202,6 +1211,27 @@ fn relay_observed_addr(
             None
         }
     }
+}
+
+fn wait_observed_addr_from_peer(
+    swarm: &mut Swarm<QuicTransport>,
+    role: &str,
+    peer_id: &PeerId,
+    deadline: Instant,
+) -> Result<Option<Multiaddr>, Box<dyn Error>> {
+    if let Some(addr) = observed_addr_from_peer(swarm, peer_id, role) {
+        return Ok(Some(addr));
+    }
+
+    let _ = swarm
+        .run_until(deadline, |ev| {
+            print_event(role, ev);
+            matches!(ev, SwarmEvent::IdentifyReceived { peer_id: p, .. } if p == peer_id)
+                || matches!(ev, SwarmEvent::PeerReady { peer_id: p, .. } if p == peer_id)
+        })
+        .map_err(|e| format!("wait-observed-addr: {e}"))?;
+
+    Ok(observed_addr_from_peer(swarm, peer_id, role))
 }
 
 fn validate_candidates_with_autonat(
@@ -1222,13 +1252,24 @@ fn validate_candidates_with_autonat(
     println!("[{role}] autonat-dialing {service}");
     wait_connected(swarm, role, &service_peer, deadline)?;
 
+    let mut probe_candidates = candidates.to_vec();
+    let identify_deadline = earlier_deadline(Instant::now() + AUTONAT_IDENTIFY_GRACE, deadline);
+    if let Some(addr) = wait_observed_addr_from_peer(swarm, role, &service_peer, identify_deadline)?
+    {
+        let before = probe_candidates.len();
+        push_unique(&mut probe_candidates, addr.clone());
+        if probe_candidates.len() > before {
+            println!("[{role}] autonat-candidate-added source=identify-observed addr={addr}");
+        }
+    }
+
     let stream_id = swarm
         .open_user_stream(&service_peer, AUTONAT_PROTOCOL_ID)
         .map_err(|e| format!("open AutoNAT stream: {e}"))?;
     wait_user_stream_ready(swarm, role, stream_id, deadline)?;
 
     let local_peer = swarm.local_peer_id().clone();
-    let mut client = AutoNatClient::new(&local_peer, candidates);
+    let mut client = AutoNatClient::new(&local_peer, &probe_candidates);
     send(swarm, &service_peer, stream_id, client.take_outbound())?;
 
     while client.outcome().is_none() {
@@ -1248,7 +1289,7 @@ fn validate_candidates_with_autonat(
                 );
             }
             println!("[{role}] autonat-public addrs={}", addrs.len());
-            let successful = successful_candidates_in_original_order(candidates, &addrs);
+            let successful = successful_candidates_in_original_order(&probe_candidates, &addrs);
             for addr in &successful {
                 swarm.confirm_external_address(ExternalAddressSource::AutoNat, addr.clone());
             }
@@ -1256,11 +1297,11 @@ fn validate_candidates_with_autonat(
         }
         Reachability::Private { status, reason } => {
             println!("[{role}] autonat-private status={status:?} reason={reason}");
-            Ok(candidates.to_vec())
+            Ok(probe_candidates)
         }
         Reachability::Unknown { status, reason } => {
             println!("[{role}] autonat-unknown status={status:?} reason={reason}");
-            Ok(candidates.to_vec())
+            Ok(probe_candidates)
         }
     }
 }

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -96,11 +96,20 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         relay_observed_addr(&swarm, &relay_peer_id, role),
     );
     let initial_candidates = append_stun_candidates(role, initial_candidates, &stun_candidates);
-    let our_observed = validate_candidates_with_autonat(
+    let mut our_observed = validate_candidates_with_autonat(
         &mut swarm,
         role,
         &options,
         &initial_candidates,
+        deadline,
+    )?;
+    refresh_relay_after_slow_discovery(
+        &mut swarm,
+        role,
+        &options,
+        &relay_addr,
+        &relay_peer_id,
+        &mut our_observed,
         deadline,
     )?;
     print_candidates(role, &our_observed);
@@ -466,11 +475,20 @@ pub fn run_dial(
         relay_observed_addr(&swarm, &relay_peer_id, role),
     );
     let initial_candidates = append_stun_candidates(role, initial_candidates, &stun_candidates);
-    let our_observed = validate_candidates_with_autonat(
+    let mut our_observed = validate_candidates_with_autonat(
         &mut swarm,
         role,
         &options,
         &initial_candidates,
+        deadline,
+    )?;
+    refresh_relay_after_slow_discovery(
+        &mut swarm,
+        role,
+        &options,
+        &relay_addr,
+        &relay_peer_id,
+        &mut our_observed,
         deadline,
     )?;
     print_candidates(role, &our_observed);
@@ -810,6 +828,33 @@ fn retry_relay_connection(
             false
         })
         .map_err(|e| format!("relay retry drain: {e}"))?;
+    Ok(())
+}
+
+fn refresh_relay_after_slow_discovery(
+    swarm: &mut Swarm<QuicTransport>,
+    role: &str,
+    options: &RunOptions,
+    relay_addr: &PeerAddr,
+    relay_peer_id: &PeerId,
+    candidates: &mut Vec<Multiaddr>,
+    deadline: Instant,
+) -> Result<(), Box<dyn Error>> {
+    if options.autonat.is_none() {
+        return Ok(());
+    }
+
+    println!("[{role}] refreshing-relay after=autonat");
+    prepare_relay(swarm, role, relay_addr, relay_peer_id, deadline)?;
+
+    if let Some(addr) = relay_observed_addr(swarm, relay_peer_id, role) {
+        let before = candidates.len();
+        push_unique(candidates, addr.clone());
+        if candidates.len() > before {
+            println!("[{role}] candidate-added source=identify-observed-refresh addr={addr}");
+        }
+    }
+
     Ok(())
 }
 

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -248,7 +248,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     // Using an address-match heuristic rather than a raw count
     // comparison prevents unrelated inbound connections -- relay
     // probe-backs, autonat probes, random scanners -- from being
-    // misinterpreted as hole-punch success.
+    // misinterpreted as direct path success.
     let remote_match_targets: Vec<(String, u16)> = remote_paths
         .addrs()
         .iter()
@@ -324,8 +324,8 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     // --- 7. Resolve based on the hole-punch outcome -------------------------
     match outcome {
         HolePunchOutcome::DirectConnected(peer_id) => {
-            print_direct_path_summary(role, "hole-punch-attempts", &remote_paths);
-            println!("[{role}] direct-connected peer={peer_id} (hole-punch success)");
+            print_direct_path_summary(role, "direct-path-attempts", &remote_paths);
+            println!("[{role}] direct-connected peer={peer_id} (direct path success)");
             ping_and_exit(&mut swarm, role, peer_id, deadline)
         }
         HolePunchOutcome::InboundConnectionSeen => {
@@ -338,7 +338,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
             // mTLS identity. Give QUIC one short grace window to complete the
             // identity event so this side can direct-ping too.
             println!(
-                "[{role}] inbound-direct-connection detected (hole-punch success; \
+                "[{role}] inbound-direct-connection detected (direct path success; \
                  waiting for verified mTLS identity)"
             );
             let grace_deadline = Instant::now() + Duration::from_secs(2);
@@ -371,7 +371,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         }
         HolePunchOutcome::Timeout => {
             remote_paths.fail_attempts(elapsed_ms(punch_start));
-            print_direct_path_summary(role, "hole-punch-failed", &remote_paths);
+            print_direct_path_summary(role, "direct-path-failed", &remote_paths);
             println!("[{role}] hole-punch-timeout reason=deadline elapsed -> relay-ping fallback");
             relay_ping_fallback(&mut swarm, role, &relay_peer_id, bridge_stream)
         }
@@ -428,7 +428,7 @@ fn extract_ip_port(addr: &Multiaddr) -> Option<(String, u16)> {
 /// Returns `true` if at least one of `sources` has the same `(host, port)`
 /// as any of `targets`.
 ///
-/// Used by the listener's hole-punch success heuristic to filter out
+/// Used by the listener's direct path success heuristic to filter out
 /// inbound connections from unrelated peers (autonat probes, scans,
 /// etc.). A connection source matches only when it came from an
 /// address the remote peer advertised via DCUtR.
@@ -618,7 +618,7 @@ pub fn run_dial(
 
     // --- 6. Direct ping or relay-ping fallback -----------------------------
     if punched {
-        println!("[{role}] direct-connected peer={target} (hole-punch success)");
+        println!("[{role}] direct-connected peer={target} (direct path success)");
         ping_and_exit(&mut swarm, role, target, deadline)
     } else {
         println!("[{role}] hole-punch-timeout reason=deadline elapsed -> relay-ping fallback");
@@ -1098,7 +1098,7 @@ fn wait_for_direct_with_udp_blast(
         let now = Instant::now();
         if now >= deadline {
             paths.fail_attempts(elapsed_ms(started_at));
-            print_direct_path_summary(role, "hole-punch-failed", paths);
+            print_direct_path_summary(role, "direct-path-failed", paths);
             return Ok(false);
         }
         if now >= next_blast {
@@ -1114,7 +1114,7 @@ fn wait_for_direct_with_udp_blast(
         for ev in swarm.poll().map_err(|e| format!("holepunch poll: {e}"))? {
             print_event(role, &ev);
             if matches!(&ev, SwarmEvent::ConnectionEstablished { peer_id: p } if p == peer_id) {
-                print_direct_path_summary(role, "hole-punch-attempts", paths);
+                print_direct_path_summary(role, "direct-path-attempts", paths);
                 return Ok(true);
             }
         }

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -62,6 +62,7 @@ const AUTONAT_REQUEST_DEADLINE: Duration = Duration::from_secs(5);
 // deadline. Generic /dns candidates may try two bind families; /ip4, /ip6,
 // /dns4, and /dns6 try one.
 const AUTONAT_DIALBACK_DEADLINE: Duration = Duration::from_secs(5);
+const STUN_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(2);
 const LISTEN_FOREVER: Duration = Duration::from_secs(60 * 60 * 24 * 365);
 const RELAY_READY_ATTEMPTS: usize = 3;
 const RELAY_READY_ATTEMPT_DEADLINE: Duration = Duration::from_secs(12);
@@ -80,6 +81,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         .map_err(|e| format!("listen failed: {e}"))?;
     println!("[{role}] bound={our_addr}");
     println!("[{role}] us={}", swarm.local_peer_id());
+    let stun_candidates = discover_stun_candidates(&swarm, role, &options);
 
     let relay_peer_id = relay_addr.peer_id().clone();
     let deadline = Instant::now() + LISTEN_DEADLINE;
@@ -93,6 +95,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         &confirmed_external_addrs(&swarm),
         relay_observed_addr(&swarm, &relay_peer_id, role),
     );
+    let initial_candidates = append_stun_candidates(role, initial_candidates, &stun_candidates);
     let our_observed = validate_candidates_with_autonat(
         &mut swarm,
         role,
@@ -427,6 +430,7 @@ pub fn run_dial(
     println!("[{role}] bound={our_addr}");
     println!("[{role}] us={}", swarm.local_peer_id());
     println!("[{role}] target={target}");
+    let stun_candidates = discover_stun_candidates(&swarm, role, &options);
 
     let relay_peer_id = relay_addr.peer_id().clone();
     let deadline = Instant::now() + LISTEN_DEADLINE;
@@ -440,6 +444,7 @@ pub fn run_dial(
         &confirmed_external_addrs(&swarm),
         relay_observed_addr(&swarm, &relay_peer_id, role),
     );
+    let initial_candidates = append_stun_candidates(role, initial_candidates, &stun_candidates);
     let our_observed = validate_candidates_with_autonat(
         &mut swarm,
         role,
@@ -1129,6 +1134,51 @@ fn confirmed_external_addrs(swarm: &Swarm<QuicTransport>) -> Vec<Multiaddr> {
         .iter()
         .map(|entry| entry.addr.clone())
         .collect()
+}
+
+fn discover_stun_candidates(
+    swarm: &Swarm<QuicTransport>,
+    role: &str,
+    options: &RunOptions,
+) -> Vec<Multiaddr> {
+    let mut candidates = Vec::new();
+    for server in &options.stun_servers {
+        println!("[{role}] stun-probing server={server}");
+        match swarm
+            .transport()
+            .discover_external_addr_stun(server, STUN_DISCOVERY_TIMEOUT)
+        {
+            Ok(addr) => {
+                if candidates.iter().any(|existing| existing == &addr) {
+                    println!("[{role}] stun-candidate-duplicate server={server} addr={addr}");
+                } else {
+                    println!("[{role}] stun-candidate-added server={server} addr={addr}");
+                    candidates.push(addr);
+                }
+            }
+            Err(e) => {
+                eprintln!("[{role}] stun-probe-failed server={server} reason={e}");
+            }
+        }
+    }
+    candidates
+}
+
+fn append_stun_candidates(
+    role: &str,
+    mut candidates: Vec<Multiaddr>,
+    stun_candidates: &[Multiaddr],
+) -> Vec<Multiaddr> {
+    for addr in stun_candidates {
+        let before = candidates.len();
+        push_unique(&mut candidates, addr.clone());
+        if candidates.len() > before {
+            println!("[{role}] candidate-added source=stun addr={addr}");
+        } else {
+            println!("[{role}] candidate-skipped source=stun addr={addr} reason=duplicate");
+        }
+    }
+    candidates
 }
 
 fn dialback_candidate(

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -15,7 +15,8 @@ use minip2p_autonat::{
     AUTONAT_PROTOCOL_ID, AutoNatClient, AutoNatServer, Reachability, ResponseStatus,
 };
 use minip2p_core::{
-    ExternalAddressSource, Multiaddr, PeerAddr, PeerId, Protocol, select_direct_candidates,
+    DirectPathBook, DirectPathSource, ExternalAddressSource, Multiaddr, PeerAddr, PeerId, Protocol,
+    select_direct_candidates,
 };
 use minip2p_dcutr::{
     DCUTR_PROTOCOL_ID, DcutrInitiator, DcutrResponder, InitiatorOutcome, ResponderEvent,
@@ -195,10 +196,17 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
 
     // --- 6. Hole-punch: dial + blast UDP, wait for direct or timeout -------
     println!("[{role}] dcutr-sync-received -> holepunching");
-    print_remote_candidates(role, &remote_addrs);
-    dial_direct_candidates(&mut swarm, role, &remote_peer_id, &remote_addrs);
     let punch_start = Instant::now();
     let punch_deadline = punch_start + HOLEPUNCH_DEADLINE;
+    let mut remote_paths = remote_path_book(&remote_addrs);
+    print_remote_paths(role, &remote_paths);
+    dial_direct_candidates(
+        &mut swarm,
+        role,
+        &remote_peer_id,
+        &mut remote_paths,
+        elapsed_ms(punch_start),
+    );
     let mut next_blast = punch_start + RESPONDER_SYNC_DELAY;
 
     // Extract the host+port shape of each address we expect the remote
@@ -213,8 +221,11 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     // comparison prevents unrelated inbound connections -- relay
     // probe-backs, autonat probes, random scanners -- from being
     // misinterpreted as hole-punch success.
-    let remote_match_targets: Vec<(String, u16)> =
-        remote_addrs.iter().filter_map(extract_ip_port).collect();
+    let remote_match_targets: Vec<(String, u16)> = remote_paths
+        .addrs()
+        .iter()
+        .filter_map(extract_ip_port)
+        .collect();
 
     // Check any connections already present (e.g. the remote's direct
     // Initial may have arrived BEFORE we observed the SYNC message on
@@ -230,7 +241,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
             break HolePunchOutcome::Timeout;
         }
         if now >= next_blast {
-            blast_remote_addrs(&swarm, &remote_addrs, role);
+            blast_remote_paths(&swarm, &remote_paths, role);
             next_blast = now + next_holepunch_delay();
         }
 
@@ -274,6 +285,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     // --- 7. Resolve based on the hole-punch outcome -------------------------
     match outcome {
         HolePunchOutcome::DirectConnected(peer_id) => {
+            print_direct_path_summary(role, "hole-punch-open", &remote_paths);
             println!("[{role}] direct-connected peer={peer_id} (hole-punch success)");
             ping_and_exit(&mut swarm, role, peer_id, deadline)
         }
@@ -314,6 +326,8 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
             Ok(())
         }
         HolePunchOutcome::Timeout => {
+            remote_paths.fail_attempts(elapsed_ms(punch_start));
+            print_direct_path_summary(role, "hole-punch-failed", &remote_paths);
             println!("[{role}] hole-punch-timeout reason=deadline elapsed -> relay-ping fallback");
             relay_ping_fallback(&mut swarm, role, &relay_peer_id, bridge_stream)
         }
@@ -500,7 +514,8 @@ pub fn run_dial(
         "[{role}] dcutr-dialnow addrs={} rtt={rtt_ms}ms",
         remote_addrs.len()
     );
-    print_remote_candidates(role, &remote_addrs);
+    let mut remote_paths = remote_path_book(&remote_addrs);
+    print_remote_paths(role, &remote_paths);
 
     // --- 4. Flush SYNC and dial every observed remote address in parallel --
     dcutr
@@ -513,15 +528,23 @@ pub fn run_dial(
         dcutr.take_outbound(),
     )?;
 
-    dial_direct_candidates(&mut swarm, role, &target, &remote_addrs);
+    let punch_start = Instant::now();
+    dial_direct_candidates(
+        &mut swarm,
+        role,
+        &target,
+        &mut remote_paths,
+        elapsed_ms(punch_start),
+    );
 
     // --- 5. Wait for direct connection or hole-punch timeout ---------------
     let punched = wait_for_direct_with_udp_blast(
         &mut swarm,
         role,
         &target,
-        &remote_addrs,
-        Instant::now() + HOLEPUNCH_DEADLINE,
+        &mut remote_paths,
+        punch_start,
+        punch_start + HOLEPUNCH_DEADLINE,
     )?;
 
     // --- 6. Direct ping or relay-ping fallback -----------------------------
@@ -921,16 +944,34 @@ fn drain_dcutr_responder_events(
     sync
 }
 
+fn remote_path_book(addrs: &[Multiaddr]) -> DirectPathBook {
+    let mut book = DirectPathBook::new();
+    for addr in addrs.iter().rev() {
+        book.insert(DirectPathSource::Dcutr, addr.clone(), 0);
+    }
+    book
+}
+
 fn dial_direct_candidates(
     swarm: &mut Swarm<QuicTransport>,
     role: &str,
     peer_id: &PeerId,
-    addrs: &[Multiaddr],
+    paths: &mut DirectPathBook,
+    now_ms: u64,
 ) {
+    let addrs = paths.begin_attempts(now_ms);
+    if addrs.is_empty() {
+        println!("[{role}] direct-dial-skipped reason=no-path-ready");
+        return;
+    }
+
     for addr in addrs {
         match PeerAddr::new(addr.clone(), peer_id.clone()) {
             Ok(peer_addr) => match swarm.dial(&peer_addr) {
-                Ok(_) => println!("[{role}] direct-dial-attempt {peer_addr}"),
+                Ok(_) => {
+                    let attempts = path_attempts(paths, &addr).unwrap_or_default();
+                    println!("[{role}] direct-dial-attempt attempt={attempts} {peer_addr}");
+                }
                 Err(e) => eprintln!("[{role}] direct-dial-failed addr={peer_addr} reason={e}"),
             },
             Err(e) => eprintln!("[{role}] bad PeerAddr for {addr}: {e}"),
@@ -942,23 +983,27 @@ fn wait_for_direct_with_udp_blast(
     swarm: &mut Swarm<QuicTransport>,
     role: &str,
     peer_id: &PeerId,
-    addrs: &[Multiaddr],
+    paths: &mut DirectPathBook,
+    started_at: Instant,
     deadline: Instant,
 ) -> Result<bool, Box<dyn Error>> {
     let mut next_blast = Instant::now();
     loop {
         let now = Instant::now();
         if now >= deadline {
+            paths.fail_attempts(elapsed_ms(started_at));
+            print_direct_path_summary(role, "hole-punch-failed", paths);
             return Ok(false);
         }
         if now >= next_blast {
-            blast_remote_addrs(swarm, addrs, role);
+            blast_remote_paths(swarm, paths, role);
             next_blast = now + next_holepunch_delay();
         }
 
         for ev in swarm.poll().map_err(|e| format!("holepunch poll: {e}"))? {
             print_event(role, &ev);
             if matches!(&ev, SwarmEvent::ConnectionEstablished { peer_id: p } if p == peer_id) {
+                print_direct_path_summary(role, "hole-punch-open", paths);
                 return Ok(true);
             }
         }
@@ -1334,22 +1379,56 @@ fn print_candidates(role: &str, candidates: &[Multiaddr]) {
     println!("[{role}] dcutr-candidates [{rendered}]");
 }
 
-fn print_remote_candidates(role: &str, candidates: &[Multiaddr]) {
-    let rendered = candidates
+fn print_remote_paths(role: &str, paths: &DirectPathBook) {
+    print_direct_path_summary(role, "remote-direct-paths", paths);
+}
+
+fn print_direct_path_summary(role: &str, label: &str, paths: &DirectPathBook) {
+    if paths.is_empty() {
+        println!("[{role}] {label} []");
+        return;
+    }
+
+    let rendered = paths
+        .paths()
         .iter()
-        .map(ToString::to_string)
+        .map(|path| {
+            format!(
+                "{};source={};status={};attempts={}",
+                path.addr,
+                path.source.as_str(),
+                path.status.as_str(),
+                path.attempts
+            )
+        })
         .collect::<Vec<_>>()
         .join(",");
-    println!("[{role}] remote-dcutr-candidates [{rendered}]");
+    println!("[{role}] {label} [{rendered}]");
+}
+
+fn path_attempts(paths: &DirectPathBook, addr: &Multiaddr) -> Option<u32> {
+    paths
+        .paths()
+        .iter()
+        .find(|path| &path.addr == addr)
+        .map(|path| path.attempts)
+}
+
+fn elapsed_ms(started_at: Instant) -> u64 {
+    started_at.elapsed().as_millis() as u64
 }
 
 /// Sends a random 32-byte UDP payload to every remote address. These
 /// packets open the NAT binding so the remote's QUIC packets can reach
 /// us; the content is irrelevant per the DCUtR spec.
-fn blast_remote_addrs(swarm: &Swarm<QuicTransport>, addrs: &[Multiaddr], role: &str) {
+fn blast_remote_paths(swarm: &Swarm<QuicTransport>, paths: &DirectPathBook, role: &str) {
     let payload = random_bytes(RELAY_PING_LEN);
+    let addrs = match paths.usable_addrs() {
+        addrs if addrs.is_empty() => paths.addrs(),
+        addrs => addrs,
+    };
     for addr in addrs {
-        if let Err(e) = swarm.transport().send_raw_udp(addr, &payload) {
+        if let Err(e) = swarm.transport().send_raw_udp(&addr, &payload) {
             eprintln!("[{role}] udp-blast {addr} failed: {e}");
         }
     }

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -324,15 +324,13 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     match outcome {
         HolePunchOutcome::DirectConnected(peer_id) => {
             print_direct_path_summary(role, "hole-punch-attempts", &remote_paths);
-            println!("[{role}] direct-connected peer={peer_id} (hole-punch success) -- done");
-            Ok(())
+            println!("[{role}] direct-connected peer={peer_id} (hole-punch success)");
+            ping_and_exit(&mut swarm, role, peer_id, deadline)
         }
         HolePunchOutcome::InboundConnectionSeen => {
             if swarm.connected_peers().iter().any(|p| p == &remote_peer_id) {
-                println!(
-                    "[{role}] direct-connected peer={remote_peer_id} (mTLS already verified) -- done"
-                );
-                return Ok(());
+                println!("[{role}] direct-connected peer={remote_peer_id} (mTLS already verified)");
+                return ping_and_exit(&mut swarm, role, remote_peer_id, deadline);
             }
 
             // The address heuristic fired before Swarm surfaced the verified
@@ -351,8 +349,8 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
                 .map_err(|e| format!("grace poll: {e}"))?;
             match verified {
                 Some(SwarmEvent::ConnectionEstablished { peer_id }) => {
-                    println!("[{role}] direct-connected peer={peer_id} (mTLS verified) -- done");
-                    Ok(())
+                    println!("[{role}] direct-connected peer={peer_id} (mTLS verified)");
+                    ping_and_exit(&mut swarm, role, peer_id, deadline)
                 }
                 _ => {
                     println!("[{role}] grace-elapsed before mTLS identity -> relay-ping fallback");

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -109,7 +109,14 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     let hop_stream = swarm
         .open_user_stream(&relay_peer_id, HOP_PROTOCOL_ID)
         .map_err(|e| format!("open HOP: {e}"))?;
-    wait_user_stream_ready(&mut swarm, role, hop_stream, deadline)?;
+    wait_user_stream_ready(
+        &mut swarm,
+        role,
+        &relay_peer_id,
+        hop_stream,
+        HOP_PROTOCOL_ID,
+        deadline,
+    )?;
     let mut reservation = HopReservation::new();
     send(
         &mut swarm,
@@ -119,7 +126,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     )?;
 
     while reservation.outcome().is_none() {
-        let data = wait_user_stream_data(&mut swarm, role, hop_stream, deadline)?;
+        let data = wait_user_stream_data(&mut swarm, role, &relay_peer_id, hop_stream, deadline)?;
         reservation
             .on_data(&data)
             .map_err(|e| format!("HOP decode: {e}"))?;
@@ -144,7 +151,8 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     // --- 4. STOP responder: accept the CONNECT, keep any pipelined bytes ---
     let mut stop = StopResponder::new();
     let remote_peer_id: PeerId = loop {
-        let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
+        let data =
+            wait_user_stream_data(&mut swarm, role, &relay_peer_id, bridge_stream, deadline)?;
         stop.on_data(&data)
             .map_err(|e| format!("STOP decode: {e}"))?;
         if let Some(request) = stop.request() {
@@ -185,7 +193,8 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         if drain_dcutr_responder_events(&mut dcutr, role, &mut captured_remote_addrs) {
             break captured_remote_addrs.take().unwrap_or_default();
         }
-        let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
+        let data =
+            wait_user_stream_data(&mut swarm, role, &relay_peer_id, bridge_stream, deadline)?;
         dcutr
             .on_data(&data)
             .map_err(|e| format!("DCUtR decode: {e}"))?;
@@ -259,7 +268,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
                     break 'outer HolePunchOutcome::DirectConnected(peer_id);
                 }
             }
-            if is_bridge_closed_event(&ev, bridge_stream) {
+            if is_bridge_closed_event(&ev, &relay_peer_id, bridge_stream) {
                 break 'outer HolePunchOutcome::BridgeClosed;
             }
         }
@@ -408,14 +417,19 @@ fn any_source_matches(sources: &[Multiaddr], targets: &[(String, u16)]) -> bool 
         .any(|src| targets.iter().any(|tgt| &src == tgt))
 }
 
-fn is_bridge_closed_event(ev: &SwarmEvent, bridge_stream: StreamId) -> bool {
+fn is_bridge_closed_event(
+    ev: &SwarmEvent,
+    relay_peer_id: &PeerId,
+    bridge_stream: StreamId,
+) -> bool {
     matches!(
         ev,
-        SwarmEvent::UserStreamRemoteWriteClosed { stream_id, .. }
-            if *stream_id == bridge_stream
+        SwarmEvent::UserStreamRemoteWriteClosed { peer_id, stream_id }
+            if peer_id == relay_peer_id && *stream_id == bridge_stream
     ) || matches!(
         ev,
-        SwarmEvent::UserStreamClosed { stream_id, .. } if *stream_id == bridge_stream
+        SwarmEvent::UserStreamClosed { peer_id, stream_id }
+            if peer_id == relay_peer_id && *stream_id == bridge_stream
     )
 }
 
@@ -465,12 +479,19 @@ pub fn run_dial(
     let hop_stream = swarm
         .open_user_stream(&relay_peer_id, HOP_PROTOCOL_ID)
         .map_err(|e| format!("open HOP: {e}"))?;
-    wait_user_stream_ready(&mut swarm, role, hop_stream, deadline)?;
+    wait_user_stream_ready(
+        &mut swarm,
+        role,
+        &relay_peer_id,
+        hop_stream,
+        HOP_PROTOCOL_ID,
+        deadline,
+    )?;
     let mut hop = HopConnect::new(target.to_bytes());
     send(&mut swarm, &relay_peer_id, hop_stream, hop.take_outbound())?;
 
     while hop.outcome().is_none() {
-        let data = wait_user_stream_data(&mut swarm, role, hop_stream, deadline)?;
+        let data = wait_user_stream_data(&mut swarm, role, &relay_peer_id, hop_stream, deadline)?;
         hop.on_data(&data).map_err(|e| format!("HOP decode: {e}"))?;
     }
     match hop.outcome() {
@@ -516,7 +537,8 @@ pub fn run_dial(
             }
             break (remote_addrs, rtt_ms);
         }
-        let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
+        let data =
+            wait_user_stream_data(&mut swarm, role, &relay_peer_id, bridge_stream, deadline)?;
         let elapsed_ms = dcutr_sent_at.elapsed().as_millis() as u64;
         dcutr
             .on_data(&data, elapsed_ms)
@@ -569,7 +591,8 @@ pub fn run_dial(
         let sent_at = Instant::now();
         send(&mut swarm, &relay_peer_id, bridge_stream, payload.clone())?;
         loop {
-            let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
+            let data =
+                wait_user_stream_data(&mut swarm, role, &relay_peer_id, bridge_stream, deadline)?;
             if data == payload {
                 let rtt = sent_at.elapsed().as_millis();
                 println!("[{role}] ping-via-relay peer={target} rtt={rtt}ms -- done");
@@ -635,7 +658,8 @@ fn handle_autonat_request(
     let mut server = AutoNatServer::new();
     let request_deadline = Instant::now() + AUTONAT_REQUEST_DEADLINE;
     let request = loop {
-        let data = wait_user_stream_data(swarm, role, stream_id, request_deadline)?;
+        let data =
+            wait_user_stream_data(swarm, role, &requester_peer, stream_id, request_deadline)?;
         server
             .on_data(&data)
             .map_err(|e| format!("AutoNAT decode: {e}"))?;
@@ -820,11 +844,13 @@ fn wait_connected(
         .ok_or_else(|| format!("deadline exceeded before connection to {peer_id}").into())
 }
 
-/// Wait for a locally-initiated `UserStreamReady` on `stream_id`.
+/// Wait for a locally-initiated `UserStreamReady` on a specific peer stream.
 fn wait_user_stream_ready(
     swarm: &mut Swarm<QuicTransport>,
     role: &str,
+    peer_id: &PeerId,
     stream_id: StreamId,
+    protocol_id: &str,
     deadline: Instant,
 ) -> Result<(), Box<dyn Error>> {
     let found = swarm
@@ -833,17 +859,20 @@ fn wait_user_stream_ready(
             matches!(
                 ev,
                 SwarmEvent::UserStreamReady {
+                    peer_id: p,
                     stream_id: s,
+                    protocol_id: pid,
                     initiated_locally: true,
-                    ..
-                } if *s == stream_id
+                } if p == peer_id && *s == stream_id && pid == protocol_id
             ) || matches!(
                 ev,
-                SwarmEvent::UserStreamClosed { stream_id: s, .. } if *s == stream_id
+                SwarmEvent::UserStreamClosed { peer_id: p, stream_id: s }
+                    if p == peer_id && *s == stream_id
             ) || matches!(
                 ev,
                 SwarmEvent::Error(error)
-                    if error.detail.contains(&format!("stream {stream_id}"))
+                    if error.peer_id.as_ref() == Some(peer_id)
+                        && error.detail.contains(&format!("stream {stream_id}"))
             )
         })
         .map_err(|e| format!("wait-user-stream-ready: {e}"))?;
@@ -892,11 +921,12 @@ fn wait_inbound_stream(
     Ok(stream_id)
 }
 
-/// Wait for the next `UserStreamData` event on `stream_id`, returning
-/// the data payload.
+/// Wait for the next `UserStreamData` event on a specific peer stream,
+/// returning the data payload.
 fn wait_user_stream_data(
     swarm: &mut Swarm<QuicTransport>,
     role: &str,
+    peer_id: &PeerId,
     stream_id: StreamId,
     deadline: Instant,
 ) -> Result<Vec<u8>, Box<dyn Error>> {
@@ -905,7 +935,8 @@ fn wait_user_stream_data(
             print_event(role, ev);
             matches!(
                 ev,
-                SwarmEvent::UserStreamData { stream_id: s, .. } if *s == stream_id
+                SwarmEvent::UserStreamData { peer_id: p, stream_id: s, .. }
+                    if p == peer_id && *s == stream_id
             )
         })
         .map_err(|e| format!("wait-user-stream-data: {e}"))?
@@ -1040,8 +1071,9 @@ fn relay_ping_fallback(
             print_event(role, ev);
             matches!(
                 ev,
-                SwarmEvent::UserStreamData { stream_id: s, .. } if *s == bridge_stream
-            ) || is_bridge_closed_event(ev, bridge_stream)
+                SwarmEvent::UserStreamData { peer_id, stream_id: s, .. }
+                    if peer_id == relay_peer_id && *s == bridge_stream
+            ) || is_bridge_closed_event(ev, relay_peer_id, bridge_stream)
         })
         .map_err(|e| format!("fallback poll: {e}"))?;
 
@@ -1372,14 +1404,21 @@ fn validate_candidates_with_autonat(
         Instant::now() + autonat_probe_timeout(&probe_candidates),
         deadline,
     );
-    wait_user_stream_ready(swarm, role, stream_id, request_deadline)?;
+    wait_user_stream_ready(
+        swarm,
+        role,
+        &service_peer,
+        stream_id,
+        AUTONAT_PROTOCOL_ID,
+        request_deadline,
+    )?;
 
     let local_peer = swarm.local_peer_id().clone();
     let mut client = AutoNatClient::new(&local_peer, &probe_candidates);
     send(swarm, &service_peer, stream_id, client.take_outbound())?;
 
     while client.outcome().is_none() {
-        let data = wait_user_stream_data(swarm, role, stream_id, request_deadline)?;
+        let data = wait_user_stream_data(swarm, role, &service_peer, stream_id, request_deadline)?;
         client
             .on_data(&data)
             .map_err(|e| format!("AutoNAT decode: {e}"))?;

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -39,8 +39,9 @@ use crate::runtime::{bind_addr, load_keypair};
 
 const AGENT: &str = "minip2p-peer/0.1.0";
 /// Top-level deadline: the whole reservation + circuit + hole-punch
-/// flow should complete well inside this on a local relay.
-const LISTEN_DEADLINE: Duration = Duration::from_secs(60);
+/// flow should complete inside this even when AutoNAT has several
+/// candidates to probe before the relay circuit is opened.
+const LISTEN_DEADLINE: Duration = Duration::from_secs(120);
 /// Hole-punch window after SYNC is received / sent.
 ///
 /// Direct dials succeed in milliseconds on LAN/loopback; real-world NATs may
@@ -55,7 +56,6 @@ const HOLEPUNCH_INTERVAL_MAX_MS: u64 = 200;
 const RESPONDER_SYNC_DELAY: Duration = Duration::from_millis(50);
 /// Payload length used by the relay-ping fallback.
 const RELAY_PING_LEN: usize = 32;
-const AUTONAT_CLIENT_DEADLINE: Duration = Duration::from_secs(20);
 const AUTONAT_IDENTIFY_GRACE: Duration = Duration::from_secs(2);
 const AUTONAT_REQUEST_DEADLINE: Duration = Duration::from_secs(5);
 // Client deadline must absorb candidate_count * binds_per_candidate * dialback
@@ -101,7 +101,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         role,
         &options,
         &initial_candidates,
-        Instant::now() + AUTONAT_CLIENT_DEADLINE,
+        deadline,
     )?;
     print_candidates(role, &our_observed);
 
@@ -288,11 +288,18 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     // --- 7. Resolve based on the hole-punch outcome -------------------------
     match outcome {
         HolePunchOutcome::DirectConnected(peer_id) => {
-            print_direct_path_summary(role, "hole-punch-success", &remote_paths);
-            println!("[{role}] direct-connected peer={peer_id} (hole-punch success)");
-            ping_and_exit(&mut swarm, role, peer_id, deadline)
+            print_direct_path_summary(role, "hole-punch-attempts", &remote_paths);
+            println!("[{role}] direct-connected peer={peer_id} (hole-punch success) -- done");
+            Ok(())
         }
         HolePunchOutcome::InboundConnectionSeen => {
+            if swarm.connected_peers().iter().any(|p| p == &remote_peer_id) {
+                println!(
+                    "[{role}] direct-connected peer={remote_peer_id} (mTLS already verified) -- done"
+                );
+                return Ok(());
+            }
+
             // The address heuristic fired before Swarm surfaced the verified
             // mTLS identity. Give QUIC one short grace window to complete the
             // identity event so this side can direct-ping too.
@@ -309,8 +316,8 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
                 .map_err(|e| format!("grace poll: {e}"))?;
             match verified {
                 Some(SwarmEvent::ConnectionEstablished { peer_id }) => {
-                    println!("[{role}] direct-connected peer={peer_id} (mTLS verified)");
-                    ping_and_exit(&mut swarm, role, peer_id, deadline)
+                    println!("[{role}] direct-connected peer={peer_id} (mTLS verified) -- done");
+                    Ok(())
                 }
                 _ => {
                     println!("[{role}] grace-elapsed before mTLS identity -> relay-ping fallback");
@@ -450,7 +457,7 @@ pub fn run_dial(
         role,
         &options,
         &initial_candidates,
-        Instant::now() + AUTONAT_CLIENT_DEADLINE,
+        deadline,
     )?;
     print_candidates(role, &our_observed);
 
@@ -1008,7 +1015,7 @@ fn wait_for_direct_with_udp_blast(
         for ev in swarm.poll().map_err(|e| format!("holepunch poll: {e}"))? {
             print_event(role, &ev);
             if matches!(&ev, SwarmEvent::ConnectionEstablished { peer_id: p } if p == peer_id) {
-                print_direct_path_summary(role, "hole-punch-success", paths);
+                print_direct_path_summary(role, "hole-punch-attempts", paths);
                 return Ok(true);
             }
         }
@@ -1361,14 +1368,18 @@ fn validate_candidates_with_autonat(
     let stream_id = swarm
         .open_user_stream(&service_peer, AUTONAT_PROTOCOL_ID)
         .map_err(|e| format!("open AutoNAT stream: {e}"))?;
-    wait_user_stream_ready(swarm, role, stream_id, deadline)?;
+    let request_deadline = earlier_deadline(
+        Instant::now() + autonat_probe_timeout(&probe_candidates),
+        deadline,
+    );
+    wait_user_stream_ready(swarm, role, stream_id, request_deadline)?;
 
     let local_peer = swarm.local_peer_id().clone();
     let mut client = AutoNatClient::new(&local_peer, &probe_candidates);
     send(swarm, &service_peer, stream_id, client.take_outbound())?;
 
     while client.outcome().is_none() {
-        let data = wait_user_stream_data(swarm, role, stream_id, deadline)?;
+        let data = wait_user_stream_data(swarm, role, stream_id, request_deadline)?;
         client
             .on_data(&data)
             .map_err(|e| format!("AutoNAT decode: {e}"))?;
@@ -1399,6 +1410,15 @@ fn validate_candidates_with_autonat(
             Ok(probe_candidates)
         }
     }
+}
+
+fn autonat_probe_timeout(candidates: &[Multiaddr]) -> Duration {
+    let dialback_budget = candidates
+        .iter()
+        .map(|addr| dialback_bind_addrs(addr).len() as u32)
+        .sum::<u32>()
+        .max(1);
+    AUTONAT_REQUEST_DEADLINE + AUTONAT_DIALBACK_DEADLINE * dialback_budget
 }
 
 fn successful_candidates_in_original_order(
@@ -1527,6 +1547,21 @@ mod tests {
         assert_eq!(dialback_bind_addrs(&dns4), &["0.0.0.0:0"]);
         assert_eq!(dialback_bind_addrs(&ip6), &["[::]:0"]);
         assert_eq!(dialback_bind_addrs(&dns6), &["[::]:0"]);
+    }
+
+    #[test]
+    fn autonat_probe_timeout_scales_with_candidates_and_bind_families() {
+        let ip4 = Multiaddr::from_str("/ip4/203.0.113.7/udp/4001/quic-v1").unwrap();
+        let dns = Multiaddr::from_str("/dns/example.com/udp/4001/quic-v1").unwrap();
+
+        assert_eq!(
+            autonat_probe_timeout(&[ip4]),
+            AUTONAT_REQUEST_DEADLINE + AUTONAT_DIALBACK_DEADLINE
+        );
+        assert_eq!(
+            autonat_probe_timeout(&[dns]),
+            AUTONAT_REQUEST_DEADLINE + AUTONAT_DIALBACK_DEADLINE * 2
+        );
     }
 
     #[test]

--- a/examples/peer/src/runtime.rs
+++ b/examples/peer/src/runtime.rs
@@ -2,7 +2,7 @@
 
 use std::error::Error;
 use std::fs;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::path::Path;
 
 use minip2p_core::{Multiaddr, Protocol};
@@ -50,6 +50,94 @@ pub fn bind_addr(options: &RunOptions) -> Result<String, Box<dyn Error>> {
         Some(addr) => multiaddr_to_socket_addr(addr).map(|addr| addr.to_string()),
         None => Ok(DEFAULT_BIND.into()),
     }
+}
+
+/// Returns global IPv6 interface addresses using the UDP port from `bound_transport`.
+///
+/// This is std-only CLI glue for DCUtR experiments. Core remains transport and
+/// platform agnostic; the example merely turns local interface information into
+/// extra direct candidates when the user binds an IPv6 socket.
+pub fn local_global_ipv6_quic_addrs(bound_transport: &Multiaddr) -> Vec<Multiaddr> {
+    if !matches!(bound_transport.protocols().first(), Some(Protocol::Ip6(_))) {
+        return Vec::new();
+    }
+
+    let Some(port) = udp_port(bound_transport) else {
+        return Vec::new();
+    };
+
+    local_global_ipv6_addrs()
+        .into_iter()
+        .map(|ip| ipv6_quic_addr(ip, port))
+        .collect()
+}
+
+fn ipv6_quic_addr(ip: Ipv6Addr, port: u16) -> Multiaddr {
+    Multiaddr::from_protocols(vec![
+        Protocol::Ip6(ip.octets()),
+        Protocol::Udp(port),
+        Protocol::QuicV1,
+    ])
+}
+
+fn udp_port(addr: &Multiaddr) -> Option<u16> {
+    addr.protocols().iter().find_map(|protocol| match protocol {
+        Protocol::Udp(port) => Some(*port),
+        _ => None,
+    })
+}
+
+#[cfg(unix)]
+fn local_global_ipv6_addrs() -> Vec<Ipv6Addr> {
+    let mut head = std::ptr::null_mut();
+    let rc = unsafe { libc::getifaddrs(&mut head) };
+    if rc != 0 || head.is_null() {
+        return Vec::new();
+    }
+
+    struct IfAddrsGuard(*mut libc::ifaddrs);
+    impl Drop for IfAddrsGuard {
+        fn drop(&mut self) {
+            unsafe { libc::freeifaddrs(self.0) };
+        }
+    }
+    let _guard = IfAddrsGuard(head);
+
+    let mut addrs = Vec::new();
+    let mut cursor = head;
+    while !cursor.is_null() {
+        let ifaddr = unsafe { &*cursor };
+        if !ifaddr.ifa_addr.is_null() {
+            let family = unsafe { (*ifaddr.ifa_addr).sa_family as i32 };
+            if family == libc::AF_INET6 {
+                let sockaddr = unsafe { &*(ifaddr.ifa_addr as *const libc::sockaddr_in6) };
+                let ip = Ipv6Addr::from(sockaddr.sin6_addr.s6_addr);
+                if is_global_unicast_ipv6(&ip) && !addrs.iter().any(|existing| existing == &ip) {
+                    addrs.push(ip);
+                }
+            }
+        }
+        cursor = ifaddr.ifa_next;
+    }
+
+    addrs
+}
+
+#[cfg(not(unix))]
+fn local_global_ipv6_addrs() -> Vec<Ipv6Addr> {
+    Vec::new()
+}
+
+fn is_global_unicast_ipv6(ip: &Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    let first = segments[0];
+
+    !ip.is_unspecified()
+        && !ip.is_loopback()
+        && !ip.is_multicast()
+        && (first & 0xffc0) != 0xfe80
+        && (first & 0xfe00) != 0xfc00
+        && !(segments[0] == 0x2001 && segments[1] == 0x0db8)
 }
 
 fn write_secret(
@@ -131,5 +219,41 @@ fn hex_value(byte: u8) -> Result<u8, String> {
         b'a'..=b'f' => Ok(byte - b'a' + 10),
         b'A'..=b'F' => Ok(byte - b'A' + 10),
         _ => Err(format!("non-hex byte 0x{byte:02x}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn local_ipv6_candidates_use_bound_udp_port() {
+        let bound = Multiaddr::from_str("/ip6/::/udp/4242/quic-v1").unwrap();
+        let candidate = ipv6_quic_addr(Ipv6Addr::LOCALHOST, udp_port(&bound).unwrap());
+
+        assert_eq!(candidate.to_string(), "/ip6/::1/udp/4242/quic-v1");
+    }
+
+    #[test]
+    fn global_ipv6_filter_skips_non_public_ranges() {
+        assert!(!is_global_unicast_ipv6(&Ipv6Addr::UNSPECIFIED));
+        assert!(!is_global_unicast_ipv6(&Ipv6Addr::LOCALHOST));
+        assert!(!is_global_unicast_ipv6(
+            &Ipv6Addr::from_str("fe80::1").unwrap()
+        ));
+        assert!(!is_global_unicast_ipv6(
+            &Ipv6Addr::from_str("fd00::1").unwrap()
+        ));
+        assert!(!is_global_unicast_ipv6(
+            &Ipv6Addr::from_str("ff02::1").unwrap()
+        ));
+        assert!(!is_global_unicast_ipv6(
+            &Ipv6Addr::from_str("2001:db8::1").unwrap()
+        ));
+        assert!(is_global_unicast_ipv6(
+            &Ipv6Addr::from_str("2001:4860:4860::8888").unwrap()
+        ));
     }
 }

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -30,6 +30,8 @@ const STUN_HEADER_LEN: usize = 20;
 const STUN_TRANSACTION_ID_LEN: usize = 12;
 const STUN_ATTR_MAPPED_ADDRESS: u16 = 0x0001;
 const STUN_ATTR_XOR_MAPPED_ADDRESS: u16 = 0x0020;
+const STUN_ATTR_SOFTWARE: u16 = 0x8022;
+const STUN_SOFTWARE: &[u8] = b"tailnode";
 const MAX_BUFFERED_UDP_DATAGRAMS: usize = 256;
 
 /// Parses a QUIC multiaddr into (host protocol, port), validating the /host/udp/port/quic-v1 shape.
@@ -583,11 +585,18 @@ impl QuicTransport {
     }
 }
 
-fn stun_binding_request(transaction_id: [u8; STUN_TRANSACTION_ID_LEN]) -> [u8; STUN_HEADER_LEN] {
-    let mut out = [0u8; STUN_HEADER_LEN];
+fn stun_binding_request(transaction_id: [u8; STUN_TRANSACTION_ID_LEN]) -> Vec<u8> {
+    let attr_len = STUN_SOFTWARE.len();
+    let attr_padding = padding_for(attr_len);
+    let msg_len = 4 + attr_len + attr_padding;
+    let mut out = vec![0u8; STUN_HEADER_LEN + msg_len];
     out[..2].copy_from_slice(&STUN_BINDING_REQUEST.to_be_bytes());
+    out[2..4].copy_from_slice(&(msg_len as u16).to_be_bytes());
     out[4..8].copy_from_slice(&STUN_MAGIC_COOKIE.to_be_bytes());
-    out[8..].copy_from_slice(&transaction_id);
+    out[8..20].copy_from_slice(&transaction_id);
+    out[20..22].copy_from_slice(&STUN_ATTR_SOFTWARE.to_be_bytes());
+    out[22..24].copy_from_slice(&(attr_len as u16).to_be_bytes());
+    out[24..24 + attr_len].copy_from_slice(STUN_SOFTWARE);
     out
 }
 
@@ -764,6 +773,31 @@ mod stun_tests {
     }
 
     #[test]
+    fn binding_request_includes_software_attribute_for_derp_stun() {
+        let transaction_id = [3u8; STUN_TRANSACTION_ID_LEN];
+        let request = stun_binding_request(transaction_id);
+
+        assert_eq!(
+            u16::from_be_bytes([request[0], request[1]]),
+            STUN_BINDING_REQUEST
+        );
+        assert_eq!(
+            u16::from_be_bytes([request[2], request[3]]) as usize,
+            request.len() - STUN_HEADER_LEN
+        );
+        assert_eq!(&request[8..20], &transaction_id);
+        assert_eq!(
+            u16::from_be_bytes([request[20], request[21]]),
+            STUN_ATTR_SOFTWARE
+        );
+        assert_eq!(
+            u16::from_be_bytes([request[22], request[23]]) as usize,
+            STUN_SOFTWARE.len()
+        );
+        assert_eq!(&request[24..24 + STUN_SOFTWARE.len()], STUN_SOFTWARE);
+    }
+
+    #[test]
     fn stun_probe_buffers_unmatched_datagrams() {
         let keypair = minip2p_identity::Ed25519Keypair::generate();
         let mut transport =
@@ -773,9 +807,9 @@ mod stun_tests {
         let server_addr = server.local_addr().unwrap();
 
         let handle = std::thread::spawn(move || {
-            let mut request = [0u8; STUN_HEADER_LEN];
+            let mut request = [0u8; 128];
             let (n, from) = server.recv_from(&mut request).unwrap();
-            assert_eq!(n, STUN_HEADER_LEN);
+            assert!(n >= STUN_HEADER_LEN);
             assert_eq!(from, transport_addr);
             server.send_to(b"not-stun", from).unwrap();
 

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -3,7 +3,7 @@
 //! Implements [`Transport`] with a poll-driven, non-blocking UDP socket.
 //! No async runtime required.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs, UdpSocket};
 use std::time::{Duration, Instant};
 
@@ -30,6 +30,7 @@ const STUN_HEADER_LEN: usize = 20;
 const STUN_TRANSACTION_ID_LEN: usize = 12;
 const STUN_ATTR_MAPPED_ADDRESS: u16 = 0x0001;
 const STUN_ATTR_XOR_MAPPED_ADDRESS: u16 = 0x0020;
+const MAX_BUFFERED_UDP_DATAGRAMS: usize = 256;
 
 /// Parses a QUIC multiaddr into (host protocol, port), validating the /host/udp/port/quic-v1 shape.
 fn extract_quic_host_and_port(
@@ -277,6 +278,8 @@ pub struct QuicTransport {
     peer_connections: HashMap<PeerId, BTreeSet<ConnectionId>>,
     /// Events queued between poll() calls.
     pending_events: Vec<TransportEvent>,
+    /// Non-STUN datagrams seen while running a synchronous STUN probe.
+    buffered_datagrams: VecDeque<(Vec<u8>, SocketAddr)>,
     /// The socket address we're listening on, if any.
     listen_addr: Option<SocketAddr>,
     /// Auto-incrementing connection id counter.
@@ -307,6 +310,7 @@ impl QuicTransport {
             cid_to_connection: HashMap::new(),
             peer_connections: HashMap::new(),
             pending_events: Vec::new(),
+            buffered_datagrams: VecDeque::new(),
             listen_addr: None,
             next_connection_id: 1,
             node_config,
@@ -347,21 +351,26 @@ impl QuicTransport {
     /// advertised or confirmed; callers decide whether to feed it into DCUtR,
     /// AutoNAT, or an external-address book.
     pub fn discover_external_addr_stun(
-        &self,
+        &mut self,
         server: &str,
         timeout: Duration,
     ) -> Result<Multiaddr, TransportError> {
-        let server_addr = server
-            .to_socket_addrs()
-            .map_err(|e| TransportError::InvalidAddress {
+        let local_addr = self.local_addr()?;
+        let mut resolved =
+            server
+                .to_socket_addrs()
+                .map_err(|e| TransportError::InvalidAddress {
+                    context: "stun server",
+                    reason: format!("resolution failed for {server}: {e}"),
+                })?;
+        let server_addr = select_stun_server_addr(&mut resolved, local_addr).ok_or_else(|| {
+            TransportError::InvalidAddress {
                 context: "stun server",
-                reason: format!("resolution failed for {server}: {e}"),
-            })?
-            .next()
-            .ok_or_else(|| TransportError::InvalidAddress {
-                context: "stun server",
-                reason: format!("resolution returned no usable address for {server}"),
-            })?;
+                reason: format!(
+                    "resolution returned no address matching local socket family for {server}"
+                ),
+            }
+        })?;
 
         let mut transaction_id = [0u8; STUN_TRANSACTION_ID_LEN];
         getrandom::fill(&mut transaction_id).map_err(|e| TransportError::PollError {
@@ -376,13 +385,14 @@ impl QuicTransport {
             })?;
 
         let deadline = Instant::now() + timeout;
-        let mut buf = [0u8; 1500];
+        let mut buf = [0u8; 65535];
         loop {
             match self.socket.recv_from(&mut buf) {
-                Ok((n, _)) => {
+                Ok((n, from)) => {
                     if let Some(addr) = parse_stun_binding_response(&buf[..n], &transaction_id) {
                         return Ok(socket_addr_to_multiaddr(addr));
                     }
+                    self.buffer_udp_datagram(buf[..n].to_vec(), from);
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     if Instant::now() >= deadline {
@@ -537,6 +547,40 @@ impl QuicTransport {
             self.remove_peer_connection(&peer_id, id);
         }
     }
+
+    fn buffer_udp_datagram(&mut self, data: Vec<u8>, from: SocketAddr) {
+        if self.buffered_datagrams.len() >= MAX_BUFFERED_UDP_DATAGRAMS {
+            self.buffered_datagrams.pop_front();
+        }
+        self.buffered_datagrams.push_back((data, from));
+    }
+
+    fn recv_udp_datagram(
+        &mut self,
+        buf: &mut [u8],
+    ) -> Result<Option<(usize, SocketAddr)>, TransportError> {
+        if let Some((data, from)) = self.buffered_datagrams.pop_front() {
+            if data.len() > buf.len() {
+                return Err(TransportError::PollError {
+                    reason: format!(
+                        "buffered udp datagram too large: {} > {}",
+                        data.len(),
+                        buf.len()
+                    ),
+                });
+            }
+            buf[..data.len()].copy_from_slice(&data);
+            return Ok(Some((data.len(), from)));
+        }
+
+        match self.socket.recv_from(buf) {
+            Ok(v) => Ok(Some(v)),
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+            Err(e) => Err(TransportError::PollError {
+                reason: format!("udp recv error: {e}"),
+            }),
+        }
+    }
 }
 
 fn stun_binding_request(transaction_id: [u8; STUN_TRANSACTION_ID_LEN]) -> [u8; STUN_HEADER_LEN] {
@@ -545,6 +589,15 @@ fn stun_binding_request(transaction_id: [u8; STUN_TRANSACTION_ID_LEN]) -> [u8; S
     out[4..8].copy_from_slice(&STUN_MAGIC_COOKIE.to_be_bytes());
     out[8..].copy_from_slice(&transaction_id);
     out
+}
+
+fn select_stun_server_addr(
+    addrs: impl IntoIterator<Item = SocketAddr>,
+    local_addr: SocketAddr,
+) -> Option<SocketAddr> {
+    addrs
+        .into_iter()
+        .find(|addr| addr.is_ipv4() == local_addr.is_ipv4())
 }
 
 fn parse_stun_binding_response(
@@ -696,6 +749,51 @@ mod stun_tests {
         let parsed = parse_stun_binding_response(&response, &transaction_id).unwrap();
 
         assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn selects_stun_server_matching_bound_socket_family() {
+        let resolved = [
+            SocketAddr::from(([0x2001, 0x0db8, 0, 0, 0, 0, 0, 1], 3478)),
+            SocketAddr::from(([203, 0, 113, 10], 3478)),
+        ];
+
+        let selected = select_stun_server_addr(resolved, SocketAddr::from(([0, 0, 0, 0], 0)));
+
+        assert_eq!(selected, Some(SocketAddr::from(([203, 0, 113, 10], 3478))));
+    }
+
+    #[test]
+    fn stun_probe_buffers_unmatched_datagrams() {
+        let keypair = minip2p_identity::Ed25519Keypair::generate();
+        let mut transport =
+            QuicTransport::new(QuicNodeConfig::new(keypair), "127.0.0.1:0").unwrap();
+        let transport_addr = transport.local_addr().unwrap();
+        let server = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let server_addr = server.local_addr().unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let mut request = [0u8; STUN_HEADER_LEN];
+            let (n, from) = server.recv_from(&mut request).unwrap();
+            assert_eq!(n, STUN_HEADER_LEN);
+            assert_eq!(from, transport_addr);
+            server.send_to(b"not-stun", from).unwrap();
+
+            let mut transaction_id = [0u8; STUN_TRANSACTION_ID_LEN];
+            transaction_id.copy_from_slice(&request[8..20]);
+            let response = stun_response_with_xor_mapped_ipv4(transaction_id, from);
+            server.send_to(&response, from).unwrap();
+        });
+
+        let discovered = transport
+            .discover_external_addr_stun(&server_addr.to_string(), Duration::from_secs(1))
+            .unwrap();
+
+        handle.join().unwrap();
+        assert_eq!(discovered, socket_addr_to_multiaddr(transport_addr));
+        let (data, from) = transport.buffered_datagrams.pop_front().unwrap();
+        assert_eq!(data, b"not-stun");
+        assert_eq!(from, server_addr);
     }
 
     fn stun_response_with_xor_mapped_ipv4(
@@ -903,14 +1001,8 @@ impl Transport for QuicTransport {
         let mut events = std::mem::take(&mut self.pending_events);
 
         loop {
-            let (len, from) = match self.socket.recv_from(&mut buf) {
-                Ok(v) => v,
-                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
-                Err(e) => {
-                    return Err(TransportError::PollError {
-                        reason: format!("udp recv error: {e}"),
-                    });
-                }
+            let Some((len, from)) = self.recv_udp_datagram(&mut buf)? else {
+                break;
             };
 
             let local_addr = self.local_addr()?;

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -5,6 +5,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs, UdpSocket};
+use std::time::{Duration, Instant};
 
 use boring::pkey::PKey;
 use boring::ssl::{SslContextBuilder, SslMethod, SslVerifyMode};
@@ -21,6 +22,14 @@ mod connection;
 pub use config::QuicNodeConfig;
 
 use connection::QuicConnection;
+
+const STUN_BINDING_REQUEST: u16 = 0x0001;
+const STUN_BINDING_SUCCESS_RESPONSE: u16 = 0x0101;
+const STUN_MAGIC_COOKIE: u32 = 0x2112_a442;
+const STUN_HEADER_LEN: usize = 20;
+const STUN_TRANSACTION_ID_LEN: usize = 12;
+const STUN_ATTR_MAPPED_ADDRESS: u16 = 0x0001;
+const STUN_ATTR_XOR_MAPPED_ADDRESS: u16 = 0x0020;
 
 /// Parses a QUIC multiaddr into (host protocol, port), validating the /host/udp/port/quic-v1 shape.
 fn extract_quic_host_and_port(
@@ -331,6 +340,67 @@ impl QuicTransport {
         Ok(())
     }
 
+    /// Sends a STUN binding request from this transport's UDP socket and
+    /// returns the discovered external QUIC multiaddr.
+    ///
+    /// This is a std/runtime helper. The STUN result is not automatically
+    /// advertised or confirmed; callers decide whether to feed it into DCUtR,
+    /// AutoNAT, or an external-address book.
+    pub fn discover_external_addr_stun(
+        &self,
+        server: &str,
+        timeout: Duration,
+    ) -> Result<Multiaddr, TransportError> {
+        let server_addr = server
+            .to_socket_addrs()
+            .map_err(|e| TransportError::InvalidAddress {
+                context: "stun server",
+                reason: format!("resolution failed for {server}: {e}"),
+            })?
+            .next()
+            .ok_or_else(|| TransportError::InvalidAddress {
+                context: "stun server",
+                reason: format!("resolution returned no usable address for {server}"),
+            })?;
+
+        let mut transaction_id = [0u8; STUN_TRANSACTION_ID_LEN];
+        getrandom::fill(&mut transaction_id).map_err(|e| TransportError::PollError {
+            reason: format!("failed to generate STUN transaction id: {e}"),
+        })?;
+
+        let request = stun_binding_request(transaction_id);
+        self.socket
+            .send_to(&request, server_addr)
+            .map_err(|e| TransportError::PollError {
+                reason: format!("STUN send to {server_addr} failed: {e}"),
+            })?;
+
+        let deadline = Instant::now() + timeout;
+        let mut buf = [0u8; 1500];
+        loop {
+            match self.socket.recv_from(&mut buf) {
+                Ok((n, _)) => {
+                    if let Some(addr) = parse_stun_binding_response(&buf[..n], &transaction_id) {
+                        return Ok(socket_addr_to_multiaddr(addr));
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        return Err(TransportError::PollError {
+                            reason: format!("STUN timeout waiting for {server_addr}"),
+                        });
+                    }
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                Err(e) => {
+                    return Err(TransportError::PollError {
+                        reason: format!("STUN receive failed: {e}"),
+                    });
+                }
+            }
+        }
+    }
+
     /// Exposes the bound local socket address as a multiaddr for external use.
     pub fn local_multiaddr(&self) -> Result<Multiaddr, TransportError> {
         Ok(socket_addr_to_multiaddr(self.local_addr()?))
@@ -466,6 +536,193 @@ impl QuicTransport {
         if let Some(peer_id) = peer_id {
             self.remove_peer_connection(&peer_id, id);
         }
+    }
+}
+
+fn stun_binding_request(transaction_id: [u8; STUN_TRANSACTION_ID_LEN]) -> [u8; STUN_HEADER_LEN] {
+    let mut out = [0u8; STUN_HEADER_LEN];
+    out[..2].copy_from_slice(&STUN_BINDING_REQUEST.to_be_bytes());
+    out[4..8].copy_from_slice(&STUN_MAGIC_COOKIE.to_be_bytes());
+    out[8..].copy_from_slice(&transaction_id);
+    out
+}
+
+fn parse_stun_binding_response(
+    bytes: &[u8],
+    transaction_id: &[u8; STUN_TRANSACTION_ID_LEN],
+) -> Option<SocketAddr> {
+    if bytes.len() < STUN_HEADER_LEN {
+        return None;
+    }
+    let msg_type = u16::from_be_bytes([bytes[0], bytes[1]]);
+    if msg_type != STUN_BINDING_SUCCESS_RESPONSE {
+        return None;
+    }
+    let msg_len = u16::from_be_bytes([bytes[2], bytes[3]]) as usize;
+    if u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]) != STUN_MAGIC_COOKIE {
+        return None;
+    }
+    if &bytes[8..20] != transaction_id {
+        return None;
+    }
+    let end = STUN_HEADER_LEN.checked_add(msg_len)?;
+    if end > bytes.len() {
+        return None;
+    }
+
+    let mut offset = STUN_HEADER_LEN;
+    while offset + 4 <= end {
+        let attr_type = u16::from_be_bytes([bytes[offset], bytes[offset + 1]]);
+        let attr_len = u16::from_be_bytes([bytes[offset + 2], bytes[offset + 3]]) as usize;
+        offset += 4;
+        let attr_end = offset.checked_add(attr_len)?;
+        if attr_end > end {
+            return None;
+        }
+        let attr = &bytes[offset..attr_end];
+        match attr_type {
+            STUN_ATTR_XOR_MAPPED_ADDRESS => {
+                if let Some(addr) = parse_stun_address(attr, true, transaction_id) {
+                    return Some(addr);
+                }
+            }
+            STUN_ATTR_MAPPED_ADDRESS => {
+                if let Some(addr) = parse_stun_address(attr, false, transaction_id) {
+                    return Some(addr);
+                }
+            }
+            _ => {}
+        }
+        offset = attr_end + padding_for(attr_len);
+    }
+
+    None
+}
+
+fn parse_stun_address(
+    bytes: &[u8],
+    xor: bool,
+    transaction_id: &[u8; STUN_TRANSACTION_ID_LEN],
+) -> Option<SocketAddr> {
+    if bytes.len() < 4 || bytes[0] != 0 {
+        return None;
+    }
+    let family = bytes[1];
+    let mut port = u16::from_be_bytes([bytes[2], bytes[3]]);
+    if xor {
+        port ^= (STUN_MAGIC_COOKIE >> 16) as u16;
+    }
+
+    match family {
+        0x01 => {
+            if bytes.len() < 8 {
+                return None;
+            }
+            let mut ip = [bytes[4], bytes[5], bytes[6], bytes[7]];
+            if xor {
+                let cookie = STUN_MAGIC_COOKIE.to_be_bytes();
+                for (byte, mask) in ip.iter_mut().zip(cookie) {
+                    *byte ^= mask;
+                }
+            }
+            Some(SocketAddr::new(IpAddr::from(ip), port))
+        }
+        0x02 => {
+            if bytes.len() < 20 {
+                return None;
+            }
+            let mut ip = [0u8; 16];
+            ip.copy_from_slice(&bytes[4..20]);
+            if xor {
+                let cookie = STUN_MAGIC_COOKIE.to_be_bytes();
+                for idx in 0..4 {
+                    ip[idx] ^= cookie[idx];
+                }
+                for idx in 0..STUN_TRANSACTION_ID_LEN {
+                    ip[idx + 4] ^= transaction_id[idx];
+                }
+            }
+            Some(SocketAddr::new(IpAddr::from(ip), port))
+        }
+        _ => None,
+    }
+}
+
+fn padding_for(len: usize) -> usize {
+    (4 - (len % 4)) % 4
+}
+
+#[cfg(test)]
+mod stun_tests {
+    use super::*;
+
+    #[test]
+    fn parses_xor_mapped_ipv4_response() {
+        let transaction_id = [7u8; STUN_TRANSACTION_ID_LEN];
+        let expected = SocketAddr::from(([203, 0, 113, 7], 4242));
+        let response = stun_response_with_xor_mapped_ipv4(transaction_id, expected);
+
+        let parsed = parse_stun_binding_response(&response, &transaction_id).unwrap();
+
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn ignores_response_with_wrong_transaction_id() {
+        let transaction_id = [7u8; STUN_TRANSACTION_ID_LEN];
+        let response = stun_response_with_xor_mapped_ipv4(
+            transaction_id,
+            SocketAddr::from(([203, 0, 113, 7], 4242)),
+        );
+
+        assert!(parse_stun_binding_response(&response, &[8u8; STUN_TRANSACTION_ID_LEN]).is_none());
+    }
+
+    #[test]
+    fn parses_mapped_ipv4_response_fallback() {
+        let transaction_id = [9u8; STUN_TRANSACTION_ID_LEN];
+        let expected = SocketAddr::from(([198, 51, 100, 12], 3478));
+        let mut response = Vec::new();
+        response.extend_from_slice(&STUN_BINDING_SUCCESS_RESPONSE.to_be_bytes());
+        response.extend_from_slice(&12u16.to_be_bytes());
+        response.extend_from_slice(&STUN_MAGIC_COOKIE.to_be_bytes());
+        response.extend_from_slice(&transaction_id);
+        response.extend_from_slice(&STUN_ATTR_MAPPED_ADDRESS.to_be_bytes());
+        response.extend_from_slice(&8u16.to_be_bytes());
+        response.extend_from_slice(&[0, 1]);
+        response.extend_from_slice(&expected.port().to_be_bytes());
+        response.extend_from_slice(&[198, 51, 100, 12]);
+
+        let parsed = parse_stun_binding_response(&response, &transaction_id).unwrap();
+
+        assert_eq!(parsed, expected);
+    }
+
+    fn stun_response_with_xor_mapped_ipv4(
+        transaction_id: [u8; STUN_TRANSACTION_ID_LEN],
+        addr: SocketAddr,
+    ) -> Vec<u8> {
+        let SocketAddr::V4(addr) = addr else {
+            panic!("test helper expects ipv4");
+        };
+        let cookie = STUN_MAGIC_COOKIE.to_be_bytes();
+        let xored_port = addr.port() ^ ((STUN_MAGIC_COOKIE >> 16) as u16);
+        let mut xored_ip = addr.ip().octets();
+        for idx in 0..4 {
+            xored_ip[idx] ^= cookie[idx];
+        }
+
+        let mut response = Vec::new();
+        response.extend_from_slice(&STUN_BINDING_SUCCESS_RESPONSE.to_be_bytes());
+        response.extend_from_slice(&12u16.to_be_bytes());
+        response.extend_from_slice(&STUN_MAGIC_COOKIE.to_be_bytes());
+        response.extend_from_slice(&transaction_id);
+        response.extend_from_slice(&STUN_ATTR_XOR_MAPPED_ADDRESS.to_be_bytes());
+        response.extend_from_slice(&8u16.to_be_bytes());
+        response.extend_from_slice(&[0, 1]);
+        response.extend_from_slice(&xored_port.to_be_bytes());
+        response.extend_from_slice(&xored_ip);
+        response
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds external address discovery/confirmation, a direct-path manager, and STUN-based candidate discovery to improve DCUtR reliability. Swarm now advertises confirmed addresses, prioritizes them when dialing, buffers non-STUN UDP during STUN probing, refreshes the relay after discovery, tightens relay stream event matching, redials direct paths during the hole‑punch window, verifies listener-side direct punches with a ping, and clarifies direct path logs.

- **New Features**
  - Core: `ExternalAddressBook` (sources: Manual, IdentifyObserved, AutoNat, PortMapped, Stun; cap 20; candidate/confirmed views) and `DirectPathBook` (sources incl. Dcutr; statuses Unknown/Dialing/Open/Inactive/Failed; attempts + retry timing; cap 30; evicts failed first; clearer path summaries in logs).
  - Candidates: `DirectCandidateSource::Manual` → `ConfirmedExternal`; selector priority = confirmed external > Identify observed > local listen.
  - Swarm API/events: `external_addresses`, `external_address_candidates`, `add_external_address`, `confirm_external_address`, `remove_external_address`; events `ExternalAddrCandidate`, `ExternalAddrConfirmed`, `ExternalAddrExpired`. Identify parses `observed_addr` as candidates; advertised addrs = local listen + confirmed externals.
  - QUIC: `discover_external_addr_stun(server, timeout)` selects a server matching the local socket family, supports XOR-MAPPED/MAPPED, buffers non-STUN UDP during the probe, and adds a SOFTWARE attribute for better STUN/DERP interop.
  - Examples: CLI adds `--stun`; registers manual externals; confirms AutoNAT successes and includes Identify‑observed from the AutoNAT server; refreshes the relay after discovery to include updated relay‑observed addresses; hole‑punch widened to 10s with jittered UDP blasts and periodic direct redials; dialing/wait uses `DirectPathBook` with attempt gating and path summaries; AutoNAT request timeout scales with candidate/bind counts and waits briefly for Identify; tighter stream event matching to peer/stream/protocol; clean exit on direct success with a direct ping on both sides; adds global IPv6 interface QUIC candidates when bound to IPv6.

- **Migration**
  - `select_direct_candidates` now takes confirmed external addresses as its first arg (renamed from `manual`). Use `swarm.external_addresses()` and map to `Multiaddr`, or populate via `add_external_address`/`confirm_external_address`.

<sup>Written for commit 616e15a22d4101af847831d5d99a9f02b82c8057. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

