### PR TITLE
Sans I/O changes

### DIFF
--- a/crates/autonat/README.md
+++ b/crates/autonat/README.md
@@ -22,16 +22,27 @@ Runtime adapters or applications perform dial-back attempts and feed the result 
 ## Usage Sketch
 
 ```rust
-use minip2p_autonat::{AutoNatClient, AutoNatServer, Reachability};
+use minip2p_autonat::{
+    AutoNatClient, AutoNatClientOutput, AutoNatServer, AutoNatServerInput, AutoNatServerOutput,
+};
+use minip2p_core::SansIoProtocol;
 
 let mut client = AutoNatClient::new(&our_peer_id, &candidate_addrs);
-let outbound = client.take_outbound(); // send on an outbound AutoNAT stream
-
 let mut server = AutoNatServer::new();
-server.on_data(&outbound)?;
-if let Some(request) = server.request() {
-    // Runtime dials request.addrs for request.peer_id, then responds:
-    server.respond_public(&request.addrs);
+
+while let Some(AutoNatClientOutput::Outbound(bytes)) = client.poll_output() {
+    send_to_server(bytes);
+}
+
+server.handle_input(AutoNatServerInput::Data(bytes_from_client))?;
+while let Some(output) = server.poll_output() {
+    match output {
+        AutoNatServerOutput::DialBack(request) => {
+            // Runtime dials request.addrs for request.peer_id, then responds:
+            server.handle_input(AutoNatServerInput::RespondPublic { addrs: request.addrs })?;
+        }
+        AutoNatServerOutput::Outbound(bytes) => send_to_client(bytes),
+    }
 }
 ```
 

--- a/crates/autonat/src/lib.rs
+++ b/crates/autonat/src/lib.rs
@@ -13,7 +13,9 @@ extern crate alloc;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use minip2p_core::{Multiaddr, PeerId, VarintError, read_uvarint, uvarint_len, write_uvarint};
+use minip2p_core::{
+    Multiaddr, PeerId, SansIoProtocol, VarintError, read_uvarint, uvarint_len, write_uvarint,
+};
 
 /// Protocol id for AutoNAT v1.
 pub const AUTONAT_PROTOCOL_ID: &str = "/libp2p/autonat/1.0.0";
@@ -117,6 +119,51 @@ pub struct AutoNatRequest {
     pub raw_addrs: Vec<Vec<u8>>,
 }
 
+/// Input accepted by [`AutoNatClient`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AutoNatClientInput {
+    /// Drain any queued request bytes into an output.
+    Flush,
+    /// Bytes received from the AutoNAT service stream.
+    Data(Vec<u8>),
+}
+
+/// Output produced by [`AutoNatClient`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AutoNatClientOutput {
+    /// Bytes to write to the AutoNAT service stream.
+    Outbound(Vec<u8>),
+    /// Reachability result decoded from the service response.
+    Outcome(Reachability),
+}
+
+/// Input accepted by [`AutoNatServer`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AutoNatServerInput {
+    /// Bytes received from the requester stream.
+    Data(Vec<u8>),
+    /// Queue a successful DIAL_RESPONSE with dialable addresses.
+    RespondPublic { addrs: Vec<Multiaddr> },
+    /// Queue an unsuccessful DIAL_RESPONSE.
+    RespondError {
+        /// Response status.
+        status: ResponseStatus,
+        /// Human-readable reason.
+        reason: String,
+    },
+    /// Drain any queued response bytes into an output.
+    Flush,
+}
+
+/// Output produced by [`AutoNatServer`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AutoNatServerOutput {
+    /// Dial-back request decoded from the requester.
+    Request(AutoNatRequest),
+    /// Bytes to write to the requester stream.
+    Outbound(Vec<u8>),
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct PeerInfo {
     id: Vec<u8>,
@@ -190,6 +237,7 @@ pub struct AutoNatClient {
     recv_buf: Vec<u8>,
     state: FlowState,
     outcome: Option<Reachability>,
+    emitted_outcome: bool,
 }
 
 /// Server-side AutoNAT request handler.
@@ -197,6 +245,7 @@ pub struct AutoNatServer {
     outbound: Vec<u8>,
     recv_buf: Vec<u8>,
     request: Option<AutoNatRequest>,
+    emitted_request: bool,
     state: ServerState,
 }
 
@@ -231,6 +280,7 @@ impl AutoNatClient {
             recv_buf: Vec::new(),
             state: FlowState::Pending,
             outcome: None,
+            emitted_outcome: false,
         }
     }
 
@@ -305,6 +355,7 @@ impl AutoNatServer {
             outbound: Vec::new(),
             recv_buf: Vec::new(),
             request: None,
+            emitted_request: false,
             state: ServerState::AwaitingRequest,
         }
     }
@@ -382,8 +433,77 @@ impl AutoNatServer {
             addrs,
             raw_addrs: peer.addrs,
         });
+        self.emitted_request = false;
         self.state = ServerState::RequestReady;
         Ok(())
+    }
+}
+
+impl SansIoProtocol for AutoNatClient {
+    type Input = AutoNatClientInput;
+    type Output = AutoNatClientOutput;
+    type Error = AutoNatError;
+
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        match input {
+            AutoNatClientInput::Flush => {}
+            AutoNatClientInput::Data(data) => self.on_data(&data)?,
+        }
+        Ok(())
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        let outbound = self.take_outbound();
+        if !outbound.is_empty() {
+            return Some(AutoNatClientOutput::Outbound(outbound));
+        }
+        if !self.emitted_outcome {
+            if let Some(outcome) = self.outcome.clone() {
+                self.emitted_outcome = true;
+                return Some(AutoNatClientOutput::Outcome(outcome));
+            }
+        }
+        None
+    }
+
+    fn is_idle(&self) -> bool {
+        self.outbound.is_empty() && (self.emitted_outcome || self.outcome.is_none())
+    }
+}
+
+impl SansIoProtocol for AutoNatServer {
+    type Input = AutoNatServerInput;
+    type Output = AutoNatServerOutput;
+    type Error = AutoNatError;
+
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        match input {
+            AutoNatServerInput::Data(data) => self.on_data(&data)?,
+            AutoNatServerInput::RespondPublic { addrs } => self.respond_public(&addrs),
+            AutoNatServerInput::RespondError { status, reason } => {
+                self.respond_error(status, reason)
+            }
+            AutoNatServerInput::Flush => {}
+        }
+        Ok(())
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        if !self.emitted_request {
+            if let Some(request) = self.request.clone() {
+                self.emitted_request = true;
+                return Some(AutoNatServerOutput::Request(request));
+            }
+        }
+        let outbound = self.take_outbound();
+        if !outbound.is_empty() {
+            return Some(AutoNatServerOutput::Outbound(outbound));
+        }
+        None
+    }
+
+    fn is_idle(&self) -> bool {
+        self.outbound.is_empty() && (self.emitted_request || self.request.is_none())
     }
 }
 
@@ -770,5 +890,45 @@ mod tests {
                 len: MAX_MESSAGE_SIZE + 1
             }
         );
+    }
+
+    #[test]
+    fn client_and_server_implement_sans_io_protocol() {
+        let peer_id = PeerId::from_str(PEER_ID).unwrap();
+        let addr = Multiaddr::from_str("/ip4/203.0.113.7/udp/4001/quic-v1").unwrap();
+        let mut client = AutoNatClient::new(&peer_id, core::slice::from_ref(&addr));
+        let mut server = AutoNatServer::new();
+
+        client.handle_input(AutoNatClientInput::Flush).unwrap();
+        let Some(AutoNatClientOutput::Outbound(request_bytes)) = client.poll_output() else {
+            panic!("client should emit request bytes");
+        };
+
+        server
+            .handle_input(AutoNatServerInput::Data(request_bytes))
+            .unwrap();
+        let Some(AutoNatServerOutput::Request(request)) = server.poll_output() else {
+            panic!("server should emit request");
+        };
+        assert_eq!(request.peer_id, peer_id);
+
+        server
+            .handle_input(AutoNatServerInput::RespondPublic {
+                addrs: request.addrs,
+            })
+            .unwrap();
+        let Some(AutoNatServerOutput::Outbound(response_bytes)) = server.poll_output() else {
+            panic!("server should emit response bytes");
+        };
+
+        client
+            .handle_input(AutoNatClientInput::Data(response_bytes))
+            .unwrap();
+        assert!(matches!(
+            client.poll_output(),
+            Some(AutoNatClientOutput::Outcome(Reachability::Public { addrs, .. }))
+                if addrs == vec![addr]
+        ));
+        assert!(client.is_idle());
     }
 }

--- a/crates/autonat/src/lib.rs
+++ b/crates/autonat/src/lib.rs
@@ -285,7 +285,7 @@ impl AutoNatClient {
     }
 
     /// Drains pending outbound bytes.
-    pub fn take_outbound(&mut self) -> Vec<u8> {
+    fn take_outbound(&mut self) -> Vec<u8> {
         if self.state == FlowState::Pending {
             self.state = FlowState::AwaitingResponse;
         }
@@ -293,7 +293,7 @@ impl AutoNatClient {
     }
 
     /// Feeds incoming bytes from the AutoNAT service stream.
-    pub fn on_data(&mut self, data: &[u8]) -> Result<(), AutoNatError> {
+    fn on_data(&mut self, data: &[u8]) -> Result<(), AutoNatError> {
         if self.state == FlowState::Done {
             return Ok(());
         }
@@ -302,7 +302,8 @@ impl AutoNatClient {
     }
 
     /// Returns the reachability outcome, if available.
-    pub fn outcome(&self) -> Option<&Reachability> {
+    #[cfg(test)]
+    fn outcome(&self) -> Option<&Reachability> {
         self.outcome.as_ref()
     }
 
@@ -361,7 +362,7 @@ impl AutoNatServer {
     }
 
     /// Feeds incoming bytes from a requester.
-    pub fn on_data(&mut self, data: &[u8]) -> Result<(), AutoNatError> {
+    fn on_data(&mut self, data: &[u8]) -> Result<(), AutoNatError> {
         if self.state != ServerState::AwaitingRequest {
             return Ok(());
         }
@@ -370,22 +371,23 @@ impl AutoNatServer {
     }
 
     /// Returns the parsed dial-back request, if ready.
-    pub fn request(&self) -> Option<&AutoNatRequest> {
+    #[cfg(test)]
+    fn request(&self) -> Option<&AutoNatRequest> {
         self.request.as_ref()
     }
 
     /// Queues a successful DIAL_RESPONSE with dialable addresses.
-    pub fn respond_public(&mut self, addrs: &[Multiaddr]) {
+    fn respond_public(&mut self, addrs: &[Multiaddr]) {
         self.respond(ResponseStatus::Ok, None, addrs);
     }
 
     /// Queues an unsuccessful DIAL_RESPONSE.
-    pub fn respond_error(&mut self, status: ResponseStatus, reason: impl Into<String>) {
+    fn respond_error(&mut self, status: ResponseStatus, reason: impl Into<String>) {
         self.respond(status, Some(reason.into()), &[]);
     }
 
     /// Drains pending outbound bytes.
-    pub fn take_outbound(&mut self) -> Vec<u8> {
+    fn take_outbound(&mut self) -> Vec<u8> {
         core::mem::take(&mut self.outbound)
     }
 

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -8,7 +8,7 @@ This crate focuses on typed address handling and peer-qualified endpoint types.
 
 - `Multiaddr` parsing/formatting for a minimal protocol set.
 - `PeerAddr` helper for validated `transport + peer id` addresses with terminal `/p2p/<peer-id>`.
-- `SansIo` trait for poll-driven, runtime-agnostic protocol engines.
+- `SansIoProtocol` trait for poll-driven, runtime-agnostic protocol engines.
 - Typed error model with actionable parse context.
 - `no_std` support (`alloc`-based), with `std` enabled by default.
 

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -8,6 +8,7 @@ This crate focuses on typed address handling and peer-qualified endpoint types.
 
 - `Multiaddr` parsing/formatting for a minimal protocol set.
 - `PeerAddr` helper for validated `transport + peer id` addresses with terminal `/p2p/<peer-id>`.
+- `SansIo` trait for poll-driven, runtime-agnostic protocol engines.
 - Typed error model with actionable parse context.
 - `no_std` support (`alloc`-based), with `std` enabled by default.
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -25,4 +25,4 @@ pub use minip2p_identity::{VarintError, read_uvarint, uvarint_len, write_uvarint
 pub use multiaddr::Multiaddr;
 pub use peer_addr::PeerAddr;
 pub use protocol::Protocol;
-pub use sans_io::SansIo;
+pub use sans_io::SansIoProtocol;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,6 +13,7 @@ mod error;
 mod multiaddr;
 mod peer_addr;
 mod protocol;
+mod sans_io;
 
 pub use candidates::{
     DirectCandidate, DirectCandidateRejectReason, DirectCandidateRejection,
@@ -24,3 +25,4 @@ pub use minip2p_identity::{VarintError, read_uvarint, uvarint_len, write_uvarint
 pub use multiaddr::Multiaddr;
 pub use peer_addr::PeerAddr;
 pub use protocol::Protocol;
+pub use sans_io::SansIo;

--- a/crates/core/src/sans_io.rs
+++ b/crates/core/src/sans_io.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 /// Common interface for poll-driven Sans-I/O state machines.
 ///
 /// Implementors accept exactly one input mutation at a time, then expose any
@@ -12,13 +14,57 @@ pub trait SansIoProtocol {
     type Input;
     /// Output produced by the state machine.
     type Output;
+    /// Error returned when an input is rejected synchronously.
+    type Error;
 
     /// Feeds one input into the state machine.
-    fn handle_input(&mut self, input: Self::Input);
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error>;
 
     /// Returns the next pending output, if any.
     fn poll_output(&mut self) -> Option<Self::Output>;
 
     /// Returns true when there are no pending outputs.
     fn is_idle(&self) -> bool;
+}
+
+impl<P> SansIoProtocol for &mut P
+where
+    P: SansIoProtocol + ?Sized,
+{
+    type Input = P::Input;
+    type Output = P::Output;
+    type Error = P::Error;
+
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        (**self).handle_input(input)
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        (**self).poll_output()
+    }
+
+    fn is_idle(&self) -> bool {
+        (**self).is_idle()
+    }
+}
+
+impl<P> SansIoProtocol for Box<P>
+where
+    P: SansIoProtocol + ?Sized,
+{
+    type Input = P::Input;
+    type Output = P::Output;
+    type Error = P::Error;
+
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        (**self).handle_input(input)
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        (**self).poll_output()
+    }
+
+    fn is_idle(&self) -> bool {
+        (**self).is_idle()
+    }
 }

--- a/crates/core/src/sans_io.rs
+++ b/crates/core/src/sans_io.rs
@@ -1,0 +1,24 @@
+/// Common interface for poll-driven Sans-I/O state machines.
+///
+/// Implementors accept exactly one input mutation at a time, then expose any
+/// resulting outputs through repeated calls to [`SansIo::poll_output`].
+/// Drivers should drain outputs until `None` before waiting on external I/O,
+/// timers, or application input again.
+///
+/// The trait is intentionally tiny and fully `no_std` compatible. Concrete
+/// protocols keep their own strongly typed input and output enums.
+pub trait SansIo {
+    /// Input accepted by the state machine.
+    type Input;
+    /// Output produced by the state machine.
+    type Output;
+
+    /// Feeds one input into the state machine.
+    fn handle_input(&mut self, input: Self::Input);
+
+    /// Returns the next pending output, if any.
+    fn poll_output(&mut self) -> Option<Self::Output>;
+
+    /// Returns true when there are no pending outputs.
+    fn is_idle(&self) -> bool;
+}

--- a/crates/core/src/sans_io.rs
+++ b/crates/core/src/sans_io.rs
@@ -1,13 +1,13 @@
 /// Common interface for poll-driven Sans-I/O state machines.
 ///
 /// Implementors accept exactly one input mutation at a time, then expose any
-/// resulting outputs through repeated calls to [`SansIo::poll_output`].
+/// resulting outputs through repeated calls to [`SansIoProtocol::poll_output`].
 /// Drivers should drain outputs until `None` before waiting on external I/O,
 /// timers, or application input again.
 ///
 /// The trait is intentionally tiny and fully `no_std` compatible. Concrete
 /// protocols keep their own strongly typed input and output enums.
-pub trait SansIo {
+pub trait SansIoProtocol {
     /// Input accepted by the state machine.
     type Input;
     /// Output produced by the state machine.

--- a/crates/dcutr/README.md
+++ b/crates/dcutr/README.md
@@ -19,7 +19,7 @@ This crate implements the message state machines only. It does **not**:
 
 Both machines accept `&[Multiaddr]` at construction time and automatically serialize them to the wire using multicodec-binary encoding (via `Multiaddr::to_bytes()` in `minip2p-core`). Incoming `obs_addrs` are decoded the same way; entries that fail to parse are dropped silently but remain available as raw bytes in `remote_addr_bytes` for diagnostics.
 
-Each machine accepts raw bytes via `on_data(&[u8])` and exposes pending outbound bytes via `take_outbound()`. The wire format is length-prefixed protobuf `HolePunch` messages; the frame helpers (`encode_frame`, `decode_frame`, `FrameDecode`) are re-exported from the crate root.
+Each machine is driven through `SansIoProtocol`: feed `DcutrInitiatorInput` / `DcutrResponderInput` values, then drain `DcutrInitiatorOutput` / `DcutrResponderOutput` values until idle. The wire format is length-prefixed protobuf `HolePunch` messages; the frame helpers (`encode_frame`, `decode_frame`, `FrameDecode`) are re-exported from the crate root.
 
 ## Protocol ID
 
@@ -30,17 +30,24 @@ Each machine accepts raw bytes via `on_data(&[u8])` and exposes pending outbound
 
 ```rust
 use minip2p_core::Multiaddr;
-use minip2p_dcutr::{DcutrInitiator, InitiatorOutcome};
+use minip2p_core::SansIoProtocol;
+use minip2p_dcutr::{DcutrInitiator, DcutrInitiatorInput, DcutrInitiatorOutput, InitiatorOutcome};
 
 let mut initiator = DcutrInitiator::new(&our_observed_addrs); // &[Multiaddr]
-let out = initiator.take_outbound(); // send these bytes on the negotiated stream
 
-// Feed incoming bytes + measured RTT:
-// initiator.on_data(&data, rtt_ms)?;
-// if let Some(InitiatorOutcome::DialNow { remote_addrs, rtt_ms, .. }) = initiator.outcome() {
-//     // dial each remote Multiaddr directly, wait rtt_ms for a connection,
-//     // fall back to relayed ping if none succeeds.
-// }
+while let Some(output) = initiator.poll_output() {
+    match output {
+        DcutrInitiatorOutput::Outbound(bytes) => send_on_relay_stream(bytes),
+        DcutrInitiatorOutput::Outcome(InitiatorOutcome::DialNow { remote_addrs, rtt_ms, .. }) => {
+            // Dial each remote Multiaddr directly, wait rtt_ms for a connection,
+            // then queue SYNC once the simultaneous dial attempt starts.
+            initiator.handle_input(DcutrInitiatorInput::SendSync)?;
+        }
+    }
+}
+
+// Feed incoming bytes + measured relay RTT:
+// initiator.handle_input(DcutrInitiatorInput::Data { bytes: data, rtt_ms })?;
 ```
 
 The timing rules (wait `rtt / 2` on the responder side before blasting UDP, etc.) live in the caller -- see `holepunch-plan.md` for the CLI's approach.

--- a/crates/dcutr/src/lib.rs
+++ b/crates/dcutr/src/lib.rs
@@ -164,7 +164,7 @@ impl DcutrInitiator {
     }
 
     /// Drains and returns any pending outbound bytes.
-    pub fn take_outbound(&mut self) -> Vec<u8> {
+    fn take_outbound(&mut self) -> Vec<u8> {
         let bytes = core::mem::take(&mut self.outbound);
         self.state = match self.state {
             InitiatorState::Pending => InitiatorState::AwaitingConnectReply,
@@ -179,7 +179,7 @@ impl DcutrInitiator {
     /// `rtt_ms` is the caller's measured RTT from when they sent CONNECT
     /// (via `take_outbound`) to now. It is passed through into the
     /// `DialNow` outcome so the caller can use it for SYNC timing.
-    pub fn on_data(&mut self, data: &[u8], rtt_ms: u64) -> Result<(), DcutrError> {
+    fn on_data(&mut self, data: &[u8], rtt_ms: u64) -> Result<(), DcutrError> {
         if matches!(
             self.state,
             InitiatorState::Done | InitiatorState::SyncPending
@@ -192,13 +192,14 @@ impl DcutrInitiator {
     }
 
     /// Notifies the state machine that the remote closed its write side.
-    pub fn on_remote_write_closed(&mut self) -> Result<(), DcutrError> {
+    fn on_remote_write_closed(&mut self) -> Result<(), DcutrError> {
         // No-op: the outcome is already resolved by the time we'd care.
         Ok(())
     }
 
     /// Returns the current outcome, if available.
-    pub fn outcome(&self) -> Option<&InitiatorOutcome> {
+    #[cfg(test)]
+    fn outcome(&self) -> Option<&InitiatorOutcome> {
         self.outcome.as_ref()
     }
 
@@ -211,7 +212,7 @@ impl DcutrInitiator {
     ///
     /// Call this after you have initiated your simultaneous dial, per the
     /// spec. After calling, flush [`take_outbound`] to the stream.
-    pub fn send_sync(&mut self) -> Result<(), DcutrError> {
+    fn send_sync(&mut self) -> Result<(), DcutrError> {
         if self.state != InitiatorState::ReadyToSync {
             return Err(DcutrError::UnexpectedMessage(alloc::format!(
                 "cannot send SYNC from state {:?}",
@@ -362,12 +363,12 @@ impl DcutrResponder {
     }
 
     /// Drains and returns any pending outbound bytes.
-    pub fn take_outbound(&mut self) -> Vec<u8> {
+    fn take_outbound(&mut self) -> Vec<u8> {
         core::mem::take(&mut self.outbound)
     }
 
     /// Feeds incoming stream bytes.
-    pub fn on_data(&mut self, data: &[u8]) -> Result<(), DcutrError> {
+    fn on_data(&mut self, data: &[u8]) -> Result<(), DcutrError> {
         if self.state == ResponderState::Done {
             return Ok(());
         }
@@ -377,12 +378,13 @@ impl DcutrResponder {
     }
 
     /// Notifies the state machine that the remote closed its write side.
-    pub fn on_remote_write_closed(&mut self) -> Result<(), DcutrError> {
+    fn on_remote_write_closed(&mut self) -> Result<(), DcutrError> {
         self.try_decode()
     }
 
     /// Drains buffered events.
-    pub fn poll_events(&mut self) -> Vec<ResponderEvent> {
+    #[cfg(test)]
+    fn poll_events(&mut self) -> Vec<ResponderEvent> {
         core::mem::take(&mut self.events)
     }
 

--- a/crates/dcutr/src/lib.rs
+++ b/crates/dcutr/src/lib.rs
@@ -112,11 +112,13 @@ pub enum DcutrInitiatorOutput {
 ///
 /// Usage:
 /// 1. Construct with [`DcutrInitiator::new`], passing our observed addresses.
-/// 2. Call [`DcutrInitiator::take_outbound`] and send the bytes.
-/// 3. Record the send time; feed stream data via [`DcutrInitiator::on_data`].
-/// 4. When [`DcutrInitiator::outcome`] returns `DialNow`, the caller:
+/// 2. Drain [`DcutrInitiatorOutput::Outbound`] from
+///    [`SansIoProtocol::poll_output`] and send the bytes.
+/// 3. Record the send time; feed stream data with
+///    [`DcutrInitiatorInput::Data`].
+/// 4. When [`DcutrInitiatorOutput::Outcome`] returns `DialNow`, the caller:
 ///    - dials the returned addresses immediately,
-///    - calls [`DcutrInitiator::send_sync`] to queue the SYNC frame,
+///    - feeds [`DcutrInitiatorInput::SendSync`] to queue the SYNC frame,
 ///    - flushes the outbound bytes.
 pub struct DcutrInitiator {
     outbound: Vec<u8>,
@@ -211,7 +213,8 @@ impl DcutrInitiator {
     /// Queues the SYNC message to be sent.
     ///
     /// Call this after you have initiated your simultaneous dial, per the
-    /// spec. After calling, flush [`take_outbound`] to the stream.
+    /// spec. After feeding [`DcutrInitiatorInput::SendSync`], drain
+    /// [`DcutrInitiatorOutput::Outbound`] to the stream.
     fn send_sync(&mut self) -> Result<(), DcutrError> {
         if self.state != InitiatorState::ReadyToSync {
             return Err(DcutrError::UnexpectedMessage(alloc::format!(
@@ -325,9 +328,13 @@ pub enum DcutrResponderOutput {
 /// Usage:
 /// 1. Construct with [`DcutrResponder::new`], passing our observed addresses.
 ///    Our CONNECT reply is queued automatically.
-/// 2. Feed incoming bytes via [`DcutrResponder::on_data`].
-/// 3. Poll [`DcutrResponder::poll_events`] to collect [`ResponderEvent`]s.
-/// 4. Flush [`DcutrResponder::take_outbound`] to the stream.
+/// 2. Feed incoming bytes with [`DcutrResponderInput::Data`].
+/// 3. Drain [`DcutrResponderOutput`] values from
+///    [`SansIoProtocol::poll_output`].
+/// 4. Send [`DcutrResponderOutput::Outbound`] bytes back on the relay stream.
+/// 5. On [`DcutrResponderOutput::Event`] with
+///    [`ResponderEvent::SyncReceived`], start the responder-side dial timing /
+///    UDP bombardment strategy.
 pub struct DcutrResponder {
     own_addrs: Vec<Vec<u8>>,
     outbound: Vec<u8>,

--- a/crates/dcutr/src/lib.rs
+++ b/crates/dcutr/src/lib.rs
@@ -31,7 +31,7 @@ mod message;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use minip2p_core::Multiaddr;
+use minip2p_core::{Multiaddr, SansIoProtocol};
 
 pub use message::{
     DcutrMessageError, FrameDecode, HolePunch, HolePunchType, decode_frame, encode_frame,
@@ -86,6 +86,28 @@ pub enum InitiatorOutcome {
     },
 }
 
+/// Input accepted by [`DcutrInitiator`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DcutrInitiatorInput {
+    /// Drain queued CONNECT or SYNC bytes into an output.
+    Flush,
+    /// Bytes received from the relay stream, with measured relay RTT.
+    Data { bytes: Vec<u8>, rtt_ms: u64 },
+    /// Remote write side closed.
+    RemoteWriteClosed,
+    /// Queue the SYNC frame after the caller has started direct dialing.
+    SendSync,
+}
+
+/// Output produced by [`DcutrInitiator`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DcutrInitiatorOutput {
+    /// Bytes to write to the DCUtR stream.
+    Outbound(Vec<u8>),
+    /// Direct-dial instruction decoded from the remote CONNECT reply.
+    Outcome(InitiatorOutcome),
+}
+
 /// Client-side (initiator) state machine.
 ///
 /// Usage:
@@ -101,6 +123,7 @@ pub struct DcutrInitiator {
     recv_buf: Vec<u8>,
     state: InitiatorState,
     outcome: Option<InitiatorOutcome>,
+    emitted_outcome: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -136,6 +159,7 @@ impl DcutrInitiator {
             recv_buf: Vec::new(),
             state: InitiatorState::Pending,
             outcome: None,
+            emitted_outcome: false,
         }
     }
 
@@ -244,6 +268,7 @@ impl DcutrInitiator {
             remote_addr_bytes: reply.obs_addrs,
             rtt_ms,
         });
+        self.emitted_outcome = false;
 
         Ok(())
     }
@@ -272,6 +297,26 @@ pub enum ResponderEvent {
     /// RTT/2 and then start sending random UDP packets to the remote's
     /// addresses to open its NAT binding.
     SyncReceived,
+}
+
+/// Input accepted by [`DcutrResponder`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DcutrResponderInput {
+    /// Drain queued CONNECT reply bytes into an output.
+    Flush,
+    /// Bytes received from the relay stream.
+    Data(Vec<u8>),
+    /// Remote write side closed.
+    RemoteWriteClosed,
+}
+
+/// Output produced by [`DcutrResponder`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DcutrResponderOutput {
+    /// Bytes to write to the DCUtR stream.
+    Outbound(Vec<u8>),
+    /// Responder event decoded from incoming messages.
+    Event(ResponderEvent),
 }
 
 /// Server-side (responder) state machine.
@@ -403,6 +448,71 @@ impl DcutrResponder {
                 }
             }
         }
+    }
+}
+
+impl SansIoProtocol for DcutrInitiator {
+    type Input = DcutrInitiatorInput;
+    type Output = DcutrInitiatorOutput;
+    type Error = DcutrError;
+
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        match input {
+            DcutrInitiatorInput::Flush => {}
+            DcutrInitiatorInput::Data { bytes, rtt_ms } => self.on_data(&bytes, rtt_ms)?,
+            DcutrInitiatorInput::RemoteWriteClosed => self.on_remote_write_closed()?,
+            DcutrInitiatorInput::SendSync => self.send_sync()?,
+        }
+        Ok(())
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        let outbound = self.take_outbound();
+        if !outbound.is_empty() {
+            return Some(DcutrInitiatorOutput::Outbound(outbound));
+        }
+        if !self.emitted_outcome {
+            if let Some(outcome) = self.outcome.clone() {
+                self.emitted_outcome = true;
+                return Some(DcutrInitiatorOutput::Outcome(outcome));
+            }
+        }
+        None
+    }
+
+    fn is_idle(&self) -> bool {
+        self.outbound.is_empty() && (self.emitted_outcome || self.outcome.is_none())
+    }
+}
+
+impl SansIoProtocol for DcutrResponder {
+    type Input = DcutrResponderInput;
+    type Output = DcutrResponderOutput;
+    type Error = DcutrError;
+
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        match input {
+            DcutrResponderInput::Flush => {}
+            DcutrResponderInput::Data(data) => self.on_data(&data)?,
+            DcutrResponderInput::RemoteWriteClosed => self.on_remote_write_closed()?,
+        }
+        Ok(())
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        let outbound = self.take_outbound();
+        if !outbound.is_empty() {
+            return Some(DcutrResponderOutput::Outbound(outbound));
+        }
+        if self.events.is_empty() {
+            None
+        } else {
+            Some(DcutrResponderOutput::Event(self.events.remove(0)))
+        }
+    }
+
+    fn is_idle(&self) -> bool {
+        self.outbound.is_empty() && self.events.is_empty()
     }
 }
 
@@ -688,5 +798,42 @@ mod tests {
         let large = vec![0u8; MAX_MESSAGE_SIZE + 1];
         let err = resp.on_data(&large).unwrap_err();
         assert!(matches!(err, DcutrError::MessageTooLarge { .. }));
+    }
+
+    #[test]
+    fn initiator_and_responder_implement_sans_io_protocol() {
+        let own = [addr("/ip4/10.0.0.1/udp/1234/quic-v1")];
+        let mut init = DcutrInitiator::new(&own);
+        let mut resp = DcutrResponder::new(&own);
+
+        init.handle_input(DcutrInitiatorInput::Flush).unwrap();
+        let Some(DcutrInitiatorOutput::Outbound(connect)) = init.poll_output() else {
+            panic!("initiator should emit CONNECT");
+        };
+
+        resp.handle_input(DcutrResponderInput::Data(connect))
+            .unwrap();
+        let Some(DcutrResponderOutput::Outbound(reply)) = resp.poll_output() else {
+            panic!("responder should emit CONNECT reply");
+        };
+        assert!(matches!(
+            resp.poll_output(),
+            Some(DcutrResponderOutput::Event(
+                ResponderEvent::ConnectReceived { .. }
+            ))
+        ));
+
+        init.handle_input(DcutrInitiatorInput::Data {
+            bytes: reply,
+            rtt_ms: 42,
+        })
+        .unwrap();
+        assert!(matches!(
+            init.poll_output(),
+            Some(DcutrInitiatorOutput::Outcome(InitiatorOutcome::DialNow {
+                rtt_ms: 42,
+                ..
+            }))
+        ));
     }
 }

--- a/crates/identify/README.md
+++ b/crates/identify/README.md
@@ -13,14 +13,14 @@ Identify is the libp2p handshake that lets two peers exchange their supported pr
 - Protobuf encode/decode for `IdentifyMessage` (field-number order on encode, any-order accept on decode; unknown fields with known wire types are silently skipped).
 - 8 KiB inbound message size cap.
 - Peer-id migration support for swarms that discover the real `PeerId` after connection establishment.
-- `IdentifyAction` commands (`Send`, `CloseStreamWrite`) for the host to execute.
-- `IdentifyEvent` notifications (`Received`, `Error`).
+- `IdentifyInput` values for stream lifecycle, peer migration, and received bytes.
+- `IdentifyOutput` values wrapping host actions (`Send`, `CloseStreamWrite`) and protocol events (`Received`, `Error`).
 
 ## Usage
 
 ```rust
-use minip2p_core::{Multiaddr, PeerId};
-use minip2p_identify::{IdentifyConfig, IdentifyProtocol};
+use minip2p_core::{Multiaddr, PeerId, SansIoProtocol};
+use minip2p_identify::{IdentifyConfig, IdentifyInput, IdentifyOutput, IdentifyProtocol};
 use minip2p_transport::StreamId;
 
 let config = IdentifyConfig {
@@ -33,22 +33,28 @@ let mut identify = IdentifyProtocol::new(config);
 
 // After multistream-select negotiates /ipfs/id/1.0.0:
 //   - inbound stream (we respond):
-//     let actions = identify.register_outbound_stream(
+//     identify.handle_input(IdentifyInput::RegisterOutboundStream {
 //         peer_id,
 //         stream_id,
-//         Some(remote_addr),   // observed_addr
-//         &listen_addrs,       // from the transport
-//     )?;
+//         observed_addr: Some(remote_addr),
+//         listen_addrs,
+//     })?;
 //   - outbound stream (we receive the remote's info):
-//     identify.register_inbound_stream(peer_id, stream_id);
+//     identify.handle_input(IdentifyInput::RegisterInboundStream { peer_id, stream_id })?;
 
 // Feed stream data / lifecycle events:
-// identify.on_stream_data(peer_id, stream_id, data);
-// let actions = identify.on_stream_remote_write_closed(peer_id, stream_id);
-// identify.on_stream_closed(peer_id, stream_id);
+// identify.handle_input(IdentifyInput::StreamData { peer_id, stream_id, data })?;
+// identify.handle_input(IdentifyInput::StreamRemoteWriteClosed { peer_id, stream_id })?;
+// identify.handle_input(IdentifyInput::StreamClosed { peer_id, stream_id })?;
 
-// Drain events and run actions through the host/transport:
-// let events = identify.poll_events();
+// Drain outputs and run actions through the host/transport:
+// while let Some(output) = identify.poll_output() {
+//     match output {
+//         IdentifyOutput::Action(action) => execute(action),
+//         IdentifyOutput::Event(event) => handle(event),
+//     }
+// }
+// assert!(identify.is_idle());
 ```
 
 `observed_addr` should be the transport address we observed the remote dialing us from. Pass `None` when the information is not available.
@@ -72,4 +78,4 @@ minip2p-identify = { path = "crates/identify", default-features = false }
 
 ## Scope
 
-This crate implements the identify protocol state machine only. It does not open streams, perform multistream-select, or serialize multiaddrs. The host is responsible for driving negotiation, plumbing `IdentifyAction` commands to the transport, and feeding transport events back into `IdentifyProtocol`.
+This crate implements the identify protocol state machine only. It does not open streams or perform multistream-select. The host is responsible for driving negotiation, feeding `IdentifyInput` values into `IdentifyProtocol`, executing `IdentifyOutput::Action` commands against the transport, and draining outputs until `SansIoProtocol::is_idle()` returns `true`.

--- a/crates/identify/src/lib.rs
+++ b/crates/identify/src/lib.rs
@@ -41,7 +41,7 @@ const MAX_MESSAGE_SIZE: usize = 8192;
 /// auto-populates it from the underlying transport's `local_addresses()`
 /// at send time, so the advertised set always reflects what the peer
 /// is actually listening on. See
-/// [`IdentifyProtocol::register_outbound_stream`].
+/// [`IdentifyInput::RegisterOutboundStream`].
 #[derive(Clone, Debug)]
 pub struct IdentifyConfig {
     /// Protocol version string (e.g. `"ipfs/0.1.0"`).
@@ -171,10 +171,11 @@ struct PeerIdentifyState {
 
 /// Sans-IO state machine for the identify protocol.
 ///
-/// The host drives this by:
-/// 1. Calling input methods (`on_stream_data`, etc.) when transport events arrive.
-/// 2. Executing the returned [`IdentifyAction`] commands on the transport.
-/// 3. Polling [`poll_events`] to collect [`IdentifyEvent`] notifications.
+/// Drive this through [`SansIoProtocol`]: feed [`IdentifyInput`] values with
+/// [`SansIoProtocol::handle_input`], execute [`IdentifyOutput::Action`]
+/// commands against the transport, surface [`IdentifyOutput::Event`]
+/// notifications to the application, and keep draining
+/// [`SansIoProtocol::poll_output`] until [`SansIoProtocol::is_idle`] is true.
 pub struct IdentifyProtocol {
     /// Per-peer identify state.
     peers: BTreeMap<PeerId, PeerIdentifyState>,
@@ -484,7 +485,7 @@ impl SansIoProtocol for IdentifyProtocol {
 /// Prepends a varint length prefix to a protobuf-encoded Identify payload.
 ///
 /// The libp2p Identify spec requires this framing on the wire; see the
-/// call site in [`IdentifyProtocol::register_outbound_stream`] for why
+/// call site for [`IdentifyInput::RegisterOutboundStream`] for why
 /// omitting it breaks interop with third-party libp2p peers.
 fn encode_length_prefixed(payload: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(10 + payload.len());

--- a/crates/identify/src/lib.rs
+++ b/crates/identify/src/lib.rs
@@ -12,12 +12,12 @@ extern crate alloc;
 
 mod message;
 
-use alloc::collections::BTreeMap;
+use alloc::collections::{BTreeMap, VecDeque};
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use minip2p_core::{Multiaddr, PeerId, VarintError, read_uvarint, write_uvarint};
+use minip2p_core::{Multiaddr, PeerId, SansIoProtocol, VarintError, read_uvarint, write_uvarint};
 use minip2p_transport::StreamId;
 use thiserror::Error;
 
@@ -90,6 +90,52 @@ pub enum IdentifyEvent {
     },
 }
 
+/// Inputs accepted by [`IdentifyProtocol`] when driven through
+/// [`SansIoProtocol`].
+#[derive(Clone, Debug)]
+pub enum IdentifyInput {
+    /// Register a stream where we send our identify info.
+    RegisterOutboundStream {
+        peer_id: PeerId,
+        stream_id: StreamId,
+        observed_addr: Option<Multiaddr>,
+        listen_addrs: Vec<Multiaddr>,
+    },
+    /// Register a stream where we receive identify info.
+    RegisterInboundStream {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+    /// Received stream data.
+    StreamData {
+        peer_id: PeerId,
+        stream_id: StreamId,
+        data: Vec<u8>,
+    },
+    /// The remote closed its write side.
+    StreamRemoteWriteClosed {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+    /// The stream fully closed.
+    StreamClosed {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+    /// Remove all state for a peer.
+    RemovePeer { peer_id: PeerId },
+}
+
+/// Outputs produced by [`IdentifyProtocol`] when driven through
+/// [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum IdentifyOutput {
+    /// Command the host must execute.
+    Action(IdentifyAction),
+    /// Application/protocol event.
+    Event(IdentifyEvent),
+}
+
 /// Errors returned by identify protocol methods.
 #[derive(Clone, Debug, Eq, PartialEq, Error)]
 pub enum IdentifyError {
@@ -129,6 +175,8 @@ pub struct IdentifyProtocol {
     peers: BTreeMap<PeerId, PeerIdentifyState>,
     /// Buffered events for the host to poll.
     events: Vec<IdentifyEvent>,
+    /// Actions buffered for [`SansIoProtocol::poll_output`].
+    actions: VecDeque<IdentifyAction>,
     /// Local identify info used when responding.
     config: IdentifyConfig,
 }
@@ -139,6 +187,7 @@ impl IdentifyProtocol {
         Self {
             peers: BTreeMap::new(),
             events: Vec::new(),
+            actions: VecDeque::new(),
             config,
         }
     }
@@ -358,6 +407,66 @@ impl IdentifyProtocol {
     }
 }
 
+impl SansIoProtocol for IdentifyProtocol {
+    type Input = IdentifyInput;
+    type Output = IdentifyOutput;
+    type Error = IdentifyError;
+
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        match input {
+            IdentifyInput::RegisterOutboundStream {
+                peer_id,
+                stream_id,
+                observed_addr,
+                listen_addrs,
+            } => {
+                let actions = self.register_outbound_stream(
+                    peer_id,
+                    stream_id,
+                    observed_addr,
+                    &listen_addrs,
+                )?;
+                self.actions.extend(actions);
+            }
+            IdentifyInput::RegisterInboundStream { peer_id, stream_id } => {
+                self.register_inbound_stream(peer_id, stream_id);
+            }
+            IdentifyInput::StreamData {
+                peer_id,
+                stream_id,
+                data,
+            } => {
+                let actions = self.on_stream_data(peer_id, stream_id, data);
+                self.actions.extend(actions);
+            }
+            IdentifyInput::StreamRemoteWriteClosed { peer_id, stream_id } => {
+                let actions = self.on_stream_remote_write_closed(peer_id, stream_id);
+                self.actions.extend(actions);
+            }
+            IdentifyInput::StreamClosed { peer_id, stream_id } => {
+                self.on_stream_closed(peer_id, stream_id);
+            }
+            IdentifyInput::RemovePeer { peer_id } => self.remove_peer(&peer_id),
+        }
+        Ok(())
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        if let Some(action) = self.actions.pop_front() {
+            return Some(IdentifyOutput::Action(action));
+        }
+        if self.events.is_empty() {
+            None
+        } else {
+            Some(IdentifyOutput::Event(self.events.remove(0)))
+        }
+    }
+
+    fn is_idle(&self) -> bool {
+        self.actions.is_empty() && self.events.is_empty()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Wire framing helpers
 // ---------------------------------------------------------------------------
@@ -413,6 +522,39 @@ mod tests {
     fn sample_peer() -> PeerId {
         // Deterministic peer id so test output is stable across runs.
         PeerId::from_public_key_protobuf(b"test-fixture-identify-lib")
+    }
+
+    #[test]
+    fn identify_protocol_implements_sans_io_protocol() {
+        let mut identify = IdentifyProtocol::new(sample_config());
+        let peer = sample_peer();
+        let stream_id = StreamId::new(1);
+
+        identify
+            .handle_input(IdentifyInput::RegisterOutboundStream {
+                peer_id: peer.clone(),
+                stream_id,
+                observed_addr: None,
+                listen_addrs: Vec::new(),
+            })
+            .expect("register outbound");
+
+        assert!(matches!(
+            identify.poll_output(),
+            Some(IdentifyOutput::Action(IdentifyAction::Send {
+                peer_id: p,
+                stream_id: sid,
+                data,
+            })) if p == peer && sid == stream_id && !data.is_empty()
+        ));
+        assert!(matches!(
+            identify.poll_output(),
+            Some(IdentifyOutput::Action(IdentifyAction::CloseStreamWrite {
+                peer_id: p,
+                stream_id: sid,
+            })) if p == peer && sid == stream_id
+        ));
+        assert!(identify.is_idle());
     }
 
     #[test]

--- a/crates/identify/src/lib.rs
+++ b/crates/identify/src/lib.rs
@@ -124,6 +124,11 @@ pub enum IdentifyInput {
     },
     /// Remove all state for a peer.
     RemovePeer { peer_id: PeerId },
+    /// Move all peer-scoped state from an old id to a verified id.
+    MigratePeer {
+        old_peer_id: PeerId,
+        new_peer_id: PeerId,
+    },
 }
 
 /// Outputs produced by [`IdentifyProtocol`] when driven through
@@ -212,7 +217,7 @@ impl IdentifyProtocol {
     ///
     /// The returned actions send our identify message and close the write
     /// side.
-    pub fn register_outbound_stream(
+    fn register_outbound_stream(
         &mut self,
         peer_id: PeerId,
         stream_id: StreamId,
@@ -271,7 +276,7 @@ impl IdentifyProtocol {
     /// Call this after multistream-select negotiates `/ipfs/id/1.0.0` on an
     /// outbound stream. The protocol will buffer incoming data until the
     /// remote closes its write side.
-    pub fn register_inbound_stream(&mut self, peer_id: PeerId, stream_id: StreamId) {
+    fn register_inbound_stream(&mut self, peer_id: PeerId, stream_id: StreamId) {
         let state = self.peers.entry(peer_id).or_default();
         state.inbound_streams.entry(stream_id).or_default();
     }
@@ -280,7 +285,7 @@ impl IdentifyProtocol {
     ///
     /// Returns actions the host must execute (none expected for the initiator
     /// side, but included for consistency).
-    pub fn on_stream_data(
+    fn on_stream_data(
         &mut self,
         peer_id: PeerId,
         stream_id: StreamId,
@@ -315,7 +320,7 @@ impl IdentifyProtocol {
     /// signals the message is complete. The initiator closes its own write
     /// side in response so that the stream can reach the `Closed` state and
     /// have its transport-level and protocol-level state reclaimed.
-    pub fn on_stream_remote_write_closed(
+    fn on_stream_remote_write_closed(
         &mut self,
         peer_id: PeerId,
         stream_id: StreamId,
@@ -354,7 +359,7 @@ impl IdentifyProtocol {
     }
 
     /// Notify that a stream was fully closed.
-    pub fn on_stream_closed(&mut self, peer_id: PeerId, stream_id: StreamId) {
+    fn on_stream_closed(&mut self, peer_id: PeerId, stream_id: StreamId) {
         let Some(state) = self.peers.get_mut(&peer_id) else {
             return;
         };
@@ -371,7 +376,7 @@ impl IdentifyProtocol {
     }
 
     /// Remove all state for a peer.
-    pub fn remove_peer(&mut self, peer_id: &PeerId) {
+    fn remove_peer(&mut self, peer_id: &PeerId) {
         self.peers.remove(peer_id);
     }
 
@@ -381,7 +386,7 @@ impl IdentifyProtocol {
     /// initially registering the connection under a placeholder. Any buffered
     /// events referencing `old_peer_id` are rewritten to `new_peer_id` so the
     /// application only ever sees events under the real peer identity.
-    pub fn migrate_peer(&mut self, old_peer_id: &PeerId, new_peer_id: &PeerId) {
+    fn migrate_peer(&mut self, old_peer_id: &PeerId, new_peer_id: &PeerId) {
         if old_peer_id == new_peer_id {
             return;
         }
@@ -402,7 +407,8 @@ impl IdentifyProtocol {
     }
 
     /// Drain buffered events.
-    pub fn poll_events(&mut self) -> Vec<IdentifyEvent> {
+    #[cfg(test)]
+    fn poll_events(&mut self) -> Vec<IdentifyEvent> {
         core::mem::take(&mut self.events)
     }
 }
@@ -447,6 +453,10 @@ impl SansIoProtocol for IdentifyProtocol {
                 self.on_stream_closed(peer_id, stream_id);
             }
             IdentifyInput::RemovePeer { peer_id } => self.remove_peer(&peer_id),
+            IdentifyInput::MigratePeer {
+                old_peer_id,
+                new_peer_id,
+            } => self.migrate_peer(&old_peer_id, &new_peer_id),
         }
         Ok(())
     }

--- a/crates/multistream-select/README.md
+++ b/crates/multistream-select/README.md
@@ -8,7 +8,7 @@ This crate implements the [multistream-select](https://github.com/multiformats/m
 
 - Varint-length-prefixed wire format (spec-compliant framing).
 - Dialer and listener roles.
-- Incremental `receive()` API that handles chunked/partial input.
+- Incremental `MultistreamInput::Data` handling for chunked/partial input.
 - `MultistreamOutput` events for outbound data, negotiation result, and errors.
 - Typed `MultistreamError` with actionable context.
 - Zero-copy decoding where possible.
@@ -26,23 +26,29 @@ Each message is framed as:
 Negotiate a protocol between a dialer and listener:
 
 ```rust
-use minip2p_multistream_select::{MultistreamSelect, MultistreamOutput, MULTISTREAM_PROTOCOL_ID};
+use minip2p_core::SansIoProtocol;
+use minip2p_multistream_select::{
+    MultistreamInput, MultistreamOutput, MultistreamSelect, MULTISTREAM_PROTOCOL_ID,
+};
 
 // Dialer side
 let mut dialer = MultistreamSelect::dialer("/ipfs/ping/1.0.0");
-let outbound = dialer.start(); // sends multistream header
+dialer.handle_input(MultistreamInput::Start)?; // queues multistream header
 
 // Listener side
 let mut listener = MultistreamSelect::listener(["/ipfs/ping/1.0.0".to_string()]);
-let outbound = listener.start(); // sends multistream header
+listener.handle_input(MultistreamInput::Start)?; // queues multistream header
 
 // Feed received bytes into each side:
-// let outputs = dialer.receive(&bytes_from_listener);
-// let outputs = listener.receive(&bytes_from_dialer);
+// dialer.handle_input(MultistreamInput::Data(bytes_from_listener))?;
+// listener.handle_input(MultistreamInput::Data(bytes_from_dialer))?;
 //
-// Check outputs for MultistreamOutput::Negotiated { protocol } to know
-// when negotiation succeeds, or MultistreamOutput::NotAvailable if the
-// listener does not support the requested protocol.
+// Drain outputs and check for MultistreamOutput::Negotiated { protocol }
+// to know when negotiation succeeds, or MultistreamOutput::NotAvailable
+// if the listener does not support the requested protocol.
+// while let Some(output) = dialer.poll_output() {
+//     handle(output);
+// }
 ```
 
 ## no_std

--- a/crates/multistream-select/src/lib.rs
+++ b/crates/multistream-select/src/lib.rs
@@ -7,11 +7,11 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeSet;
+use alloc::collections::{BTreeSet, VecDeque};
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
-use minip2p_core::{VarintError, read_uvarint, uvarint_len, write_uvarint};
+use minip2p_core::{SansIoProtocol, VarintError, read_uvarint, uvarint_len, write_uvarint};
 use thiserror::Error;
 
 /// The multistream-select protocol identifier.
@@ -32,6 +32,15 @@ pub enum MultistreamOutput {
     NotAvailable,
     /// A protocol-level error occurred; negotiation is terminated.
     ProtocolError { reason: String },
+}
+
+/// Input accepted by [`MultistreamSelect`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MultistreamInput {
+    /// Begin negotiation by emitting the multistream header.
+    Start,
+    /// Bytes received from the remote peer.
+    Data(Vec<u8>),
 }
 
 /// Errors encountered during multistream-select framing or negotiation.
@@ -81,6 +90,7 @@ pub struct MultistreamSelect {
     supported_protocols: BTreeSet<String>,
     recv_buf: Vec<u8>,
     started: bool,
+    pending_outputs: VecDeque<MultistreamOutput>,
 }
 
 impl MultistreamSelect {
@@ -93,6 +103,7 @@ impl MultistreamSelect {
             supported_protocols: BTreeSet::new(),
             recv_buf: Vec::new(),
             started: false,
+            pending_outputs: VecDeque::new(),
         }
     }
 
@@ -105,6 +116,7 @@ impl MultistreamSelect {
             supported_protocols: protocols.into_iter().collect(),
             recv_buf: Vec::new(),
             started: false,
+            pending_outputs: VecDeque::new(),
         }
     }
 
@@ -176,6 +188,29 @@ impl MultistreamSelect {
         }
 
         outputs
+    }
+}
+
+impl SansIoProtocol for MultistreamSelect {
+    type Input = MultistreamInput;
+    type Output = MultistreamOutput;
+    type Error = MultistreamError;
+
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        let outputs = match input {
+            MultistreamInput::Start => self.start(),
+            MultistreamInput::Data(data) => self.receive(&data),
+        };
+        self.pending_outputs.extend(outputs);
+        Ok(())
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        self.pending_outputs.pop_front()
+    }
+
+    fn is_idle(&self) -> bool {
+        self.pending_outputs.is_empty()
     }
 }
 
@@ -510,5 +545,27 @@ mod tests {
 
         let out = dialer.receive(&encode_message("na"));
         assert_eq!(out, vec![MultistreamOutput::NotAvailable]);
+    }
+
+    #[test]
+    fn multistream_select_implements_sans_io_protocol() {
+        let mut dialer = MultistreamSelect::dialer(PING);
+
+        dialer.handle_input(MultistreamInput::Start).unwrap();
+        assert!(matches!(
+            dialer.poll_output(),
+            Some(MultistreamOutput::OutboundData(_))
+        ));
+        assert!(dialer.is_idle());
+
+        dialer
+            .handle_input(MultistreamInput::Data(encode_message(
+                MULTISTREAM_PROTOCOL_ID,
+            )))
+            .unwrap();
+        assert_eq!(
+            dialer.poll_output(),
+            Some(MultistreamOutput::OutboundData(encode_message(PING)))
+        );
     }
 }

--- a/crates/multistream-select/src/lib.rs
+++ b/crates/multistream-select/src/lib.rs
@@ -121,7 +121,7 @@ impl MultistreamSelect {
     }
 
     /// Produces the initial multistream header to send. Idempotent.
-    pub fn start(&mut self) -> Vec<MultistreamOutput> {
+    fn start(&mut self) -> Vec<MultistreamOutput> {
         if self.started {
             return Vec::new();
         }
@@ -149,7 +149,7 @@ impl MultistreamSelect {
     }
 
     /// Feeds received bytes into the state machine and returns any outputs.
-    pub fn receive(&mut self, bytes: &[u8]) -> Vec<MultistreamOutput> {
+    fn receive(&mut self, bytes: &[u8]) -> Vec<MultistreamOutput> {
         if self.state == State::Done {
             return Vec::new();
         }

--- a/crates/ping/README.md
+++ b/crates/ping/README.md
@@ -10,34 +10,41 @@ Ping measures round-trip latency by sending a 32-byte payload and waiting for th
 - Fragmentation-safe: buffers partial payloads on both inbound and outbound paths.
 - Configurable request timeout with `PingConfig`.
 - RTT measurement via caller-provided timestamps (no internal clock dependency).
-- `PingAction` commands (`Send`, `CloseStreamWrite`, `ResetStream`) for the host to execute.
-- `PingEvent` notifications (`RttMeasured`, `Timeout`, `ProtocolViolation`, etc.).
+- `PingInput` values for stream lifecycle, payload, and tick inputs.
+- `PingOutput` values wrapping host actions (`Send`, `CloseStreamWrite`, `ResetStream`) and protocol events (`RttMeasured`, `Timeout`, `ProtocolViolation`, etc.).
 - Per-peer state tracking with inbound stream limits.
 
 ## Usage
 
 ```rust
-use minip2p_ping::{PingProtocol, PingConfig, PingAction, PingEvent, PING_PAYLOAD_LEN};
-use minip2p_transport::StreamId;
 use minip2p_core::PeerId;
+use minip2p_core::SansIoProtocol;
+use minip2p_ping::{PingConfig, PingInput, PingOutput, PingProtocol, PING_PAYLOAD_LEN};
+use minip2p_transport::StreamId;
 
 let mut ping = PingProtocol::new(PingConfig::default());
 
 // After protocol negotiation succeeds on a stream, register it:
-// ping.register_outbound_stream(&peer_id, stream_id);
-// ping.register_inbound_stream(&peer_id, stream_id);
+// ping.handle_input(PingInput::RegisterOutboundStream { peer_id, stream_id })?;
+// ping.handle_input(PingInput::RegisterInboundStream { peer_id, stream_id })?;
 
 // Send a ping (caller provides the payload and current timestamp):
-// let actions = ping.send_ping(&peer_id, payload, now_ms)?;
+// ping.handle_input(PingInput::SendPing { peer_id, payload, now_ms })?;
 
 // Feed incoming stream data:
-// let actions = ping.on_stream_data(&peer_id, stream_id, &data, now_ms);
+// ping.handle_input(PingInput::StreamData { peer_id, stream_id, data, now_ms })?;
 
 // Check for timeouts periodically:
-// let actions = ping.on_tick(now_ms);
+// ping.handle_input(PingInput::Tick { now_ms })?;
 
-// Drain events:
-// let events = ping.poll_events();
+// Drain outputs:
+// while let Some(output) = ping.poll_output() {
+//     match output {
+//         PingOutput::Action(action) => execute(action),
+//         PingOutput::Event(event) => handle(event),
+//     }
+// }
+// assert!(ping.is_idle());
 ```
 
 ## Protocol
@@ -58,4 +65,4 @@ minip2p-ping = { path = "crates/ping", default-features = false }
 
 ## Scope
 
-This crate implements the ping protocol state machine only. It does not open streams, send bytes over the network, or negotiate protocols. The host is responsible for wiring `PingAction` commands to the transport and feeding transport events back into `PingProtocol`.
+This crate implements the ping protocol state machine only. It does not open streams, send bytes over the network, or negotiate protocols. The host is responsible for feeding `PingInput` values into `PingProtocol`, executing `PingOutput::Action` commands against the transport, and draining outputs until `SansIoProtocol::is_idle()` returns `true`.

--- a/crates/ping/src/lib.rs
+++ b/crates/ping/src/lib.rs
@@ -123,6 +123,8 @@ pub enum PingInput {
         payload: [u8; PING_PAYLOAD_LEN],
         now_ms: u64,
     },
+    /// Close the write side of the outbound ping stream.
+    CloseOutboundStreamWrite { peer_id: PeerId },
     /// Received stream data.
     StreamData {
         peer_id: PeerId,
@@ -142,6 +144,11 @@ pub enum PingInput {
     },
     /// Remove all state for a peer.
     RemovePeer { peer_id: PeerId },
+    /// Move all peer-scoped state from an old id to a verified id.
+    MigratePeer {
+        old_peer_id: PeerId,
+        new_peer_id: PeerId,
+    },
     /// Time advanced.
     Tick { now_ms: u64 },
 }
@@ -227,7 +234,7 @@ impl PingProtocol {
     }
 
     /// Registers a negotiated outbound stream for a peer.
-    pub fn register_outbound_stream(
+    fn register_outbound_stream(
         &mut self,
         peer_id: PeerId,
         stream_id: StreamId,
@@ -260,11 +267,7 @@ impl PingProtocol {
     }
 
     /// Registers a negotiated inbound stream from a peer.
-    pub fn register_inbound_stream(
-        &mut self,
-        peer_id: PeerId,
-        stream_id: StreamId,
-    ) -> Vec<PingAction> {
+    fn register_inbound_stream(&mut self, peer_id: PeerId, stream_id: StreamId) -> Vec<PingAction> {
         let peer = self.peers.entry(peer_id.clone()).or_default();
         if peer.inbound_streams.contains(&stream_id) {
             return Vec::new();
@@ -287,7 +290,7 @@ impl PingProtocol {
     }
 
     /// Sends a ping with the given 32-byte payload. Returns the action to execute.
-    pub fn send_ping(
+    fn send_ping(
         &mut self,
         peer_id: &PeerId,
         payload: &[u8],
@@ -333,10 +336,7 @@ impl PingProtocol {
     }
 
     /// Half-closes the outbound stream. Fails if a ping is in flight.
-    pub fn close_outbound_stream_write(
-        &mut self,
-        peer_id: &PeerId,
-    ) -> Result<PingAction, PingError> {
+    fn close_outbound_stream_write(&mut self, peer_id: &PeerId) -> Result<PingAction, PingError> {
         let peer = self
             .peers
             .get_mut(peer_id)
@@ -363,7 +363,7 @@ impl PingProtocol {
     }
 
     /// Feeds received stream data into the protocol. Returns actions to execute.
-    pub fn on_stream_data(
+    fn on_stream_data(
         &mut self,
         peer_id: &PeerId,
         stream_id: StreamId,
@@ -470,7 +470,7 @@ impl PingProtocol {
     }
 
     /// Notifies the protocol that the remote peer closed its write side.
-    pub fn on_stream_remote_write_closed(
+    fn on_stream_remote_write_closed(
         &mut self,
         peer_id: &PeerId,
         stream_id: StreamId,
@@ -510,7 +510,7 @@ impl PingProtocol {
     }
 
     /// Notifies the protocol that a stream was fully closed.
-    pub fn on_stream_closed(&mut self, peer_id: &PeerId, stream_id: StreamId) {
+    fn on_stream_closed(&mut self, peer_id: &PeerId, stream_id: StreamId) {
         let Some(peer) = self.peers.get_mut(peer_id) else {
             return;
         };
@@ -525,7 +525,7 @@ impl PingProtocol {
 
     /// Remove all state for a peer. Call this when the connection to a peer is
     /// closed to prevent unbounded memory growth.
-    pub fn remove_peer(&mut self, peer_id: &PeerId) {
+    fn remove_peer(&mut self, peer_id: &PeerId) {
         self.peers.remove(peer_id);
     }
 
@@ -539,7 +539,7 @@ impl PingProtocol {
     /// the application only ever sees events under the real PeerId.
     ///
     /// If there is no state for `old_peer_id`, this is a no-op.
-    pub fn migrate_peer(&mut self, old_peer_id: &PeerId, new_peer_id: &PeerId) {
+    fn migrate_peer(&mut self, old_peer_id: &PeerId, new_peer_id: &PeerId) {
         if old_peer_id == new_peer_id {
             return;
         }
@@ -566,7 +566,7 @@ impl PingProtocol {
     }
 
     /// Checks for timed-out ping requests. Call periodically.
-    pub fn on_tick(&mut self, now_ms: u64) -> Vec<PingAction> {
+    fn on_tick(&mut self, now_ms: u64) -> Vec<PingAction> {
         let mut actions = Vec::new();
 
         for (peer_id, peer) in self.peers.iter_mut() {
@@ -602,7 +602,8 @@ impl PingProtocol {
     }
 
     /// Drains and returns all pending events.
-    pub fn poll_events(&mut self) -> Vec<PingEvent> {
+    #[cfg(test)]
+    fn poll_events(&mut self) -> Vec<PingEvent> {
         core::mem::take(&mut self.pending_events)
     }
 
@@ -648,6 +649,10 @@ impl SansIoProtocol for PingProtocol {
                 let action = self.send_ping(&peer_id, &payload, now_ms)?;
                 self.pending_actions.push_back(action);
             }
+            PingInput::CloseOutboundStreamWrite { peer_id } => {
+                let action = self.close_outbound_stream_write(&peer_id)?;
+                self.pending_actions.push_back(action);
+            }
             PingInput::StreamData {
                 peer_id,
                 stream_id,
@@ -665,6 +670,10 @@ impl SansIoProtocol for PingProtocol {
                 self.on_stream_closed(&peer_id, stream_id);
             }
             PingInput::RemovePeer { peer_id } => self.remove_peer(&peer_id),
+            PingInput::MigratePeer {
+                old_peer_id,
+                new_peer_id,
+            } => self.migrate_peer(&old_peer_id, &new_peer_id),
             PingInput::Tick { now_ms } => {
                 let actions = self.on_tick(now_ms);
                 self.pending_actions.extend(actions);

--- a/crates/ping/src/lib.rs
+++ b/crates/ping/src/lib.rs
@@ -7,13 +7,14 @@
 
 extern crate alloc;
 
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
 use alloc::format;
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 
 use minip2p_core::PeerId;
+use minip2p_core::SansIoProtocol;
 use minip2p_transport::StreamId;
 use thiserror::Error;
 
@@ -102,6 +103,59 @@ pub enum PingEvent {
     },
 }
 
+/// Inputs accepted by [`PingProtocol`] when driven through
+/// [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PingInput {
+    /// Register a negotiated outbound ping stream.
+    RegisterOutboundStream {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+    /// Register a negotiated inbound ping stream.
+    RegisterInboundStream {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+    /// Send one ping payload on the outbound stream.
+    SendPing {
+        peer_id: PeerId,
+        payload: [u8; PING_PAYLOAD_LEN],
+        now_ms: u64,
+    },
+    /// Received stream data.
+    StreamData {
+        peer_id: PeerId,
+        stream_id: StreamId,
+        data: Vec<u8>,
+        now_ms: u64,
+    },
+    /// The remote closed its write side.
+    StreamRemoteWriteClosed {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+    /// The stream fully closed.
+    StreamClosed {
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+    /// Remove all state for a peer.
+    RemovePeer { peer_id: PeerId },
+    /// Time advanced.
+    Tick { now_ms: u64 },
+}
+
+/// Outputs produced by [`PingProtocol`] when driven through
+/// [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PingOutput {
+    /// Command the host must execute.
+    Action(PingAction),
+    /// Application/protocol event.
+    Event(PingEvent),
+}
+
 /// Errors returned by ping protocol operations.
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum PingError {
@@ -149,6 +203,8 @@ pub struct PingProtocol {
     peers: BTreeMap<PeerId, PeerPingState>,
     /// Events buffered until the next `poll_events` call.
     pending_events: Vec<PingEvent>,
+    /// Actions buffered for [`SansIoProtocol::poll_output`].
+    pending_actions: VecDeque<PingAction>,
     /// Protocol configuration.
     config: PingConfig,
 }
@@ -165,6 +221,7 @@ impl PingProtocol {
         Self {
             peers: BTreeMap::new(),
             pending_events: Vec::new(),
+            pending_actions: VecDeque::new(),
             config,
         }
     }
@@ -569,6 +626,69 @@ impl PingProtocol {
     }
 }
 
+impl SansIoProtocol for PingProtocol {
+    type Input = PingInput;
+    type Output = PingOutput;
+    type Error = PingError;
+
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        match input {
+            PingInput::RegisterOutboundStream { peer_id, stream_id } => {
+                self.register_outbound_stream(peer_id, stream_id)?;
+            }
+            PingInput::RegisterInboundStream { peer_id, stream_id } => {
+                let actions = self.register_inbound_stream(peer_id, stream_id);
+                self.pending_actions.extend(actions);
+            }
+            PingInput::SendPing {
+                peer_id,
+                payload,
+                now_ms,
+            } => {
+                let action = self.send_ping(&peer_id, &payload, now_ms)?;
+                self.pending_actions.push_back(action);
+            }
+            PingInput::StreamData {
+                peer_id,
+                stream_id,
+                data,
+                now_ms,
+            } => {
+                let actions = self.on_stream_data(&peer_id, stream_id, &data, now_ms);
+                self.pending_actions.extend(actions);
+            }
+            PingInput::StreamRemoteWriteClosed { peer_id, stream_id } => {
+                let actions = self.on_stream_remote_write_closed(&peer_id, stream_id);
+                self.pending_actions.extend(actions);
+            }
+            PingInput::StreamClosed { peer_id, stream_id } => {
+                self.on_stream_closed(&peer_id, stream_id);
+            }
+            PingInput::RemovePeer { peer_id } => self.remove_peer(&peer_id),
+            PingInput::Tick { now_ms } => {
+                let actions = self.on_tick(now_ms);
+                self.pending_actions.extend(actions);
+            }
+        }
+        Ok(())
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        if let Some(action) = self.pending_actions.pop_front() {
+            return Some(PingOutput::Action(action));
+        }
+        if self.pending_events.is_empty() {
+            None
+        } else {
+            Some(PingOutput::Event(self.pending_events.remove(0)))
+        }
+    }
+
+    fn is_idle(&self) -> bool {
+        self.pending_actions.is_empty() && self.pending_events.is_empty()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use core::str::FromStr;
@@ -581,6 +701,47 @@ mod tests {
 
     fn test_peer() -> PeerId {
         peer("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N")
+    }
+
+    #[test]
+    fn ping_protocol_implements_sans_io_protocol() {
+        let mut ping = PingProtocol::default();
+        let peer = test_peer();
+        let stream_id = StreamId::new(1);
+
+        ping.handle_input(PingInput::RegisterInboundStream {
+            peer_id: peer.clone(),
+            stream_id,
+        })
+        .expect("register inbound");
+
+        let mut payload = [0u8; PING_PAYLOAD_LEN];
+        payload[0] = 7;
+        ping.handle_input(PingInput::StreamData {
+            peer_id: peer.clone(),
+            stream_id,
+            data: payload.to_vec(),
+            now_ms: 10,
+        })
+        .expect("stream data");
+
+        assert!(matches!(
+            ping.poll_output(),
+            Some(PingOutput::Action(PingAction::Send {
+                peer_id: p,
+                stream_id: sid,
+                data,
+            })) if p == peer && sid == stream_id && data == payload
+        ));
+        assert!(!ping.is_idle());
+        assert!(matches!(
+            ping.poll_output(),
+            Some(PingOutput::Event(PingEvent::InboundStreamAccepted {
+                peer_id: p,
+                stream_id: sid,
+            })) if p == peer && sid == stream_id
+        ));
+        assert!(ping.is_idle());
     }
 
     #[test]

--- a/crates/ping/src/lib.rs
+++ b/crates/ping/src/lib.rs
@@ -208,7 +208,7 @@ struct PeerPingState {
 pub struct PingProtocol {
     /// Per-peer protocol state.
     peers: BTreeMap<PeerId, PeerPingState>,
-    /// Events buffered until the next `poll_events` call.
+    /// Events buffered until the next `SansIoProtocol::poll_output` call.
     pending_events: Vec<PingEvent>,
     /// Actions buffered for [`SansIoProtocol::poll_output`].
     pending_actions: VecDeque<PingAction>,

--- a/crates/relay/README.md
+++ b/crates/relay/README.md
@@ -20,7 +20,7 @@ Interop goal for this crate is bridging two minip2p peers through a third-party 
 - **`HopConnect`** -- drives `HOP.CONNECT` against a relay to open a circuit to another reserved peer (peer A's "dial" side). Produces `ConnectOutcome::Bridged` with the stream now acting as a bidirectional byte pipe.
 - **`StopResponder`** -- responds to an incoming `STOP.CONNECT` from the relay (peer B's "accept incoming circuit" side). Accept or reject the request; on accept, subsequent bytes flow through the same stream as the relayed data.
 
-Each machine exposes `on_data(&[u8])`, `outbound()` (take pending outbound bytes), and an outcome accessor. Bytes that arrive pipelined after the initial `STATUS:OK` reply are preserved via `take_bridge_bytes()` on the connect/stop side so the caller can feed them into an upper-layer stream without a second poll round.
+Each machine is driven through `SansIoProtocol`: feed role-specific inputs (`HopReservationInput`, `HopConnectInput`, `StopResponderInput`) and drain role-specific outputs until idle. Bytes that arrive pipelined after the initial `STATUS:OK` reply are emitted as bridge-data outputs on the connect/stop side so the caller can feed them into an upper-layer stream without a second poll round.
 
 ## Protocol IDs
 
@@ -31,17 +31,23 @@ Each machine exposes `on_data(&[u8])`, `outbound()` (take pending outbound bytes
 ## Usage (reservation)
 
 ```rust
-use minip2p_relay::{HopReservation, ReservationOutcome};
+use minip2p_core::SansIoProtocol;
+use minip2p_relay::{HopReservation, HopReservationInput, HopReservationOutput};
 
 let mut reservation = HopReservation::new();
-let initial_outbound = reservation.start(); // send these bytes on the negotiated stream
+
+while let Some(output) = reservation.poll_output() {
+    match output {
+        HopReservationOutput::Outbound(bytes) => send_to_relay(bytes),
+        HopReservationOutput::Outcome(outcome) => handle(outcome),
+    }
+}
 
 // Feed incoming bytes:
-// reservation.on_data(&data);
-// if let Some(outcome) = reservation.outcome() { ... }
+// reservation.handle_input(HopReservationInput::Data(data))?;
 ```
 
-`HopConnect` and `StopResponder` follow the same `start` / `on_data` / `outcome` shape.
+`HopConnect` and `StopResponder` follow the same input / output / drain-loop shape.
 
 ## no_std
 

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -153,7 +153,7 @@ impl HopReservation {
     ///
     /// Call this after construction and whenever you need to flush data to
     /// the relay stream.
-    pub fn take_outbound(&mut self) -> Vec<u8> {
+    fn take_outbound(&mut self) -> Vec<u8> {
         if self.state == FlowState::Pending {
             self.state = FlowState::AwaitingResponse;
         }
@@ -161,7 +161,7 @@ impl HopReservation {
     }
 
     /// Feeds incoming stream bytes from the relay.
-    pub fn on_data(&mut self, data: &[u8]) -> Result<(), RelayError> {
+    fn on_data(&mut self, data: &[u8]) -> Result<(), RelayError> {
         if self.state == FlowState::Done {
             return Ok(());
         }
@@ -174,12 +174,13 @@ impl HopReservation {
     ///
     /// If a complete response has not yet been decoded, this is not itself
     /// an error -- callers can still receive partial buffered data.
-    pub fn on_remote_write_closed(&mut self) -> Result<(), RelayError> {
+    fn on_remote_write_closed(&mut self) -> Result<(), RelayError> {
         self.try_decode_response()
     }
 
     /// Returns the outcome of the flow, if available.
-    pub fn outcome(&self) -> Option<&ReservationOutcome> {
+    #[cfg(test)]
+    fn outcome(&self) -> Option<&ReservationOutcome> {
         self.outcome.as_ref()
     }
 
@@ -369,7 +370,7 @@ impl HopConnect {
     }
 
     /// Drains and returns any pending outbound bytes.
-    pub fn take_outbound(&mut self) -> Vec<u8> {
+    fn take_outbound(&mut self) -> Vec<u8> {
         if self.state == FlowState::Pending {
             self.state = FlowState::AwaitingResponse;
         }
@@ -381,7 +382,7 @@ impl HopConnect {
     /// After the CONNECT is accepted, any further bytes passed here are
     /// buffered as bridged relay traffic; drain them with
     /// [`HopConnect::take_bridge_bytes`].
-    pub fn on_data(&mut self, data: &[u8]) -> Result<(), RelayError> {
+    fn on_data(&mut self, data: &[u8]) -> Result<(), RelayError> {
         if self.state == FlowState::Done {
             // Already bridged or errored — any further bytes belong to the
             // bridged channel (or are garbage after an error).
@@ -396,12 +397,13 @@ impl HopConnect {
     }
 
     /// Notifies the state machine that the remote closed its write side.
-    pub fn on_remote_write_closed(&mut self) -> Result<(), RelayError> {
+    fn on_remote_write_closed(&mut self) -> Result<(), RelayError> {
         self.try_decode_response()
     }
 
     /// Returns the outcome of the flow, if available.
-    pub fn outcome(&self) -> Option<&ConnectOutcome> {
+    #[cfg(test)]
+    fn outcome(&self) -> Option<&ConnectOutcome> {
         self.outcome.as_ref()
     }
 
@@ -413,7 +415,7 @@ impl HopConnect {
     /// Drains any bridged relay traffic received since the last call.
     ///
     /// Only yields bytes after the flow transitions to `Bridged`.
-    pub fn take_bridge_bytes(&mut self) -> Vec<u8> {
+    fn take_bridge_bytes(&mut self) -> Vec<u8> {
         core::mem::take(&mut self.bridge_bytes)
     }
 
@@ -598,12 +600,12 @@ impl StopResponder {
     }
 
     /// Drains and returns any pending outbound bytes.
-    pub fn take_outbound(&mut self) -> Vec<u8> {
+    fn take_outbound(&mut self) -> Vec<u8> {
         core::mem::take(&mut self.outbound)
     }
 
     /// Feeds incoming stream bytes from the relay.
-    pub fn on_data(&mut self, data: &[u8]) -> Result<(), RelayError> {
+    fn on_data(&mut self, data: &[u8]) -> Result<(), RelayError> {
         if self.state == StopState::Bridged {
             self.bridge_bytes.extend_from_slice(data);
             return Ok(());
@@ -618,12 +620,13 @@ impl StopResponder {
     }
 
     /// Notifies the state machine that the remote closed its write side.
-    pub fn on_remote_write_closed(&mut self) -> Result<(), RelayError> {
+    fn on_remote_write_closed(&mut self) -> Result<(), RelayError> {
         self.try_decode_connect()
     }
 
     /// Returns the decoded CONNECT request, if received.
-    pub fn request(&self) -> Option<&StopConnectRequest> {
+    #[cfg(test)]
+    fn request(&self) -> Option<&StopConnectRequest> {
         self.request.as_ref()
     }
 
@@ -636,7 +639,7 @@ impl StopResponder {
     ///
     /// After this, the stream becomes the bridged circuit; any further bytes
     /// received from the relay are queued into [`StopResponder::take_bridge_bytes`].
-    pub fn accept(&mut self) -> Result<(), RelayError> {
+    fn accept(&mut self) -> Result<(), RelayError> {
         self.send_status(Status::Ok, StopState::Bridged)?;
         // Any bytes the relay pipelined after its CONNECT belong to the bridge.
         if !self.recv_buf.is_empty() {
@@ -646,12 +649,12 @@ impl StopResponder {
     }
 
     /// Rejects the CONNECT request with the given status code.
-    pub fn reject(&mut self, status: Status) -> Result<(), RelayError> {
+    fn reject(&mut self, status: Status) -> Result<(), RelayError> {
         self.send_status(status, StopState::Done)
     }
 
     /// Drains any bridged relay traffic received since the last call.
-    pub fn take_bridge_bytes(&mut self) -> Vec<u8> {
+    fn take_bridge_bytes(&mut self) -> Vec<u8> {
         core::mem::take(&mut self.bridge_bytes)
     }
 

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -5,10 +5,9 @@
 //! - [`HopConnect`] -- ask a relay to connect us to another peer (client -> relay).
 //! - [`StopResponder`] -- accept an incoming circuit from a relay (relay -> us).
 //!
-//! Each state machine is driven by feeding stream bytes in via [`on_data`]
-//! methods and reading out a byte slice to send to the peer via
-//! [`take_outbound`]. No I/O is performed inside; the caller is responsible
-//! for writing to and reading from the underlying transport stream.
+//! Each state machine is driven through [`SansIoProtocol`]: callers feed
+//! role-specific input enums, drain output enums, and execute outbound bytes
+//! against the underlying transport stream. No I/O is performed inside.
 //!
 //! `no_std` + `alloc` compatible.
 
@@ -103,11 +102,11 @@ pub enum HopReservationOutput {
 ///
 /// Usage:
 /// 1. Construct with [`HopReservation::new`].
-/// 2. Call [`HopReservation::take_outbound`] and send the returned bytes on
-///    the relay stream.
-/// 3. Feed incoming stream bytes via [`HopReservation::on_data`].
-/// 4. Poll [`HopReservation::outcome`] after each step; `Some(_)` means the
-///    flow has completed (accepted or refused).
+/// 2. Drain [`HopReservationOutput::Outbound`] from
+///    [`SansIoProtocol::poll_output`] and send the bytes on the relay stream.
+/// 3. Feed incoming stream bytes with [`HopReservationInput::Data`].
+/// 4. Drain [`HopReservationOutput::Outcome`] to observe accepted/refused
+///    completion.
 pub struct HopReservation {
     outbound: Vec<u8>,
     recv_buf: Vec<u8>,
@@ -326,12 +325,12 @@ pub enum HopConnectOutput {
 ///
 /// Usage:
 /// 1. Construct with [`HopConnect::new`], passing the target peer's id.
-/// 2. Call [`HopConnect::take_outbound`] and send the returned bytes.
-/// 3. Feed incoming stream bytes via [`HopConnect::on_data`].
-/// 4. When [`HopConnect::outcome`] returns `ConnectOutcome::Bridged`, the
-///    stream becomes the relay circuit: caller may drain leftover bytes via
-///    [`HopConnect::take_bridge_bytes`] and treat subsequent stream data as
-///    relayed peer-to-peer traffic.
+/// 2. Drain [`HopConnectOutput::Outbound`] from
+///    [`SansIoProtocol::poll_output`] and send the bytes.
+/// 3. Feed incoming stream bytes with [`HopConnectInput::Data`].
+/// 4. When [`HopConnectOutput::Outcome`] returns `ConnectOutcome::Bridged`,
+///    the stream becomes the relay circuit; drain
+///    [`HopConnectOutput::BridgeData`] for any pipelined peer-to-peer bytes.
 pub struct HopConnect {
     outbound: Vec<u8>,
     recv_buf: Vec<u8>,
@@ -557,13 +556,13 @@ pub enum StopResponderOutput {
 ///
 /// Flow:
 /// 1. Relay opens a STOP stream to us and sends a CONNECT message.
-/// 2. We decode it via [`StopResponder::on_data`] -> observe
-///    [`StopResponder::request`] populated.
-/// 3. We decide to accept or reject and call [`StopResponder::accept`] or
-///    [`StopResponder::reject`].
-/// 4. We send the resulting outbound bytes via [`StopResponder::take_outbound`].
-/// 5. If accepted, the stream becomes the bridged circuit; drain leftover
-///    bytes via [`StopResponder::take_bridge_bytes`].
+/// 2. Feed bytes with [`StopResponderInput::Data`] and drain
+///    [`StopResponderOutput::Request`].
+/// 3. Decide to accept or reject with [`StopResponderInput::Accept`] or
+///    [`StopResponderInput::Reject`].
+/// 4. Send resulting [`StopResponderOutput::Outbound`] bytes to the relay.
+/// 5. If accepted, the stream becomes the bridged circuit; drain
+///    [`StopResponderOutput::BridgeData`] for any pipelined bytes.
 pub struct StopResponder {
     outbound: Vec<u8>,
     recv_buf: Vec<u8>,

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -21,6 +21,8 @@ mod message;
 use alloc::string::String;
 use alloc::vec::Vec;
 
+use minip2p_core::SansIoProtocol;
+
 pub use message::{
     FrameDecode, HopMessage, HopMessageType, Limit, Peer, RelayMessageError, Reservation, Status,
     StopMessage, StopMessageType, decode_frame, describe_status, encode_frame,
@@ -77,6 +79,26 @@ pub enum ReservationOutcome {
     },
 }
 
+/// Input accepted by [`HopReservation`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HopReservationInput {
+    /// Drain queued RESERVE bytes into an output.
+    Flush,
+    /// Bytes received from the relay stream.
+    Data(Vec<u8>),
+    /// Remote write side closed.
+    RemoteWriteClosed,
+}
+
+/// Output produced by [`HopReservation`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HopReservationOutput {
+    /// Bytes to write to the relay stream.
+    Outbound(Vec<u8>),
+    /// Reservation result decoded from the relay response.
+    Outcome(ReservationOutcome),
+}
+
 /// Client-side state machine for the HOP RESERVE flow.
 ///
 /// Usage:
@@ -91,6 +113,7 @@ pub struct HopReservation {
     recv_buf: Vec<u8>,
     state: FlowState,
     outcome: Option<ReservationOutcome>,
+    emitted_outcome: bool,
 }
 
 /// Common flow states for client-initiated request/response exchanges.
@@ -122,6 +145,7 @@ impl HopReservation {
             recv_buf: Vec::new(),
             state: FlowState::Pending,
             outcome: None,
+            emitted_outcome: false,
         }
     }
 
@@ -211,8 +235,42 @@ impl HopReservation {
                 reason: describe_status(status),
             }
         });
+        self.emitted_outcome = false;
 
         Ok(())
+    }
+}
+
+impl SansIoProtocol for HopReservation {
+    type Input = HopReservationInput;
+    type Output = HopReservationOutput;
+    type Error = RelayError;
+
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        match input {
+            HopReservationInput::Flush => {}
+            HopReservationInput::Data(data) => self.on_data(&data)?,
+            HopReservationInput::RemoteWriteClosed => self.on_remote_write_closed()?,
+        }
+        Ok(())
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        let outbound = self.take_outbound();
+        if !outbound.is_empty() {
+            return Some(HopReservationOutput::Outbound(outbound));
+        }
+        if !self.emitted_outcome {
+            if let Some(outcome) = self.outcome.clone() {
+                self.emitted_outcome = true;
+                return Some(HopReservationOutput::Outcome(outcome));
+            }
+        }
+        None
+    }
+
+    fn is_idle(&self) -> bool {
+        self.outbound.is_empty() && (self.emitted_outcome || self.outcome.is_none())
     }
 }
 
@@ -241,6 +299,28 @@ pub enum ConnectOutcome {
     Refused { status: Status, reason: String },
 }
 
+/// Input accepted by [`HopConnect`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HopConnectInput {
+    /// Drain queued CONNECT bytes into an output.
+    Flush,
+    /// Bytes received from the relay stream.
+    Data(Vec<u8>),
+    /// Remote write side closed.
+    RemoteWriteClosed,
+}
+
+/// Output produced by [`HopConnect`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HopConnectOutput {
+    /// Bytes to write to the relay stream.
+    Outbound(Vec<u8>),
+    /// CONNECT result decoded from the relay response.
+    Outcome(ConnectOutcome),
+    /// Bytes received after the relay circuit was bridged.
+    BridgeData(Vec<u8>),
+}
+
 /// Client-side state machine for the HOP CONNECT flow.
 ///
 /// Usage:
@@ -256,6 +336,7 @@ pub struct HopConnect {
     recv_buf: Vec<u8>,
     state: FlowState,
     outcome: Option<ConnectOutcome>,
+    emitted_outcome: bool,
     bridge_bytes: Vec<u8>,
 }
 
@@ -282,6 +363,7 @@ impl HopConnect {
             recv_buf: Vec::new(),
             state: FlowState::Pending,
             outcome: None,
+            emitted_outcome: false,
             bridge_bytes: Vec::new(),
         }
     }
@@ -385,8 +467,48 @@ impl HopConnect {
                 reason: describe_status(status),
             }
         });
+        self.emitted_outcome = false;
 
         Ok(())
+    }
+}
+
+impl SansIoProtocol for HopConnect {
+    type Input = HopConnectInput;
+    type Output = HopConnectOutput;
+    type Error = RelayError;
+
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        match input {
+            HopConnectInput::Flush => {}
+            HopConnectInput::Data(data) => self.on_data(&data)?,
+            HopConnectInput::RemoteWriteClosed => self.on_remote_write_closed()?,
+        }
+        Ok(())
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        let outbound = self.take_outbound();
+        if !outbound.is_empty() {
+            return Some(HopConnectOutput::Outbound(outbound));
+        }
+        if !self.emitted_outcome {
+            if let Some(outcome) = self.outcome.clone() {
+                self.emitted_outcome = true;
+                return Some(HopConnectOutput::Outcome(outcome));
+            }
+        }
+        let bridge_bytes = self.take_bridge_bytes();
+        if !bridge_bytes.is_empty() {
+            return Some(HopConnectOutput::BridgeData(bridge_bytes));
+        }
+        None
+    }
+
+    fn is_idle(&self) -> bool {
+        self.outbound.is_empty()
+            && self.bridge_bytes.is_empty()
+            && (self.emitted_outcome || self.outcome.is_none())
     }
 }
 
@@ -401,6 +523,32 @@ pub struct StopConnectRequest {
     pub source_peer_id: Vec<u8>,
     /// Connection limits, if any.
     pub limit: Option<Limit>,
+}
+
+/// Input accepted by [`StopResponder`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StopResponderInput {
+    /// Drain queued STATUS bytes into an output.
+    Flush,
+    /// Bytes received from the relay stream.
+    Data(Vec<u8>),
+    /// Remote write side closed.
+    RemoteWriteClosed,
+    /// Accept the pending CONNECT request.
+    Accept,
+    /// Reject the pending CONNECT request with a status.
+    Reject(Status),
+}
+
+/// Output produced by [`StopResponder`] through [`SansIoProtocol`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StopResponderOutput {
+    /// Decoded CONNECT request.
+    Request(StopConnectRequest),
+    /// Bytes to write to the relay stream.
+    Outbound(Vec<u8>),
+    /// Bytes received after the relay circuit was bridged.
+    BridgeData(Vec<u8>),
 }
 
 /// Server-side state machine for the STOP protocol (we are the destination).
@@ -419,6 +567,7 @@ pub struct StopResponder {
     recv_buf: Vec<u8>,
     state: StopState,
     request: Option<StopConnectRequest>,
+    emitted_request: bool,
     bridge_bytes: Vec<u8>,
 }
 
@@ -443,6 +592,7 @@ impl StopResponder {
             recv_buf: Vec::new(),
             state: StopState::AwaitingConnect,
             request: None,
+            emitted_request: false,
             bridge_bytes: Vec::new(),
         }
     }
@@ -570,9 +720,51 @@ impl StopResponder {
             source_peer_id: peer.id,
             limit: msg.limit,
         });
+        self.emitted_request = false;
         self.state = StopState::AwaitingDecision;
 
         Ok(())
+    }
+}
+
+impl SansIoProtocol for StopResponder {
+    type Input = StopResponderInput;
+    type Output = StopResponderOutput;
+    type Error = RelayError;
+
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
+        match input {
+            StopResponderInput::Flush => {}
+            StopResponderInput::Data(data) => self.on_data(&data)?,
+            StopResponderInput::RemoteWriteClosed => self.on_remote_write_closed()?,
+            StopResponderInput::Accept => self.accept()?,
+            StopResponderInput::Reject(status) => self.reject(status)?,
+        }
+        Ok(())
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        if !self.emitted_request {
+            if let Some(request) = self.request.clone() {
+                self.emitted_request = true;
+                return Some(StopResponderOutput::Request(request));
+            }
+        }
+        let outbound = self.take_outbound();
+        if !outbound.is_empty() {
+            return Some(StopResponderOutput::Outbound(outbound));
+        }
+        let bridge_bytes = self.take_bridge_bytes();
+        if !bridge_bytes.is_empty() {
+            return Some(StopResponderOutput::BridgeData(bridge_bytes));
+        }
+        None
+    }
+
+    fn is_idle(&self) -> bool {
+        self.outbound.is_empty()
+            && self.bridge_bytes.is_empty()
+            && (self.emitted_request || self.request.is_none())
     }
 }
 
@@ -979,5 +1171,62 @@ mod tests {
         }
 
         assert!(flow.request().is_some());
+    }
+
+    #[test]
+    fn relay_flows_implement_sans_io_protocol() {
+        let mut reservation = HopReservation::new();
+        reservation
+            .handle_input(HopReservationInput::Flush)
+            .unwrap();
+        assert!(matches!(
+            reservation.poll_output(),
+            Some(HopReservationOutput::Outbound(_))
+        ));
+
+        let response = frame_hop(HopMessage {
+            kind: HopMessageType::Status,
+            peer: None,
+            reservation: None,
+            limit: None,
+            status: Some(Status::Ok),
+        });
+        reservation
+            .handle_input(HopReservationInput::Data(response))
+            .unwrap();
+        assert!(matches!(
+            reservation.poll_output(),
+            Some(HopReservationOutput::Outcome(
+                ReservationOutcome::Accepted { .. }
+            ))
+        ));
+
+        let mut stop = StopResponder::new();
+        let mut connect = frame_stop(StopMessage {
+            kind: StopMessageType::Connect,
+            peer: Some(Peer {
+                id: b"src".to_vec(),
+                addrs: vec![],
+            }),
+            limit: None,
+            status: None,
+        });
+        connect.extend_from_slice(b"bridge");
+        stop.handle_input(StopResponderInput::Data(connect))
+            .unwrap();
+        assert!(matches!(
+            stop.poll_output(),
+            Some(StopResponderOutput::Request(_))
+        ));
+
+        stop.handle_input(StopResponderInput::Accept).unwrap();
+        assert!(matches!(
+            stop.poll_output(),
+            Some(StopResponderOutput::Outbound(_))
+        ));
+        assert_eq!(
+            stop.poll_output(),
+            Some(StopResponderOutput::BridgeData(b"bridge".to_vec()))
+        );
     }
 }

--- a/crates/swarm/README.md
+++ b/crates/swarm/README.md
@@ -46,9 +46,21 @@ core.add_user_protocol("/myapp/1.0.0");
 // Drive it:
 // core.on_transport_event(event, now_ms);
 // core.on_tick(now_ms);
-// for action in core.take_actions() { execute(action); }
-// for event in core.poll_events() { ... }
+// while let Some(action) = core.poll_action() { execute(action); }
+// while let Some(event) = core.poll_event() { ... }
 ```
+
+### Driver loop contract
+
+The core is deterministic when callers use a simple mutate-then-drain loop:
+
+1. Feed exactly one external input into the core: a `TransportEvent`, a timer tick via `on_tick(now_ms)`, or one application intent such as `ping`, `open_user_stream`, or `send_user_stream`.
+2. Drain `core.poll_action()` and execute each `SwarmAction` against your transport.
+3. If executing an action feeds a result back into the core, such as `on_stream_opened` or `on_open_stream_failed`, drain actions again until no new actions are produced.
+4. Drain `core.poll_event()` and hand those events to the application.
+5. Before waiting on I/O again, `core.is_idle()` should be true.
+
+That shape mirrors the std `Swarm<T>` driver while keeping sockets, clocks, sleeps, async runtimes, and allocation policy outside the Sans-I/O core.
 
 ## Std driver usage
 

--- a/crates/swarm/README.md
+++ b/crates/swarm/README.md
@@ -36,7 +36,7 @@ Orchestration layer that composes minip2p's protocol state machines into a singl
 ## Sans-I/O usage
 
 ```rust
-use minip2p_swarm::{SwarmCore, SwarmEvent};
+use minip2p_swarm::{SwarmCore, SwarmInput, SwarmOutput};
 use minip2p_identify::IdentifyConfig;
 use minip2p_ping::PingConfig;
 
@@ -44,21 +44,26 @@ let mut core = SwarmCore::new(identify_config, PingConfig::default());
 core.add_user_protocol("/myapp/1.0.0");
 
 // Drive it:
-// core.on_transport_event(event, now_ms);
-// core.on_tick(now_ms);
-// while let Some(action) = core.poll_action() { execute(action); }
-// while let Some(event) = core.poll_event() { ... }
+// core.handle_input(SwarmInput::Transport { event, now_ms });
+// core.handle_input(SwarmInput::Tick { now_ms });
+// while let Some(output) = core.poll_output() {
+//     match output {
+//         SwarmOutput::Action(action) => execute(action),
+//         SwarmOutput::Event(event) => { /* hand to app */ }
+//     }
+// }
 ```
 
 ### Driver loop contract
 
 The core is deterministic when callers use a simple mutate-then-drain loop:
 
-1. Feed exactly one external input into the core: a `TransportEvent`, a timer tick via `on_tick(now_ms)`, or one application intent such as `ping`, `open_user_stream`, or `send_user_stream`.
-2. Drain `core.poll_action()` and execute each `SwarmAction` against your transport.
-3. If executing an action feeds a result back into the core, such as `on_stream_opened` or `on_open_stream_failed`, drain actions again until no new actions are produced.
-4. Drain `core.poll_event()` and hand those events to the application.
-5. Before waiting on I/O again, `core.is_idle()` should be true.
+1. Feed exactly one external input into the core with `core.handle_input(...)`, or call one application intent such as `ping`, `open_user_stream`, or `send_user_stream`.
+2. Drain `core.poll_output()`.
+3. Execute each `SwarmOutput::Action` against your transport.
+4. Feed driver results back with `SwarmInput::StreamOpened`, `SwarmInput::OpenStreamFailed`, or `SwarmInput::RuntimeError`.
+5. Hand each `SwarmOutput::Event` to the application.
+6. Before waiting on I/O again, `core.is_idle()` should be true.
 
 That shape mirrors the std `Swarm<T>` driver while keeping sockets, clocks, sleeps, async runtimes, and allocation policy outside the Sans-I/O core.
 

--- a/crates/swarm/README.md
+++ b/crates/swarm/README.md
@@ -4,7 +4,7 @@ Orchestration layer that composes minip2p's protocol state machines into a singl
 
 ## Two layers
 
-- **`SwarmCore`** (`no_std + alloc`): pure state machine. Consumes `TransportEvent` values (with caller-supplied `now_ms`), emits `SwarmAction` commands and `SwarmEvent` notifications. No sockets, no async runtime, no clock reads. Composes `IdentifyProtocol`, `PingProtocol`, and `MultistreamSelect`; tracks connections, streams, and pending stream opens.
+- **`SwarmCore`** (`no_std + alloc`): pure state machine. Consumes `SwarmInput` values through `handle_input`, emits `SwarmOutput` values through `poll_output`, and reports quiescence with `is_idle`. Outputs wrap `SwarmAction` commands for the driver and `SwarmEvent` notifications for the application. No sockets, no async runtime, no clock reads. Composes `IdentifyProtocol`, `PingProtocol`, and `MultistreamSelect`; tracks connections, streams, and pending stream opens.
 - **`Swarm<T: Transport>`** (`std` feature, default): thin driver around `SwarmCore`. Owns a concrete transport, reads `std::time::Instant` for `now_ms`, and shuttles events and actions between the transport and the core. Preserves the one-call DX (`swarm.dial`, `swarm.ping`, `swarm.open_user_stream`).
 
 ## Features

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -32,7 +32,7 @@ use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 
-use minip2p_core::{Multiaddr, PeerId};
+use minip2p_core::{Multiaddr, PeerId, SansIo};
 use minip2p_identify::{
     IDENTIFY_PROTOCOL_ID, IdentifyAction, IdentifyConfig, IdentifyEvent, IdentifyMessage,
     IdentifyProtocol,
@@ -1427,6 +1427,23 @@ impl SwarmCore {
     }
 }
 
+impl SansIo for SwarmCore {
+    type Input = SwarmInput;
+    type Output = SwarmOutput;
+
+    fn handle_input(&mut self, input: Self::Input) {
+        Self::handle_input(self, input);
+    }
+
+    fn poll_output(&mut self) -> Option<Self::Output> {
+        Self::poll_output(self)
+    }
+
+    fn is_idle(&self) -> bool {
+        Self::is_idle(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use core::str::FromStr;
@@ -1477,6 +1494,18 @@ mod tests {
             }
         }
         events
+    }
+
+    #[test]
+    fn swarm_core_implements_common_sans_io_trait() {
+        fn drive_idle<S: SansIo<Input = SwarmInput, Output = SwarmOutput>>(engine: &mut S) {
+            engine.handle_input(SwarmInput::Tick { now_ms: 0 });
+            while engine.poll_output().is_some() {}
+            assert!(engine.is_idle());
+        }
+
+        let mut core = test_core();
+        drive_idle(&mut core);
     }
 
     #[test]

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -119,7 +119,7 @@ pub struct SwarmCore {
     stream_owner: BTreeMap<(ConnectionId, StreamId), ProtocolKind>,
     /// Outstanding OpenStream requests keyed by token; populated when the
     /// core emits `SwarmAction::OpenStream` and drained when the driver
-    /// reports the allocated stream id back via `on_stream_opened`.
+    /// reports the allocated stream id back via [`SwarmInput::StreamOpened`].
     pending_opens: BTreeMap<OpenStreamToken, PendingOpen>,
     /// Auto-incrementing source for [`OpenStreamToken`]s.
     next_open_token: u64,
@@ -216,49 +216,10 @@ impl SwarmCore {
     /// action can feed more input back into the core. Once no actions remain,
     /// events are yielded in FIFO order.
     pub fn poll_output(&mut self) -> Option<SwarmOutput> {
-        self.poll_action()
-            .map(SwarmOutput::Action)
-            .or_else(|| self.poll_event().map(SwarmOutput::Event))
-    }
-
-    /// Returns the next pending driver action, if any.
-    ///
-    /// Polling one item at a time lets custom drivers execute an action and
-    /// immediately feed any resulting mutation back into the core before
-    /// continuing the drain loop.
-    pub fn poll_action(&mut self) -> Option<SwarmAction> {
-        if self.actions.is_empty() {
-            None
-        } else {
-            self.actions.pop_front()
+        if let Some(action) = self.actions.pop_front() {
+            return Some(SwarmOutput::Action(action));
         }
-    }
-
-    /// Returns the next application-visible event, if any.
-    pub fn poll_event(&mut self) -> Option<SwarmEvent> {
-        if self.events.is_empty() {
-            None
-        } else {
-            self.events.pop_front()
-        }
-    }
-
-    /// Drains all buffered actions for the driver to execute.
-    pub fn take_actions(&mut self) -> Vec<SwarmAction> {
-        let mut actions = Vec::new();
-        while let Some(action) = self.poll_action() {
-            actions.push(action);
-        }
-        actions
-    }
-
-    /// Drains all buffered application-visible events.
-    pub fn poll_events(&mut self) -> Vec<SwarmEvent> {
-        let mut events = Vec::new();
-        while let Some(event) = self.poll_event() {
-            events.push(event);
-        }
-        events
+        self.events.pop_front().map(SwarmOutput::Event)
     }
 
     /// Returns true when the core has no pending driver actions or
@@ -274,32 +235,21 @@ impl SwarmCore {
     /// Feeds one external input into the core.
     pub fn handle_input(&mut self, input: SwarmInput) {
         match input {
-            SwarmInput::Transport { event, now_ms } => self.on_transport_event(event, now_ms),
-            SwarmInput::Tick { now_ms } => self.on_tick(now_ms),
+            SwarmInput::Transport { event, now_ms } => self.handle_transport_event(event, now_ms),
+            SwarmInput::Tick { now_ms } => self.handle_tick(now_ms),
             SwarmInput::StreamOpened {
                 conn_id,
                 stream_id,
                 token,
                 now_ms,
-            } => self.on_stream_opened(conn_id, stream_id, token, now_ms),
+            } => self.handle_stream_opened(conn_id, stream_id, token, now_ms),
             SwarmInput::OpenStreamFailed {
                 token,
                 reason,
                 now_ms,
-            } => self.on_open_stream_failed(token, reason, now_ms),
-            SwarmInput::RuntimeError(error) => self.record_error(error),
+            } => self.handle_open_stream_failed(token, reason, now_ms),
+            SwarmInput::RuntimeError(error) => self.record_runtime_error(error),
         }
-    }
-
-    /// Records a non-fatal error observed by the driver while executing a
-    /// queued action (e.g. a [`SwarmAction::SendStream`] call on the
-    /// transport failed).
-    ///
-    /// Surfaces as a [`SwarmEvent::Error`] on the next
-    /// [`Self::poll_events`]. Used by the driver so transport-level
-    /// failures are never silently dropped.
-    pub fn record_error(&mut self, error: SwarmRuntimeError) {
-        self.events.push_back(SwarmEvent::Error(error));
     }
 
     // -----------------------------------------------------------------------
@@ -356,7 +306,7 @@ impl SwarmCore {
 
     /// Opens a new outbound stream and starts multistream-select negotiation
     /// for `protocol_id`. The actual stream id is not known until the driver
-    /// reports back via [`Self::on_stream_opened`].
+    /// reports back via [`SwarmInput::StreamOpened`].
     pub fn open_user_stream(
         &mut self,
         peer_id: &PeerId,
@@ -475,8 +425,11 @@ impl SwarmCore {
     // Ingress
     // -----------------------------------------------------------------------
 
-    /// Feeds a transport event into the core.
-    pub fn on_transport_event(&mut self, event: TransportEvent, now_ms: u64) {
+    fn record_runtime_error(&mut self, error: SwarmRuntimeError) {
+        self.events.push_back(SwarmEvent::Error(error));
+    }
+
+    fn handle_transport_event(&mut self, event: TransportEvent, now_ms: u64) {
         match event {
             TransportEvent::Connected { id, endpoint } => {
                 self.active_connections.insert(id, true);
@@ -515,7 +468,7 @@ impl SwarmCore {
             }
             TransportEvent::StreamOpened { .. } => {
                 // Outbound stream id allocation is driver-synchronous; the
-                // core tracks opens via `on_stream_opened` rather than this
+                // core tracks opens via `SwarmInput::StreamOpened` rather than this
                 // event. No-op here.
             }
             TransportEvent::StreamData {
@@ -546,8 +499,7 @@ impl SwarmCore {
         }
     }
 
-    /// Advances time-based protocol state (e.g. ping timeouts).
-    pub fn on_tick(&mut self, now_ms: u64) {
+    fn handle_tick(&mut self, now_ms: u64) {
         let tick_actions = self.ping.on_tick(now_ms);
         for action in tick_actions {
             self.execute_ping_action(action);
@@ -555,15 +507,7 @@ impl SwarmCore {
         self.collect_protocol_events();
     }
 
-    /// Reports the result of an [`SwarmAction::OpenStream`] back to the core.
-    ///
-    /// The driver calls this after `transport.open_stream(conn_id)`
-    /// succeeds. The core starts multistream-select on the stream and emits
-    /// the outbound handshake as `SendStream` actions.
-    ///
-    /// Prefer [`SwarmCore::handle_input`] with [`SwarmInput::StreamOpened`]
-    /// in new drivers.
-    pub fn on_stream_opened(
+    fn handle_stream_opened(
         &mut self,
         conn_id: ConnectionId,
         stream_id: StreamId,
@@ -615,11 +559,7 @@ impl SwarmCore {
         );
     }
 
-    /// Reports that an [`SwarmAction::OpenStream`] failed at the driver.
-    ///
-    /// Prefer [`SwarmCore::handle_input`] with
-    /// [`SwarmInput::OpenStreamFailed`] in new drivers.
-    pub fn on_open_stream_failed(&mut self, token: OpenStreamToken, reason: String, _now_ms: u64) {
+    fn handle_open_stream_failed(&mut self, token: OpenStreamToken, reason: String, _now_ms: u64) {
         let pending = self.pending_opens.remove(&token);
         let (peer_id, conn_id, detail) = match pending {
             Some(p) => (
@@ -1513,6 +1453,32 @@ mod tests {
         Multiaddr::from_str("/ip4/127.0.0.1/udp/4001/quic-v1").expect("valid multiaddr")
     }
 
+    fn feed(core: &mut SwarmCore, event: TransportEvent) {
+        core.handle_input(SwarmInput::Transport { event, now_ms: 0 });
+    }
+
+    fn drain_actions(core: &mut SwarmCore) -> Vec<SwarmAction> {
+        let mut actions = Vec::new();
+        while let Some(output) = core.poll_output() {
+            match output {
+                SwarmOutput::Action(action) => actions.push(action),
+                SwarmOutput::Event(_) => {}
+            }
+        }
+        actions
+    }
+
+    fn drain_events(core: &mut SwarmCore) -> Vec<SwarmEvent> {
+        let mut events = Vec::new();
+        while let Some(output) = core.poll_output() {
+            match output {
+                SwarmOutput::Action(_) => {}
+                SwarmOutput::Event(event) => events.push(event),
+            }
+        }
+        events
+    }
+
     #[test]
     fn is_idle_reflects_pending_actions_and_events() {
         let mut core = test_core();
@@ -1521,17 +1487,16 @@ mod tests {
 
         assert!(core.is_idle());
 
-        core.on_transport_event(
+        feed(
+            &mut core,
             TransportEvent::Connected {
                 id: conn_id,
                 endpoint: ConnectionEndpoint::with_peer_id(loopback_transport(), peer_id.clone()),
             },
-            0,
         );
         assert!(!core.is_idle());
 
-        let _ = core.take_actions();
-        let _ = core.poll_events();
+        while core.poll_output().is_some() {}
         assert!(core.is_idle());
     }
 
@@ -1540,22 +1505,22 @@ mod tests {
         let mut core = test_core();
         let conn_id = ConnectionId::new(7);
 
-        core.on_transport_event(
+        feed(
+            &mut core,
             TransportEvent::Connected {
                 id: conn_id,
                 endpoint: ConnectionEndpoint::new(loopback_transport()),
             },
-            0,
         );
-        core.on_transport_event(
+        feed(
+            &mut core,
             TransportEvent::Error {
                 id: conn_id,
                 message: "boom".into(),
             },
-            0,
         );
 
-        let events = core.poll_events();
+        let events = drain_events(&mut core);
         let error = events
             .iter()
             .find_map(|event| match event {
@@ -1573,22 +1538,22 @@ mod tests {
         let conn_id = ConnectionId::new(8);
         let peer_id = PeerId::from_public_key_protobuf(b"known-peer");
 
-        core.on_transport_event(
+        feed(
+            &mut core,
             TransportEvent::Connected {
                 id: conn_id,
                 endpoint: ConnectionEndpoint::with_peer_id(loopback_transport(), peer_id.clone()),
             },
-            0,
         );
-        core.on_transport_event(
+        feed(
+            &mut core,
             TransportEvent::Error {
                 id: conn_id,
                 message: "boom".into(),
             },
-            0,
         );
 
-        let events = core.poll_events();
+        let events = drain_events(&mut core);
         let error = events
             .iter()
             .find_map(|event| match event {
@@ -1618,7 +1583,7 @@ mod tests {
 
         core.send_user_stream(&peer_id, stream_id, b"ok".to_vec())
             .expect("user stream should be active on original connection");
-        let actions = core.take_actions();
+        let actions = drain_actions(&mut core);
 
         assert!(matches!(
             actions.as_slice(),
@@ -1635,24 +1600,24 @@ mod tests {
         let newer_conn = ConnectionId::new(11);
         let stream_id = StreamId::new(8);
 
-        core.on_transport_event(
+        feed(
+            &mut core,
             TransportEvent::Connected {
                 id: original_conn,
                 endpoint: ConnectionEndpoint::with_peer_id(loopback_transport(), peer_id.clone()),
             },
-            0,
         );
         core.stream_owner.insert(
             (original_conn, stream_id),
             ProtocolKind::User("/minip2p/test/1.0.0".into()),
         );
 
-        core.on_transport_event(
+        feed(
+            &mut core,
             TransportEvent::Connected {
                 id: newer_conn,
                 endpoint: ConnectionEndpoint::with_peer_id(loopback_transport(), peer_id.clone()),
             },
-            0,
         );
 
         let err = core

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -1,9 +1,11 @@
 //! Sans-I/O core of the swarm.
 //!
-//! [`SwarmCore`] is a pure state machine: it consumes [`TransportEvent`]
-//! values (plus a caller-supplied wall-clock timestamp) and emits
-//! [`SwarmAction`] commands for a driver to execute against a concrete
-//! transport. No sockets, no async runtime, no clock reads.
+//! [`SwarmCore`] is a pure state machine: it consumes [`SwarmInput`] values
+//! through [`SwarmCore::handle_input`], emits [`SwarmOutput`] values through
+//! [`SwarmCore::poll_output`], and reports quiescence through
+//! [`SwarmCore::is_idle`]. Outputs wrap [`SwarmAction`] commands for a driver
+//! to execute against a concrete transport and [`SwarmEvent`] notifications
+//! for the application. No sockets, no async runtime, no clock reads.
 //!
 //! `no_std + alloc` compatible. The std [`crate::Swarm`] driver is a thin
 //! wrapper that owns a transport, reads the clock via [`std::time::Instant`],

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -32,7 +32,7 @@ use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 
-use minip2p_core::{Multiaddr, PeerId, SansIo};
+use minip2p_core::{Multiaddr, PeerId, SansIoProtocol};
 use minip2p_identify::{
     IDENTIFY_PROTOCOL_ID, IdentifyAction, IdentifyConfig, IdentifyEvent, IdentifyMessage,
     IdentifyProtocol,
@@ -1427,7 +1427,7 @@ impl SwarmCore {
     }
 }
 
-impl SansIo for SwarmCore {
+impl SansIoProtocol for SwarmCore {
     type Input = SwarmInput;
     type Output = SwarmOutput;
 
@@ -1497,8 +1497,8 @@ mod tests {
     }
 
     #[test]
-    fn swarm_core_implements_common_sans_io_trait() {
-        fn drive_idle<S: SansIo<Input = SwarmInput, Output = SwarmOutput>>(engine: &mut S) {
+    fn swarm_core_implements_common_sans_io_protocol_trait() {
+        fn drive_idle<S: SansIoProtocol<Input = SwarmInput, Output = SwarmOutput>>(engine: &mut S) {
             engine.handle_input(SwarmInput::Tick { now_ms: 0 });
             while engine.poll_output().is_some() {}
             assert!(engine.is_idle());

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -1349,6 +1349,7 @@ impl SwarmCore {
                         .push_back(SwarmAction::ResetStream { conn_id, stream_id });
                     return;
                 }
+                self.drain_ping_outputs();
 
                 if let Some(payload) = self.pending_pings.remove(&peer_id) {
                     match self.ping.handle_input(PingInput::SendPing {
@@ -1623,6 +1624,22 @@ mod tests {
 
         while core.poll_output().is_some() {}
         assert!(core.is_idle());
+    }
+
+    #[test]
+    fn outbound_ping_registration_without_payload_leaves_protocol_idle() {
+        let mut core = test_core();
+        let peer_id = PeerId::from_public_key_protobuf(b"known-peer");
+        let conn_id = ConnectionId::new(2);
+        let stream_id = StreamId::new(9);
+
+        core.conn_to_peer.insert(conn_id, peer_id.clone());
+        core.peer_to_conn.insert(peer_id, conn_id);
+
+        core.on_outbound_negotiated(conn_id, stream_id, ProtocolKind::Ping, 0);
+
+        assert!(core.ping.is_idle());
+        assert!(core.poll_output().is_none());
     }
 
     #[test]

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -31,6 +31,7 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
+use core::convert::Infallible;
 
 use minip2p_core::{Multiaddr, PeerId, SansIoProtocol};
 use minip2p_identify::{
@@ -1430,9 +1431,11 @@ impl SwarmCore {
 impl SansIoProtocol for SwarmCore {
     type Input = SwarmInput;
     type Output = SwarmOutput;
+    type Error = Infallible;
 
-    fn handle_input(&mut self, input: Self::Input) {
+    fn handle_input(&mut self, input: Self::Input) -> Result<(), Self::Error> {
         Self::handle_input(self, input);
+        Ok(())
     }
 
     fn poll_output(&mut self) -> Option<Self::Output> {
@@ -1499,7 +1502,7 @@ mod tests {
     #[test]
     fn swarm_core_implements_common_sans_io_protocol_trait() {
         fn drive_idle<S: SansIoProtocol<Input = SwarmInput, Output = SwarmOutput>>(engine: &mut S) {
-            engine.handle_input(SwarmInput::Tick { now_ms: 0 });
+            let _ = engine.handle_input(SwarmInput::Tick { now_ms: 0 });
             while engine.poll_output().is_some() {}
             assert!(engine.is_idle());
         }

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -13,13 +13,11 @@
 //!
 //! External drivers should follow a drain loop:
 //!
-//! 1. perform one mutation (`on_transport_event`, `on_tick`, or an
-//!    application-facing method such as `ping`);
-//! 2. drain and execute every [`SwarmAction`] from [`SwarmCore::poll_action`],
-//!    reporting stream-open results back through `on_stream_opened` /
-//!    `on_open_stream_failed`;
-//! 3. repeat action draining until no new actions are produced;
-//! 4. drain application events via [`SwarmCore::poll_event`].
+//! 1. perform one mutation (`handle_input` or an application-facing method
+//!    such as `ping`);
+//! 2. drain [`SwarmOutput`] values from [`SwarmCore::poll_output`], executing
+//!    each action and feeding driver results back through `handle_input`;
+//! 3. repeat output draining until no new outputs are produced.
 //!
 //! After a full drain, [`SwarmCore::is_idle`] returns `true`. Treating that as
 //! the handoff point before waiting on external I/O keeps the Sans-I/O state
@@ -46,7 +44,8 @@ use minip2p_ping::{
 use minip2p_transport::{ConnectionId, StreamId, TransportEvent};
 
 use crate::events::{
-    OpenStreamToken, SwarmAction, SwarmError, SwarmErrorKind, SwarmEvent, SwarmRuntimeError,
+    OpenStreamToken, SwarmAction, SwarmError, SwarmErrorKind, SwarmEvent, SwarmInput, SwarmOutput,
+    SwarmRuntimeError,
 };
 
 // ---------------------------------------------------------------------------
@@ -211,6 +210,17 @@ impl SwarmCore {
     // Egress (driver drains these)
     // -----------------------------------------------------------------------
 
+    /// Returns the next core output, if any.
+    ///
+    /// Actions are prioritized over application events because executing an
+    /// action can feed more input back into the core. Once no actions remain,
+    /// events are yielded in FIFO order.
+    pub fn poll_output(&mut self) -> Option<SwarmOutput> {
+        self.poll_action()
+            .map(SwarmOutput::Action)
+            .or_else(|| self.poll_event().map(SwarmOutput::Event))
+    }
+
     /// Returns the next pending driver action, if any.
     ///
     /// Polling one item at a time lets custom drivers execute an action and
@@ -259,6 +269,26 @@ impl SwarmCore {
     /// application input again.
     pub fn is_idle(&self) -> bool {
         self.actions.is_empty() && self.events.is_empty()
+    }
+
+    /// Feeds one external input into the core.
+    pub fn handle_input(&mut self, input: SwarmInput) {
+        match input {
+            SwarmInput::Transport { event, now_ms } => self.on_transport_event(event, now_ms),
+            SwarmInput::Tick { now_ms } => self.on_tick(now_ms),
+            SwarmInput::StreamOpened {
+                conn_id,
+                stream_id,
+                token,
+                now_ms,
+            } => self.on_stream_opened(conn_id, stream_id, token, now_ms),
+            SwarmInput::OpenStreamFailed {
+                token,
+                reason,
+                now_ms,
+            } => self.on_open_stream_failed(token, reason, now_ms),
+            SwarmInput::RuntimeError(error) => self.record_error(error),
+        }
     }
 
     /// Records a non-fatal error observed by the driver while executing a
@@ -530,6 +560,9 @@ impl SwarmCore {
     /// The driver calls this after `transport.open_stream(conn_id)`
     /// succeeds. The core starts multistream-select on the stream and emits
     /// the outbound handshake as `SendStream` actions.
+    ///
+    /// Prefer [`SwarmCore::handle_input`] with [`SwarmInput::StreamOpened`]
+    /// in new drivers.
     pub fn on_stream_opened(
         &mut self,
         conn_id: ConnectionId,
@@ -583,6 +616,9 @@ impl SwarmCore {
     }
 
     /// Reports that an [`SwarmAction::OpenStream`] failed at the driver.
+    ///
+    /// Prefer [`SwarmCore::handle_input`] with
+    /// [`SwarmInput::OpenStreamFailed`] in new drivers.
     pub fn on_open_stream_failed(&mut self, token: OpenStreamToken, reason: String, _now_ms: u64) {
         let pending = self.pending_opens.remove(&token);
         let (peer_id, conn_id, detail) = match pending {

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -8,10 +8,27 @@
 //! `no_std + alloc` compatible. The std [`crate::Swarm`] driver is a thin
 //! wrapper that owns a transport, reads the clock via [`std::time::Instant`],
 //! and shuttles events and actions between the transport and the core.
+//!
+//! # Driver contract
+//!
+//! External drivers should follow a drain loop:
+//!
+//! 1. perform one mutation (`on_transport_event`, `on_tick`, or an
+//!    application-facing method such as `ping`);
+//! 2. drain and execute every [`SwarmAction`] from [`SwarmCore::poll_action`],
+//!    reporting stream-open results back through `on_stream_opened` /
+//!    `on_open_stream_failed`;
+//! 3. repeat action draining until no new actions are produced;
+//! 4. drain application events via [`SwarmCore::poll_event`].
+//!
+//! After a full drain, [`SwarmCore::is_idle`] returns `true`. Treating that as
+//! the handoff point before waiting on external I/O keeps the Sans-I/O state
+//! machine deterministic and avoids leaving protocol bytes buffered inside the
+//! core.
 
 extern crate alloc;
 
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
 use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec;
@@ -131,8 +148,8 @@ pub struct SwarmCore {
     established_peers: BTreeSet<PeerId>,
 
     // --- Output queues ---
-    events: Vec<SwarmEvent>,
-    actions: Vec<SwarmAction>,
+    events: VecDeque<SwarmEvent>,
+    actions: VecDeque<SwarmAction>,
 }
 
 impl SwarmCore {
@@ -162,8 +179,8 @@ impl SwarmCore {
             peer_info: BTreeMap::new(),
             ready_peers: BTreeSet::new(),
             established_peers: BTreeSet::new(),
-            events: Vec::new(),
-            actions: Vec::new(),
+            events: VecDeque::new(),
+            actions: VecDeque::new(),
         }
     }
 
@@ -194,14 +211,54 @@ impl SwarmCore {
     // Egress (driver drains these)
     // -----------------------------------------------------------------------
 
+    /// Returns the next pending driver action, if any.
+    ///
+    /// Polling one item at a time lets custom drivers execute an action and
+    /// immediately feed any resulting mutation back into the core before
+    /// continuing the drain loop.
+    pub fn poll_action(&mut self) -> Option<SwarmAction> {
+        if self.actions.is_empty() {
+            None
+        } else {
+            self.actions.pop_front()
+        }
+    }
+
+    /// Returns the next application-visible event, if any.
+    pub fn poll_event(&mut self) -> Option<SwarmEvent> {
+        if self.events.is_empty() {
+            None
+        } else {
+            self.events.pop_front()
+        }
+    }
+
     /// Drains all buffered actions for the driver to execute.
     pub fn take_actions(&mut self) -> Vec<SwarmAction> {
-        core::mem::take(&mut self.actions)
+        let mut actions = Vec::new();
+        while let Some(action) = self.poll_action() {
+            actions.push(action);
+        }
+        actions
     }
 
     /// Drains all buffered application-visible events.
     pub fn poll_events(&mut self) -> Vec<SwarmEvent> {
-        core::mem::take(&mut self.events)
+        let mut events = Vec::new();
+        while let Some(event) = self.poll_event() {
+            events.push(event);
+        }
+        events
+    }
+
+    /// Returns true when the core has no pending driver actions or
+    /// application-visible events.
+    ///
+    /// Custom Sans-I/O drivers can use this as a cheap assertion that they
+    /// have fully drained the core before waiting on sockets, timers, or
+    /// application input again.
+    pub fn is_idle(&self) -> bool {
+        self.actions.is_empty() && self.events.is_empty()
     }
 
     /// Records a non-fatal error observed by the driver while executing a
@@ -212,7 +269,7 @@ impl SwarmCore {
     /// [`Self::poll_events`]. Used by the driver so transport-level
     /// failures are never silently dropped.
     pub fn record_error(&mut self, error: SwarmRuntimeError) {
-        self.events.push(SwarmEvent::Error(error));
+        self.events.push_back(SwarmEvent::Error(error));
     }
 
     // -----------------------------------------------------------------------
@@ -315,7 +372,7 @@ impl SwarmCore {
         data: Vec<u8>,
     ) -> Result<(), SwarmError> {
         let conn_id = self.require_user_stream_conn(peer_id, stream_id)?;
-        self.actions.push(SwarmAction::SendStream {
+        self.actions.push_back(SwarmAction::SendStream {
             conn_id,
             stream_id,
             data,
@@ -331,7 +388,7 @@ impl SwarmCore {
     ) -> Result<(), SwarmError> {
         let conn_id = self.require_user_stream_conn(peer_id, stream_id)?;
         self.actions
-            .push(SwarmAction::CloseStreamWrite { conn_id, stream_id });
+            .push_back(SwarmAction::CloseStreamWrite { conn_id, stream_id });
         Ok(())
     }
 
@@ -343,14 +400,15 @@ impl SwarmCore {
     ) -> Result<(), SwarmError> {
         let conn_id = self.require_user_stream_conn(peer_id, stream_id)?;
         self.actions
-            .push(SwarmAction::ResetStream { conn_id, stream_id });
+            .push_back(SwarmAction::ResetStream { conn_id, stream_id });
         Ok(())
     }
 
     /// Closes the connection to `peer_id`.
     pub fn disconnect(&mut self, peer_id: &PeerId) -> Result<(), SwarmError> {
         let conn_id = self.require_conn(peer_id)?;
-        self.actions.push(SwarmAction::CloseConnection { conn_id });
+        self.actions
+            .push_back(SwarmAction::CloseConnection { conn_id });
         Ok(())
     }
 
@@ -507,7 +565,7 @@ impl SwarmCore {
         let mut negotiator = MultistreamSelect::dialer(pending.protocol.as_str());
         for output in negotiator.start() {
             if let MultistreamOutput::OutboundData(bytes) = output {
-                self.actions.push(SwarmAction::SendStream {
+                self.actions.push_back(SwarmAction::SendStream {
                     conn_id,
                     stream_id,
                     data: bytes,
@@ -603,7 +661,7 @@ impl SwarmCore {
         conn_id: Option<ConnectionId>,
         detail: impl Into<String>,
     ) {
-        self.events.push(SwarmEvent::Error(SwarmRuntimeError {
+        self.events.push_back(SwarmEvent::Error(SwarmRuntimeError {
             kind,
             peer_id,
             conn_id,
@@ -623,7 +681,7 @@ impl SwarmCore {
         }
 
         self.ready_peers.insert(peer_id.clone());
-        self.events.push(SwarmEvent::PeerReady {
+        self.events.push_back(SwarmEvent::PeerReady {
             peer_id: peer_id.clone(),
             protocols: info.protocols.clone(),
         });
@@ -673,7 +731,7 @@ impl SwarmCore {
             },
         );
         self.actions
-            .push(SwarmAction::OpenStream { conn_id, token });
+            .push_back(SwarmAction::OpenStream { conn_id, token });
         Ok(())
     }
 
@@ -718,7 +776,7 @@ impl SwarmCore {
 
         if is_new {
             self.established_peers.insert(peer_id.clone());
-            self.events.push(SwarmEvent::ConnectionEstablished {
+            self.events.push_back(SwarmEvent::ConnectionEstablished {
                 peer_id: peer_id.clone(),
             });
 
@@ -753,7 +811,7 @@ impl SwarmCore {
             .retain(|(cid, _), _| *cid != old_id);
         self.pending_opens.retain(|_, p| p.conn_id != old_id);
         self.actions
-            .push(SwarmAction::CloseConnection { conn_id: old_id });
+            .push_back(SwarmAction::CloseConnection { conn_id: old_id });
     }
 
     fn upgrade_connection_identity(&mut self, conn_id: ConnectionId, new_peer_id: PeerId) {
@@ -786,7 +844,7 @@ impl SwarmCore {
         self.peer_to_conn.insert(new_peer_id.clone(), conn_id);
         self.established_peers.insert(new_peer_id.clone());
 
-        self.events.push(SwarmEvent::ConnectionEstablished {
+        self.events.push_back(SwarmEvent::ConnectionEstablished {
             peer_id: new_peer_id.clone(),
         });
 
@@ -854,7 +912,7 @@ impl SwarmCore {
 
         for output in outputs {
             if let MultistreamOutput::OutboundData(bytes) = output {
-                self.actions.push(SwarmAction::SendStream {
+                self.actions.push_back(SwarmAction::SendStream {
                     conn_id,
                     stream_id,
                     data: bytes,
@@ -913,7 +971,7 @@ impl SwarmCore {
                 // Responder doesn't expect data; ignore.
             }
             ProtocolKind::User(_) => {
-                self.events.push(SwarmEvent::UserStreamData {
+                self.events.push_back(SwarmEvent::UserStreamData {
                     peer_id,
                     stream_id,
                     data,
@@ -945,7 +1003,7 @@ impl SwarmCore {
             ProtocolKind::IdentifyResponder => {}
             ProtocolKind::User(_) => {
                 self.events
-                    .push(SwarmEvent::UserStreamRemoteWriteClosed { peer_id, stream_id });
+                    .push_back(SwarmEvent::UserStreamRemoteWriteClosed { peer_id, stream_id });
             }
         }
     }
@@ -965,7 +1023,7 @@ impl SwarmCore {
                 }
                 ProtocolKind::User(_) => {
                     self.events
-                        .push(SwarmEvent::UserStreamClosed { peer_id, stream_id });
+                        .push_back(SwarmEvent::UserStreamClosed { peer_id, stream_id });
                 }
             }
         }
@@ -988,7 +1046,8 @@ impl SwarmCore {
                 self.peer_info.remove(&peer_id);
                 self.ready_peers.remove(&peer_id);
                 self.established_peers.remove(&peer_id);
-                self.events.push(SwarmEvent::ConnectionClosed { peer_id });
+                self.events
+                    .push_back(SwarmEvent::ConnectionClosed { peer_id });
             }
         }
 
@@ -1023,7 +1082,7 @@ impl SwarmCore {
         for output in outputs {
             match output {
                 MultistreamOutput::OutboundData(bytes) => {
-                    self.actions.push(SwarmAction::SendStream {
+                    self.actions.push_back(SwarmAction::SendStream {
                         conn_id,
                         stream_id,
                         data: bytes,
@@ -1035,7 +1094,7 @@ impl SwarmCore {
                 MultistreamOutput::NotAvailable => {
                     self.inbound_negotiators.remove(&key);
                     self.actions
-                        .push(SwarmAction::ResetStream { conn_id, stream_id });
+                        .push_back(SwarmAction::ResetStream { conn_id, stream_id });
                     return;
                 }
                 MultistreamOutput::ProtocolError { reason } => {
@@ -1047,7 +1106,7 @@ impl SwarmCore {
                     );
                     self.inbound_negotiators.remove(&key);
                     self.actions
-                        .push(SwarmAction::ResetStream { conn_id, stream_id });
+                        .push_back(SwarmAction::ResetStream { conn_id, stream_id });
                     return;
                 }
             }
@@ -1089,7 +1148,7 @@ impl SwarmCore {
         for output in outputs {
             match output {
                 MultistreamOutput::OutboundData(bytes) => {
-                    self.actions.push(SwarmAction::SendStream {
+                    self.actions.push_back(SwarmAction::SendStream {
                         conn_id,
                         stream_id,
                         data: bytes,
@@ -1107,7 +1166,7 @@ impl SwarmCore {
                     );
                     self.outbound_negotiators.remove(&key);
                     self.actions
-                        .push(SwarmAction::ResetStream { conn_id, stream_id });
+                        .push_back(SwarmAction::ResetStream { conn_id, stream_id });
                     return;
                 }
                 MultistreamOutput::ProtocolError { reason } => {
@@ -1119,7 +1178,7 @@ impl SwarmCore {
                     );
                     self.outbound_negotiators.remove(&key);
                     self.actions
-                        .push(SwarmAction::ResetStream { conn_id, stream_id });
+                        .push_back(SwarmAction::ResetStream { conn_id, stream_id });
                     return;
                 }
             }
@@ -1198,7 +1257,7 @@ impl SwarmCore {
                         format!("identify responder error: {e}"),
                     );
                     self.actions
-                        .push(SwarmAction::ResetStream { conn_id, stream_id });
+                        .push_back(SwarmAction::ResetStream { conn_id, stream_id });
                 }
             }
             return;
@@ -1209,7 +1268,7 @@ impl SwarmCore {
                 (conn_id, stream_id),
                 ProtocolKind::User(protocol.to_string()),
             );
-            self.events.push(SwarmEvent::UserStreamReady {
+            self.events.push_back(SwarmEvent::UserStreamReady {
                 peer_id,
                 stream_id,
                 protocol_id: protocol.to_string(),
@@ -1243,7 +1302,7 @@ impl SwarmCore {
                     );
                     self.stream_owner.remove(&(conn_id, stream_id));
                     self.actions
-                        .push(SwarmAction::ResetStream { conn_id, stream_id });
+                        .push_back(SwarmAction::ResetStream { conn_id, stream_id });
                     return;
                 }
 
@@ -1264,7 +1323,7 @@ impl SwarmCore {
             }
             ProtocolKind::IdentifyResponder => {}
             ProtocolKind::User(protocol_id) => {
-                self.events.push(SwarmEvent::UserStreamReady {
+                self.events.push_back(SwarmEvent::UserStreamReady {
                     peer_id,
                     stream_id,
                     protocol_id,
@@ -1286,7 +1345,7 @@ impl SwarmCore {
                 data,
             } => {
                 if let Some(&conn_id) = self.peer_to_conn.get(peer_id) {
-                    self.actions.push(SwarmAction::SendStream {
+                    self.actions.push_back(SwarmAction::SendStream {
                         conn_id,
                         stream_id,
                         data: data.to_vec(),
@@ -1299,7 +1358,7 @@ impl SwarmCore {
             } => {
                 if let Some(&conn_id) = self.peer_to_conn.get(peer_id) {
                     self.actions
-                        .push(SwarmAction::CloseStreamWrite { conn_id, stream_id });
+                        .push_back(SwarmAction::CloseStreamWrite { conn_id, stream_id });
                 }
             }
             PingAction::ResetStream {
@@ -1308,7 +1367,7 @@ impl SwarmCore {
             } => {
                 if let Some(&conn_id) = self.peer_to_conn.get(peer_id) {
                     self.actions
-                        .push(SwarmAction::ResetStream { conn_id, stream_id });
+                        .push_back(SwarmAction::ResetStream { conn_id, stream_id });
                 }
             }
         }
@@ -1323,7 +1382,7 @@ impl SwarmCore {
                     ref data,
                 } => {
                     if let Some(&conn_id) = self.peer_to_conn.get(peer_id) {
-                        self.actions.push(SwarmAction::SendStream {
+                        self.actions.push_back(SwarmAction::SendStream {
                             conn_id,
                             stream_id,
                             data: data.clone(),
@@ -1336,7 +1395,7 @@ impl SwarmCore {
                 } => {
                     if let Some(&conn_id) = self.peer_to_conn.get(peer_id) {
                         self.actions
-                            .push(SwarmAction::CloseStreamWrite { conn_id, stream_id });
+                            .push_back(SwarmAction::CloseStreamWrite { conn_id, stream_id });
                     }
                 }
             }
@@ -1350,10 +1409,10 @@ impl SwarmCore {
                     peer_id, rtt_ms, ..
                 } => {
                     self.events
-                        .push(SwarmEvent::PingRttMeasured { peer_id, rtt_ms });
+                        .push_back(SwarmEvent::PingRttMeasured { peer_id, rtt_ms });
                 }
                 PingEvent::Timeout { peer_id, .. } => {
-                    self.events.push(SwarmEvent::PingTimeout { peer_id });
+                    self.events.push_back(SwarmEvent::PingTimeout { peer_id });
                 }
                 PingEvent::ProtocolViolation {
                     peer_id, reason, ..
@@ -1373,7 +1432,7 @@ impl SwarmCore {
             match event {
                 IdentifyEvent::Received { peer_id, info } => {
                     self.peer_info.insert(peer_id.clone(), info.clone());
-                    self.events.push(SwarmEvent::IdentifyReceived {
+                    self.events.push_back(SwarmEvent::IdentifyReceived {
                         peer_id: peer_id.clone(),
                         info,
                     });
@@ -1416,6 +1475,28 @@ mod tests {
 
     fn loopback_transport() -> Multiaddr {
         Multiaddr::from_str("/ip4/127.0.0.1/udp/4001/quic-v1").expect("valid multiaddr")
+    }
+
+    #[test]
+    fn is_idle_reflects_pending_actions_and_events() {
+        let mut core = test_core();
+        let peer_id = PeerId::from_public_key_protobuf(b"known-peer");
+        let conn_id = ConnectionId::new(1);
+
+        assert!(core.is_idle());
+
+        core.on_transport_event(
+            TransportEvent::Connected {
+                id: conn_id,
+                endpoint: ConnectionEndpoint::with_peer_id(loopback_transport(), peer_id.clone()),
+            },
+            0,
+        );
+        assert!(!core.is_idle());
+
+        let _ = core.take_actions();
+        let _ = core.poll_events();
+        assert!(core.is_idle());
     }
 
     #[test]

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -35,12 +35,13 @@ use core::convert::Infallible;
 
 use minip2p_core::{Multiaddr, PeerId, SansIoProtocol};
 use minip2p_identify::{
-    IDENTIFY_PROTOCOL_ID, IdentifyAction, IdentifyConfig, IdentifyEvent, IdentifyMessage,
-    IdentifyProtocol,
+    IDENTIFY_PROTOCOL_ID, IdentifyAction, IdentifyConfig, IdentifyEvent, IdentifyInput,
+    IdentifyMessage, IdentifyOutput, IdentifyProtocol,
 };
-use minip2p_multistream_select::{MultistreamOutput, MultistreamSelect};
+use minip2p_multistream_select::{MultistreamInput, MultistreamOutput, MultistreamSelect};
 use minip2p_ping::{
-    PING_PAYLOAD_LEN, PING_PROTOCOL_ID, PingAction, PingConfig, PingEvent, PingProtocol,
+    PING_PAYLOAD_LEN, PING_PROTOCOL_ID, PingAction, PingConfig, PingEvent, PingInput, PingOutput,
+    PingProtocol,
 };
 use minip2p_transport::{ConnectionId, StreamId, TransportEvent};
 
@@ -283,13 +284,16 @@ impl SwarmCore {
 
         // Case 1: a ping stream is already negotiated -- fire now.
         if self.find_negotiated_ping_stream(peer_id).is_some() {
-            let action = self
-                .ping
-                .send_ping(peer_id, &payload, now_ms)
+            self.ping
+                .handle_input(PingInput::SendPing {
+                    peer_id: peer_id.clone(),
+                    payload,
+                    now_ms,
+                })
                 .map_err(|e| SwarmError::PingError {
                     reason: format!("{e}"),
                 })?;
-            self.execute_ping_action(action);
+            self.drain_ping_outputs();
             return Ok(());
         }
 
@@ -501,10 +505,7 @@ impl SwarmCore {
     }
 
     fn handle_tick(&mut self, now_ms: u64) {
-        let tick_actions = self.ping.on_tick(now_ms);
-        for action in tick_actions {
-            self.execute_ping_action(action);
-        }
+        let _ = self.ping.handle_input(PingInput::Tick { now_ms });
         self.collect_protocol_events();
     }
 
@@ -541,14 +542,16 @@ impl SwarmCore {
         }
 
         let mut negotiator = MultistreamSelect::dialer(pending.protocol.as_str());
-        for output in negotiator.start() {
-            if let MultistreamOutput::OutboundData(bytes) = output {
-                self.actions.push_back(SwarmAction::SendStream {
-                    conn_id,
-                    stream_id,
-                    data: bytes,
-                });
-            }
+        if let Err(error) = negotiator.handle_input(MultistreamInput::Start) {
+            self.emit_error(
+                SwarmErrorKind::Multistream,
+                self.established_peer_for_conn(conn_id),
+                Some(conn_id),
+                format!("multistream start failed on outbound stream {stream_id}: {error}"),
+            );
+        }
+        while let Some(output) = negotiator.poll_output() {
+            self.handle_multistream_output(conn_id, stream_id, output, &mut None);
         }
 
         self.outbound_negotiators.insert(
@@ -798,8 +801,16 @@ impl SwarmCore {
             Some(ref current) if *current == new_peer_id => return,
             Some(ref stale) => {
                 self.peer_to_conn.remove(stale);
-                self.ping.migrate_peer(stale, &new_peer_id);
-                self.identify.migrate_peer(stale, &new_peer_id);
+                let _ = self.ping.handle_input(PingInput::MigratePeer {
+                    old_peer_id: stale.clone(),
+                    new_peer_id: new_peer_id.clone(),
+                });
+                let _ = self.identify.handle_input(IdentifyInput::MigratePeer {
+                    old_peer_id: stale.clone(),
+                    new_peer_id: new_peer_id.clone(),
+                });
+                self.drain_ping_outputs();
+                self.drain_identify_outputs();
                 if let Some(payload) = self.pending_pings.remove(stale) {
                     self.pending_pings.insert(new_peer_id.clone(), payload);
                 }
@@ -883,18 +894,23 @@ impl SwarmCore {
 
     fn handle_incoming_stream(&mut self, conn_id: ConnectionId, stream_id: StreamId) {
         let mut listener = MultistreamSelect::listener(self.supported_protocols.clone());
-        let outputs = listener.start();
+        if let Err(error) = listener.handle_input(MultistreamInput::Start) {
+            self.emit_error(
+                SwarmErrorKind::Multistream,
+                self.established_peer_for_conn(conn_id),
+                Some(conn_id),
+                format!("multistream start failed on inbound stream {stream_id}: {error}"),
+            );
+        }
         self.inbound_negotiators
             .insert((conn_id, stream_id), listener);
 
-        for output in outputs {
-            if let MultistreamOutput::OutboundData(bytes) = output {
-                self.actions.push_back(SwarmAction::SendStream {
-                    conn_id,
-                    stream_id,
-                    data: bytes,
-                });
-            }
+        while let Some(output) = self
+            .inbound_negotiators
+            .get_mut(&(conn_id, stream_id))
+            .and_then(SansIoProtocol::poll_output)
+        {
+            self.handle_multistream_output(conn_id, stream_id, output, &mut None);
         }
     }
 
@@ -935,14 +951,21 @@ impl SwarmCore {
 
         match protocol {
             ProtocolKind::Ping => {
-                let actions = self.ping.on_stream_data(&peer_id, stream_id, &data, now_ms);
-                for action in actions {
-                    self.execute_ping_action(action);
-                }
+                let _ = self.ping.handle_input(PingInput::StreamData {
+                    peer_id,
+                    stream_id,
+                    data,
+                    now_ms,
+                });
+                self.drain_ping_outputs();
             }
             ProtocolKind::IdentifyInitiator => {
-                let actions = self.identify.on_stream_data(peer_id, stream_id, data);
-                self.execute_identify_actions(actions);
+                let _ = self.identify.handle_input(IdentifyInput::StreamData {
+                    peer_id,
+                    stream_id,
+                    data,
+                });
+                self.drain_identify_outputs();
             }
             ProtocolKind::IdentifyResponder => {
                 // Responder doesn't expect data; ignore.
@@ -966,16 +989,16 @@ impl SwarmCore {
 
         match protocol {
             ProtocolKind::Ping => {
-                let actions = self.ping.on_stream_remote_write_closed(&peer_id, stream_id);
-                for action in actions {
-                    self.execute_ping_action(action);
-                }
+                let _ = self
+                    .ping
+                    .handle_input(PingInput::StreamRemoteWriteClosed { peer_id, stream_id });
+                self.drain_ping_outputs();
             }
             ProtocolKind::IdentifyInitiator => {
-                let actions = self
+                let _ = self
                     .identify
-                    .on_stream_remote_write_closed(peer_id, stream_id);
-                self.execute_identify_actions(actions);
+                    .handle_input(IdentifyInput::StreamRemoteWriteClosed { peer_id, stream_id });
+                self.drain_identify_outputs();
             }
             ProtocolKind::IdentifyResponder => {}
             ProtocolKind::User(_) => {
@@ -993,10 +1016,16 @@ impl SwarmCore {
         {
             match protocol {
                 ProtocolKind::Ping => {
-                    self.ping.on_stream_closed(&peer_id, stream_id);
+                    let _ = self
+                        .ping
+                        .handle_input(PingInput::StreamClosed { peer_id, stream_id });
+                    self.drain_ping_outputs();
                 }
                 ProtocolKind::IdentifyInitiator | ProtocolKind::IdentifyResponder => {
-                    self.identify.on_stream_closed(peer_id, stream_id);
+                    let _ = self
+                        .identify
+                        .handle_input(IdentifyInput::StreamClosed { peer_id, stream_id });
+                    self.drain_identify_outputs();
                 }
                 ProtocolKind::User(_) => {
                     self.events
@@ -1017,8 +1046,14 @@ impl SwarmCore {
             let was_active = self.peer_to_conn.get(&peer_id) == Some(&conn_id);
             if was_active {
                 self.peer_to_conn.remove(&peer_id);
-                self.ping.remove_peer(&peer_id);
-                self.identify.remove_peer(&peer_id);
+                let _ = self.ping.handle_input(PingInput::RemovePeer {
+                    peer_id: peer_id.clone(),
+                });
+                let _ = self.identify.handle_input(IdentifyInput::RemovePeer {
+                    peer_id: peer_id.clone(),
+                });
+                self.drain_ping_outputs();
+                self.drain_identify_outputs();
                 self.pending_pings.remove(&peer_id);
                 self.peer_info.remove(&peer_id);
                 self.ready_peers.remove(&peer_id);
@@ -1053,39 +1088,31 @@ impl SwarmCore {
             None => return,
         };
 
-        let outputs = negotiator.receive(data);
         let mut negotiated_protocol = None;
+        if let Err(error) = negotiator.handle_input(MultistreamInput::Data(data.to_vec())) {
+            self.emit_error(
+                SwarmErrorKind::Multistream,
+                self.established_peer_for_conn(conn_id),
+                Some(conn_id),
+                format!("multistream input failed on inbound stream {stream_id}: {error}"),
+            );
+            self.inbound_negotiators.remove(&key);
+            self.actions
+                .push_back(SwarmAction::ResetStream { conn_id, stream_id });
+            return;
+        }
 
-        for output in outputs {
-            match output {
-                MultistreamOutput::OutboundData(bytes) => {
-                    self.actions.push_back(SwarmAction::SendStream {
-                        conn_id,
-                        stream_id,
-                        data: bytes,
-                    });
-                }
-                MultistreamOutput::Negotiated { protocol } => {
-                    negotiated_protocol = Some(protocol);
-                }
-                MultistreamOutput::NotAvailable => {
-                    self.inbound_negotiators.remove(&key);
-                    self.actions
-                        .push_back(SwarmAction::ResetStream { conn_id, stream_id });
-                    return;
-                }
-                MultistreamOutput::ProtocolError { reason } => {
-                    self.emit_error(
-                        SwarmErrorKind::Multistream,
-                        self.established_peer_for_conn(conn_id),
-                        Some(conn_id),
-                        format!("multistream error on inbound stream {stream_id}: {reason}"),
-                    );
-                    self.inbound_negotiators.remove(&key);
-                    self.actions
-                        .push_back(SwarmAction::ResetStream { conn_id, stream_id });
-                    return;
-                }
+        while let Some(output) = self
+            .inbound_negotiators
+            .get_mut(&key)
+            .and_then(SansIoProtocol::poll_output)
+        {
+            if self.handle_multistream_output(conn_id, stream_id, output, &mut negotiated_protocol)
+            {
+                self.inbound_negotiators.remove(&key);
+                self.actions
+                    .push_back(SwarmAction::ResetStream { conn_id, stream_id });
+                return;
             }
         }
 
@@ -1118,22 +1145,31 @@ impl SwarmCore {
             None => return,
         };
 
-        let outputs = pending.negotiator.receive(data);
+        if let Err(error) = pending
+            .negotiator
+            .handle_input(MultistreamInput::Data(data.to_vec()))
+        {
+            self.emit_error(
+                SwarmErrorKind::Multistream,
+                self.established_peer_for_conn(conn_id),
+                Some(conn_id),
+                format!("multistream input failed on outbound stream {stream_id}: {error}"),
+            );
+            self.outbound_negotiators.remove(&key);
+            self.actions
+                .push_back(SwarmAction::ResetStream { conn_id, stream_id });
+            return;
+        }
         let target = pending.target.clone();
         let mut negotiated = false;
 
-        for output in outputs {
+        while let Some(output) = self
+            .outbound_negotiators
+            .get_mut(&key)
+            .and_then(|pending| pending.negotiator.poll_output())
+        {
             match output {
-                MultistreamOutput::OutboundData(bytes) => {
-                    self.actions.push_back(SwarmAction::SendStream {
-                        conn_id,
-                        stream_id,
-                        data: bytes,
-                    });
-                }
-                MultistreamOutput::Negotiated { .. } => {
-                    negotiated = true;
-                }
+                MultistreamOutput::Negotiated { .. } => negotiated = true,
                 MultistreamOutput::NotAvailable => {
                     self.emit_error(
                         SwarmErrorKind::UnsupportedProtocol,
@@ -1146,17 +1182,13 @@ impl SwarmCore {
                         .push_back(SwarmAction::ResetStream { conn_id, stream_id });
                     return;
                 }
-                MultistreamOutput::ProtocolError { reason } => {
-                    self.emit_error(
-                        SwarmErrorKind::Multistream,
-                        self.established_peer_for_conn(conn_id),
-                        Some(conn_id),
-                        format!("multistream error on outbound stream {stream_id}: {reason}"),
-                    );
-                    self.outbound_negotiators.remove(&key);
-                    self.actions
-                        .push_back(SwarmAction::ResetStream { conn_id, stream_id });
-                    return;
+                other => {
+                    if self.handle_multistream_output(conn_id, stream_id, other, &mut None) {
+                        self.outbound_negotiators.remove(&key);
+                        self.actions
+                            .push_back(SwarmAction::ResetStream { conn_id, stream_id });
+                        return;
+                    }
                 }
             }
         }
@@ -1177,6 +1209,39 @@ impl SwarmCore {
         }
     }
 
+    fn handle_multistream_output(
+        &mut self,
+        conn_id: ConnectionId,
+        stream_id: StreamId,
+        output: MultistreamOutput,
+        negotiated_protocol: &mut Option<String>,
+    ) -> bool {
+        match output {
+            MultistreamOutput::OutboundData(bytes) => {
+                self.actions.push_back(SwarmAction::SendStream {
+                    conn_id,
+                    stream_id,
+                    data: bytes,
+                });
+                false
+            }
+            MultistreamOutput::Negotiated { protocol } => {
+                *negotiated_protocol = Some(protocol);
+                false
+            }
+            MultistreamOutput::NotAvailable => true,
+            MultistreamOutput::ProtocolError { reason } => {
+                self.emit_error(
+                    SwarmErrorKind::Multistream,
+                    self.established_peer_for_conn(conn_id),
+                    Some(conn_id),
+                    format!("multistream error on stream {stream_id}: {reason}"),
+                );
+                true
+            }
+        }
+    }
+
     fn on_inbound_negotiated(
         &mut self,
         conn_id: ConnectionId,
@@ -1188,10 +1253,10 @@ impl SwarmCore {
         if protocol == PING_PROTOCOL_ID {
             self.stream_owner
                 .insert((conn_id, stream_id), ProtocolKind::Ping);
-            let actions = self.ping.register_inbound_stream(peer_id, stream_id);
-            for action in actions {
-                self.execute_ping_action(action);
-            }
+            let _ = self
+                .ping
+                .handle_input(PingInput::RegisterInboundStream { peer_id, stream_id });
+            self.drain_ping_outputs();
             return;
         }
 
@@ -1206,21 +1271,23 @@ impl SwarmCore {
             let observed_addr = self.conn_to_remote_addr.get(&conn_id).cloned();
             // Snapshot of the transport's listening addresses at this
             // moment; the driver keeps `local_addresses` refreshed.
-            let listen_addrs = self.local_addresses.as_slice();
+            let listen_addrs = self.local_addresses.clone();
             let responder_peer_id = peer_id.clone();
-            match self.identify.register_outbound_stream(
-                peer_id,
-                stream_id,
-                observed_addr,
-                listen_addrs,
-            ) {
-                Ok(actions) => {
+            match self
+                .identify
+                .handle_input(IdentifyInput::RegisterOutboundStream {
+                    peer_id,
+                    stream_id,
+                    observed_addr,
+                    listen_addrs,
+                }) {
+                Ok(()) => {
                     // Only record ownership on success, so a rejected
                     // registration doesn't leave the stream tracked here
                     // with no owning handler.
                     self.stream_owner
                         .insert((conn_id, stream_id), ProtocolKind::IdentifyResponder);
-                    self.execute_identify_actions(actions);
+                    self.drain_identify_outputs();
                 }
                 Err(e) => {
                     // Registration refused (e.g. identify already has a
@@ -1267,10 +1334,10 @@ impl SwarmCore {
 
         match target {
             ProtocolKind::Ping => {
-                if let Err(e) = self
-                    .ping
-                    .register_outbound_stream(peer_id.clone(), stream_id)
-                {
+                if let Err(e) = self.ping.handle_input(PingInput::RegisterOutboundStream {
+                    peer_id: peer_id.clone(),
+                    stream_id,
+                }) {
                     self.emit_error(
                         SwarmErrorKind::Ping,
                         Some(peer_id.clone()),
@@ -1284,8 +1351,12 @@ impl SwarmCore {
                 }
 
                 if let Some(payload) = self.pending_pings.remove(&peer_id) {
-                    match self.ping.send_ping(&peer_id, &payload, now_ms) {
-                        Ok(action) => self.execute_ping_action(action),
+                    match self.ping.handle_input(PingInput::SendPing {
+                        peer_id: peer_id.clone(),
+                        payload,
+                        now_ms,
+                    }) {
+                        Ok(()) => self.drain_ping_outputs(),
                         Err(e) => self.emit_error(
                             SwarmErrorKind::Ping,
                             Some(peer_id.clone()),
@@ -1296,7 +1367,10 @@ impl SwarmCore {
                 }
             }
             ProtocolKind::IdentifyInitiator => {
-                self.identify.register_inbound_stream(peer_id, stream_id);
+                let _ = self
+                    .identify
+                    .handle_input(IdentifyInput::RegisterInboundStream { peer_id, stream_id });
+                self.drain_identify_outputs();
             }
             ProtocolKind::IdentifyResponder => {}
             ProtocolKind::User(protocol_id) => {
@@ -1350,79 +1424,98 @@ impl SwarmCore {
         }
     }
 
-    fn execute_identify_actions(&mut self, actions: Vec<IdentifyAction>) {
-        for action in actions {
-            match action {
-                IdentifyAction::Send {
-                    ref peer_id,
-                    stream_id,
-                    ref data,
-                } => {
-                    if let Some(&conn_id) = self.peer_to_conn.get(peer_id) {
-                        self.actions.push_back(SwarmAction::SendStream {
-                            conn_id,
-                            stream_id,
-                            data: data.clone(),
-                        });
-                    }
+    fn execute_identify_action(&mut self, action: IdentifyAction) {
+        match action {
+            IdentifyAction::Send {
+                ref peer_id,
+                stream_id,
+                ref data,
+            } => {
+                if let Some(&conn_id) = self.peer_to_conn.get(peer_id) {
+                    self.actions.push_back(SwarmAction::SendStream {
+                        conn_id,
+                        stream_id,
+                        data: data.clone(),
+                    });
                 }
-                IdentifyAction::CloseStreamWrite {
-                    ref peer_id,
-                    stream_id,
-                } => {
-                    if let Some(&conn_id) = self.peer_to_conn.get(peer_id) {
-                        self.actions
-                            .push_back(SwarmAction::CloseStreamWrite { conn_id, stream_id });
-                    }
+            }
+            IdentifyAction::CloseStreamWrite {
+                ref peer_id,
+                stream_id,
+            } => {
+                if let Some(&conn_id) = self.peer_to_conn.get(peer_id) {
+                    self.actions
+                        .push_back(SwarmAction::CloseStreamWrite { conn_id, stream_id });
                 }
             }
         }
     }
 
-    fn collect_protocol_events(&mut self) {
-        for event in self.ping.poll_events() {
-            match event {
-                PingEvent::RttMeasured {
-                    peer_id, rtt_ms, ..
-                } => {
-                    self.events
-                        .push_back(SwarmEvent::PingRttMeasured { peer_id, rtt_ms });
-                }
-                PingEvent::Timeout { peer_id, .. } => {
-                    self.events.push_back(SwarmEvent::PingTimeout { peer_id });
-                }
-                PingEvent::ProtocolViolation {
-                    peer_id, reason, ..
-                } => {
-                    self.emit_error(
-                        SwarmErrorKind::Ping,
-                        Some(peer_id.clone()),
-                        self.conn_for(&peer_id),
-                        format!("ping protocol violation from {peer_id}: {reason}"),
-                    );
-                }
-                _ => {}
+    fn drain_ping_outputs(&mut self) {
+        while let Some(output) = self.ping.poll_output() {
+            match output {
+                PingOutput::Action(action) => self.execute_ping_action(action),
+                PingOutput::Event(event) => self.handle_ping_event(event),
             }
         }
+    }
 
-        for event in self.identify.poll_events() {
-            match event {
-                IdentifyEvent::Received { peer_id, info } => {
-                    self.peer_info.insert(peer_id.clone(), info.clone());
-                    self.events.push_back(SwarmEvent::IdentifyReceived {
-                        peer_id: peer_id.clone(),
-                        info,
-                    });
-                    self.try_emit_peer_ready(&peer_id);
-                }
-                IdentifyEvent::Error { error, .. } => {
-                    self.emit_error(
-                        SwarmErrorKind::Identify,
-                        None,
-                        None,
-                        format!("identify error: {error}"),
-                    );
-                }
+    fn drain_identify_outputs(&mut self) {
+        while let Some(output) = self.identify.poll_output() {
+            match output {
+                IdentifyOutput::Action(action) => self.execute_identify_action(action),
+                IdentifyOutput::Event(event) => self.handle_identify_event(event),
+            }
+        }
+    }
+
+    fn collect_protocol_events(&mut self) {
+        self.drain_ping_outputs();
+        self.drain_identify_outputs();
+    }
+
+    fn handle_ping_event(&mut self, event: PingEvent) {
+        match event {
+            PingEvent::RttMeasured {
+                peer_id, rtt_ms, ..
+            } => {
+                self.events
+                    .push_back(SwarmEvent::PingRttMeasured { peer_id, rtt_ms });
+            }
+            PingEvent::Timeout { peer_id, .. } => {
+                self.events.push_back(SwarmEvent::PingTimeout { peer_id });
+            }
+            PingEvent::ProtocolViolation {
+                peer_id, reason, ..
+            } => {
+                self.emit_error(
+                    SwarmErrorKind::Ping,
+                    Some(peer_id.clone()),
+                    self.conn_for(&peer_id),
+                    format!("ping protocol violation from {peer_id}: {reason}"),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_identify_event(&mut self, event: IdentifyEvent) {
+        match event {
+            IdentifyEvent::Received { peer_id, info } => {
+                self.peer_info.insert(peer_id.clone(), info.clone());
+                self.events.push_back(SwarmEvent::IdentifyReceived {
+                    peer_id: peer_id.clone(),
+                    info,
+                });
+                self.try_emit_peer_ready(&peer_id);
+            }
+            IdentifyEvent::Error { error, .. } => {
+                self.emit_error(
+                    SwarmErrorKind::Identify,
+                    None,
+                    None,
+                    format!("identify error: {error}"),
+                );
             }
         }
     }

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -14,7 +14,9 @@ use minip2p_ping::{PING_PAYLOAD_LEN, PingConfig};
 use minip2p_transport::{ConnectionId, StreamId, Transport, TransportError};
 
 use crate::core::SwarmCore;
-use crate::events::{SwarmAction, SwarmError, SwarmErrorKind, SwarmEvent, SwarmRuntimeError};
+use crate::events::{
+    SwarmAction, SwarmError, SwarmErrorKind, SwarmEvent, SwarmInput, SwarmOutput, SwarmRuntimeError,
+};
 
 /// Sleep cadence when [`Swarm::poll_next`] idles.
 ///
@@ -269,8 +271,13 @@ impl<T: Transport> Swarm<T> {
         // Flush all actions, capturing the stream id allocated for this
         // user-protocol open. We inspect actions as we execute them.
         let mut allocated_stream: Option<StreamId> = None;
-        while let Some(action) = self.core.poll_action() {
-            self.dispatch_action(action, &mut allocated_stream);
+        while let Some(output) = self.core.poll_output() {
+            match output {
+                SwarmOutput::Action(action) => {
+                    self.dispatch_action(action, &mut allocated_stream);
+                }
+                SwarmOutput::Event(event) => self.event_buffer.push_back(event),
+            }
         }
 
         // Any cascade from dispatch_action (e.g. MSS header SendStream) is
@@ -340,19 +347,23 @@ impl<T: Transport> Swarm<T> {
         // 1. Feed transport events to the core.
         let events = self.transport.poll()?;
         for event in events {
-            self.core.on_transport_event(event, now_ms);
+            self.core
+                .handle_input(SwarmInput::Transport { event, now_ms });
         }
 
         // 2. Advance timers.
-        self.core.on_tick(now_ms);
+        self.core.handle_input(SwarmInput::Tick { now_ms });
 
         // 3. Execute all queued actions (may cascade -- see flush_actions).
         self.flush_actions();
 
         // 4. Return the application's events.
-        let mut events = Vec::new();
-        while let Some(event) = self.core.poll_event() {
-            events.push(event);
+        let mut events: Vec<SwarmEvent> = self.event_buffer.drain(..).collect();
+        while let Some(output) = self.core.poll_output() {
+            match output {
+                SwarmOutput::Action(action) => self.dispatch_action(action, &mut None),
+                SwarmOutput::Event(event) => events.push(event),
+            }
         }
         Ok(events)
     }
@@ -429,8 +440,11 @@ impl<T: Transport> Swarm<T> {
     /// reported back).
     fn flush_actions(&mut self) {
         let mut allocated: Option<StreamId> = None;
-        while let Some(action) = self.core.poll_action() {
-            self.dispatch_action(action, &mut allocated);
+        while let Some(output) = self.core.poll_output() {
+            match output {
+                SwarmOutput::Action(action) => self.dispatch_action(action, &mut allocated),
+                SwarmOutput::Event(event) => self.event_buffer.push_back(event),
+            }
         }
     }
 
@@ -448,13 +462,20 @@ impl<T: Transport> Swarm<T> {
             {
                 Ok(stream_id) => {
                     *captured_stream_id = Some(stream_id);
-                    self.core
-                        .on_stream_opened(conn_id, stream_id, token, self.now_ms());
+                    self.core.handle_input(SwarmInput::StreamOpened {
+                        conn_id,
+                        stream_id,
+                        token,
+                        now_ms: self.now_ms(),
+                    });
                 }
                 Err(e) => {
                     let reason = format!("{e}");
-                    self.core
-                        .on_open_stream_failed(token, reason, self.now_ms());
+                    self.core.handle_input(SwarmInput::OpenStreamFailed {
+                        token,
+                        reason,
+                        now_ms: self.now_ms(),
+                    });
                 }
             },
             SwarmAction::SendStream {
@@ -463,44 +484,46 @@ impl<T: Transport> Swarm<T> {
                 data,
             } => {
                 if let Err(e) = self.transport.send_stream(conn_id, stream_id, data) {
-                    self.core.record_error(runtime_error(
-                        SwarmErrorKind::Transport,
-                        Some(conn_id),
-                        format!(
-                            "send_stream to connection {conn_id} stream {stream_id} failed: {e}"
-                        ),
-                    ));
+                    self.core
+                        .handle_input(SwarmInput::RuntimeError(runtime_error(
+                            SwarmErrorKind::Transport,
+                            Some(conn_id),
+                            format!(
+                                "send_stream to connection {conn_id} stream {stream_id} failed: {e}"
+                            ),
+                        )));
                 }
             }
             SwarmAction::CloseStreamWrite { conn_id, stream_id } => {
                 if let Err(e) = self.transport.close_stream_write(conn_id, stream_id) {
-                    self.core.record_error(runtime_error(
+                    self.core.handle_input(SwarmInput::RuntimeError(runtime_error(
                         SwarmErrorKind::Transport,
                         Some(conn_id),
                         format!(
                             "close_stream_write on connection {conn_id} stream {stream_id} failed: {e}"
                         ),
-                    ));
+                    )));
                 }
             }
             SwarmAction::ResetStream { conn_id, stream_id } => {
                 if let Err(e) = self.transport.reset_stream(conn_id, stream_id) {
-                    self.core.record_error(runtime_error(
+                    self.core.handle_input(SwarmInput::RuntimeError(runtime_error(
                         SwarmErrorKind::Transport,
                         Some(conn_id),
                         format!(
                             "reset_stream on connection {conn_id} stream {stream_id} failed: {e}"
                         ),
-                    ));
+                    )));
                 }
             }
             SwarmAction::CloseConnection { conn_id } => {
                 if let Err(e) = self.transport.close(conn_id) {
-                    self.core.record_error(runtime_error(
-                        SwarmErrorKind::Transport,
-                        Some(conn_id),
-                        format!("close on connection {conn_id} failed: {e}"),
-                    ));
+                    self.core
+                        .handle_input(SwarmInput::RuntimeError(runtime_error(
+                            SwarmErrorKind::Transport,
+                            Some(conn_id),
+                            format!("close on connection {conn_id} failed: {e}"),
+                        )));
                 }
             }
         }

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -268,9 +268,8 @@ impl<T: Transport> Swarm<T> {
 
         // Flush all actions, capturing the stream id allocated for this
         // user-protocol open. We inspect actions as we execute them.
-        let actions = self.core.take_actions();
         let mut allocated_stream: Option<StreamId> = None;
-        for action in actions {
+        while let Some(action) = self.core.poll_action() {
             self.dispatch_action(action, &mut allocated_stream);
         }
 
@@ -351,7 +350,11 @@ impl<T: Transport> Swarm<T> {
         self.flush_actions();
 
         // 4. Return the application's events.
-        Ok(self.core.poll_events())
+        let mut events = Vec::new();
+        while let Some(event) = self.core.poll_event() {
+            events.push(event);
+        }
+        Ok(events)
     }
 
     /// Returns the next swarm event, sleeping internally until one arrives
@@ -426,14 +429,8 @@ impl<T: Transport> Swarm<T> {
     /// reported back).
     fn flush_actions(&mut self) {
         let mut allocated: Option<StreamId> = None;
-        loop {
-            let actions = self.core.take_actions();
-            if actions.is_empty() {
-                break;
-            }
-            for action in actions {
-                self.dispatch_action(action, &mut allocated);
-            }
+        while let Some(action) = self.core.poll_action() {
+            self.dispatch_action(action, &mut allocated);
         }
     }
 

--- a/crates/swarm/src/events.rs
+++ b/crates/swarm/src/events.rs
@@ -10,7 +10,7 @@ use alloc::vec::Vec;
 
 use minip2p_core::PeerId;
 use minip2p_identify::IdentifyMessage;
-use minip2p_transport::{ConnectionId, StreamId};
+use minip2p_transport::{ConnectionId, StreamId, TransportEvent};
 
 /// Events emitted by the swarm to the application.
 #[derive(Clone, Debug)]
@@ -110,12 +110,60 @@ pub enum SwarmErrorKind {
 ///
 /// The core emits it as part of [`SwarmAction::OpenStream`]; the driver
 /// echoes it back unchanged when reporting the stream id (or failure) via
-/// the core's `on_stream_opened` / `on_open_stream_failed` methods.
+/// [`SwarmInput::StreamOpened`] / [`SwarmInput::OpenStreamFailed`].
 ///
 /// The token's numeric value is an implementation detail and meaningless
 /// outside the core.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct OpenStreamToken(pub(crate) u64);
+
+/// Inputs accepted by the Sans-I/O swarm core.
+///
+/// A custom runtime feeds exactly one input, then drains [`SwarmOutput`] values
+/// through `SwarmCore::poll_output()` before feeding the next input.
+#[derive(Clone, Debug)]
+pub enum SwarmInput {
+    /// An event produced by the underlying transport.
+    Transport {
+        event: TransportEvent,
+        /// Monotonic milliseconds supplied by the driver.
+        now_ms: u64,
+    },
+    /// Time advanced; used for protocol timers such as ping timeouts.
+    Tick {
+        /// Monotonic milliseconds supplied by the driver.
+        now_ms: u64,
+    },
+    /// The driver successfully opened an outbound stream requested by
+    /// [`SwarmAction::OpenStream`].
+    StreamOpened {
+        conn_id: ConnectionId,
+        stream_id: StreamId,
+        token: OpenStreamToken,
+        /// Monotonic milliseconds supplied by the driver.
+        now_ms: u64,
+    },
+    /// The driver failed to open an outbound stream requested by
+    /// [`SwarmAction::OpenStream`].
+    OpenStreamFailed {
+        token: OpenStreamToken,
+        reason: String,
+        /// Monotonic milliseconds supplied by the driver.
+        now_ms: u64,
+    },
+    /// A non-fatal runtime error observed by the driver while executing a
+    /// [`SwarmAction`].
+    RuntimeError(SwarmRuntimeError),
+}
+
+/// Outputs produced by the Sans-I/O swarm core.
+#[derive(Clone, Debug)]
+pub enum SwarmOutput {
+    /// A command the runtime must execute against its transport.
+    Action(SwarmAction),
+    /// An application-visible event.
+    Event(SwarmEvent),
+}
 
 /// Commands the swarm asks its driver to execute against the underlying
 /// transport.
@@ -129,8 +177,8 @@ pub enum SwarmAction {
     ///
     /// The driver calls `transport.open_stream(conn_id)`. On success it
     /// reports the allocated stream id back to the core via
-    /// `on_stream_opened(conn_id, stream_id, token, now_ms)`. On failure it
-    /// reports the error via `on_open_stream_failed(token, error, now_ms)`.
+    /// [`SwarmInput::StreamOpened`]. On failure it reports the error via
+    /// [`SwarmInput::OpenStreamFailed`].
     /// The driver must echo `token` unchanged.
     OpenStream {
         conn_id: ConnectionId,

--- a/crates/swarm/src/lib.rs
+++ b/crates/swarm/src/lib.rs
@@ -36,7 +36,8 @@ mod driver;
 
 pub use crate::core::SwarmCore;
 pub use crate::events::{
-    OpenStreamToken, SwarmAction, SwarmError, SwarmErrorKind, SwarmEvent, SwarmRuntimeError,
+    OpenStreamToken, SwarmAction, SwarmError, SwarmErrorKind, SwarmEvent, SwarmInput, SwarmOutput,
+    SwarmRuntimeError,
 };
 
 #[cfg(feature = "std")]

--- a/crates/swarm/src/lib.rs
+++ b/crates/swarm/src/lib.rs
@@ -3,10 +3,12 @@
 //! This crate provides two layers:
 //!
 //! - [`SwarmCore`] -- pure Sans-I/O state machine. `no_std + alloc`
-//!   compatible. Consumes [`minip2p_transport::TransportEvent`]s and a
-//!   caller-supplied `now_ms`, emits [`SwarmAction`]s for a driver to
-//!   execute and [`SwarmEvent`]s for the application to observe. No
-//!   sockets, no async runtime, no clock reads.
+//!   compatible. Callers feed it [`SwarmInput`] values through
+//!   [`SwarmCore::handle_input`], then drain [`SwarmOutput`] values through
+//!   [`SwarmCore::poll_output`] until [`SwarmCore::is_idle`] returns true.
+//!   Outputs wrap [`SwarmAction`]s for a driver to execute and [`SwarmEvent`]s
+//!   for the application to observe. No sockets, no async runtime, no clock
+//!   reads.
 //!
 //! - [`Swarm`] -- std driver that owns a concrete [`Transport`] and a
 //!   monotonic clock ([`std::time::Instant`]), and preserves the one-call

--- a/crates/swarm/tests/relay_holepunch_flow.rs
+++ b/crates/swarm/tests/relay_holepunch_flow.rs
@@ -25,16 +25,17 @@
 use std::collections::{HashMap, VecDeque};
 use std::str::FromStr;
 
-use minip2p_core::{Multiaddr, PeerId};
+use minip2p_core::{Multiaddr, PeerId, SansIoProtocol};
 use minip2p_dcutr::{
-    DcutrInitiator, DcutrResponder, InitiatorOutcome, ResponderEvent,
-    decode_frame as dcutr_decode_frame,
+    DcutrInitiator, DcutrInitiatorInput, DcutrInitiatorOutput, DcutrResponder, DcutrResponderInput,
+    DcutrResponderOutput, InitiatorOutcome, ResponderEvent, decode_frame as dcutr_decode_frame,
 };
 use minip2p_identity::Ed25519Keypair;
 use minip2p_relay::{
-    FrameDecode, HopConnect, HopMessage, HopMessageType, HopReservation, Peer, Reservation,
-    ReservationOutcome, Status, StopMessage, StopMessageType, StopResponder,
-    decode_frame as relay_decode_frame, encode_frame as relay_encode_frame,
+    FrameDecode, HopConnect, HopConnectInput, HopConnectOutput, HopMessage, HopMessageType,
+    HopReservation, HopReservationInput, HopReservationOutput, Peer, Reservation,
+    ReservationOutcome, Status, StopMessage, StopMessageType, StopResponder, StopResponderInput,
+    StopResponderOutput, decode_frame as relay_decode_frame, encode_frame as relay_encode_frame,
 };
 
 // ---------------------------------------------------------------------------
@@ -265,16 +266,16 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
     let mut b_reservation = HopReservation::new();
 
     // B sends RESERVE. Relay stores reservation and responds with STATUS:OK.
-    let reserve_bytes = b_reservation.take_outbound();
+    let reserve_bytes = reserve_flush(&mut b_reservation);
     relay.on_reserve_request(&peer_b, &reserve_bytes).unwrap();
 
     // B receives the relay's response on its HOP stream.
     let relay_to_b = relay.drain_hop_bytes_for(&peer_b);
-    b_reservation.on_data(&relay_to_b).unwrap();
+    let reservation_outcome = reserve_feed(&mut b_reservation, relay_to_b);
     assert!(b_reservation.is_done());
     assert!(matches!(
-        b_reservation.outcome(),
-        Some(ReservationOutcome::Accepted { .. })
+        reservation_outcome,
+        ReservationOutcome::Accepted { .. }
     ));
     assert_eq!(
         relay.events[0],
@@ -288,7 +289,7 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
     let mut a_connect = HopConnect::new(peer_b.to_bytes());
 
     // A sends HOP CONNECT(peer=B).
-    let connect_bytes = a_connect.take_outbound();
+    let connect_bytes = connect_flush(&mut a_connect);
 
     // The relay forwards a STOP CONNECT to B and remembers to send A a
     // STATUS:OK once B acks.
@@ -302,15 +303,12 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
 
     let mut b_stop = StopResponder::new();
     let stop_to_b = relay.drain_stop_bytes_for(&peer_b);
-    b_stop.on_data(&stop_to_b).unwrap();
-
-    let b_stop_request = b_stop.request().expect("CONNECT received");
+    let b_stop_request = stop_feed(&mut b_stop, stop_to_b);
     // The source peer id in the STOP CONNECT must be A.
     assert_eq!(b_stop_request.source_peer_id, peer_a.to_bytes());
 
     // B accepts; outbound STATUS:OK goes back to the relay.
-    b_stop.accept().unwrap();
-    let b_stop_ok = b_stop.take_outbound();
+    let b_stop_ok = stop_accept_flush(&mut b_stop);
 
     // Relay forwards the ack to A as HOP STATUS:OK.
     relay
@@ -318,11 +316,11 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
         .unwrap();
 
     // A receives the HOP STATUS:OK: the stream is now bridged.
-    a_connect.on_data(&initiator_inbox).unwrap();
+    let connect_outcome = connect_feed(&mut a_connect, initiator_inbox);
     assert!(a_connect.is_done());
     assert!(matches!(
-        a_connect.outcome(),
-        Some(minip2p_relay::ConnectOutcome::Bridged { .. })
+        connect_outcome,
+        minip2p_relay::ConnectOutcome::Bridged { .. }
     ));
 
     // Sanity check: the relay recorded both the CONNECT bridge and the final
@@ -349,50 +347,48 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
     let mut dcutr_b = DcutrResponder::new(&b_observed);
 
     // A sends CONNECT over the bridge.
-    push_bytes(&mut a_to_b, &dcutr_a.take_outbound());
+    push_bytes(&mut a_to_b, &dcutr_initiator_flush(&mut dcutr_a));
 
     // B receives CONNECT, queues a reply, emits ConnectReceived event.
     let bytes = drain_pipe(&mut a_to_b);
-    dcutr_b.on_data(&bytes).unwrap();
+    dcutr_responder_feed(&mut dcutr_b, bytes);
 
-    let events_b = dcutr_b.poll_events();
+    // B flushes its CONNECT reply toward A.
+    push_bytes(&mut b_to_a, &dcutr_responder_flush(&mut dcutr_b));
+
+    let events_b = dcutr_responder_events(&mut dcutr_b);
     assert!(matches!(
         events_b.first(),
         Some(ResponderEvent::ConnectReceived { remote_addrs, .. })
             if *remote_addrs == a_observed
     ));
 
-    // B flushes its CONNECT reply toward A.
-    push_bytes(&mut b_to_a, &dcutr_b.take_outbound());
-
     // A receives CONNECT reply, records remote addrs and RTT.
     let bytes = drain_pipe(&mut b_to_a);
     let simulated_rtt_ms = 42;
-    dcutr_a.on_data(&bytes, simulated_rtt_ms).unwrap();
+    let initiator_outcome = dcutr_initiator_feed(&mut dcutr_a, bytes, simulated_rtt_ms);
 
-    match dcutr_a.outcome() {
-        Some(InitiatorOutcome::DialNow {
+    match initiator_outcome {
+        InitiatorOutcome::DialNow {
             remote_addrs,
             rtt_ms,
             ..
-        }) => {
-            assert_eq!(*remote_addrs, b_observed);
-            assert_eq!(*rtt_ms, simulated_rtt_ms);
+        } => {
+            assert_eq!(remote_addrs, b_observed);
+            assert_eq!(rtt_ms, simulated_rtt_ms);
         }
-        other => panic!("unexpected initiator outcome: {other:?}"),
     }
 
     // A sends SYNC over the bridge and (in a real system) immediately dials
     // B's observed addresses directly.
-    dcutr_a.send_sync().unwrap();
-    push_bytes(&mut a_to_b, &dcutr_a.take_outbound());
+    push_bytes(&mut a_to_b, &dcutr_send_sync_flush(&mut dcutr_a));
     assert!(dcutr_a.is_done());
 
     // B receives SYNC: in a real system it would now send random UDP to A's
     // addresses after an RTT/2 delay.
     let bytes = drain_pipe(&mut a_to_b);
-    dcutr_b.on_data(&bytes).unwrap();
-    let events_b = dcutr_b.poll_events();
+    dcutr_responder_feed(&mut dcutr_b, bytes);
+    let events_b = dcutr_responder_events(&mut dcutr_b);
     assert_eq!(events_b.as_slice(), [ResponderEvent::SyncReceived]);
     assert!(dcutr_b.is_done());
 
@@ -414,18 +410,18 @@ fn connect_refused_when_target_not_reserved() {
     let mut relay = RelayEmulator::new();
 
     let mut a_connect = HopConnect::new(target.to_bytes());
-    let connect_bytes = a_connect.take_outbound();
+    let connect_bytes = connect_flush(&mut a_connect);
 
     let mut initiator_inbox: Vec<u8> = Vec::new();
     relay
         .on_connect_request(&peer_a, &connect_bytes, &mut initiator_inbox)
         .unwrap();
 
-    a_connect.on_data(&initiator_inbox).unwrap();
+    let outcome = connect_feed(&mut a_connect, initiator_inbox);
 
-    match a_connect.outcome() {
-        Some(minip2p_relay::ConnectOutcome::Refused { status, .. }) => {
-            assert_eq!(*status, Status::NoReservation);
+    match outcome {
+        minip2p_relay::ConnectOutcome::Refused { status, .. } => {
+            assert_eq!(status, Status::NoReservation);
         }
         other => panic!("expected refusal, got {other:?}"),
     }
@@ -436,16 +432,14 @@ fn dcutr_rtt_is_reported_back_to_initiator() {
     let mut a = DcutrInitiator::new(&[Multiaddr::from_str("/ip4/1.2.3.4/udp/1/quic-v1").unwrap()]);
     let mut b = DcutrResponder::new(&[Multiaddr::from_str("/ip4/5.6.7.8/udp/2/quic-v1").unwrap()]);
 
-    let connect_from_a = a.take_outbound();
-    b.on_data(&connect_from_a).unwrap();
-    let _ = b.poll_events();
+    let connect_from_a = dcutr_initiator_flush(&mut a);
+    dcutr_responder_feed(&mut b, connect_from_a);
+    let reply_from_b = dcutr_responder_flush(&mut b);
+    let _ = dcutr_responder_events(&mut b);
+    let outcome = dcutr_initiator_feed(&mut a, reply_from_b, 123);
 
-    let reply_from_b = b.take_outbound();
-    a.on_data(&reply_from_b, 123).unwrap();
-
-    match a.outcome() {
-        Some(InitiatorOutcome::DialNow { rtt_ms, .. }) => assert_eq!(*rtt_ms, 123),
-        _ => panic!("expected DialNow"),
+    match outcome {
+        InitiatorOutcome::DialNow { rtt_ms, .. } => assert_eq!(rtt_ms, 123),
     }
 }
 
@@ -459,6 +453,102 @@ fn push_bytes(pipe: &mut VecDeque<u8>, bytes: &[u8]) {
 
 fn drain_pipe(pipe: &mut VecDeque<u8>) -> Vec<u8> {
     pipe.drain(..).collect()
+}
+
+fn reserve_flush(flow: &mut HopReservation) -> Vec<u8> {
+    flow.handle_input(HopReservationInput::Flush).unwrap();
+    match flow.poll_output() {
+        Some(HopReservationOutput::Outbound(bytes)) => bytes,
+        other => panic!("expected reservation outbound, got {other:?}"),
+    }
+}
+
+fn reserve_feed(flow: &mut HopReservation, bytes: Vec<u8>) -> ReservationOutcome {
+    flow.handle_input(HopReservationInput::Data(bytes)).unwrap();
+    match flow.poll_output() {
+        Some(HopReservationOutput::Outcome(outcome)) => outcome,
+        other => panic!("expected reservation outcome, got {other:?}"),
+    }
+}
+
+fn connect_flush(flow: &mut HopConnect) -> Vec<u8> {
+    flow.handle_input(HopConnectInput::Flush).unwrap();
+    match flow.poll_output() {
+        Some(HopConnectOutput::Outbound(bytes)) => bytes,
+        other => panic!("expected connect outbound, got {other:?}"),
+    }
+}
+
+fn connect_feed(flow: &mut HopConnect, bytes: Vec<u8>) -> minip2p_relay::ConnectOutcome {
+    flow.handle_input(HopConnectInput::Data(bytes)).unwrap();
+    match flow.poll_output() {
+        Some(HopConnectOutput::Outcome(outcome)) => outcome,
+        other => panic!("expected connect outcome, got {other:?}"),
+    }
+}
+
+fn stop_feed(flow: &mut StopResponder, bytes: Vec<u8>) -> minip2p_relay::StopConnectRequest {
+    flow.handle_input(StopResponderInput::Data(bytes)).unwrap();
+    match flow.poll_output() {
+        Some(StopResponderOutput::Request(request)) => request,
+        other => panic!("expected stop request, got {other:?}"),
+    }
+}
+
+fn stop_accept_flush(flow: &mut StopResponder) -> Vec<u8> {
+    flow.handle_input(StopResponderInput::Accept).unwrap();
+    match flow.poll_output() {
+        Some(StopResponderOutput::Outbound(bytes)) => bytes,
+        other => panic!("expected stop outbound, got {other:?}"),
+    }
+}
+
+fn dcutr_initiator_flush(flow: &mut DcutrInitiator) -> Vec<u8> {
+    flow.handle_input(DcutrInitiatorInput::Flush).unwrap();
+    match flow.poll_output() {
+        Some(DcutrInitiatorOutput::Outbound(bytes)) => bytes,
+        other => panic!("expected dcutr initiator outbound, got {other:?}"),
+    }
+}
+
+fn dcutr_initiator_feed(
+    flow: &mut DcutrInitiator,
+    bytes: Vec<u8>,
+    rtt_ms: u64,
+) -> InitiatorOutcome {
+    flow.handle_input(DcutrInitiatorInput::Data { bytes, rtt_ms })
+        .unwrap();
+    match flow.poll_output() {
+        Some(DcutrInitiatorOutput::Outcome(outcome)) => outcome,
+        other => panic!("expected dcutr initiator outcome, got {other:?}"),
+    }
+}
+
+fn dcutr_send_sync_flush(flow: &mut DcutrInitiator) -> Vec<u8> {
+    flow.handle_input(DcutrInitiatorInput::SendSync).unwrap();
+    dcutr_initiator_flush(flow)
+}
+
+fn dcutr_responder_feed(flow: &mut DcutrResponder, bytes: Vec<u8>) {
+    flow.handle_input(DcutrResponderInput::Data(bytes)).unwrap();
+}
+
+fn dcutr_responder_flush(flow: &mut DcutrResponder) -> Vec<u8> {
+    flow.handle_input(DcutrResponderInput::Flush).unwrap();
+    match flow.poll_output() {
+        Some(DcutrResponderOutput::Outbound(bytes)) => bytes,
+        other => panic!("expected dcutr responder outbound, got {other:?}"),
+    }
+}
+
+fn dcutr_responder_events(flow: &mut DcutrResponder) -> Vec<ResponderEvent> {
+    let mut events = Vec::new();
+    while let Some(output) = flow.poll_output() {
+        if let DcutrResponderOutput::Event(event) = output {
+            events.push(event);
+        }
+    }
+    events
 }
 
 /// Sanity test: the DCUtR frame decoder is the same across the encode/decode

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -172,6 +172,7 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
 
     // --- 5. DCUtR responder over the same bridge stream --------------------
     let mut dcutr = DcutrResponder::new(&our_observed);
+    let mut captured_remote_addrs: Option<Vec<Multiaddr>> = None;
     if !bridge_bytes.is_empty() {
         dcutr_responder_feed(&mut dcutr, bridge_bytes)?;
     }
@@ -179,26 +180,21 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         &mut swarm,
         &relay_peer_id,
         bridge_stream,
-        dcutr_responder_flush(&mut dcutr),
+        drain_dcutr_responder_outputs(&mut dcutr, role, &mut captured_remote_addrs),
     )?;
 
     // DCUtR responder events arrive across multiple poll cycles:
     // `ConnectReceived` fires in one call, `SyncReceived` in a later
     // one. We thread the captured remote-addrs through the loop so
     // the CONNECT payload isn't thrown away when the SYNC arrives.
-    let mut captured_remote_addrs: Option<Vec<Multiaddr>> = None;
     let remote_addrs: Vec<Multiaddr> = loop {
-        if drain_dcutr_responder_events(&mut dcutr, role, &mut captured_remote_addrs) {
-            break captured_remote_addrs.take().unwrap_or_default();
-        }
         let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
         dcutr_responder_feed(&mut dcutr, data)?;
-        send(
-            &mut swarm,
-            &relay_peer_id,
-            bridge_stream,
-            dcutr_responder_flush(&mut dcutr),
-        )?;
+        let outbound = drain_dcutr_responder_outputs(&mut dcutr, role, &mut captured_remote_addrs);
+        send(&mut swarm, &relay_peer_id, bridge_stream, outbound)?;
+        if dcutr.is_done() {
+            break captured_remote_addrs.take().unwrap_or_default();
+        }
     };
 
     // --- 6. Hole-punch: dial + blast UDP, wait for direct or timeout -------
@@ -770,12 +766,22 @@ fn stop_bridge_bytes(flow: &mut StopResponder) -> Vec<u8> {
     }
 }
 
-fn dcutr_responder_flush(flow: &mut DcutrResponder) -> Vec<u8> {
+fn drain_dcutr_responder_outputs(
+    flow: &mut DcutrResponder,
+    role: &str,
+    captured: &mut Option<Vec<Multiaddr>>,
+) -> Vec<u8> {
     let _ = flow.handle_input(DcutrResponderInput::Flush);
-    match flow.poll_output() {
-        Some(DcutrResponderOutput::Outbound(bytes)) => bytes,
-        _ => Vec::new(),
+    let mut outbound = Vec::new();
+    while let Some(output) = flow.poll_output() {
+        match output {
+            DcutrResponderOutput::Outbound(bytes) => outbound.extend(bytes),
+            DcutrResponderOutput::Event(ev) => {
+                handle_dcutr_responder_event(ev, role, captured);
+            }
+        }
     }
+    outbound
 }
 
 fn dcutr_responder_feed(flow: &mut DcutrResponder, data: Vec<u8>) -> Result<(), Box<dyn Error>> {
@@ -1065,47 +1071,32 @@ fn wait_user_stream_data(
     Ok(data)
 }
 
-/// Drains any pending DCUtR responder events into the caller's
-/// `captured` slot. Returns `true` when `SyncReceived` has fired
-/// (i.e. the responder flow is complete).
-///
-/// `captured` is threaded by reference because `ConnectReceived` and
-/// `SyncReceived` can arrive in separate poll cycles -- persisting the
-/// captured remote addresses across calls is essential so they aren't
-/// lost by the time SYNC arrives.
-fn drain_dcutr_responder_events(
-    dcutr: &mut DcutrResponder,
+fn handle_dcutr_responder_event(
+    ev: ResponderEvent,
     role: &str,
     captured: &mut Option<Vec<Multiaddr>>,
-) -> bool {
-    let mut sync = false;
-    while let Some(output) = dcutr.poll_output() {
-        let DcutrResponderOutput::Event(ev) = output else {
-            continue;
-        };
-        match ev {
-            ResponderEvent::ConnectReceived {
-                remote_addrs,
-                remote_addr_bytes,
-            } => {
-                if remote_addrs.len() < remote_addr_bytes.len() {
-                    eprintln!(
-                        "[{role}] dcutr-connect-received: {} of {} remote addrs \
-                         failed to parse and were ignored",
-                        remote_addr_bytes.len() - remote_addrs.len(),
-                        remote_addr_bytes.len()
-                    );
-                }
-                println!(
-                    "[{role}] dcutr-connect-received addrs={}",
-                    remote_addrs.len()
+) {
+    match ev {
+        ResponderEvent::ConnectReceived {
+            remote_addrs,
+            remote_addr_bytes,
+        } => {
+            if remote_addrs.len() < remote_addr_bytes.len() {
+                eprintln!(
+                    "[{role}] dcutr-connect-received: {} of {} remote addrs \
+                     failed to parse and were ignored",
+                    remote_addr_bytes.len() - remote_addrs.len(),
+                    remote_addr_bytes.len()
                 );
-                *captured = Some(remote_addrs);
             }
-            ResponderEvent::SyncReceived => sync = true,
+            println!(
+                "[{role}] dcutr-connect-received addrs={}",
+                remote_addrs.len()
+            );
+            *captured = Some(remote_addrs);
         }
+        ResponderEvent::SyncReceived => {}
     }
-    sync
 }
 
 fn dial_direct_candidates(

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -12,20 +12,23 @@ use std::error::Error;
 use std::time::{Duration, Instant};
 
 use minip2p_autonat::{
-    AUTONAT_PROTOCOL_ID, AutoNatClient, AutoNatServer, Reachability, ResponseStatus,
+    AUTONAT_PROTOCOL_ID, AutoNatClient, AutoNatClientInput, AutoNatClientOutput, AutoNatServer,
+    AutoNatServerInput, AutoNatServerOutput, Reachability, ResponseStatus,
 };
 use minip2p_core::{
     DirectCandidateRejectReason, DirectCandidateRejection, Multiaddr, PeerAddr, PeerId, Protocol,
-    select_direct_candidates,
+    SansIoProtocol, select_direct_candidates,
 };
 use minip2p_dcutr::{
-    DCUTR_PROTOCOL_ID, DcutrInitiator, DcutrResponder, InitiatorOutcome, ResponderEvent,
+    DCUTR_PROTOCOL_ID, DcutrInitiator, DcutrInitiatorInput, DcutrInitiatorOutput, DcutrResponder,
+    DcutrResponderInput, DcutrResponderOutput, InitiatorOutcome, ResponderEvent,
 };
 use minip2p_identity::Ed25519Keypair;
 use minip2p_quic::{QuicEndpoint, QuicNodeConfig, QuicTransport};
 use minip2p_relay::{
-    ConnectOutcome, HOP_PROTOCOL_ID, HopConnect, HopReservation, ReservationOutcome,
-    STOP_PROTOCOL_ID, StopResponder,
+    ConnectOutcome, HOP_PROTOCOL_ID, HopConnect, HopConnectInput, HopConnectOutput, HopReservation,
+    HopReservationInput, HopReservationOutput, ReservationOutcome, STOP_PROTOCOL_ID, StopResponder,
+    StopResponderInput, StopResponderOutput,
 };
 use minip2p_swarm::{Swarm, SwarmBuilder, SwarmEvent};
 use minip2p_transport::{StreamId, Transport};
@@ -124,25 +127,24 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
         &mut swarm,
         &relay_peer_id,
         hop_stream,
-        reservation.take_outbound(),
+        relay_reservation_flush(&mut reservation),
     )?;
 
-    while reservation.outcome().is_none() {
+    let reservation_outcome = loop {
         let data = wait_user_stream_data(&mut swarm, role, hop_stream, deadline)?;
-        reservation
-            .on_data(&data)
-            .map_err(|e| format!("HOP decode: {e}"))?;
-    }
-    match reservation.outcome() {
-        Some(ReservationOutcome::Accepted { .. }) => {
+        if let Some(outcome) = relay_reservation_feed(&mut reservation, data)? {
+            break outcome;
+        }
+    };
+    match reservation_outcome {
+        ReservationOutcome::Accepted { .. } => {
             println!("[{role}] reserved-on-relay");
         }
-        Some(ReservationOutcome::Refused { status, reason }) => {
+        ReservationOutcome::Refused { status, reason } => {
             return Err(
                 format!("relay refused reservation: status={status:?} reason={reason}").into(),
             );
         }
-        None => unreachable!(),
     }
 
     // --- 3. Wait for the relay to push a STOP stream at us ------------------
@@ -154,35 +156,30 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     let mut stop = StopResponder::new();
     let remote_peer_id: PeerId = loop {
         let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
-        stop.on_data(&data)
-            .map_err(|e| format!("STOP decode: {e}"))?;
-        if let Some(request) = stop.request() {
+        if let Some(request) = stop_feed(&mut stop, data)? {
             break PeerId::from_bytes(&request.source_peer_id)
                 .map_err(|e| format!("bad STOP source peer id: {e}"))?;
         }
     };
     println!("[{role}] stop-connect-from peer={remote_peer_id}");
-    stop.accept().map_err(|e| format!("STOP accept: {e}"))?;
     send(
         &mut swarm,
         &relay_peer_id,
         bridge_stream,
-        stop.take_outbound(),
+        stop_accept_flush(&mut stop)?,
     )?;
-    let bridge_bytes = stop.take_bridge_bytes();
+    let bridge_bytes = stop_bridge_bytes(&mut stop);
 
     // --- 5. DCUtR responder over the same bridge stream --------------------
     let mut dcutr = DcutrResponder::new(&our_observed);
     if !bridge_bytes.is_empty() {
-        dcutr
-            .on_data(&bridge_bytes)
-            .map_err(|e| format!("DCUtR decode (pipelined): {e}"))?;
+        dcutr_responder_feed(&mut dcutr, bridge_bytes)?;
     }
     send(
         &mut swarm,
         &relay_peer_id,
         bridge_stream,
-        dcutr.take_outbound(),
+        dcutr_responder_flush(&mut dcutr),
     )?;
 
     // DCUtR responder events arrive across multiple poll cycles:
@@ -195,14 +192,12 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
             break captured_remote_addrs.take().unwrap_or_default();
         }
         let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
-        dcutr
-            .on_data(&data)
-            .map_err(|e| format!("DCUtR decode: {e}"))?;
+        dcutr_responder_feed(&mut dcutr, data)?;
         send(
             &mut swarm,
             &relay_peer_id,
             bridge_stream,
-            dcutr.take_outbound(),
+            dcutr_responder_flush(&mut dcutr),
         )?;
     };
 
@@ -453,23 +448,29 @@ pub fn run_dial(
         .map_err(|e| format!("open HOP: {e}"))?;
     wait_user_stream_ready(&mut swarm, role, hop_stream, deadline)?;
     let mut hop = HopConnect::new(target.to_bytes());
-    send(&mut swarm, &relay_peer_id, hop_stream, hop.take_outbound())?;
+    send(
+        &mut swarm,
+        &relay_peer_id,
+        hop_stream,
+        hop_connect_flush(&mut hop),
+    )?;
 
-    while hop.outcome().is_none() {
+    let hop_outcome = loop {
         let data = wait_user_stream_data(&mut swarm, role, hop_stream, deadline)?;
-        hop.on_data(&data).map_err(|e| format!("HOP decode: {e}"))?;
-    }
-    match hop.outcome() {
-        Some(ConnectOutcome::Bridged { .. }) => {
+        if let Some(outcome) = hop_connect_feed(&mut hop, data)? {
+            break outcome;
+        }
+    };
+    match hop_outcome {
+        ConnectOutcome::Bridged { .. } => {
             println!("[{role}] bridge-established via-relay");
         }
-        Some(ConnectOutcome::Refused { status, reason }) => {
+        ConnectOutcome::Refused { status, reason } => {
             return Err(format!("relay refused CONNECT: status={status:?} reason={reason}").into());
         }
-        None => unreachable!(),
     }
     let bridge_stream = hop_stream; // same stream, now carrying DCUtR bytes
-    let bridge_bytes = hop.take_bridge_bytes();
+    let bridge_bytes = hop_connect_bridge_bytes(&mut hop);
 
     // --- 3. DCUtR initiator over the bridge --------------------------------
     let mut dcutr = DcutrInitiator::new(&our_observed);
@@ -478,16 +479,23 @@ pub fn run_dial(
         &mut swarm,
         &relay_peer_id,
         bridge_stream,
-        dcutr.take_outbound(),
+        dcutr_initiator_flush(&mut dcutr),
     )?;
+    let mut pending_dialnow = None;
     if !bridge_bytes.is_empty() {
-        dcutr
-            .on_data(&bridge_bytes, 0)
-            .map_err(|e| format!("DCUtR decode (pipelined): {e}"))?;
+        pending_dialnow = dcutr_initiator_feed(&mut dcutr, bridge_bytes, 0)?;
     }
 
     let (remote_addrs, rtt_ms) = loop {
-        if let Some(outcome) = dcutr.outcome().cloned() {
+        let outcome = match pending_dialnow.take() {
+            Some(outcome) => Some(outcome),
+            None => {
+                let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
+                let elapsed_ms = dcutr_sent_at.elapsed().as_millis() as u64;
+                dcutr_initiator_feed(&mut dcutr, data, elapsed_ms)?
+            }
+        };
+        if let Some(outcome) = outcome {
             let InitiatorOutcome::DialNow {
                 remote_addrs,
                 remote_addr_bytes,
@@ -502,11 +510,6 @@ pub fn run_dial(
             }
             break (remote_addrs, rtt_ms);
         }
-        let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
-        let elapsed_ms = dcutr_sent_at.elapsed().as_millis() as u64;
-        dcutr
-            .on_data(&data, elapsed_ms)
-            .map_err(|e| format!("DCUtR decode: {e}"))?;
     };
     println!(
         "[{role}] dcutr-dialnow addrs={} rtt={rtt_ms}ms",
@@ -515,14 +518,11 @@ pub fn run_dial(
     print_remote_candidates(role, &remote_addrs);
 
     // --- 4. Flush SYNC and dial every observed remote address in parallel --
-    dcutr
-        .send_sync()
-        .map_err(|e| format!("DCUtR send_sync: {e}"))?;
     send(
         &mut swarm,
         &relay_peer_id,
         bridge_stream,
-        dcutr.take_outbound(),
+        dcutr_initiator_send_sync_flush(&mut dcutr)?,
     )?;
 
     dial_direct_candidates(&mut swarm, role, &target, &remote_addrs);
@@ -614,10 +614,7 @@ fn handle_autonat_request(
     let request_deadline = Instant::now() + AUTONAT_REQUEST_DEADLINE;
     let request = loop {
         let data = wait_user_stream_data(swarm, role, stream_id, request_deadline)?;
-        server
-            .on_data(&data)
-            .map_err(|e| format!("AutoNAT decode: {e}"))?;
-        if let Some(request) = server.request().cloned() {
+        if let Some(request) = autonat_server_feed(&mut server, data)? {
             break request;
         }
     };
@@ -636,11 +633,18 @@ fn handle_autonat_request(
     }
 
     if request.peer_id != requester_peer {
-        server.respond_error(
-            ResponseStatus::BadRequest,
-            "AutoNAT request peer id did not match stream peer",
-        );
-        send(swarm, &requester_peer, stream_id, server.take_outbound())?;
+        server
+            .handle_input(AutoNatServerInput::RespondError {
+                status: ResponseStatus::BadRequest,
+                reason: "AutoNAT request peer id did not match stream peer".into(),
+            })
+            .map_err(|e| format!("AutoNAT respond: {e}"))?;
+        send(
+            swarm,
+            &requester_peer,
+            stream_id,
+            autonat_server_flush(&mut server),
+        )?;
         println!("[{role}] probe-rejected reason=peer-id-mismatch");
         return Ok(());
     }
@@ -658,26 +662,193 @@ fn handle_autonat_request(
     }
 
     if !dialable.is_empty() {
-        server.respond_public(&dialable);
+        let dialable_len = dialable.len();
+        server
+            .handle_input(AutoNatServerInput::RespondPublic { addrs: dialable })
+            .map_err(|e| format!("AutoNAT respond: {e}"))?;
         println!(
             "[{role}] probe-public peer={} addrs={}",
-            request.peer_id,
-            dialable.len()
+            request.peer_id, dialable_len
         );
     } else {
-        server.respond_error(ResponseStatus::DialError, "dialback deadline elapsed");
+        server
+            .handle_input(AutoNatServerInput::RespondError {
+                status: ResponseStatus::DialError,
+                reason: "dialback deadline elapsed".into(),
+            })
+            .map_err(|e| format!("AutoNAT respond: {e}"))?;
         println!(
             "[{role}] probe-private peer={} reason=timeout",
             request.peer_id
         );
     }
 
-    send(swarm, &requester_peer, stream_id, server.take_outbound())
+    send(
+        swarm,
+        &requester_peer,
+        stream_id,
+        autonat_server_flush(&mut server),
+    )
 }
 
 // ---------------------------------------------------------------------------
 // Small helpers
 // ---------------------------------------------------------------------------
+
+fn relay_reservation_flush(flow: &mut HopReservation) -> Vec<u8> {
+    let _ = flow.handle_input(HopReservationInput::Flush);
+    match flow.poll_output() {
+        Some(HopReservationOutput::Outbound(bytes)) => bytes,
+        _ => Vec::new(),
+    }
+}
+
+fn relay_reservation_feed(
+    flow: &mut HopReservation,
+    data: Vec<u8>,
+) -> Result<Option<ReservationOutcome>, Box<dyn Error>> {
+    flow.handle_input(HopReservationInput::Data(data))
+        .map_err(|e| format!("HOP decode: {e}"))?;
+    Ok(match flow.poll_output() {
+        Some(HopReservationOutput::Outcome(outcome)) => Some(outcome),
+        _ => None,
+    })
+}
+
+fn hop_connect_flush(flow: &mut HopConnect) -> Vec<u8> {
+    let _ = flow.handle_input(HopConnectInput::Flush);
+    match flow.poll_output() {
+        Some(HopConnectOutput::Outbound(bytes)) => bytes,
+        _ => Vec::new(),
+    }
+}
+
+fn hop_connect_feed(
+    flow: &mut HopConnect,
+    data: Vec<u8>,
+) -> Result<Option<ConnectOutcome>, Box<dyn Error>> {
+    flow.handle_input(HopConnectInput::Data(data))
+        .map_err(|e| format!("HOP decode: {e}"))?;
+    Ok(match flow.poll_output() {
+        Some(HopConnectOutput::Outcome(outcome)) => Some(outcome),
+        _ => None,
+    })
+}
+
+fn hop_connect_bridge_bytes(flow: &mut HopConnect) -> Vec<u8> {
+    match flow.poll_output() {
+        Some(HopConnectOutput::BridgeData(bytes)) => bytes,
+        _ => Vec::new(),
+    }
+}
+
+fn stop_feed(
+    flow: &mut StopResponder,
+    data: Vec<u8>,
+) -> Result<Option<minip2p_relay::StopConnectRequest>, Box<dyn Error>> {
+    flow.handle_input(StopResponderInput::Data(data))
+        .map_err(|e| format!("STOP decode: {e}"))?;
+    Ok(match flow.poll_output() {
+        Some(StopResponderOutput::Request(request)) => Some(request),
+        _ => None,
+    })
+}
+
+fn stop_accept_flush(flow: &mut StopResponder) -> Result<Vec<u8>, Box<dyn Error>> {
+    flow.handle_input(StopResponderInput::Accept)
+        .map_err(|e| format!("STOP accept: {e}"))?;
+    Ok(match flow.poll_output() {
+        Some(StopResponderOutput::Outbound(bytes)) => bytes,
+        _ => Vec::new(),
+    })
+}
+
+fn stop_bridge_bytes(flow: &mut StopResponder) -> Vec<u8> {
+    match flow.poll_output() {
+        Some(StopResponderOutput::BridgeData(bytes)) => bytes,
+        _ => Vec::new(),
+    }
+}
+
+fn dcutr_responder_flush(flow: &mut DcutrResponder) -> Vec<u8> {
+    let _ = flow.handle_input(DcutrResponderInput::Flush);
+    match flow.poll_output() {
+        Some(DcutrResponderOutput::Outbound(bytes)) => bytes,
+        _ => Vec::new(),
+    }
+}
+
+fn dcutr_responder_feed(flow: &mut DcutrResponder, data: Vec<u8>) -> Result<(), Box<dyn Error>> {
+    flow.handle_input(DcutrResponderInput::Data(data))
+        .map_err(|e| format!("DCUtR decode: {e}").into())
+}
+
+fn dcutr_initiator_flush(flow: &mut DcutrInitiator) -> Vec<u8> {
+    let _ = flow.handle_input(DcutrInitiatorInput::Flush);
+    match flow.poll_output() {
+        Some(DcutrInitiatorOutput::Outbound(bytes)) => bytes,
+        _ => Vec::new(),
+    }
+}
+
+fn dcutr_initiator_feed(
+    flow: &mut DcutrInitiator,
+    bytes: Vec<u8>,
+    rtt_ms: u64,
+) -> Result<Option<InitiatorOutcome>, Box<dyn Error>> {
+    flow.handle_input(DcutrInitiatorInput::Data { bytes, rtt_ms })
+        .map_err(|e| format!("DCUtR decode: {e}"))?;
+    Ok(match flow.poll_output() {
+        Some(DcutrInitiatorOutput::Outcome(outcome)) => Some(outcome),
+        _ => None,
+    })
+}
+
+fn dcutr_initiator_send_sync_flush(flow: &mut DcutrInitiator) -> Result<Vec<u8>, Box<dyn Error>> {
+    flow.handle_input(DcutrInitiatorInput::SendSync)
+        .map_err(|e| format!("DCUtR send_sync: {e}"))?;
+    Ok(dcutr_initiator_flush(flow))
+}
+
+fn autonat_client_flush(flow: &mut AutoNatClient) -> Vec<u8> {
+    let _ = flow.handle_input(AutoNatClientInput::Flush);
+    match flow.poll_output() {
+        Some(AutoNatClientOutput::Outbound(bytes)) => bytes,
+        _ => Vec::new(),
+    }
+}
+
+fn autonat_client_feed(
+    flow: &mut AutoNatClient,
+    data: Vec<u8>,
+) -> Result<Option<Reachability>, Box<dyn Error>> {
+    flow.handle_input(AutoNatClientInput::Data(data))
+        .map_err(|e| format!("AutoNAT decode: {e}"))?;
+    Ok(match flow.poll_output() {
+        Some(AutoNatClientOutput::Outcome(outcome)) => Some(outcome),
+        _ => None,
+    })
+}
+
+fn autonat_server_feed(
+    flow: &mut AutoNatServer,
+    data: Vec<u8>,
+) -> Result<Option<minip2p_autonat::AutoNatRequest>, Box<dyn Error>> {
+    flow.handle_input(AutoNatServerInput::Data(data))
+        .map_err(|e| format!("AutoNAT decode: {e}"))?;
+    Ok(match flow.poll_output() {
+        Some(AutoNatServerOutput::Request(request)) => Some(request),
+        _ => None,
+    })
+}
+
+fn autonat_server_flush(flow: &mut AutoNatServer) -> Vec<u8> {
+    let _ = flow.handle_input(AutoNatServerInput::Flush);
+    match flow.poll_output() {
+        Some(AutoNatServerOutput::Outbound(bytes)) => bytes,
+        _ => Vec::new(),
+    }
+}
 
 fn prepare_relay(
     swarm: &mut Swarm<QuicEndpoint>,
@@ -908,7 +1079,10 @@ fn drain_dcutr_responder_events(
     captured: &mut Option<Vec<Multiaddr>>,
 ) -> bool {
     let mut sync = false;
-    for ev in dcutr.poll_events() {
+    while let Some(output) = dcutr.poll_output() {
+        let DcutrResponderOutput::Event(ev) = output else {
+            continue;
+        };
         match ev {
             ResponderEvent::ConnectReceived {
                 remote_addrs,
@@ -1214,16 +1388,21 @@ fn validate_candidates_with_autonat(
 
     let local_peer = swarm.local_peer_id().clone();
     let mut client = AutoNatClient::new(&local_peer, candidates);
-    send(swarm, &service_peer, stream_id, client.take_outbound())?;
+    send(
+        swarm,
+        &service_peer,
+        stream_id,
+        autonat_client_flush(&mut client),
+    )?;
 
-    while client.outcome().is_none() {
+    let outcome = loop {
         let data = wait_user_stream_data(swarm, role, stream_id, deadline)?;
-        client
-            .on_data(&data)
-            .map_err(|e| format!("AutoNAT decode: {e}"))?;
-    }
+        if let Some(outcome) = autonat_client_feed(&mut client, data)? {
+            break outcome;
+        }
+    };
 
-    match client.outcome().cloned().expect("outcome checked") {
+    match outcome {
         Reachability::Public { addrs, raw_addrs } => {
             if addrs.len() < raw_addrs.len() {
                 eprintln!(

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -282,7 +282,14 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     match outcome {
         HolePunchOutcome::DirectConnected(peer_id) => {
             println!("[{role}] direct-connected peer={peer_id} (hole-punch success)");
-            ping_and_exit(&mut swarm, role, peer_id, deadline)
+            ping_and_exit(
+                &mut swarm,
+                role,
+                peer_id,
+                &relay_peer_id,
+                bridge_stream,
+                deadline,
+            )
         }
         HolePunchOutcome::InboundConnectionSeen => {
             // The address heuristic fired before Swarm surfaced the verified
@@ -302,7 +309,14 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
             match verified {
                 Some(SwarmEvent::ConnectionEstablished { peer_id }) => {
                     println!("[{role}] direct-connected peer={peer_id} (mTLS verified)");
-                    ping_and_exit(&mut swarm, role, peer_id, deadline)
+                    ping_and_exit(
+                        &mut swarm,
+                        role,
+                        peer_id,
+                        &relay_peer_id,
+                        bridge_stream,
+                        deadline,
+                    )
                 }
                 _ => {
                     println!("[{role}] grace-elapsed before mTLS identity -> relay-ping fallback");
@@ -542,7 +556,14 @@ pub fn run_dial(
     // --- 6. Direct ping or relay-ping fallback -----------------------------
     if punched.is_some() {
         println!("[{role}] direct-connected peer={target} (hole-punch success)");
-        ping_and_exit(&mut swarm, role, target, deadline)
+        ping_and_exit(
+            &mut swarm,
+            role,
+            target,
+            &relay_peer_id,
+            bridge_stream,
+            deadline,
+        )
     } else {
         println!("[{role}] hole-punch-timeout reason=deadline elapsed -> relay-ping fallback");
         let payload = random_bytes(RELAY_PING_LEN);
@@ -1174,6 +1195,8 @@ fn ping_and_exit(
     swarm: &mut Swarm<QuicEndpoint>,
     role: &str,
     peer_id: PeerId,
+    relay_peer_id: &PeerId,
+    bridge_stream: StreamId,
     deadline: Instant,
 ) -> Result<(), Box<dyn Error>> {
     swarm.ping(&peer_id).map_err(|e| format!("ping: {e}"))?;
@@ -1187,7 +1210,51 @@ fn ping_and_exit(
     let SwarmEvent::PingRttMeasured { rtt_ms, .. } = ev else {
         unreachable!()
     };
+    println!("[{role}] ping-direct peer={peer_id} rtt={rtt_ms}ms");
+    close_relay_bridge_after_direct_success(swarm, role, relay_peer_id, bridge_stream)?;
     println!("[{role}] ping-direct peer={peer_id} rtt={rtt_ms}ms -- done");
+    Ok(())
+}
+
+/// Once direct QUIC is proven, the relayed bridge is no longer part of the
+/// data path. Half-close our write side so the relay can retire the circuit
+/// promptly instead of reporting a later idle timeout.
+fn close_relay_bridge_after_direct_success(
+    swarm: &mut Swarm<QuicEndpoint>,
+    role: &str,
+    relay_peer_id: &PeerId,
+    bridge_stream: StreamId,
+) -> Result<(), Box<dyn Error>> {
+    println!("[{role}] bridge-close stream={bridge_stream} reason=direct-path-ready");
+    match swarm.close_user_stream_write(relay_peer_id, bridge_stream) {
+        Ok(()) => {}
+        Err(e) => {
+            // The remote side may have already closed the relayed stream after
+            // its own direct success. Treat that as terminally clean for this
+            // CLI; the direct ping above is the correctness signal.
+            println!("[{role}] bridge-close-skipped stream={bridge_stream} reason={e}");
+            return Ok(());
+        }
+    }
+
+    // Give the close action one short poll window to flush and surface any
+    // immediate close event without delaying the successful CLI path.
+    let drain_deadline = Instant::now() + Duration::from_millis(200);
+    while Instant::now() < drain_deadline {
+        let events = swarm
+            .poll()
+            .map_err(|e| format!("bridge close poll: {e}"))?;
+        if events.is_empty() {
+            break;
+        }
+        for ev in events {
+            print_event(role, &ev);
+            if is_bridge_closed_event(&ev, bridge_stream) {
+                return Ok(());
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/examples/peer/src/relay.rs
+++ b/examples/peer/src/relay.rs
@@ -188,6 +188,9 @@ pub fn run_listen(relay_addr: PeerAddr, options: RunOptions) -> Result<(), Box<d
     // one. We thread the captured remote-addrs through the loop so
     // the CONNECT payload isn't thrown away when the SYNC arrives.
     let remote_addrs: Vec<Multiaddr> = loop {
+        if dcutr.is_done() {
+            break captured_remote_addrs.take().unwrap_or_default();
+        }
         let data = wait_user_stream_data(&mut swarm, role, bridge_stream, deadline)?;
         dcutr_responder_feed(&mut dcutr, data)?;
         let outbound = drain_dcutr_responder_outputs(&mut dcutr, role, &mut captured_remote_addrs);

--- a/transports/quic/tests/ping_e2e.rs
+++ b/transports/quic/tests/ping_e2e.rs
@@ -1,9 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Instant;
 
-use minip2p_core::{PeerAddr, PeerId};
-use minip2p_multistream_select::{MultistreamOutput, MultistreamSelect};
-use minip2p_ping::{PING_PAYLOAD_LEN, PING_PROTOCOL_ID, PingAction, PingEvent, PingProtocol};
+use minip2p_core::{PeerAddr, PeerId, SansIoProtocol};
+use minip2p_multistream_select::{MultistreamInput, MultistreamOutput, MultistreamSelect};
+use minip2p_ping::{
+    PING_PAYLOAD_LEN, PING_PROTOCOL_ID, PingAction, PingEvent, PingInput, PingOutput, PingProtocol,
+};
 use minip2p_quic::{QuicNodeConfig, QuicTransport};
 use minip2p_transport::{ConnectionId, StreamId, Transport, TransportEvent};
 
@@ -47,6 +49,65 @@ fn apply_ping_actions(
             }
         }
     }
+}
+
+fn apply_ping_output(
+    transport: &mut QuicTransport,
+    connection_id: ConnectionId,
+    output: PingOutput,
+    events: &mut Vec<PingEvent>,
+) {
+    match output {
+        PingOutput::Action(action) => apply_ping_actions(transport, connection_id, vec![action]),
+        PingOutput::Event(event) => events.push(event),
+    }
+}
+
+fn drain_ping_outputs(
+    ping: &mut PingProtocol,
+    transport: &mut QuicTransport,
+    connection_id: ConnectionId,
+) -> Vec<PingEvent> {
+    let mut events = Vec::new();
+    while let Some(output) = ping.poll_output() {
+        apply_ping_output(transport, connection_id, output, &mut events);
+    }
+    events
+}
+
+fn drive_ping_input(
+    ping: &mut PingProtocol,
+    input: PingInput,
+    transport: &mut QuicTransport,
+    connection_id: ConnectionId,
+) -> Vec<PingEvent> {
+    ping.handle_input(input).expect("ping input");
+    drain_ping_outputs(ping, transport, connection_id)
+}
+
+fn multistream_start(negotiator: &mut MultistreamSelect) -> Vec<MultistreamOutput> {
+    negotiator
+        .handle_input(MultistreamInput::Start)
+        .expect("start multistream");
+    let mut outputs = Vec::new();
+    while let Some(output) = negotiator.poll_output() {
+        outputs.push(output);
+    }
+    outputs
+}
+
+fn multistream_receive(
+    negotiator: &mut MultistreamSelect,
+    data: Vec<u8>,
+) -> Vec<MultistreamOutput> {
+    negotiator
+        .handle_input(MultistreamInput::Data(data))
+        .expect("feed multistream");
+    let mut outputs = Vec::new();
+    while let Some(output) = negotiator.poll_output() {
+        outputs.push(output);
+    }
+    outputs
 }
 
 fn assert_no_protocol_violations(events: &[PingEvent]) {
@@ -105,7 +166,7 @@ impl PingHarness {
             .expect("open client ping stream");
 
         let mut client_negotiator = MultistreamSelect::dialer(PING_PROTOCOL_ID);
-        for output in client_negotiator.start() {
+        for output in multistream_start(&mut client_negotiator) {
             if let MultistreamOutput::OutboundData(bytes) = output {
                 client
                     .send_stream(client_conn_id, client_stream, bytes)
@@ -145,7 +206,7 @@ impl PingHarness {
                 {
                     assert_eq!(id, client_conn_id);
                     if !client_negotiated {
-                        let outputs = client_negotiator.receive(&data);
+                        let outputs = multistream_receive(&mut client_negotiator, data);
                         for output in outputs {
                             match output {
                                 MultistreamOutput::OutboundData(bytes) => {
@@ -156,12 +217,15 @@ impl PingHarness {
                                 MultistreamOutput::Negotiated { protocol } => {
                                     assert_eq!(protocol, PING_PROTOCOL_ID);
                                     assert_eq!(stream_id, client_stream);
-                                    client_ping
-                                        .register_outbound_stream(
-                                            peer_addr.peer_id().clone(),
-                                            client_stream,
-                                        )
-                                        .expect("register outbound ping stream");
+                                    drive_ping_input(
+                                        &mut client_ping,
+                                        PingInput::RegisterOutboundStream {
+                                            peer_id: peer_addr.peer_id().clone(),
+                                            stream_id: client_stream,
+                                        },
+                                        &mut client,
+                                        client_conn_id,
+                                    );
                                     client_negotiated = true;
                                 }
                                 MultistreamOutput::NotAvailable => {
@@ -259,7 +323,7 @@ impl PingHarness {
                 TransportEvent::IncomingStream { id, stream_id } => {
                     assert_eq!(*id, server_conn_id);
                     let mut listener = MultistreamSelect::listener([PING_PROTOCOL_ID.to_string()]);
-                    let start_outputs = listener.start();
+                    let start_outputs = multistream_start(&mut listener);
                     negotiators.insert(*stream_id, listener);
 
                     for output in start_outputs {
@@ -277,7 +341,7 @@ impl PingHarness {
                 } => {
                     assert_eq!(*id, server_conn_id);
                     if let Some(negotiator) = negotiators.get_mut(stream_id) {
-                        let outputs = negotiator.receive(data);
+                        let outputs = multistream_receive(negotiator, data.clone());
                         let mut negotiated_ping = false;
 
                         for output in outputs {
@@ -291,11 +355,15 @@ impl PingHarness {
                                     assert_eq!(protocol, PING_PROTOCOL_ID);
                                     negotiated_ping = true;
 
-                                    let actions = server_ping.register_inbound_stream(
-                                        peer_addr.peer_id().clone(),
-                                        *stream_id,
+                                    drive_ping_input(
+                                        server_ping,
+                                        PingInput::RegisterInboundStream {
+                                            peer_id: peer_addr.peer_id().clone(),
+                                            stream_id: *stream_id,
+                                        },
+                                        server,
+                                        server_conn_id,
                                     );
-                                    apply_ping_actions(server, server_conn_id, actions);
                                 }
                                 MultistreamOutput::NotAvailable => {
                                     panic!("listener reported protocol not available unexpectedly")
@@ -311,27 +379,45 @@ impl PingHarness {
                             ping_streams.insert(*stream_id);
                         }
                     } else if ping_streams.contains(stream_id) {
-                        let actions = server_ping.on_stream_data(
-                            peer_addr.peer_id(),
-                            *stream_id,
-                            data,
-                            start.elapsed().as_millis() as u64,
+                        drive_ping_input(
+                            server_ping,
+                            PingInput::StreamData {
+                                peer_id: peer_addr.peer_id().clone(),
+                                stream_id: *stream_id,
+                                data: data.clone(),
+                                now_ms: start.elapsed().as_millis() as u64,
+                            },
+                            server,
+                            server_conn_id,
                         );
-                        apply_ping_actions(server, server_conn_id, actions);
                     } else {
                         panic!("server received data for unknown stream {stream_id}");
                     }
                 }
                 TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
                     assert_eq!(*id, server_conn_id);
-                    let actions =
-                        server_ping.on_stream_remote_write_closed(peer_addr.peer_id(), *stream_id);
-                    apply_ping_actions(server, server_conn_id, actions);
+                    drive_ping_input(
+                        server_ping,
+                        PingInput::StreamRemoteWriteClosed {
+                            peer_id: peer_addr.peer_id().clone(),
+                            stream_id: *stream_id,
+                        },
+                        server,
+                        server_conn_id,
+                    );
                     *on_remote_write_closed = Some(*stream_id);
                 }
                 TransportEvent::StreamClosed { id, stream_id } => {
                     assert_eq!(*id, server_conn_id);
-                    server_ping.on_stream_closed(peer_addr.peer_id(), *stream_id);
+                    drive_ping_input(
+                        server_ping,
+                        PingInput::StreamClosed {
+                            peer_id: peer_addr.peer_id().clone(),
+                            stream_id: *stream_id,
+                        },
+                        server,
+                        server_conn_id,
+                    );
                     ping_streams.remove(stream_id);
                     negotiators.remove(stream_id);
                 }
@@ -357,12 +443,13 @@ impl PingHarness {
         );
 
         let now_ms = self.start.elapsed().as_millis() as u64;
-        apply_ping_actions(
+        let events = drive_ping_input(
+            &mut self.server_ping,
+            PingInput::Tick { now_ms },
             &mut self.server,
             self.server_conn_id,
-            self.server_ping.on_tick(now_ms),
         );
-        assert_no_protocol_violations(&self.server_ping.poll_events());
+        assert_no_protocol_violations(&events);
 
         client_events
     }
@@ -393,12 +480,13 @@ impl PingHarness {
         }
 
         let now_ms = self.start.elapsed().as_millis() as u64;
-        apply_ping_actions(
+        let events = drive_ping_input(
+            &mut self.server_ping,
+            PingInput::Tick { now_ms },
             &mut self.server,
             self.server_conn_id,
-            self.server_ping.on_tick(now_ms),
         );
-        assert_no_protocol_violations(&self.server_ping.poll_events());
+        assert_no_protocol_violations(&events);
 
         (client_events, closed_stream)
     }
@@ -427,6 +515,7 @@ fn ping_roundtrip_after_identity_verification_and_multistream_negotiation() {
 
     for _ in 0..400 {
         let client_events = h.drive_once();
+        let mut client_ping_events = Vec::new();
 
         for event in client_events {
             match event {
@@ -437,43 +526,69 @@ fn ping_roundtrip_after_identity_verification_and_multistream_negotiation() {
                 } => {
                     assert_eq!(id, h.client_conn_id);
                     let now = h.now_ms();
-                    let actions = h
-                        .client_ping
-                        .on_stream_data(&peer_id, stream_id, &data, now);
-                    apply_ping_actions(&mut h.client, h.client_conn_id, actions);
+                    client_ping_events.extend(drive_ping_input(
+                        &mut h.client_ping,
+                        PingInput::StreamData {
+                            peer_id: peer_id.clone(),
+                            stream_id,
+                            data,
+                            now_ms: now,
+                        },
+                        &mut h.client,
+                        h.client_conn_id,
+                    ));
                 }
                 TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
                     assert_eq!(id, h.client_conn_id);
-                    let actions = h
-                        .client_ping
-                        .on_stream_remote_write_closed(&peer_id, stream_id);
-                    apply_ping_actions(&mut h.client, h.client_conn_id, actions);
+                    client_ping_events.extend(drive_ping_input(
+                        &mut h.client_ping,
+                        PingInput::StreamRemoteWriteClosed {
+                            peer_id: peer_id.clone(),
+                            stream_id,
+                        },
+                        &mut h.client,
+                        h.client_conn_id,
+                    ));
                 }
                 TransportEvent::StreamClosed { id, stream_id } => {
                     assert_eq!(id, h.client_conn_id);
-                    h.client_ping.on_stream_closed(&peer_id, stream_id);
+                    client_ping_events.extend(drive_ping_input(
+                        &mut h.client_ping,
+                        PingInput::StreamClosed {
+                            peer_id: peer_id.clone(),
+                            stream_id,
+                        },
+                        &mut h.client,
+                        h.client_conn_id,
+                    ));
                 }
                 _ => {}
             }
         }
 
         let now_ms = h.now_ms();
-        apply_ping_actions(
+        client_ping_events.extend(drive_ping_input(
+            &mut h.client_ping,
+            PingInput::Tick { now_ms },
             &mut h.client,
             h.client_conn_id,
-            h.client_ping.on_tick(now_ms),
-        );
+        ));
 
         if !ping_sent {
-            let send = h
-                .client_ping
-                .send_ping(&peer_id, &payload, now_ms)
-                .expect("prepare ping request");
-            apply_ping_actions(&mut h.client, h.client_conn_id, vec![send]);
+            client_ping_events.extend(drive_ping_input(
+                &mut h.client_ping,
+                PingInput::SendPing {
+                    peer_id: peer_id.clone(),
+                    payload,
+                    now_ms,
+                },
+                &mut h.client,
+                h.client_conn_id,
+            ));
             ping_sent = true;
         }
 
-        for event in h.client_ping.poll_events() {
+        for event in client_ping_events {
             match event {
                 PingEvent::RttMeasured {
                     peer_id: pid,
@@ -524,6 +639,7 @@ fn repeated_ping_on_same_stream_then_close_write_exits_listener_loop() {
 
     for _ in 0..500 {
         let (client_events, server_closed_stream) = h.drive_once_with_server_close_hook();
+        let mut client_ping_events = Vec::new();
 
         if server_closed_stream.is_some() {
             server_saw_remote_write_closed = true;
@@ -538,46 +654,72 @@ fn repeated_ping_on_same_stream_then_close_write_exits_listener_loop() {
                 } => {
                     assert_eq!(id, h.client_conn_id);
                     let now = h.now_ms();
-                    let actions = h
-                        .client_ping
-                        .on_stream_data(&peer_id, stream_id, &data, now);
-                    apply_ping_actions(&mut h.client, h.client_conn_id, actions);
+                    client_ping_events.extend(drive_ping_input(
+                        &mut h.client_ping,
+                        PingInput::StreamData {
+                            peer_id: peer_id.clone(),
+                            stream_id,
+                            data,
+                            now_ms: now,
+                        },
+                        &mut h.client,
+                        h.client_conn_id,
+                    ));
                 }
                 TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
                     assert_eq!(id, h.client_conn_id);
                     if stream_id == h.client_stream {
                         client_saw_remote_write_closed = true;
                     }
-                    let actions = h
-                        .client_ping
-                        .on_stream_remote_write_closed(&peer_id, stream_id);
-                    apply_ping_actions(&mut h.client, h.client_conn_id, actions);
+                    client_ping_events.extend(drive_ping_input(
+                        &mut h.client_ping,
+                        PingInput::StreamRemoteWriteClosed {
+                            peer_id: peer_id.clone(),
+                            stream_id,
+                        },
+                        &mut h.client,
+                        h.client_conn_id,
+                    ));
                 }
                 TransportEvent::StreamClosed { id, stream_id } => {
                     assert_eq!(id, h.client_conn_id);
-                    h.client_ping.on_stream_closed(&peer_id, stream_id);
+                    client_ping_events.extend(drive_ping_input(
+                        &mut h.client_ping,
+                        PingInput::StreamClosed {
+                            peer_id: peer_id.clone(),
+                            stream_id,
+                        },
+                        &mut h.client,
+                        h.client_conn_id,
+                    ));
                 }
                 _ => {}
             }
         }
 
         let now_ms = h.now_ms();
-        apply_ping_actions(
+        client_ping_events.extend(drive_ping_input(
+            &mut h.client_ping,
+            PingInput::Tick { now_ms },
             &mut h.client,
             h.client_conn_id,
-            h.client_ping.on_tick(now_ms),
-        );
+        ));
 
         if next_ping_idx < payloads.len() && measured_rtts.len() == next_ping_idx {
-            let send = h
-                .client_ping
-                .send_ping(&peer_id, &payloads[next_ping_idx], now_ms)
-                .expect("prepare ping request");
-            apply_ping_actions(&mut h.client, h.client_conn_id, vec![send]);
+            client_ping_events.extend(drive_ping_input(
+                &mut h.client_ping,
+                PingInput::SendPing {
+                    peer_id: peer_id.clone(),
+                    payload: payloads[next_ping_idx],
+                    now_ms,
+                },
+                &mut h.client,
+                h.client_conn_id,
+            ));
             next_ping_idx += 1;
         }
 
-        for event in h.client_ping.poll_events() {
+        for event in client_ping_events {
             match event {
                 PingEvent::RttMeasured {
                     peer_id: pid,
@@ -602,11 +744,14 @@ fn repeated_ping_on_same_stream_then_close_write_exits_listener_loop() {
         }
 
         if measured_rtts.len() == payloads.len() && !close_requested {
-            let close = h
-                .client_ping
-                .close_outbound_stream_write(&peer_id)
-                .expect("close ping write side");
-            apply_ping_actions(&mut h.client, h.client_conn_id, vec![close]);
+            let _ = drive_ping_input(
+                &mut h.client_ping,
+                PingInput::CloseOutboundStreamWrite {
+                    peer_id: peer_id.clone(),
+                },
+                &mut h.client,
+                h.client_conn_id,
+            );
             close_requested = true;
         }
 

--- a/transports/quic/tests/swarm_e2e.rs
+++ b/transports/quic/tests/swarm_e2e.rs
@@ -353,7 +353,7 @@ fn open_user_stream_fails_fast_when_peer_did_not_advertise_protocol() {
 /// `observed_addr` byte vector into the Identify responder (the TODO at
 /// the former `crates/swarm/src/core.rs:982`). The fix plumbs the
 /// transport endpoint cached on `TransportEvent::Connected` /
-/// `IncomingConnection` into `IdentifyProtocol::register_outbound_stream`.
+/// `IncomingConnection` into `IdentifyInput::RegisterOutboundStream`.
 ///
 /// Note: we intentionally only assert the client-observed direction.
 /// The symmetric server-observed case requires the server to learn the


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adopt a poll‑driven Sans‑I/O API across the swarm and all protocol engines. Fixed output draining, ensured action‑before‑event ordering, documented the mutate‑then‑drain driver loop, and closed the relay bridge after a successful direct ping.

- **New Features**
  - Added common `minip2p_core::SansIoProtocol` trait; `SwarmCore` implements it (`Input=SwarmInput`, `Output=SwarmOutput`) with fixed drain semantics and `is_idle()`.
  - Converted all protocols to the trait: `PingProtocol`, `IdentifyProtocol`, `MultistreamSelect`, AutoNAT client/server, DCUtR initiator/responder, and Relay `HopReservation`/`HopConnect`/`StopResponder` with typed input/output enums.
  - Std `Swarm<T>` driver now feeds `SwarmInput` and drains `SwarmOutput`; crate READMEs updated to explain the one‑mutation‑then‑drain contract.
  - DCUtR: reliable pipelined completion (queued SYNC and remote‑close handling).
  - Relay examples/tests: close the relay circuit once a direct ping succeeds to release the bridge.

- **Migration**
  - Replace `on_transport_event(...)` with `handle_input(SwarmInput::Transport(...))`.
  - Replace `on_tick(now_ms)` with `handle_input(SwarmInput::Tick { now_ms })`.
  - Replace `on_stream_opened(...)` / `on_open_stream_failed(...)` with `handle_input(SwarmInput::StreamOpened { ... })` / `handle_input(SwarmInput::OpenStreamFailed { ... })`.
  - Replace `record_error(...)` with `handle_input(SwarmInput::RuntimeError(...))`.
  - Remove `take_actions()` / `poll_events()`; drain via repeated `poll_output()`.
  - Protocols: remove `on_data()` / `take_outbound()` / `receive()`. Drive engines via their `Input`/`Output` enums (e.g. `PingInput`/`PingOutput`, `IdentifyInput`/`IdentifyOutput`, `MultistreamInput`/`MultistreamOutput`, `AutoNat*Input`/`AutoNat*Output`, `Dcutr*Input`/`Dcutr*Output`, Relay `*Input`/`*Output`) using `handle_input(...)` and `poll_output()`.

<sup>Written for commit dd819030d0bbf209d59e7961f0413732539809b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

