### PR TITLE
NAT traversal: sans-I/O orchestrator crate + Endpoint wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,11 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo fmt --manifest-path fuzz/Cargo.toml -- --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo clippy -p minip2p --features nat --all-targets -- -D warnings
       - run: cargo clippy --manifest-path fuzz/Cargo.toml --all-targets -- -D warnings
       - run: cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm -p minip2p-nat
       - run: cargo test --workspace
+      - run: cargo test -p minip2p --features nat
       - run: cargo doc --workspace --no-deps
       - run: cargo bench -p minip2p-core --bench multiaddr --no-run
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - run: cargo fmt --manifest-path fuzz/Cargo.toml -- --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo clippy --manifest-path fuzz/Cargo.toml --all-targets -- -D warnings
-      - run: cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm
+      - run: cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm -p minip2p-nat
       - run: cargo test --workspace
       - run: cargo doc --workspace --no-deps
       - run: cargo bench -p minip2p-core --bench multiaddr --no-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,15 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           components: clippy,rustfmt
           # Real no_std target: a host check can't catch dependencies that
           # unconditionally link std.
           targets: thumbv7em-none-eabi
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
       - run: cargo fmt --manifest-path fuzz/Cargo.toml -- --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
@@ -38,11 +38,11 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # 1.88 (workspace rust-version)
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable # 1.88 (workspace rust-version) via the toolchain input
         with:
           toolchain: "1.88"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --all-targets
 
   fuzz-smoke:
@@ -52,11 +52,11 @@ jobs:
       # rust-cache key stays stable. Bump deliberately.
       NIGHTLY_TOOLCHAIN: nightly-2026-07-01
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # pinned action revision (installs the nightly toolchain below)
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable # installs the nightly toolchain below via the toolchain input
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@v2
         with:
           workspaces: fuzz
       # Swatinem/rust-cache does not cache ~/.cargo/bin, so cargo-fuzz is
@@ -66,7 +66,7 @@ jobs:
       # cargo-fuzz release is newest. Bump deliberately.
       - run: cargo install cargo-fuzz --version 0.13.2 --locked
       - run: cargo +$NIGHTLY_TOOLCHAIN fuzz run wire_inputs -- -max_total_time=30
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: fuzz-artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "minip2p-dcutr",
  "minip2p-relay",
  "minip2p-swarm",
+ "minip2p-test-support",
  "minip2p-transport",
  "thiserror",
 ]
@@ -885,8 +886,17 @@ dependencies = [
  "minip2p-multistream-select",
  "minip2p-ping",
  "minip2p-relay",
+ "minip2p-test-support",
  "minip2p-transport",
  "thiserror",
+]
+
+[[package]]
+name = "minip2p-test-support"
+version = "0.1.0"
+dependencies = [
+ "minip2p-core",
+ "minip2p-relay",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,9 +741,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 name = "minip2p"
 version = "0.1.0"
 dependencies = [
+ "getrandom",
  "minip2p-core",
  "minip2p-identify",
  "minip2p-identity",
+ "minip2p-nat",
  "minip2p-quic",
  "minip2p-swarm",
  "minip2p-transport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,7 @@ dependencies = [
 name = "minip2p-nat"
 version = "0.1.0"
 dependencies = [
+ "minip2p-autonat",
  "minip2p-core",
  "minip2p-dcutr",
  "minip2p-relay",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "minip2p-nat"
+version = "0.1.0"
+dependencies = [
+ "minip2p-core",
+ "minip2p-dcutr",
+ "minip2p-relay",
+ "minip2p-swarm",
+ "minip2p-transport",
+ "thiserror",
+]
+
+[[package]]
 name = "minip2p-peer"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/identity",
     "crates/minip2p",
     "crates/multistream-select",
+    "crates/nat",
     "crates/ping",
     "crates/relay",
     "crates/swarm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/ping",
     "crates/relay",
     "crates/swarm",
+    "crates/test-support",
     "crates/tls",
     "crates/transport",
     "transports/quic",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Sans-I/O core crates (`no_std + alloc`):
 
 Runtime adapters (`std`):
 
-- `crates/minip2p` (`minip2p`): app-facing facade that glues identity, QUIC, and the std swarm driver into an `Endpoint` API.
+- `crates/minip2p` (`minip2p`): app-facing facade that glues identity, QUIC, and the std swarm driver into an `Endpoint` API. The opt-in `nat` cargo feature wires the `minip2p-nat` traversal agent into `Endpoint` (`connect`/`wait_path`/`take_nat_events`, relay reservations, AutoNAT probing) with zero changes to the feature-off API.
 - `transports/quic` (`minip2p-quic`): QUIC transport adapter built on `quiche`, with libp2p TLS baked in.
 - `crates/swarm` (also ships a thin `std` driver `Swarm<T: Transport>` behind the `std` feature).
 
@@ -45,6 +45,7 @@ Current validated behavior:
 - Pure-state-machine integration test covering Circuit Relay v2 + DCUtR (reservation, connect, stop, hole-punch coordination).
 - AutoNAT reachability probe wire logic and state machines in `minip2p-autonat`.
 - Manual cross-network test against a rust-libp2p relay validates HOP reservation, STOP circuit establishment, DCUtR coordination, IPv6 hole punching, direct ping, and relay-ping fallback.
+- NAT-traversal orchestration (`minip2p-nat`): scripted agent tests for the dialer race, housekeeping, and responder side; a two-agent relay-emulator integration test; and a loopback QUIC e2e through the `minip2p` facade's `nat` feature.
 
 ## Architecture boundaries
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Sans-I/O core crates (`no_std + alloc`):
 - `crates/autonat` (`minip2p-autonat`): AutoNAT reachability probe state machines.
 - `crates/dcutr` (`minip2p-dcutr`): DCUtR hole-punch coordination state machines (`DcutrInitiator`, `DcutrResponder`).
 - `crates/swarm` (`minip2p-swarm`): `SwarmCore` Sans-I/O orchestrator that composes the protocol state machines, tracks connections and streams, drives multistream-select, and emits actions/events for the driver.
+- `crates/nat` (`minip2p-nat`): `NatAgent` Sans-I/O NAT-traversal orchestrator — races direct dials against a relayed circuit, hole-punches with DCUtR over the bridge, and reports explicit path establish/upgrade/fallback events.
 
 Runtime adapters (`std`):
 
@@ -124,7 +125,7 @@ Check `no_std` builds for the core crates:
 cargo check --no-default-features -p minip2p-core -p minip2p-identity \
     -p minip2p-transport -p minip2p-tls -p minip2p-identify \
     -p minip2p-multistream-select -p minip2p-ping -p minip2p-relay \
-    -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm
+    -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm -p minip2p-nat
 ```
 
 ## Documentation

--- a/crates/autonat/src/lib.rs
+++ b/crates/autonat/src/lib.rs
@@ -126,6 +126,9 @@ pub enum AutoNatClientInput {
     Flush,
     /// Bytes received from the AutoNAT service stream.
     Data(Vec<u8>),
+    /// Remote write side closed. The local side remains usable; this lets the
+    /// client finish decoding any buffered response bytes.
+    RemoteWriteClosed,
 }
 
 /// Output produced by [`AutoNatClient`] through [`SansIoProtocol`].
@@ -301,6 +304,11 @@ impl AutoNatClient {
         self.try_decode_response()
     }
 
+    /// Notifies the client that the remote write half has closed.
+    fn on_remote_write_closed(&mut self) -> Result<(), AutoNatError> {
+        self.try_decode_response()
+    }
+
     /// Returns the reachability outcome, if available.
     #[cfg(test)]
     fn outcome(&self) -> Option<&Reachability> {
@@ -450,6 +458,7 @@ impl SansIoProtocol for AutoNatClient {
         match input {
             AutoNatClientInput::Flush => {}
             AutoNatClientInput::Data(data) => self.on_data(&data)?,
+            AutoNatClientInput::RemoteWriteClosed => self.on_remote_write_closed()?,
         }
         Ok(())
     }

--- a/crates/core/src/multiaddr.rs
+++ b/crates/core/src/multiaddr.rs
@@ -153,6 +153,7 @@ impl fmt::Display for Multiaddr {
                 Protocol::Udp(port) => write!(f, "/udp/{port}")?,
                 Protocol::QuicV1 => f.write_str("/quic-v1")?,
                 Protocol::P2p(peer_id) => write!(f, "/p2p/{peer_id}")?,
+                Protocol::P2pCircuit => f.write_str("/p2p-circuit")?,
             }
         }
         Ok(())
@@ -252,6 +253,10 @@ fn parse_multiaddr(input: &str) -> Result<Multiaddr, MultiaddrError> {
             }
             "quic-v1" => {
                 protocols.push(Protocol::QuicV1);
+                idx += 1;
+            }
+            "p2p-circuit" => {
+                protocols.push(Protocol::P2pCircuit);
                 idx += 1;
             }
             "p2p" => {
@@ -432,6 +437,35 @@ mod tests {
     #[test]
     fn binary_codec_round_trips_p2p_suffix() {
         let input = format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p/{PEER_ID}");
+        let addr = Multiaddr::from_str(&input).unwrap();
+        let bytes = addr.to_bytes();
+        let decoded = Multiaddr::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.to_string(), input);
+    }
+
+    #[test]
+    fn parses_and_formats_circuit_multiaddr() {
+        let input = format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p/{PEER_ID}/p2p-circuit");
+        let parsed = Multiaddr::from_str(&input).expect("must parse");
+
+        assert_eq!(parsed.to_string(), input);
+        // A circuit address is not a direct QUIC transport address.
+        assert!(!parsed.is_quic_transport());
+    }
+
+    /// Hand-derived reference vector for `/p2p-circuit`: varint code
+    /// 0x0122 -> A2 02, no value.
+    #[test]
+    fn binary_codec_reference_vector_p2p_circuit() {
+        let addr = Multiaddr::from_protocols(vec![Protocol::P2pCircuit]);
+        let expected: Vec<u8> = vec![0xA2, 0x02];
+        assert_eq!(addr.to_bytes(), expected);
+        assert_eq!(Multiaddr::from_bytes(&expected).unwrap(), addr);
+    }
+
+    #[test]
+    fn binary_codec_round_trips_circuit_suffix() {
+        let input = format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p/{PEER_ID}/p2p-circuit");
         let addr = Multiaddr::from_str(&input).unwrap();
         let bytes = addr.to_bytes();
         let decoded = Multiaddr::from_bytes(&bytes).unwrap();

--- a/crates/core/src/protocol.rs
+++ b/crates/core/src/protocol.rs
@@ -31,6 +31,8 @@ pub const UDP_CODE: u64 = 0x0111;
 pub const QUIC_V1_CODE: u64 = 0x01cd;
 /// Multicodec code for `/p2p/<peer-id>`. Varint-length-prefixed multihash.
 pub const P2P_CODE: u64 = 0x01a5;
+/// Multicodec code for `/p2p-circuit`. No value.
+pub const P2P_CIRCUIT_CODE: u64 = 0x0122;
 
 /// A single component of a multiaddr.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -43,6 +45,7 @@ pub enum Protocol {
     Udp(u16),
     QuicV1,
     P2p(PeerId),
+    P2pCircuit,
 }
 
 impl Protocol {
@@ -65,6 +68,7 @@ impl Protocol {
             Self::Udp(_) => UDP_CODE,
             Self::QuicV1 => QUIC_V1_CODE,
             Self::P2p(_) => P2P_CODE,
+            Self::P2pCircuit => P2P_CIRCUIT_CODE,
         }
     }
 
@@ -84,7 +88,7 @@ impl Protocol {
                 out.extend_from_slice(body);
             }
             Self::Udp(port) => out.extend_from_slice(&port.to_be_bytes()),
-            Self::QuicV1 => {}
+            Self::QuicV1 | Self::P2pCircuit => {}
             Self::P2p(peer_id) => {
                 let body = peer_id.to_bytes();
                 write_uvarint(body.len() as u64, out);
@@ -117,6 +121,7 @@ impl Protocol {
                 Ok((Self::Udp(u16::from_be_bytes(value)), consumed))
             }
             QUIC_V1_CODE => Ok((Self::QuicV1, consumed)),
+            P2P_CIRCUIT_CODE => Ok((Self::P2pCircuit, consumed)),
             DNS_CODE | DNS4_CODE | DNS6_CODE => {
                 let label = match code {
                     DNS_CODE => "dns",

--- a/crates/dcutr/src/lib.rs
+++ b/crates/dcutr/src/lib.rs
@@ -278,10 +278,9 @@ impl DcutrInitiator {
 
         let (reply, consumed) = match decode_frame(&self.recv_buf) {
             FrameDecode::Complete { payload, consumed } => {
-                let reply = HolePunch::decode(payload).map_err(|e| {
-                    self.state = InitiatorState::Done;
-                    DcutrError::Malformed(e)
-                })?;
+                let reply = HolePunch::decode(payload)
+                    .map_err(DcutrError::Malformed)
+                    .map_err(|e| self.fail_reply(e))?;
                 (reply, consumed)
             }
             // Only the incomplete remainder is bounded: a complete frame
@@ -289,28 +288,27 @@ impl DcutrInitiator {
             // it, so the backstop can never reject a frame the decoder
             // would accept.
             FrameDecode::Incomplete => {
-                enforce_max_size(&self.recv_buf).inspect_err(|_| {
-                    self.state = InitiatorState::Done;
-                })?;
+                if let Err(e) = enforce_max_size(&self.recv_buf) {
+                    return Err(self.fail_reply(e));
+                }
                 return Ok(());
             }
             FrameDecode::TooLarge { len } => {
-                self.state = InitiatorState::Done;
-                return Err(DcutrError::FrameTooLarge { len });
+                return Err(self.fail_reply(DcutrError::FrameTooLarge { len }));
             }
             FrameDecode::Error(e) => {
-                self.state = InitiatorState::Done;
-                return Err(DcutrError::Malformed(DcutrMessageError::Varint(e)));
+                return Err(self.fail_reply(DcutrError::Malformed(DcutrMessageError::Varint(e))));
             }
         };
         self.recv_buf.drain(..consumed);
 
         if reply.kind != HolePunchType::Connect {
-            self.state = InitiatorState::Done;
-            return Err(DcutrError::UnexpectedMessage(alloc::format!(
-                "expected HolePunch CONNECT but got {:?}",
-                reply.kind
-            )));
+            return Err(
+                self.fail_reply(DcutrError::UnexpectedMessage(alloc::format!(
+                    "expected HolePunch CONNECT but got {:?}",
+                    reply.kind
+                ))),
+            );
         }
 
         self.state = InitiatorState::ReadyToSync;
@@ -326,6 +324,14 @@ impl DcutrInitiator {
         self.emitted_outcome = false;
 
         Ok(())
+    }
+
+    /// Terminates a failed reply exchange without retaining attacker-controlled
+    /// protocol input or its backing allocation.
+    fn fail_reply(&mut self, error: DcutrError) -> DcutrError {
+        self.state = InitiatorState::Done;
+        self.recv_buf = Vec::new();
+        error
     }
 }
 
@@ -774,11 +780,13 @@ mod tests {
         let mut init = DcutrInitiator::new(&[]);
         let _ = init.take_outbound();
 
-        let malformed = encode_frame(&[0xff]);
+        let mut malformed = encode_frame(&[0xff]);
+        malformed.extend_from_slice(&vec![0xaa; MAX_MESSAGE_SIZE * 2]);
         let err = init.on_data(&malformed, 0).unwrap_err();
         assert!(matches!(err, DcutrError::Malformed(_)));
         assert!(init.is_done());
         assert_eq!(init.take_trailing_data(), None);
+        assert_eq!(init.recv_buf.capacity(), 0);
     }
 
     #[test]
@@ -792,6 +800,7 @@ mod tests {
         assert!(matches!(err, DcutrError::FrameTooLarge { .. }));
         assert!(init.is_done());
         assert_eq!(init.take_trailing_data(), None);
+        assert_eq!(init.recv_buf.capacity(), 0);
     }
 
     #[test]

--- a/crates/dcutr/src/lib.rs
+++ b/crates/dcutr/src/lib.rs
@@ -391,6 +391,8 @@ enum ResponderState {
     AwaitingSync,
     /// SYNC received; flow complete.
     Done,
+    /// The exchange terminated with a protocol or construction error.
+    Failed,
 }
 
 impl DcutrResponder {
@@ -411,7 +413,7 @@ impl DcutrResponder {
         };
         let (connect_reply, state, pending_error) = match checked_outbound_frame(&reply.encode()) {
             Ok(frame) => (frame, ResponderState::AwaitingConnect, None),
-            Err(err) => (Vec::new(), ResponderState::Done, Some(err)),
+            Err(err) => (Vec::new(), ResponderState::Failed, Some(err)),
         };
 
         Self {
@@ -431,7 +433,7 @@ impl DcutrResponder {
 
     /// Feeds incoming stream bytes.
     fn on_data(&mut self, data: &[u8]) -> Result<(), DcutrError> {
-        if self.state == ResponderState::Done {
+        if matches!(self.state, ResponderState::Done | ResponderState::Failed) {
             return Ok(());
         }
 
@@ -450,9 +452,9 @@ impl DcutrResponder {
         self.events.drain(..).collect()
     }
 
-    /// Returns `true` if the flow has completed.
+    /// Returns `true` if the flow completed or terminated with an error.
     pub fn is_done(&self) -> bool {
-        self.state == ResponderState::Done
+        matches!(self.state, ResponderState::Done | ResponderState::Failed)
     }
 
     /// Returns bytes received after the final SYNC frame in the same stream
@@ -461,9 +463,11 @@ impl DcutrResponder {
     /// Once DCUtR completes, the caller normally hands the relay stream to
     /// its application. Keeping this remainder available avoids dropping
     /// application data that was coalesced behind SYNC by the transport.
-    /// The returned bytes are drained exactly once.
-    pub fn take_trailing_data(&mut self) -> Vec<u8> {
-        core::mem::take(&mut self.recv_buf)
+    /// Returns `None` while the exchange is incomplete, leaving the active
+    /// decode buffer untouched. After completion, the trailing bytes are
+    /// returned (and drained) exactly once.
+    pub fn take_trailing_data(&mut self) -> Option<Vec<u8>> {
+        (self.state == ResponderState::Done).then(|| core::mem::take(&mut self.recv_buf))
     }
 
     fn try_decode(&mut self) -> Result<(), DcutrError> {
@@ -474,11 +478,14 @@ impl DcutrResponder {
                 // `take_trailing_data` before handing over the raw stream.
                 return Ok(());
             }
+            if self.state == ResponderState::Failed {
+                return Ok(());
+            }
 
             let (msg, consumed) = match decode_frame(&self.recv_buf) {
                 FrameDecode::Complete { payload, consumed } => {
                     let msg = HolePunch::decode(payload).map_err(|e| {
-                        self.state = ResponderState::Done;
+                        self.state = ResponderState::Failed;
                         DcutrError::Malformed(e)
                     })?;
                     (msg, consumed)
@@ -490,16 +497,16 @@ impl DcutrResponder {
                 // the decoder would accept.
                 FrameDecode::Incomplete => {
                     enforce_max_size(&self.recv_buf).inspect_err(|_| {
-                        self.state = ResponderState::Done;
+                        self.state = ResponderState::Failed;
                     })?;
                     return Ok(());
                 }
                 FrameDecode::TooLarge { len } => {
-                    self.state = ResponderState::Done;
+                    self.state = ResponderState::Failed;
                     return Err(DcutrError::FrameTooLarge { len });
                 }
                 FrameDecode::Error(e) => {
-                    self.state = ResponderState::Done;
+                    self.state = ResponderState::Failed;
                     return Err(DcutrError::Malformed(DcutrMessageError::Varint(e)));
                 }
             };
@@ -525,7 +532,7 @@ impl DcutrResponder {
                     self.state = ResponderState::Done;
                 }
                 (current_state, actual_kind) => {
-                    self.state = ResponderState::Done;
+                    self.state = ResponderState::Failed;
                     return Err(DcutrError::UnexpectedMessage(alloc::format!(
                         "unexpected {:?} in state {:?}",
                         actual_kind,
@@ -758,8 +765,26 @@ mod tests {
         coalesced.extend_from_slice(&[0xcc; 512]);
         resp.on_data(&coalesced).unwrap();
         assert!(resp.is_done());
-        assert_eq!(resp.take_trailing_data(), vec![0xcc; 512]);
-        assert!(resp.take_trailing_data().is_empty());
+        assert_eq!(resp.take_trailing_data(), Some(vec![0xcc; 512]));
+        assert_eq!(resp.take_trailing_data(), Some(Vec::new()));
+    }
+
+    #[test]
+    fn responder_cannot_drain_protocol_bytes_before_completion() {
+        let mut resp = DcutrResponder::new(&[]);
+        let connect = frame(HolePunch {
+            kind: HolePunchType::Connect,
+            obs_addrs: Vec::new(),
+        });
+        let split = connect.len() / 2;
+        resp.on_data(&connect[..split]).unwrap();
+
+        assert_eq!(resp.take_trailing_data(), None);
+        resp.on_data(&connect[split..]).unwrap();
+        assert!(matches!(
+            resp.poll_events().as_slice(),
+            [ResponderEvent::ConnectReceived { .. }]
+        ));
     }
 
     #[test]
@@ -938,6 +963,7 @@ mod tests {
         });
         let err = resp.on_data(&sync).unwrap_err();
         assert!(matches!(err, DcutrError::UnexpectedMessage(_)));
+        assert_eq!(resp.take_trailing_data(), None);
     }
 
     #[test]

--- a/crates/dcutr/src/lib.rs
+++ b/crates/dcutr/src/lib.rs
@@ -455,13 +455,23 @@ impl DcutrResponder {
         self.state == ResponderState::Done
     }
 
+    /// Returns bytes received after the final SYNC frame in the same stream
+    /// read.
+    ///
+    /// Once DCUtR completes, the caller normally hands the relay stream to
+    /// its application. Keeping this remainder available avoids dropping
+    /// application data that was coalesced behind SYNC by the transport.
+    /// The returned bytes are drained exactly once.
+    pub fn take_trailing_data(&mut self) -> Vec<u8> {
+        core::mem::take(&mut self.recv_buf)
+    }
+
     fn try_decode(&mut self) -> Result<(), DcutrError> {
         loop {
             if self.state == ResponderState::Done {
-                // The flow is complete; free any trailing bytes the peer
-                // coalesced behind the final frame instead of retaining
-                // them for the machine's lifetime.
-                self.recv_buf = Vec::new();
+                // The flow is complete. Any bytes coalesced behind SYNC
+                // belong to the application; the caller can drain them with
+                // `take_trailing_data` before handing over the raw stream.
                 return Ok(());
             }
 
@@ -731,12 +741,12 @@ mod tests {
     }
 
     #[test]
-    fn responder_drops_trailing_bytes_after_flow_completes() {
+    fn responder_exposes_trailing_bytes_after_flow_completes() {
         let mut resp = DcutrResponder::new(&[]);
 
-        // CONNECT + SYNC + trailing garbage in one coalesced input: the
-        // flow completes and the garbage must not be retained for the
-        // machine's lifetime.
+        // CONNECT + SYNC + application bytes in one coalesced input: the
+        // flow completes, but the caller must be able to hand those bytes to
+        // the application with the released raw stream.
         let mut coalesced = frame(HolePunch {
             kind: HolePunchType::Connect,
             obs_addrs: Vec::new(),
@@ -748,7 +758,8 @@ mod tests {
         coalesced.extend_from_slice(&[0xcc; 512]);
         resp.on_data(&coalesced).unwrap();
         assert!(resp.is_done());
-        assert!(resp.recv_buf.is_empty());
+        assert_eq!(resp.take_trailing_data(), vec![0xcc; 512]);
+        assert!(resp.take_trailing_data().is_empty());
     }
 
     #[test]

--- a/crates/dcutr/src/lib.rs
+++ b/crates/dcutr/src/lib.rs
@@ -231,6 +231,19 @@ impl DcutrInitiator {
         self.state == InitiatorState::Done
     }
 
+    /// Returns bytes received after the CONNECT reply in the same stream
+    /// read.
+    ///
+    /// Once DCUtR completes, the caller normally hands the relay stream to
+    /// its application. Keeping this remainder available avoids dropping
+    /// application data that was coalesced behind the reply by the
+    /// transport. Returns `None` until SYNC has been flushed, leaving the
+    /// active decode buffer untouched. After completion, the trailing bytes
+    /// are returned (and drained) exactly once.
+    pub fn take_trailing_data(&mut self) -> Option<Vec<u8>> {
+        (self.state == InitiatorState::Done).then(|| core::mem::take(&mut self.recv_buf))
+    }
+
     /// Queues the SYNC message to be sent.
     ///
     /// Call this after you have initiated your simultaneous dial, per the
@@ -298,9 +311,9 @@ impl DcutrInitiator {
         }
 
         self.state = InitiatorState::ReadyToSync;
-        // Nothing further is expected inbound; free any trailing bytes the
-        // peer coalesced behind the reply instead of retaining them.
-        self.recv_buf = Vec::new();
+        // Nothing further is expected inbound. Bytes coalesced behind the
+        // reply belong to the application and remain available through
+        // `take_trailing_data` after SYNC has been flushed.
         let remote_addrs = decode_remote_addrs(&reply.obs_addrs);
         self.outcome = Some(InitiatorOutcome::DialNow {
             remote_addrs,
@@ -723,12 +736,12 @@ mod tests {
     }
 
     #[test]
-    fn initiator_drops_bytes_after_reply_instead_of_buffering() {
+    fn initiator_exposes_bytes_coalesced_after_reply_once_complete() {
         let mut init = DcutrInitiator::new(&[]);
         let _ = init.take_outbound();
 
-        // Reply arrives coalesced with trailing garbage: the reply must
-        // decode and the garbage must not be retained.
+        // Reply arrives coalesced with application bytes. They cannot be
+        // handed over before the protocol finishes.
         let mut coalesced = frame(HolePunch {
             kind: HolePunchType::Connect,
             obs_addrs: Vec::new(),
@@ -739,12 +752,18 @@ mod tests {
             init.outcome(),
             Some(InitiatorOutcome::DialNow { .. })
         ));
-        assert!(init.recv_buf.is_empty());
+        assert_eq!(init.take_trailing_data(), None);
 
         // Before the caller sends SYNC (`ReadyToSync`), further peer bytes
         // must be dropped, not buffered without bound.
         init.on_data(&[0xbb; 1024], 7).unwrap();
-        assert!(init.recv_buf.is_empty());
+        assert_eq!(init.take_trailing_data(), None);
+
+        init.send_sync().unwrap();
+        let _ = init.take_outbound();
+        assert!(init.is_done());
+        assert_eq!(init.take_trailing_data(), Some(vec![0xaa; 512]));
+        assert_eq!(init.take_trailing_data(), Some(Vec::new()));
     }
 
     #[test]

--- a/crates/dcutr/src/lib.rs
+++ b/crates/dcutr/src/lib.rs
@@ -238,10 +238,13 @@ impl DcutrInitiator {
     /// its application. Keeping this remainder available avoids dropping
     /// application data that was coalesced behind the reply by the
     /// transport. Returns `None` until SYNC has been flushed, leaving the
-    /// active decode buffer untouched. After completion, the trailing bytes
-    /// are returned (and drained) exactly once.
+    /// active decode buffer untouched. After successful completion, the
+    /// trailing bytes are returned (and drained) exactly once. Failed
+    /// exchanges never expose buffered control-plane bytes as application
+    /// data.
     pub fn take_trailing_data(&mut self) -> Option<Vec<u8>> {
-        (self.state == InitiatorState::Done).then(|| core::mem::take(&mut self.recv_buf))
+        (self.state == InitiatorState::Done && self.outcome.is_some())
+            .then(|| core::mem::take(&mut self.recv_buf))
     }
 
     /// Queues the SYNC message to be sent.
@@ -764,6 +767,31 @@ mod tests {
         assert!(init.is_done());
         assert_eq!(init.take_trailing_data(), Some(vec![0xaa; 512]));
         assert_eq!(init.take_trailing_data(), Some(Vec::new()));
+    }
+
+    #[test]
+    fn initiator_does_not_expose_malformed_protocol_bytes_as_trailing_data() {
+        let mut init = DcutrInitiator::new(&[]);
+        let _ = init.take_outbound();
+
+        let malformed = encode_frame(&[0xff]);
+        let err = init.on_data(&malformed, 0).unwrap_err();
+        assert!(matches!(err, DcutrError::Malformed(_)));
+        assert!(init.is_done());
+        assert_eq!(init.take_trailing_data(), None);
+    }
+
+    #[test]
+    fn initiator_does_not_expose_oversized_frame_as_trailing_data() {
+        let mut init = DcutrInitiator::new(&[]);
+        let _ = init.take_outbound();
+
+        let mut header = Vec::new();
+        minip2p_core::write_uvarint((MAX_MESSAGE_SIZE + 1) as u64, &mut header);
+        let err = init.on_data(&header, 0).unwrap_err();
+        assert!(matches!(err, DcutrError::FrameTooLarge { .. }));
+        assert!(init.is_done());
+        assert_eq!(init.take_trailing_data(), None);
     }
 
     #[test]

--- a/crates/minip2p/Cargo.toml
+++ b/crates/minip2p/Cargo.toml
@@ -8,10 +8,15 @@ readme = "README.md"
 [lints]
 workspace = true
 
+[features]
+nat = ["dep:minip2p-nat", "dep:getrandom"]
+
 [dependencies]
 minip2p-core = { path = "../core" }
 minip2p-identify = { path = "../identify" }
 minip2p-identity = { path = "../identity" }
+minip2p-nat = { path = "../nat", optional = true }
 minip2p-quic = { path = "../../transports/quic" }
 minip2p-swarm = { path = "../swarm" }
 minip2p-transport = { path = "../transport" }
+getrandom = { version = "0.4.3", optional = true }

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -49,6 +49,48 @@ pub struct Endpoint {
     pending_events: std::collections::VecDeque<Event>,
 }
 
+/// Why one NAT-aware swarm-driving step returned.
+#[cfg(feature = "nat")]
+enum NatPollKind {
+    /// An event not owned by the NAT agent is ready for the application.
+    Application,
+    /// The agent produced application-visible NAT output; NAT-focused waits
+    /// should re-check its queue immediately.
+    Progress,
+    /// The caller's deadline elapsed.
+    Deadline,
+}
+
+#[cfg(feature = "nat")]
+struct NatPoll {
+    kind: NatPollKind,
+    event: Option<Event>,
+}
+
+#[cfg(feature = "nat")]
+impl NatPoll {
+    fn application(event: Event) -> Self {
+        Self {
+            kind: NatPollKind::Application,
+            event: Some(event),
+        }
+    }
+
+    fn progress() -> Self {
+        Self {
+            kind: NatPollKind::Progress,
+            event: None,
+        }
+    }
+
+    fn deadline() -> Self {
+        Self {
+            kind: NatPollKind::Deadline,
+            event: None,
+        }
+    }
+}
+
 impl Endpoint {
     /// Starts building an endpoint.
     pub fn builder() -> EndpointBuilder {
@@ -224,7 +266,15 @@ impl Endpoint {
         if let Some(event) = self.pending_events.pop_front() {
             return Ok(Some(event));
         }
-        self.poll_new_event_with_nat(deadline)
+        let mut expired_poll_used = false;
+        loop {
+            let poll = self.poll_new_event_with_nat(deadline, &mut expired_poll_used)?;
+            match poll.kind {
+                NatPollKind::Application => return Ok(poll.event),
+                NatPollKind::Progress => {}
+                NatPollKind::Deadline => return Ok(None),
+            }
+        }
     }
 
     /// Drives the swarm and NAT agent until a newly-arrived application
@@ -232,8 +282,22 @@ impl Endpoint {
     /// drains `pending_events`: NAT-focused waits must leave application
     /// events aside instead of repeatedly picking up the same one.
     #[cfg(feature = "nat")]
-    fn poll_new_event_with_nat(&mut self, deadline: Deadline) -> Result<Option<Event>, Error> {
+    fn poll_new_event_with_nat(
+        &mut self,
+        deadline: Deadline,
+        expired_poll_used: &mut bool,
+    ) -> Result<NatPoll, Error> {
         loop {
+            // `Swarm::poll_next` deliberately performs one synchronous poll
+            // even for an expired deadline. That is useful for one-shot
+            // callers, but repeating it here under a continuous event stream
+            // would let a NAT-focused wait run forever past its deadline.
+            if deadline.has_passed() {
+                if *expired_poll_used {
+                    return Ok(NatPoll::deadline());
+                }
+                *expired_poll_used = true;
+            }
             let step = {
                 let nat = self.nat.as_ref().expect("nat checked by caller");
                 match nat.agent.next_timeout(nat.now().mono_ms) {
@@ -243,21 +307,31 @@ impl Endpoint {
                 }
             };
             let polled = self.swarm.poll_next(step)?;
+            if deadline.has_passed() {
+                *expired_poll_used = true;
+            }
             let nat = self.nat.as_mut().expect("nat checked by caller");
+            let events_before = nat.events.len();
             match polled {
                 Some(event) => {
                     let consumed = nat.ingest(&event, &mut self.swarm);
                     nat.tick(&mut self.swarm);
                     if !consumed {
-                        return Ok(Some(event));
+                        return Ok(NatPoll::application(event));
+                    }
+                    if nat.events.len() > events_before {
+                        return Ok(NatPoll::progress());
                     }
                 }
                 None => {
                     nat.tick(&mut self.swarm);
+                    if nat.events.len() > events_before {
+                        return Ok(NatPoll::progress());
+                    }
                     // Distinguish the caller's deadline from a mere agent
                     // timer that shortened this wait step.
                     if deadline.has_passed() {
-                        return Ok(None);
+                        return Ok(NatPoll::deadline());
                     }
                 }
             }
@@ -371,6 +445,7 @@ impl Endpoint {
         deadline: impl Into<Deadline>,
     ) -> Result<Option<Path>, Error> {
         let deadline = deadline.into();
+        let mut expired_poll_used = false;
         loop {
             {
                 let Some(nat) = self.nat.as_mut() else {
@@ -399,9 +474,14 @@ impl Endpoint {
                     return Ok(None);
                 }
             }
-            match self.poll_new_event_with_nat(deadline)? {
-                Some(event) => self.pending_events.push_back(event),
-                None => return Ok(None),
+            self.ensure_pending_event_capacity()?;
+            let poll = self.poll_new_event_with_nat(deadline, &mut expired_poll_used)?;
+            match poll.kind {
+                NatPollKind::Application => self
+                    .pending_events
+                    .push_back(poll.event.expect("application poll carries event")),
+                NatPollKind::Progress => {}
+                NatPollKind::Deadline => return Ok(None),
             }
         }
     }
@@ -424,6 +504,7 @@ impl Endpoint {
         deadline: impl Into<Deadline>,
     ) -> Result<Option<NatEvent>, Error> {
         let deadline = deadline.into();
+        let mut expired_poll_used = false;
         loop {
             match self.nat.as_mut() {
                 Some(nat) => {
@@ -433,9 +514,14 @@ impl Endpoint {
                 }
                 None => return Ok(None),
             }
-            match self.poll_new_event_with_nat(deadline)? {
-                Some(event) => self.pending_events.push_back(event),
-                None => return Ok(None),
+            self.ensure_pending_event_capacity()?;
+            let poll = self.poll_new_event_with_nat(deadline, &mut expired_poll_used)?;
+            match poll.kind {
+                NatPollKind::Application => self
+                    .pending_events
+                    .push_back(poll.event.expect("application poll carries event")),
+                NatPollKind::Progress => {}
+                NatPollKind::Deadline => return Ok(None),
             }
         }
     }
@@ -455,13 +541,32 @@ impl Endpoint {
         if let Some(index) = self.pending_events.iter().position(&mut predicate) {
             return Ok(self.pending_events.remove(index));
         }
+        let mut expired_poll_used = false;
         loop {
-            match self.poll_new_event_with_nat(deadline)? {
-                Some(event) if predicate(&event) => return Ok(Some(event)),
-                Some(event) => self.pending_events.push_back(event),
-                None => return Ok(None),
+            self.ensure_pending_event_capacity()?;
+            let poll = self.poll_new_event_with_nat(deadline, &mut expired_poll_used)?;
+            match poll.kind {
+                NatPollKind::Application => {
+                    let event = poll.event.expect("application poll carries event");
+                    if predicate(&event) {
+                        return Ok(Some(event));
+                    }
+                    self.pending_events.push_back(event);
+                }
+                NatPollKind::Progress => {}
+                NatPollKind::Deadline => return Ok(None),
             }
         }
+    }
+
+    #[cfg(feature = "nat")]
+    fn ensure_pending_event_capacity(&self) -> Result<(), Error> {
+        if self.pending_events.len() >= RUN_UNTIL_SKIP_LIMIT {
+            return Err(Error::EventBacklogExceeded {
+                limit: RUN_UNTIL_SKIP_LIMIT,
+            });
+        }
+        Ok(())
     }
 
     /// Our current reachability verdict from AutoNAT probing
@@ -836,6 +941,16 @@ mod tests {
                 .next_event(Duration::from_millis(1))
                 .expect("drain buffered event"),
             Some(Event::ConnectionClosed { peer_id }) if peer_id == unrelated
+        ));
+
+        for _ in 0..RUN_UNTIL_SKIP_LIMIT {
+            endpoint.pending_events.push_back(Event::ConnectionClosed {
+                peer_id: unrelated.clone(),
+            });
+        }
+        assert!(matches!(
+            endpoint.next_nat_event(Deadline::NEVER),
+            Err(Error::EventBacklogExceeded { limit }) if limit == RUN_UNTIL_SKIP_LIMIT
         ));
     }
 }

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -43,9 +43,8 @@ pub struct Endpoint {
     swarm: Swarm<QuicEndpoint>,
     #[cfg(feature = "nat")]
     nat: Option<nat::NatDriver>,
-    /// Application events set aside while a NAT-focused wait
-    /// (`Endpoint::wait_path`, `Endpoint::next_nat_event`) was driving
-    /// the endpoint; drained first by [`Endpoint::next_event`].
+    /// Application events set aside while a NAT-aware wait was driving the
+    /// endpoint; drained first by [`Endpoint::next_event`].
     #[cfg(feature = "nat")]
     pending_events: std::collections::VecDeque<Event>,
 }
@@ -222,10 +221,19 @@ impl Endpoint {
     /// waits.
     #[cfg(feature = "nat")]
     fn next_event_with_nat(&mut self, deadline: Deadline) -> Result<Option<Event>, Error> {
+        if let Some(event) = self.pending_events.pop_front() {
+            return Ok(Some(event));
+        }
+        self.poll_new_event_with_nat(deadline)
+    }
+
+    /// Drives the swarm and NAT agent until a newly-arrived application
+    /// event is available. Unlike [`Self::next_event_with_nat`], this never
+    /// drains `pending_events`: NAT-focused waits must leave application
+    /// events aside instead of repeatedly picking up the same one.
+    #[cfg(feature = "nat")]
+    fn poll_new_event_with_nat(&mut self, deadline: Deadline) -> Result<Option<Event>, Error> {
         loop {
-            if let Some(event) = self.pending_events.pop_front() {
-                return Ok(Some(event));
-            }
             let step = {
                 let nat = self.nat.as_ref().expect("nat checked by caller");
                 match nat.agent.next_timeout(nat.now().mono_ms) {
@@ -262,6 +270,13 @@ impl Endpoint {
         peer_id: &PeerId,
         deadline: impl Into<Deadline>,
     ) -> Result<Option<Event>, Error> {
+        let deadline = deadline.into();
+        #[cfg(feature = "nat")]
+        if self.nat.is_some() {
+            return self.wait_for_event_with_nat(deadline, |event| {
+                matches!(event, Event::PeerReady { peer_id: ready, .. } if ready == peer_id)
+            });
+        }
         self.swarm.run_until(
             deadline,
             |event| matches!(event, Event::PeerReady { peer_id: ready, .. } if ready == peer_id),
@@ -274,6 +289,18 @@ impl Endpoint {
         peer_id: &PeerId,
         deadline: impl Into<Deadline>,
     ) -> Result<Option<u64>, Error> {
+        let deadline = deadline.into();
+        #[cfg(feature = "nat")]
+        let event = if self.nat.is_some() {
+            self.wait_for_event_with_nat(deadline, |event| {
+                matches!(event, Event::PingRttMeasured { peer_id: ready, .. } if ready == peer_id)
+            })?
+        } else {
+            self.swarm.run_until(deadline, |event| {
+                matches!(event, Event::PingRttMeasured { peer_id: ready, .. } if ready == peer_id)
+            })?
+        };
+        #[cfg(not(feature = "nat"))]
         let event = self.swarm.run_until(deadline, |event| {
             matches!(event, Event::PingRttMeasured { peer_id: ready, .. } if ready == peer_id)
         })?;
@@ -372,7 +399,7 @@ impl Endpoint {
                     return Ok(None);
                 }
             }
-            match self.next_event_with_nat(deadline)? {
+            match self.poll_new_event_with_nat(deadline)? {
                 Some(event) => self.pending_events.push_back(event),
                 None => return Ok(None),
             }
@@ -406,7 +433,31 @@ impl Endpoint {
                 }
                 None => return Ok(None),
             }
-            match self.next_event_with_nat(deadline)? {
+            match self.poll_new_event_with_nat(deadline)? {
+                Some(event) => self.pending_events.push_back(event),
+                None => return Ok(None),
+            }
+        }
+    }
+
+    /// NAT-aware equivalent of `Swarm::run_until`. Every swarm event goes
+    /// through `NatDriver::ingest`, and non-matching application events are
+    /// retained for [`Endpoint::next_event`].
+    #[cfg(feature = "nat")]
+    fn wait_for_event_with_nat<F>(
+        &mut self,
+        deadline: Deadline,
+        mut predicate: F,
+    ) -> Result<Option<Event>, Error>
+    where
+        F: FnMut(&Event) -> bool,
+    {
+        if let Some(index) = self.pending_events.iter().position(&mut predicate) {
+            return Ok(self.pending_events.remove(index));
+        }
+        loop {
+            match self.poll_new_event_with_nat(deadline)? {
+                Some(event) if predicate(&event) => return Ok(Some(event)),
                 Some(event) => self.pending_events.push_back(event),
                 None => return Ok(None),
             }
@@ -660,6 +711,8 @@ fn build_endpoint(parts: BuilderParts, transport: QuicEndpoint) -> Result<Endpoi
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "nat")]
+    use std::time::Duration;
 
     const PROTOCOL: &str = "/myapp/1.0.0";
 
@@ -729,5 +782,60 @@ mod tests {
         endpoint
             .add_protocol(PROTOCOL)
             .expect("application ids must be accepted");
+    }
+
+    #[cfg(feature = "nat")]
+    #[test]
+    fn nat_focused_waits_do_not_repoll_buffered_application_events() {
+        let mut endpoint = Endpoint::builder()
+            .nat_config(NatConfig::default())
+            .bind_quic("127.0.0.1:0")
+            .expect("bind endpoint");
+        let unrelated = Ed25519Keypair::generate().peer_id();
+
+        endpoint.pending_events.push_back(Event::ConnectionClosed {
+            peer_id: unrelated.clone(),
+        });
+        assert!(
+            endpoint
+                .next_nat_event(Duration::from_millis(5))
+                .expect("NAT wait")
+                .is_none(),
+            "a buffered application event must not make next_nat_event spin"
+        );
+        assert!(matches!(
+            endpoint
+                .next_event(Duration::from_millis(1))
+                .expect("drain buffered event"),
+            Some(Event::ConnectionClosed { peer_id }) if peer_id == unrelated
+        ));
+
+        let id = endpoint
+            .connect(&Ed25519Keypair::generate().peer_id())
+            .expect("connect");
+        // This no-candidate attempt fails synchronously. Remove the failure
+        // to exercise the timeout path with a live ConnectId.
+        endpoint
+            .nat
+            .as_mut()
+            .expect("NAT configured")
+            .events
+            .clear();
+        endpoint.pending_events.push_back(Event::ConnectionClosed {
+            peer_id: unrelated.clone(),
+        });
+        assert!(
+            endpoint
+                .wait_path(id, Duration::from_millis(5))
+                .expect("path wait")
+                .is_none(),
+            "a buffered application event must not make wait_path spin"
+        );
+        assert!(matches!(
+            endpoint
+                .next_event(Duration::from_millis(1))
+                .expect("drain buffered event"),
+            Some(Event::ConnectionClosed { peer_id }) if peer_id == unrelated
+        ));
     }
 }

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -6,9 +6,17 @@
 //! small batteries-included API for identity, QUIC, listen/dial, ping, and
 //! event polling.
 
+#[cfg(feature = "nat")]
+mod nat;
+
 pub use minip2p_core::{Multiaddr, PeerAddr, PeerId, Protocol};
 pub use minip2p_identify::IdentifyMessage;
 pub use minip2p_identity::Ed25519Keypair;
+#[cfg(feature = "nat")]
+pub use minip2p_nat::{
+    ConnectId, NatConfig, NatError, NatEvent, Path, ReachabilityState, ReservationInfo,
+    ReservationPolicy,
+};
 pub use minip2p_quic::QuicLimits;
 use minip2p_quic::{QuicEndpoint, QuicNodeConfig};
 pub use minip2p_swarm::{
@@ -25,8 +33,21 @@ const DEFAULT_AGENT_VERSION: &str = "minip2p/0.1.0";
 /// `Endpoint` owns identity, transport, and the std swarm driver. Advanced
 /// users can still borrow the underlying [`Swarm`] with [`Endpoint::swarm`]
 /// and [`Endpoint::swarm_mut`].
+///
+/// With the `nat` cargo feature and a NAT configuration
+/// (`EndpointBuilder::relay` / `EndpointBuilder::nat_config`), the endpoint
+/// additionally runs the `minip2p_nat::NatAgent` traversal orchestrator:
+/// see `Endpoint::connect`, `Endpoint::wait_path`, and
+/// `Endpoint::take_nat_events`.
 pub struct Endpoint {
     swarm: Swarm<QuicEndpoint>,
+    #[cfg(feature = "nat")]
+    nat: Option<nat::NatDriver>,
+    /// Application events set aside while a NAT-focused wait
+    /// (`Endpoint::wait_path`, `Endpoint::next_nat_event`) was driving
+    /// the endpoint; drained first by [`Endpoint::next_event`].
+    #[cfg(feature = "nat")]
+    pending_events: std::collections::VecDeque<Event>,
 }
 
 impl Endpoint {
@@ -42,12 +63,31 @@ impl Endpoint {
 
     /// Starts listening on the transport's first already-bound address.
     pub fn listen(&mut self) -> Result<PeerAddr, Error> {
-        self.swarm.listen_on_bound_addr()
+        let addr = self.swarm.listen_on_bound_addr()?;
+        self.sync_nat_listen_addrs(std::slice::from_ref(&addr));
+        Ok(addr)
     }
 
     /// Starts listening on all transport-bound addresses.
     pub fn listen_all(&mut self) -> Result<Vec<PeerAddr>, Error> {
-        self.swarm.listen_on_bound_addrs()
+        let addrs = self.swarm.listen_on_bound_addrs()?;
+        self.sync_nat_listen_addrs(&addrs);
+        Ok(addrs)
+    }
+
+    /// Seeds the NAT agent's advertised addresses from the bound set
+    /// (wildcards and non-QUIC shapes filtered out). No-op without the
+    /// `nat` feature or when NAT is not configured.
+    #[allow(unused_variables)]
+    fn sync_nat_listen_addrs(&mut self, addrs: &[PeerAddr]) {
+        #[cfg(feature = "nat")]
+        if let Some(nat) = self.nat.as_mut() {
+            let transports: Vec<Multiaddr> =
+                addrs.iter().map(|addr| addr.transport().clone()).collect();
+            let validated =
+                minip2p_core::select_direct_candidates(&transports, None, None).into_addrs();
+            nat.agent.set_listen_addrs(&validated);
+        }
     }
 
     /// Dials a remote peer on every applicable local address family.
@@ -135,8 +175,32 @@ impl Endpoint {
     }
 
     /// Polls the endpoint once and returns all currently available events.
+    ///
+    /// With NAT configured, events belonging to the traversal agent are
+    /// consumed here (never surfaced to the application); the agent's own
+    /// events accumulate for `Endpoint::take_nat_events`.
     pub fn poll(&mut self) -> Result<Vec<Event>, Error> {
-        self.swarm.poll()
+        #[cfg(feature = "nat")]
+        {
+            let polled = self.swarm.poll()?;
+            let mut events: Vec<Event> = self.pending_events.drain(..).collect();
+            match self.nat.as_mut() {
+                Some(nat) => {
+                    for event in polled {
+                        if !nat.ingest(&event, &mut self.swarm) {
+                            events.push(event);
+                        }
+                    }
+                    nat.tick(&mut self.swarm);
+                }
+                None => events.extend(polled),
+            }
+            Ok(events)
+        }
+        #[cfg(not(feature = "nat"))]
+        {
+            self.swarm.poll()
+        }
     }
 
     /// Returns the next event, waiting internally until `deadline`.
@@ -144,7 +208,52 @@ impl Endpoint {
     /// `deadline` accepts an [`std::time::Instant`], a relative
     /// [`std::time::Duration`], or [`Deadline::NEVER`] to wait indefinitely.
     pub fn next_event(&mut self, deadline: impl Into<Deadline>) -> Result<Option<Event>, Error> {
+        let deadline = deadline.into();
+        #[cfg(feature = "nat")]
+        if self.nat.is_some() {
+            return self.next_event_with_nat(deadline);
+        }
         self.swarm.poll_next(deadline)
+    }
+
+    /// `next_event` with the NAT agent folded into the wait: the sleep
+    /// budget never overshoots the agent's next timer, agent-owned stream
+    /// events are consumed instead of surfaced, and ticks run between
+    /// waits.
+    #[cfg(feature = "nat")]
+    fn next_event_with_nat(&mut self, deadline: Deadline) -> Result<Option<Event>, Error> {
+        loop {
+            if let Some(event) = self.pending_events.pop_front() {
+                return Ok(Some(event));
+            }
+            let step = {
+                let nat = self.nat.as_ref().expect("nat checked by caller");
+                match nat.agent.next_timeout(nat.now().mono_ms) {
+                    Some(ms) => deadline
+                        .earliest(Deadline::from(std::time::Duration::from_millis(ms.max(1)))),
+                    None => deadline,
+                }
+            };
+            let polled = self.swarm.poll_next(step)?;
+            let nat = self.nat.as_mut().expect("nat checked by caller");
+            match polled {
+                Some(event) => {
+                    let consumed = nat.ingest(&event, &mut self.swarm);
+                    nat.tick(&mut self.swarm);
+                    if !consumed {
+                        return Ok(Some(event));
+                    }
+                }
+                None => {
+                    nat.tick(&mut self.swarm);
+                    // Distinguish the caller's deadline from a mere agent
+                    // timer that shortened this wait step.
+                    if deadline.has_passed() {
+                        return Ok(None);
+                    }
+                }
+            }
+        }
     }
 
     /// Waits until a peer is ready or `deadline` expires.
@@ -174,6 +283,155 @@ impl Endpoint {
         })
     }
 
+    /// Starts a NAT-traversing connect toward `peer` with no known direct
+    /// addresses: the relay leg carries the attempt and DCUtR upgrades it.
+    ///
+    /// Progress arrives as [`NatEvent`]s ([`Endpoint::take_nat_events`]);
+    /// [`Endpoint::wait_path`] blocks for the outcome.
+    #[cfg(feature = "nat")]
+    pub fn connect(&mut self, peer: &PeerId) -> Result<ConnectId, Error> {
+        self.connect_with_addrs(peer.clone(), Vec::new())
+    }
+
+    /// Starts a NAT-traversing connect racing dials of `direct_addrs`
+    /// against the relay leg.
+    #[cfg(feature = "nat")]
+    pub fn connect_with_addrs(
+        &mut self,
+        peer: PeerId,
+        direct_addrs: Vec<Multiaddr>,
+    ) -> Result<ConnectId, Error> {
+        let Some(nat) = self.nat.as_mut() else {
+            return Err(Error::Invariant {
+                reason: "NAT traversal is not configured; use EndpointBuilder::relay / nat_config",
+            });
+        };
+        let now = nat.now();
+        let id = nat.agent.connect(peer, direct_addrs, now);
+        nat.pump(&mut self.swarm);
+        Ok(id)
+    }
+
+    /// Starts a NAT-traversing connect toward a known peer address.
+    #[cfg(feature = "nat")]
+    pub fn connect_addr(&mut self, addr: &PeerAddr) -> Result<ConnectId, Error> {
+        self.connect_with_addrs(addr.peer_id().clone(), vec![addr.transport().clone()])
+    }
+
+    /// Abandons a connect attempt. Streams it holds are reset; no further
+    /// events are emitted for `id`.
+    #[cfg(feature = "nat")]
+    pub fn cancel_connect(&mut self, id: ConnectId) {
+        if let Some(nat) = self.nat.as_mut() {
+            let now = nat.now();
+            nat.agent.cancel(id, now);
+            nat.pump(&mut self.swarm);
+        }
+    }
+
+    /// Waits for the first usable path of connect attempt `id`.
+    ///
+    /// Returns `Ok(Some(path))` on [`NatEvent::PathEstablished`] (the event
+    /// is consumed), and `Ok(None)` when the attempt failed or `deadline`
+    /// passed — on failure the [`NatEvent::ConnectFailed`] stays queued so
+    /// its error remains inspectable via [`Endpoint::take_nat_events`].
+    /// Application events arriving meanwhile are buffered for later
+    /// [`Endpoint::next_event`] calls, never dropped.
+    #[cfg(feature = "nat")]
+    pub fn wait_path(
+        &mut self,
+        id: ConnectId,
+        deadline: impl Into<Deadline>,
+    ) -> Result<Option<Path>, Error> {
+        let deadline = deadline.into();
+        loop {
+            {
+                let Some(nat) = self.nat.as_mut() else {
+                    return Err(Error::Invariant {
+                        reason: "NAT traversal is not configured",
+                    });
+                };
+                if let Some(index) = nat.events.iter().position(|event| {
+                    matches!(
+                        event,
+                        NatEvent::PathEstablished { connect_id, .. } if *connect_id == id
+                    )
+                }) {
+                    let Some(NatEvent::PathEstablished { path, .. }) = nat.events.remove(index)
+                    else {
+                        unreachable!("position matched PathEstablished");
+                    };
+                    return Ok(Some(path));
+                }
+                if nat.events.iter().any(|event| {
+                    matches!(
+                        event,
+                        NatEvent::ConnectFailed { connect_id, .. } if *connect_id == id
+                    )
+                }) {
+                    return Ok(None);
+                }
+            }
+            match self.next_event_with_nat(deadline)? {
+                Some(event) => self.pending_events.push_back(event),
+                None => return Ok(None),
+            }
+        }
+    }
+
+    /// Drains all queued NAT events.
+    #[cfg(feature = "nat")]
+    pub fn take_nat_events(&mut self) -> Vec<NatEvent> {
+        match self.nat.as_mut() {
+            Some(nat) => nat.events.drain(..).collect(),
+            None => Vec::new(),
+        }
+    }
+
+    /// Returns the next NAT event, waiting internally until `deadline`.
+    /// Application events arriving meanwhile are buffered for
+    /// [`Endpoint::next_event`].
+    #[cfg(feature = "nat")]
+    pub fn next_nat_event(
+        &mut self,
+        deadline: impl Into<Deadline>,
+    ) -> Result<Option<NatEvent>, Error> {
+        let deadline = deadline.into();
+        loop {
+            match self.nat.as_mut() {
+                Some(nat) => {
+                    if let Some(event) = nat.events.pop_front() {
+                        return Ok(Some(event));
+                    }
+                }
+                None => return Ok(None),
+            }
+            match self.next_event_with_nat(deadline)? {
+                Some(event) => self.pending_events.push_back(event),
+                None => return Ok(None),
+            }
+        }
+    }
+
+    /// Our current reachability verdict from AutoNAT probing
+    /// ([`ReachabilityState::Unknown`] until probes gather confidence, or
+    /// when NAT is not configured).
+    #[cfg(feature = "nat")]
+    pub fn reachability(&self) -> ReachabilityState {
+        self.nat
+            .as_ref()
+            .map(|nat| nat.agent.reachability())
+            .unwrap_or_default()
+    }
+
+    /// The relay reservation currently held, if any.
+    #[cfg(feature = "nat")]
+    pub fn active_reservation(&self) -> Option<ReservationInfo> {
+        self.nat
+            .as_ref()
+            .and_then(|nat| nat.agent.active_reservation().cloned())
+    }
+
     /// Borrows the underlying swarm.
     pub fn swarm(&self) -> &Swarm<QuicEndpoint> {
         &self.swarm
@@ -196,6 +454,12 @@ pub struct EndpointBuilder {
     agent_version: String,
     quic_limits: QuicLimits,
     protocols: Vec<String>,
+    #[cfg(feature = "nat")]
+    nat_config: Option<NatConfig>,
+    #[cfg(feature = "nat")]
+    relays: Vec<PeerAddr>,
+    #[cfg(feature = "nat")]
+    autonat_servers: Vec<PeerAddr>,
 }
 
 impl Default for EndpointBuilder {
@@ -205,8 +469,24 @@ impl Default for EndpointBuilder {
             agent_version: DEFAULT_AGENT_VERSION.to_string(),
             quic_limits: QuicLimits::default(),
             protocols: Vec::new(),
+            #[cfg(feature = "nat")]
+            nat_config: None,
+            #[cfg(feature = "nat")]
+            relays: Vec::new(),
+            #[cfg(feature = "nat")]
+            autonat_servers: Vec::new(),
         }
     }
+}
+
+/// Validated builder output consumed by the bind step.
+struct BuilderParts {
+    keypair: Ed25519Keypair,
+    agent_version: String,
+    quic_limits: QuicLimits,
+    protocols: Vec<String>,
+    #[cfg(feature = "nat")]
+    nat_config: Option<NatConfig>,
 }
 
 impl EndpointBuilder {
@@ -241,28 +521,57 @@ impl EndpointBuilder {
         self
     }
 
+    /// Adds a relay for NAT traversal (circuit legs and reservations), in
+    /// preference order. Configuring at least one relay (or calling
+    /// [`EndpointBuilder::nat_config`]) enables the traversal agent.
+    #[cfg(feature = "nat")]
+    pub fn relay(mut self, relay: PeerAddr) -> Self {
+        self.relays.push(relay);
+        self
+    }
+
+    /// Adds an AutoNAT server used for reachability probing.
+    #[cfg(feature = "nat")]
+    pub fn autonat_server(mut self, server: PeerAddr) -> Self {
+        self.autonat_servers.push(server);
+        self
+    }
+
+    /// Sets the base NAT configuration (timeouts, punch retries,
+    /// reservation policy, …). Relays and AutoNAT servers added through
+    /// [`EndpointBuilder::relay`] / [`EndpointBuilder::autonat_server`] are
+    /// appended to the config's own lists.
+    #[cfg(feature = "nat")]
+    pub fn nat_config(mut self, config: NatConfig) -> Self {
+        self.nat_config = Some(config);
+        self
+    }
+
     /// Builds an endpoint with a QUIC transport bound to `bind_addr`.
     pub fn bind_quic(self, bind_addr: impl AsRef<str>) -> Result<Endpoint, Error> {
-        let (keypair, agent_version, limits, protocols) = self.into_parts()?;
-        let config = QuicNodeConfig::new(keypair.clone()).with_limits(limits);
+        let parts = self.into_parts()?;
+        let config =
+            QuicNodeConfig::new(parts.keypair.clone()).with_limits(parts.quic_limits.clone());
         let transport = QuicEndpoint::bind(config, bind_addr.as_ref())?;
-        build_endpoint(keypair, agent_version, protocols, transport)
+        build_endpoint(parts, transport)
     }
 
     /// Builds an endpoint with a QUIC transport bound to a QUIC multiaddr.
     pub fn bind_quic_multiaddr(self, addr: &Multiaddr) -> Result<Endpoint, Error> {
-        let (keypair, agent_version, limits, protocols) = self.into_parts()?;
-        let config = QuicNodeConfig::new(keypair.clone()).with_limits(limits);
+        let parts = self.into_parts()?;
+        let config =
+            QuicNodeConfig::new(parts.keypair.clone()).with_limits(parts.quic_limits.clone());
         let transport = QuicEndpoint::bind_multiaddr(config, addr)?;
-        build_endpoint(keypair, agent_version, protocols, transport)
+        build_endpoint(parts, transport)
     }
 
     /// Builds an endpoint with separate IPv4 and IPv6 wildcard QUIC sockets.
     pub fn bind_quic_dual_stack(self) -> Result<Endpoint, Error> {
-        let (keypair, agent_version, limits, protocols) = self.into_parts()?;
-        let config = QuicNodeConfig::new(keypair.clone()).with_limits(limits);
+        let parts = self.into_parts()?;
+        let config =
+            QuicNodeConfig::new(parts.keypair.clone()).with_limits(parts.quic_limits.clone());
         let transport = QuicEndpoint::dual_stack(config)?;
-        build_endpoint(keypair, agent_version, protocols, transport)
+        build_endpoint(parts, transport)
     }
 
     /// Validates the static configuration and decomposes the builder.
@@ -270,7 +579,7 @@ impl EndpointBuilder {
     /// Reserved protocol ids are rejected here -- before any socket is
     /// bound -- so a configuration error can neither allocate resources
     /// nor be masked by a bind failure.
-    fn into_parts(self) -> Result<(Ed25519Keypair, String, QuicLimits, Vec<String>), Error> {
+    fn into_parts(self) -> Result<BuilderParts, Error> {
         if let Some(protocol) = self
             .protocols
             .iter()
@@ -281,27 +590,71 @@ impl EndpointBuilder {
             }
             .into());
         }
-        Ok((
-            self.keypair.unwrap_or_else(Ed25519Keypair::generate),
-            self.agent_version,
-            self.quic_limits,
-            self.protocols,
-        ))
+        #[cfg(feature = "nat")]
+        let nat_config = {
+            let enabled = self.nat_config.is_some()
+                || !self.relays.is_empty()
+                || !self.autonat_servers.is_empty();
+            enabled.then(|| {
+                let mut config = self.nat_config.unwrap_or_default();
+                config.relays.extend(self.relays);
+                config.autonat_servers.extend(self.autonat_servers);
+                config
+            })
+        };
+        Ok(BuilderParts {
+            keypair: self.keypair.unwrap_or_else(Ed25519Keypair::generate),
+            agent_version: self.agent_version,
+            quic_limits: self.quic_limits,
+            protocols: self.protocols,
+            #[cfg(feature = "nat")]
+            nat_config,
+        })
     }
 }
 
-fn build_endpoint(
-    keypair: Ed25519Keypair,
-    agent_version: String,
-    protocols: Vec<String>,
-    transport: QuicEndpoint,
-) -> Result<Endpoint, Error> {
-    let mut builder = SwarmBuilder::new(&keypair).agent_version(agent_version);
+fn build_endpoint(parts: BuilderParts, transport: QuicEndpoint) -> Result<Endpoint, Error> {
+    let mut builder = SwarmBuilder::new(&parts.keypair).agent_version(parts.agent_version);
+    #[cfg(feature = "nat")]
+    let mut protocols = parts.protocols;
+    #[cfg(not(feature = "nat"))]
+    let protocols = parts.protocols;
+    #[cfg(feature = "nat")]
+    if parts.nat_config.is_some() {
+        // The traversal agent's protocols are ordinary user protocols; the
+        // swarm just needs to accept and route them.
+        for id in [
+            minip2p_nat::HOP_PROTOCOL_ID,
+            minip2p_nat::STOP_PROTOCOL_ID,
+            minip2p_nat::DCUTR_PROTOCOL_ID,
+            minip2p_nat::AUTONAT_PROTOCOL_ID,
+        ] {
+            if !protocols.iter().any(|existing| existing == id) {
+                protocols.push(id.to_string());
+            }
+        }
+    }
     for protocol in protocols {
         builder = builder.protocol(protocol);
     }
     let swarm = builder.build(transport)?;
-    Ok(Endpoint { swarm })
+    #[cfg(feature = "nat")]
+    let nat = parts.nat_config.map(|config| {
+        let relay_addrs = config
+            .relays
+            .iter()
+            .map(|relay| (relay.peer_id().clone(), relay.transport().clone()))
+            .collect();
+        let agent = minip2p_nat::NatAgent::new(swarm.local_peer_id().clone(), config);
+        nat::NatDriver::new(agent, relay_addrs)
+    });
+    Ok(Endpoint {
+        swarm,
+        #[cfg(feature = "nat")]
+        nat,
+        #[cfg(feature = "nat")]
+        pending_events: std::collections::VecDeque::new(),
+    })
 }
 
 #[cfg(test)]

--- a/crates/minip2p/src/nat.rs
+++ b/crates/minip2p/src/nat.rs
@@ -1,0 +1,195 @@
+//! Std wiring that pumps a sans-I/O [`NatAgent`] against the endpoint's
+//! swarm: clock sampling, action execution, stream-event interception, and
+//! circuit-address advertising.
+//!
+//! Available behind the `nat` cargo feature; see the `nat` methods on
+//! [`Endpoint`](crate::Endpoint) and [`EndpointBuilder`](crate::EndpointBuilder).
+
+use std::collections::VecDeque;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use minip2p_core::{Multiaddr, PeerId, Protocol};
+use minip2p_nat::{NatAction, NatAgent, NatEvent, Now};
+use minip2p_quic::QuicEndpoint;
+use minip2p_swarm::{Swarm, SwarmEvent};
+use minip2p_transport::StreamId;
+
+/// Drives a [`NatAgent`] against the endpoint's swarm.
+pub(crate) struct NatDriver {
+    pub(crate) agent: NatAgent,
+    /// NAT events awaiting the application (drained via
+    /// `Endpoint::take_nat_events` / `next_nat_event` / `wait_path`).
+    pub(crate) events: VecDeque<NatEvent>,
+    /// Monotonic epoch for the agent's `mono_ms` clock.
+    epoch: Instant,
+    /// Relays we hold a reservation on, for circuit-address advertising.
+    reserved_relays: Vec<(PeerId, Multiaddr)>,
+    /// Relay transport addresses by peer, captured at construction.
+    relay_addrs: Vec<(PeerId, Multiaddr)>,
+}
+
+impl NatDriver {
+    pub(crate) fn new(agent: NatAgent, relay_addrs: Vec<(PeerId, Multiaddr)>) -> Self {
+        Self {
+            agent,
+            events: VecDeque::new(),
+            epoch: Instant::now(),
+            reserved_relays: Vec::new(),
+            relay_addrs,
+        }
+    }
+
+    /// Samples the driver's clocks for the agent.
+    pub(crate) fn now(&self) -> Now {
+        Now {
+            mono_ms: self.epoch.elapsed().as_millis() as u64,
+            unix_secs: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .ok()
+                .map(|d| d.as_secs()),
+        }
+    }
+
+    /// Feeds one swarm event to the agent and executes its cascade.
+    ///
+    /// Returns `true` when the event belongs to an agent-owned stream and
+    /// must not be forwarded to the application. Ownership is checked both
+    /// before and after the agent runs, so a stream claimed *during* the
+    /// event (an inbound STOP) and one released *by* the event (a close)
+    /// are both consumed.
+    pub(crate) fn ingest(&mut self, event: &SwarmEvent, swarm: &mut Swarm<QuicEndpoint>) -> bool {
+        let owned_before =
+            stream_key(event).is_some_and(|(peer, stream)| self.agent.owns_stream(peer, stream));
+        let now = self.now();
+        self.agent.handle_event(event, now);
+        let owned_after =
+            stream_key(event).is_some_and(|(peer, stream)| self.agent.owns_stream(peer, stream));
+        self.pump(swarm);
+        owned_before || owned_after
+    }
+
+    /// Advances the agent's timers and executes any resulting work.
+    pub(crate) fn tick(&mut self, swarm: &mut Swarm<QuicEndpoint>) {
+        self.agent.handle_tick(self.now());
+        self.pump(swarm);
+    }
+
+    /// Drains agent actions into swarm calls (echoing synchronous results
+    /// back) and collects application-visible NAT events.
+    pub(crate) fn pump(&mut self, swarm: &mut Swarm<QuicEndpoint>) {
+        loop {
+            let mut progressed = false;
+            while let Some(action) = self.agent.poll_action() {
+                progressed = true;
+                self.execute(action, swarm);
+            }
+            while let Some(event) = self.agent.poll_event() {
+                progressed = true;
+                self.observe(&event, swarm);
+                self.events.push_back(event);
+            }
+            if !progressed {
+                break;
+            }
+        }
+    }
+
+    fn execute(&mut self, action: NatAction, swarm: &mut Swarm<QuicEndpoint>) {
+        let now = self.now();
+        match action {
+            NatAction::Dial { token, addr } => {
+                let result = swarm.dial(&addr).map_err(|e| e.to_string());
+                self.agent.dial_result(token, result, now);
+            }
+            NatAction::OpenStream {
+                token,
+                peer,
+                protocol_id,
+            } => {
+                let result = swarm
+                    .open_stream(&peer, &protocol_id)
+                    .map_err(|e| e.to_string());
+                self.agent.stream_open_result(token, result, now);
+            }
+            NatAction::SendStream {
+                peer,
+                stream_id,
+                data,
+            } => {
+                // Failures surface through the agent's own timeouts and the
+                // swarm's error events; nothing to echo synchronously.
+                let _ = swarm.send_stream(&peer, stream_id, data);
+            }
+            NatAction::CloseStreamWrite { peer, stream_id } => {
+                let _ = swarm.close_stream_write(&peer, stream_id);
+            }
+            NatAction::ResetStream { peer, stream_id } => {
+                let _ = swarm.reset_stream(&peer, stream_id);
+            }
+            NatAction::Disconnect { peer } => {
+                let _ = swarm.disconnect(&peer);
+            }
+            NatAction::SendRandomUdp {
+                target,
+                payload_len,
+            } => {
+                let mut payload = vec![0u8; payload_len];
+                if getrandom::fill(&mut payload).is_ok() {
+                    let _ = swarm.transport().send_raw_udp(&target, &payload);
+                }
+            }
+        }
+    }
+
+    /// Keeps Identify's advertised set in sync with reservation state: a
+    /// held reservation advertises `<relay>/p2p/<relay-id>/p2p-circuit`.
+    fn observe(&mut self, event: &NatEvent, swarm: &mut Swarm<QuicEndpoint>) {
+        match event {
+            NatEvent::RelayReserved { relay, .. } => {
+                if self.reserved_relays.iter().any(|(peer, _)| peer == relay) {
+                    return; // renewal — already advertised
+                }
+                let Some((_, transport)) = self.relay_addrs.iter().find(|(p, _)| p == relay) else {
+                    return;
+                };
+                let mut circuit = transport.clone();
+                circuit.push(Protocol::P2p(relay.clone()));
+                circuit.push(Protocol::P2pCircuit);
+                self.reserved_relays.push((relay.clone(), circuit));
+                self.advertise(swarm);
+            }
+            NatEvent::RelayReservationLost { relay } => {
+                let before = self.reserved_relays.len();
+                self.reserved_relays.retain(|(peer, _)| peer != relay);
+                if self.reserved_relays.len() != before {
+                    self.advertise(swarm);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn advertise(&self, swarm: &mut Swarm<QuicEndpoint>) {
+        swarm.set_external_addresses(
+            self.reserved_relays
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect(),
+        );
+    }
+}
+
+/// The (peer, stream) a stream-scoped swarm event refers to.
+fn stream_key(event: &SwarmEvent) -> Option<(&PeerId, StreamId)> {
+    match event {
+        SwarmEvent::StreamReady {
+            peer_id, stream_id, ..
+        }
+        | SwarmEvent::StreamData {
+            peer_id, stream_id, ..
+        }
+        | SwarmEvent::StreamRemoteWriteClosed { peer_id, stream_id }
+        | SwarmEvent::StreamClosed { peer_id, stream_id } => Some((peer_id, *stream_id)),
+        _ => None,
+    }
+}

--- a/crates/minip2p/src/nat.rs
+++ b/crates/minip2p/src/nat.rs
@@ -26,6 +26,8 @@ pub(crate) struct NatDriver {
     reserved_relays: Vec<(PeerId, Multiaddr)>,
     /// Relay transport addresses by peer, captured at construction.
     relay_addrs: Vec<(PeerId, Multiaddr)>,
+    /// Direct public addresses confirmed by AutoNAT.
+    public_addrs: Vec<Multiaddr>,
 }
 
 impl NatDriver {
@@ -36,6 +38,7 @@ impl NatDriver {
             epoch: Instant::now(),
             reserved_relays: Vec::new(),
             relay_addrs,
+            public_addrs: Vec::new(),
         }
     }
 
@@ -61,11 +64,11 @@ impl NatDriver {
         let owned_before =
             stream_key(event).is_some_and(|(peer, stream)| self.agent.owns_stream(peer, stream));
         let now = self.now();
-        self.agent.handle_event(event, now);
+        let handled = self.agent.handle_event_with_disposition(event, now);
         let owned_after =
             stream_key(event).is_some_and(|(peer, stream)| self.agent.owns_stream(peer, stream));
         self.pump(swarm);
-        owned_before || owned_after
+        handled || owned_before || owned_after
     }
 
     /// Advances the agent's timers and executes any resulting work.
@@ -165,17 +168,30 @@ impl NatDriver {
                     self.advertise(swarm);
                 }
             }
+            NatEvent::ReachabilityChanged {
+                confirmed_addrs, ..
+            } => {
+                if self.public_addrs != *confirmed_addrs {
+                    self.public_addrs = confirmed_addrs.clone();
+                    self.advertise(swarm);
+                }
+            }
+            NatEvent::PublicAddressesChanged { addrs } if self.public_addrs != *addrs => {
+                self.public_addrs = addrs.clone();
+                self.advertise(swarm);
+            }
             _ => {}
         }
     }
 
     fn advertise(&self, swarm: &mut Swarm<QuicEndpoint>) {
-        swarm.set_external_addresses(
-            self.reserved_relays
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect(),
-        );
+        let mut addrs = self.public_addrs.clone();
+        for (_, addr) in &self.reserved_relays {
+            if !addrs.contains(addr) {
+                addrs.push(addr.clone());
+            }
+        }
+        swarm.set_external_addresses(addrs);
     }
 }
 
@@ -191,5 +207,46 @@ fn stream_key(event: &SwarmEvent) -> Option<(&PeerId, StreamId)> {
         | SwarmEvent::StreamRemoteWriteClosed { peer_id, stream_id }
         | SwarmEvent::StreamClosed { peer_id, stream_id } => Some((peer_id, *stream_id)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Endpoint, NatConfig, ReachabilityState};
+
+    #[test]
+    fn confirmed_public_addresses_are_advertised_and_cleared() {
+        let mut endpoint = Endpoint::builder()
+            .nat_config(NatConfig::default())
+            .bind_quic("127.0.0.1:0")
+            .expect("bind endpoint");
+        let public: Multiaddr = "/ip4/203.0.113.9/udp/4001/quic-v1"
+            .parse()
+            .expect("public addr");
+        let Endpoint { swarm, nat, .. } = &mut endpoint;
+        let driver = nat.as_mut().expect("NAT configured");
+
+        driver.observe(
+            &NatEvent::ReachabilityChanged {
+                old: ReachabilityState::Unknown,
+                new: ReachabilityState::Public,
+                confirmed_addrs: vec![public.clone()],
+            },
+            swarm,
+        );
+        swarm.poll().expect("refresh identify addresses");
+        assert!(swarm.core().local_addresses().contains(&public));
+
+        driver.observe(
+            &NatEvent::ReachabilityChanged {
+                old: ReachabilityState::Public,
+                new: ReachabilityState::Private,
+                confirmed_addrs: Vec::new(),
+            },
+            swarm,
+        );
+        swarm.poll().expect("refresh identify addresses");
+        assert!(!swarm.core().local_addresses().contains(&public));
     }
 }

--- a/crates/minip2p/src/nat.rs
+++ b/crates/minip2p/src/nat.rs
@@ -12,7 +12,6 @@ use minip2p_core::{Multiaddr, PeerId, Protocol};
 use minip2p_nat::{NatAction, NatAgent, NatEvent, Now};
 use minip2p_quic::QuicEndpoint;
 use minip2p_swarm::{Swarm, SwarmEvent};
-use minip2p_transport::StreamId;
 
 /// Drives a [`NatAgent`] against the endpoint's swarm.
 pub(crate) struct NatDriver {
@@ -55,25 +54,24 @@ impl NatDriver {
 
     /// Feeds one swarm event to the agent and executes its cascade.
     ///
-    /// Returns `true` when the event belongs to an agent-owned stream and
-    /// must not be forwarded to the application. Ownership is checked both
-    /// before and after the agent runs, so a stream claimed *during* the
-    /// event (an inbound STOP) and one released *by* the event (a close)
-    /// are both consumed.
+    /// Returns `true` when the event belongs to the NAT control plane and
+    /// must not be forwarded to the application. The agent's disposition is
+    /// authoritative even when handling claims or releases the stream.
     pub(crate) fn ingest(&mut self, event: &SwarmEvent, swarm: &mut Swarm<QuicEndpoint>) -> bool {
-        let owned_before =
-            stream_key(event).is_some_and(|(peer, stream)| self.agent.owns_stream(peer, stream));
         let now = self.now();
         let handled = self.agent.handle_event_with_disposition(event, now);
-        let owned_after =
-            stream_key(event).is_some_and(|(peer, stream)| self.agent.owns_stream(peer, stream));
         self.pump(swarm);
-        handled || owned_before || owned_after
+        handled
     }
 
-    /// Advances the agent's timers and executes any resulting work.
+    /// Advances timers only when the agent reports a due deadline, then
+    /// executes any resulting work.
     pub(crate) fn tick(&mut self, swarm: &mut Swarm<QuicEndpoint>) {
-        self.agent.handle_tick(self.now());
+        let now = self.now();
+        if self.agent.next_timeout(now.mono_ms) != Some(0) {
+            return;
+        }
+        self.agent.handle_tick(now);
         self.pump(swarm);
     }
 
@@ -192,21 +190,6 @@ impl NatDriver {
             }
         }
         swarm.set_external_addresses(addrs);
-    }
-}
-
-/// The (peer, stream) a stream-scoped swarm event refers to.
-fn stream_key(event: &SwarmEvent) -> Option<(&PeerId, StreamId)> {
-    match event {
-        SwarmEvent::StreamReady {
-            peer_id, stream_id, ..
-        }
-        | SwarmEvent::StreamData {
-            peer_id, stream_id, ..
-        }
-        | SwarmEvent::StreamRemoteWriteClosed { peer_id, stream_id }
-        | SwarmEvent::StreamClosed { peer_id, stream_id } => Some((peer_id, *stream_id)),
-        _ => None,
     }
 }
 

--- a/crates/minip2p/tests/nat.rs
+++ b/crates/minip2p/tests/nat.rs
@@ -106,3 +106,49 @@ fn wait_path_buffers_application_events() {
     }
     assert!(saw_connection, "application events must survive wait_path");
 }
+
+#[test]
+fn wait_peer_ready_drives_nat_agent() {
+    let mut a = nat_endpoint();
+    let mut b = Endpoint::builder()
+        .bind_quic("127.0.0.1:0")
+        .expect("bind loopback endpoint");
+    let b_addr = b.listen().expect("b listens");
+    a.listen().expect("a listens");
+
+    // The facade wait drives only `a`, so keep the remote's socket serviced
+    // concurrently. `wait_peer_ready` must feed ConnectionEstablished to
+    // the NAT agent on the way to the matching PeerReady event.
+    let (stop_remote, remote_stop) = std::sync::mpsc::channel();
+    let remote = std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if remote_stop.try_recv().is_ok() {
+                break;
+            }
+            let _ = b.next_event(Duration::from_millis(10));
+        }
+    });
+
+    let id = a.connect_addr(&b_addr).expect("connect starts");
+    let ready = a
+        .wait_peer_ready(b_addr.peer_id(), Duration::from_secs(10))
+        .expect("wait succeeds");
+    assert!(
+        matches!(ready, Some(minip2p::Event::PeerReady { peer_id, .. }) if peer_id == *b_addr.peer_id())
+    );
+
+    let events = a.take_nat_events();
+    assert!(
+        events.iter().any(|event| {
+            matches!(
+                event,
+                NatEvent::PathEstablished { connect_id, path: Path::DirectDialed, .. }
+                    if *connect_id == id
+            )
+        }),
+        "wait_peer_ready must deliver ConnectionEstablished to NAT: {events:?}"
+    );
+    let _ = stop_remote.send(());
+    remote.join().expect("remote driver thread");
+}

--- a/crates/minip2p/tests/nat.rs
+++ b/crates/minip2p/tests/nat.rs
@@ -1,0 +1,108 @@
+//! Loopback e2e for the `nat` feature: two real QUIC endpoints, no relay —
+//! the direct leg of the race wins outright and the failure paths report
+//! cleanly. (Relay-path coverage lives at the agent level in
+//! `crates/nat/tests`; a full relay e2e needs an external relay server.)
+
+#![cfg(feature = "nat")]
+
+use std::time::{Duration, Instant};
+
+use minip2p::{Endpoint, NatConfig, NatError, NatEvent, Path};
+
+fn nat_endpoint() -> Endpoint {
+    Endpoint::builder()
+        .nat_config(NatConfig::default())
+        .bind_quic("127.0.0.1:0")
+        .expect("bind loopback endpoint")
+}
+
+#[test]
+fn direct_candidate_wins_over_loopback() {
+    let mut a = nat_endpoint();
+    let mut b = Endpoint::builder()
+        .bind_quic("127.0.0.1:0")
+        .expect("bind loopback endpoint");
+
+    let b_addr = b.listen().expect("b listens");
+    a.listen().expect("a listens");
+
+    let id = a.connect_addr(&b_addr).expect("connect starts");
+
+    // Drive both endpoints; no relay is configured, so the only leg is the
+    // direct dial of the provided candidate.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut path = None;
+    while path.is_none() {
+        assert!(Instant::now() < deadline, "direct connect timed out");
+        let _ = a.next_event(Duration::from_millis(20)).expect("a drives");
+        let _ = b.next_event(Duration::from_millis(20)).expect("b drives");
+        for event in a.take_nat_events() {
+            if let NatEvent::PathEstablished {
+                connect_id,
+                path: found,
+                ..
+            } = event
+                && connect_id == id
+            {
+                path = Some(found);
+            }
+        }
+    }
+    assert!(matches!(path, Some(Path::DirectDialed)));
+    assert!(a.connected_peers().contains(b_addr.peer_id()));
+}
+
+#[test]
+fn connect_without_candidates_or_relay_fails_fast() {
+    let mut a = nat_endpoint();
+    a.listen().expect("a listens");
+
+    let stranger = minip2p::Ed25519Keypair::generate().peer_id();
+    let id = a.connect(&stranger).expect("connect starts");
+
+    let path = a
+        .wait_path(id, Duration::from_secs(2))
+        .expect("wait_path drives");
+    assert!(path.is_none(), "no path can exist");
+    // The failure detail stays inspectable.
+    let events = a.take_nat_events();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            NatEvent::ConnectFailed { connect_id, error: NatError::NoPathAvailable, .. }
+                if *connect_id == id
+        )),
+        "expected ConnectFailed, got {events:?}"
+    );
+}
+
+#[test]
+fn wait_path_buffers_application_events() {
+    let mut a = nat_endpoint();
+    let mut b = Endpoint::builder()
+        .bind_quic("127.0.0.1:0")
+        .expect("bind loopback endpoint");
+    let b_addr = b.listen().expect("b listens");
+    a.listen().expect("a listens");
+
+    let id = a.connect_addr(&b_addr).expect("connect starts");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut path = None;
+    while path.is_none() {
+        assert!(Instant::now() < deadline, "direct connect timed out");
+        path = a.wait_path(id, Duration::from_millis(20)).expect("a waits");
+        let _ = b.next_event(Duration::from_millis(20)).expect("b drives");
+    }
+    assert!(matches!(path, Some(Path::DirectDialed)));
+
+    // The swarm events observed during the wait (ConnectionEstablished,
+    // PeerReady, ...) were buffered, not swallowed.
+    let mut saw_connection = false;
+    while let Some(event) = a.next_event(Duration::from_millis(50)).expect("drain") {
+        if matches!(event, minip2p::Event::ConnectionEstablished { .. }) {
+            saw_connection = true;
+            break;
+        }
+    }
+    assert!(saw_connection, "application events must survive wait_path");
+}

--- a/crates/nat/Cargo.toml
+++ b/crates/nat/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 [features]
 default = ["std"]
 std = [
+    "minip2p-autonat/std",
     "minip2p-core/std",
     "minip2p-dcutr/std",
     "minip2p-relay/std",
@@ -19,6 +20,7 @@ std = [
 ]
 
 [dependencies]
+minip2p-autonat = { path = "../autonat", default-features = false }
 minip2p-core = { path = "../core", default-features = false }
 minip2p-dcutr = { path = "../dcutr", default-features = false }
 minip2p-relay = { path = "../relay", default-features = false }

--- a/crates/nat/Cargo.toml
+++ b/crates/nat/Cargo.toml
@@ -27,3 +27,6 @@ minip2p-relay = { path = "../relay", default-features = false }
 minip2p-swarm = { path = "../swarm", default-features = false }
 minip2p-transport = { path = "../transport", default-features = false }
 thiserror = { version = "2.0.18", default-features = false }
+
+[dev-dependencies]
+minip2p-test-support = { path = "../test-support" }

--- a/crates/nat/Cargo.toml
+++ b/crates/nat/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "minip2p-nat"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = ["std"]
+std = [
+    "minip2p-core/std",
+    "minip2p-dcutr/std",
+    "minip2p-relay/std",
+    "minip2p-swarm/std",
+    "minip2p-transport/std",
+    "thiserror/std",
+]
+
+[dependencies]
+minip2p-core = { path = "../core", default-features = false }
+minip2p-dcutr = { path = "../dcutr", default-features = false }
+minip2p-relay = { path = "../relay", default-features = false }
+minip2p-swarm = { path = "../swarm", default-features = false }
+minip2p-transport = { path = "../transport", default-features = false }
+thiserror = { version = "2.0.18", default-features = false }

--- a/crates/nat/README.md
+++ b/crates/nat/README.md
@@ -28,11 +28,19 @@ Ranking: `DirectDialed` ≈ `DirectPunched` > `Relayed`.
 
 ## The relayed path is a raw bridge stream
 
-`Path::Relayed { relay, stream_id }` is **not** a full swarm connection: no
-identify, ping, or multistream-select runs over the circuit. Exchange raw
-bytes on `stream_id` (addressed to the relay peer) with `Swarm::send_stream`
-and receive them as ordinary `StreamData` events. A circuit transport that
-makes relayed paths look like normal connections is future work.
+`Path::Relayed { relay, stream_id, pending_data, remote_write_closed }` is
+**not** a full swarm connection: no identify, ping, or multistream-select runs
+over the circuit. Exchange raw bytes on `stream_id` (addressed to the relay
+peer) with `Swarm::send_stream` and receive later bytes as ordinary
+`StreamData` events.
+
+At handoff, consume `pending_data` before waiting for `StreamData`; it contains
+application bytes that arrived in the same transport read as the final DCUtR
+frame and is surfaced exactly once on the original `PathEstablished` event.
+When `remote_write_closed` is true, treat the remote read side as EOF after
+draining `pending_data`: the NAT agent already consumed that stream event, so
+the application will not receive it again. A circuit transport that makes
+relayed paths look like normal connections is future work.
 
 ## Driving the agent
 
@@ -46,9 +54,11 @@ agent.set_listen_addrs(&validated_external_addrs);
 let id = agent.connect(target_peer, candidate_addrs, now());
 
 loop {
-    // 1. Feed swarm events by reference; consume stream events the agent
-    //    owns (agent.owns_stream) instead of forwarding them to the app.
-    agent.handle_event(&swarm_event, now());
+    // 1. Feed swarm events by reference. The disposition stays true even
+    //    when handling claims or releases a control-plane stream, so only
+    //    forward events for which it returns false to the application.
+    let consumed = agent.handle_event_with_disposition(&swarm_event, now());
+    if !consumed { /* forward swarm_event to the application */ }
     // 2. Execute actions, echoing synchronous results back.
     while let Some(action) = agent.poll_action() {
         match action {

--- a/crates/nat/README.md
+++ b/crates/nat/README.md
@@ -71,9 +71,20 @@ loop {
 }
 ```
 
-The `minip2p` facade (feature `nat`, upcoming) wires exactly this loop into
-`Endpoint` so applications get `connect(&peer)` / `wait_path(...)` without
-touching the pump.
+The `minip2p` facade (cargo feature `nat`) wires exactly this loop into
+`Endpoint` so applications get `connect(&peer)` / `wait_path(...)` /
+`take_nat_events()` without touching the pump:
+
+```rust,ignore
+let mut node = minip2p::Endpoint::builder()
+    .relay(relay_peer_addr)
+    .bind_quic("0.0.0.0:0")?;
+node.listen_all()?;
+let id = node.connect_with_addrs(peer, candidate_addrs)?;
+if let Some(path) = node.wait_path(id, std::time::Duration::from_secs(30))? {
+    println!("reached peer via {path:?}");
+}
+```
 
 ## Own-side housekeeping
 

--- a/crates/nat/README.md
+++ b/crates/nat/README.md
@@ -91,10 +91,23 @@ Independent of connect attempts, the agent also runs:
   lost relay session. `WhenPrivate` reserves while reachability is Unknown
   or Private and releases once probes settle on Public.
 
+## Responder side
+
+A NAT'd listener holding a reservation handles inbound circuits
+automatically: the relay's STOP CONNECT is auto-accepted, the initiator's
+DCUtR exchange is answered with our validated addresses, and on SYNC the
+agent punches back — dialing the initiator's observed addresses and
+emitting `SendRandomUdp` blasts (first after `responder_sync_delay_ms`,
+then every `blast_interval_ms` until `punch_deadline_ms`). The bridge
+stream is handed to the application via `InboundRelayCircuit`; a landed
+punch is announced with `InboundDirectUpgrade`.
+
 ## Status
 
 - Dialer-side race (direct dials × relay leg × DCUtR punch): implemented,
   covered by scripted no-I/O tests in `tests/arbitration.rs`.
 - Housekeeping (AutoNAT confidence aggregation, relay reservation renewal):
   implemented, covered by `tests/housekeeping.rs`.
-- Responder side (inbound STOP circuits, punch-back, UDP blasts): planned.
+- Responder side (inbound STOP circuits, punch-back, UDP blasts):
+  implemented, covered by `tests/inbound.rs` plus a two-agent end-to-end
+  exchange over an in-memory relay emulator (`tests/two_agents.rs`).

--- a/crates/nat/README.md
+++ b/crates/nat/README.md
@@ -75,10 +75,26 @@ The `minip2p` facade (feature `nat`, upcoming) wires exactly this loop into
 `Endpoint` so applications get `connect(&peer)` / `wait_path(...)` without
 touching the pump.
 
+## Own-side housekeeping
+
+Independent of connect attempts, the agent also runs:
+
+- **Reachability probing** (`NatConfig::autonat_servers`): single-shot
+  AutoNAT probes aggregated through an M-sample window — the verdict flips
+  only when N of the last M probes agree (defaults N=3, M=5), so one flaky
+  probe never flaps `ReachabilityChanged`.
+- **Relay reservations** (`NatConfig::reservation_policy`): held per policy
+  (`Always` / `WhenPrivate` / `Never`), renewed
+  `reservation_renewal_margin_secs` before the relay-reported `expire`
+  (default-TTL fallback when the relay omits it or the host has no wall
+  clock), rotating relays with backoff on refusal, and reacquiring after a
+  lost relay session. `WhenPrivate` reserves while reachability is Unknown
+  or Private and releases once probes settle on Public.
+
 ## Status
 
 - Dialer-side race (direct dials × relay leg × DCUtR punch): implemented,
   covered by scripted no-I/O tests in `tests/arbitration.rs`.
 - Housekeeping (AutoNAT confidence aggregation, relay reservation renewal):
-  planned — knobs already exist on `NatConfig`.
+  implemented, covered by `tests/housekeeping.rs`.
 - Responder side (inbound STOP circuits, punch-back, UDP blasts): planned.

--- a/crates/nat/README.md
+++ b/crates/nat/README.md
@@ -16,8 +16,8 @@ Parallel racing with convergence — not sequential fallback:
 t0      direct leg: dial every validated candidate address
 t0+δ    relay leg (stagger δ, default 200 ms; 0 = fully parallel):
           ensure relay session → HOP CONNECT(target)
-          → Bridged ⇒ PathEstablished(Relayed)   (usable immediately)
-          → DCUtR punch starts over the bridge, in parallel
+          → Bridged ⇒ DCUtR punch starts over the bridge
+          → after SYNC, release bridge ⇒ PathEstablished(Relayed)
 first usable path wins
 a better path later  ⇒ PathUpgraded { from, to }  (+ the old bridge is reset)
 punch exhausted      ⇒ FellBackToRelay            (the bridge stays yours)

--- a/crates/nat/README.md
+++ b/crates/nat/README.md
@@ -1,0 +1,84 @@
+# minip2p-nat
+
+Sans-I/O NAT-traversal orchestrator for minip2p. The protocol machines
+(Circuit Relay v2, DCUtR, AutoNAT) live in their own crates; `NatAgent` is
+the missing conductor: it races direct dials against a relayed circuit,
+starts a DCUtR hole punch over the bridge the moment it exists, and reports
+every path decision explicitly.
+
+`no_std + alloc`, no I/O, no clocks, no async.
+
+## Connection model
+
+Parallel racing with convergence — not sequential fallback:
+
+```text
+t0      direct leg: dial every validated candidate address
+t0+δ    relay leg (stagger δ, default 200 ms; 0 = fully parallel):
+          ensure relay session → HOP CONNECT(target)
+          → Bridged ⇒ PathEstablished(Relayed)   (usable immediately)
+          → DCUtR punch starts over the bridge, in parallel
+first usable path wins
+a better path later  ⇒ PathUpgraded { from, to }  (+ the old bridge is reset)
+punch exhausted      ⇒ FellBackToRelay            (the bridge stays yours)
+nothing worked       ⇒ ConnectFailed { error }
+```
+
+Ranking: `DirectDialed` ≈ `DirectPunched` > `Relayed`.
+
+## The relayed path is a raw bridge stream
+
+`Path::Relayed { relay, stream_id }` is **not** a full swarm connection: no
+identify, ping, or multistream-select runs over the circuit. Exchange raw
+bytes on `stream_id` (addressed to the relay peer) with `Swarm::send_stream`
+and receive them as ordinary `StreamData` events. A circuit transport that
+makes relayed paths look like normal connections is future work.
+
+## Driving the agent
+
+```rust,ignore
+let mut agent = NatAgent::new(local_peer_id, NatConfig {
+    relays: vec![relay_peer_addr],
+    ..NatConfig::default()
+});
+agent.set_listen_addrs(&validated_external_addrs);
+
+let id = agent.connect(target_peer, candidate_addrs, now());
+
+loop {
+    // 1. Feed swarm events by reference; consume stream events the agent
+    //    owns (agent.owns_stream) instead of forwarding them to the app.
+    agent.handle_event(&swarm_event, now());
+    // 2. Execute actions, echoing synchronous results back.
+    while let Some(action) = agent.poll_action() {
+        match action {
+            NatAction::Dial { token, addr } =>
+                agent.dial_result(token, swarm.dial(&addr).map_err(|e| e.to_string()), now()),
+            NatAction::OpenStream { token, peer, protocol_id } =>
+                agent.stream_open_result(
+                    token,
+                    swarm.open_stream(&peer, &protocol_id).map_err(|e| e.to_string()),
+                    now(),
+                ),
+            // SendStream / ResetStream / ... map 1:1 onto Swarm methods.
+            _ => { /* ... */ }
+        }
+    }
+    // 3. Surface events to the application.
+    while let Some(event) = agent.poll_event() { /* ... */ }
+    // 4. Sleep at most `agent.next_timeout(now_ms)`, then tick.
+    agent.handle_tick(now());
+}
+```
+
+The `minip2p` facade (feature `nat`, upcoming) wires exactly this loop into
+`Endpoint` so applications get `connect(&peer)` / `wait_path(...)` without
+touching the pump.
+
+## Status
+
+- Dialer-side race (direct dials × relay leg × DCUtR punch): implemented,
+  covered by scripted no-I/O tests in `tests/arbitration.rs`.
+- Housekeeping (AutoNAT confidence aggregation, relay reservation renewal):
+  planned — knobs already exist on `NatConfig`.
+- Responder side (inbound STOP circuits, punch-back, UDP blasts): planned.

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -6,10 +6,13 @@ use minip2p_core::{Multiaddr, PeerId};
 use minip2p_swarm::SwarmEvent;
 use minip2p_transport::{ConnectionId, StreamId};
 
+use minip2p_relay::STOP_PROTOCOL_ID;
+
 use crate::attempt::ConnectAttempt;
 use crate::config::NatConfig;
 use crate::events::{NatAction, NatEvent};
 use crate::housekeeping::Housekeeping;
+use crate::inbound::InboundCircuit;
 use crate::types::{ConnectId, NatToken, Now, ReachabilityState, ReservationInfo};
 
 /// Roles a stream owned by the agent can play. Streams not in the registry
@@ -23,6 +26,8 @@ pub(crate) enum StreamRole {
     HopReserve,
     /// Outbound AutoNAT probe stream (reachability prober).
     AutonatProbe,
+    /// Inbound STOP stream from a relay (responder-side circuit).
+    StopInbound(u64),
 }
 
 /// What a pending `Dial` / `OpenStream` token was issued for.
@@ -45,6 +50,9 @@ pub(crate) enum TokenPurpose {
     ReserveDial,
     /// HOP RESERVE stream open.
     OpenReserve(PeerId),
+    /// Responder-side simultaneous-open dial of an initiator's observed
+    /// address. Results are ignored; the punch window governs.
+    InboundPunchDial,
 }
 
 impl TokenPurpose {
@@ -141,7 +149,9 @@ pub struct NatAgent {
     shared: Shared,
     attempts: BTreeMap<ConnectId, ConnectAttempt>,
     housekeeping: Housekeeping,
+    inbound: BTreeMap<u64, InboundCircuit>,
     next_connect_id: u64,
+    next_inbound_id: u64,
 }
 
 impl NatAgent {
@@ -163,7 +173,9 @@ impl NatAgent {
             },
             attempts: BTreeMap::new(),
             housekeeping,
+            inbound: BTreeMap::new(),
             next_connect_id: 0,
+            next_inbound_id: 0,
         }
     }
 
@@ -211,6 +223,9 @@ impl NatAgent {
                 for attempt in self.attempts.values_mut() {
                     attempt.on_peer_connected(peer_id, &mut self.shared, now);
                 }
+                for circuit in self.inbound.values_mut() {
+                    circuit.on_peer_connected(peer_id, &mut self.shared, now);
+                }
             }
             SwarmEvent::ConnectionClosed { peer_id } => {
                 self.shared.connected.remove(peer_id);
@@ -220,6 +235,9 @@ impl NatAgent {
                 }
                 self.housekeeping
                     .on_peer_disconnected(peer_id, &mut self.shared, now);
+                for circuit in self.inbound.values_mut() {
+                    circuit.on_relay_disconnected(peer_id, &mut self.shared);
+                }
                 // Streams on the closed connection are gone; drop any the
                 // attempts have not already cleaned up.
                 self.shared.registry.remove(peer_id);
@@ -233,9 +251,25 @@ impl NatAgent {
                     .on_peer_ready(peer_id, protocols, &mut self.shared, now);
             }
             SwarmEvent::StreamReady {
-                peer_id, stream_id, ..
+                peer_id,
+                stream_id,
+                protocol_id,
+                initiated_locally,
             } => {
-                self.route_stream(peer_id, *stream_id, StreamInput::Ready, now);
+                if !initiated_locally && protocol_id == STOP_PROTOCOL_ID {
+                    // A relay is bridging an inbound circuit to us: claim
+                    // the stream and run the responder flow on it.
+                    let id = self.next_inbound_id;
+                    self.next_inbound_id += 1;
+                    self.shared
+                        .own_stream(peer_id, *stream_id, StreamRole::StopInbound(id));
+                    self.inbound.insert(
+                        id,
+                        InboundCircuit::new(peer_id.clone(), *stream_id, &self.shared, now),
+                    );
+                } else {
+                    self.route_stream(peer_id, *stream_id, StreamInput::Ready, now);
+                }
             }
             SwarmEvent::StreamData {
                 peer_id,
@@ -263,6 +297,9 @@ impl NatAgent {
             attempt.on_tick(&mut self.shared, now);
         }
         self.housekeeping.on_tick(&mut self.shared, now);
+        for circuit in self.inbound.values_mut() {
+            circuit.on_tick(&mut self.shared, now);
+        }
         self.reap_done();
     }
 
@@ -351,6 +388,11 @@ impl NatAgent {
             .values()
             .filter_map(ConnectAttempt::next_deadline)
             .chain(self.housekeeping.next_deadline())
+            .chain(
+                self.inbound
+                    .values()
+                    .filter_map(InboundCircuit::next_deadline),
+            )
             .min()
             .map(|due| due.saturating_sub(now_ms))
     }
@@ -383,6 +425,7 @@ impl NatAgent {
         self.shared.actions.is_empty()
             && self.shared.events.is_empty()
             && self.attempts.is_empty()
+            && self.inbound.is_empty()
             && self.housekeeping.is_quiet()
     }
 
@@ -404,10 +447,16 @@ impl NatAgent {
                 self.housekeeping
                     .on_stream_input(role, stream, input, &mut self.shared, now);
             }
+            StreamRole::StopInbound(id) => {
+                if let Some(circuit) = self.inbound.get_mut(&id) {
+                    circuit.on_stream_input(stream, input, &mut self.shared, now);
+                }
+            }
         }
     }
 
     fn reap_done(&mut self) {
         self.attempts.retain(|_, attempt| !attempt.is_done());
+        self.inbound.retain(|_, circuit| !circuit.is_done());
     }
 }

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -268,9 +268,43 @@ impl NatAgent {
     /// Feeds one swarm event. Events for streams the agent does not own are
     /// ignored with a single map lookup and zero clones.
     pub fn handle_event(&mut self, event: &SwarmEvent, now: Now) {
+        let _ = self.handle_event_with_disposition(event, now);
+    }
+
+    /// Feeds one swarm event and reports whether it belongs to the NAT
+    /// control plane even when the event did not leave a stream registered.
+    /// Drivers use this to consume rejected inbound control streams.
+    pub fn handle_event_with_disposition(&mut self, event: &SwarmEvent, now: Now) -> bool {
+        let mut handled = false;
         match event {
             SwarmEvent::ConnectionEstablished { peer_id } => {
-                self.shared.connected.insert(peer_id.clone());
+                let superseded = !self.shared.connected.insert(peer_id.clone());
+                if superseded {
+                    // The swarm's last-connection-wins policy emits a second
+                    // establishment without closing the retired connection.
+                    // Stream ids are peer-scoped here, so scrub them before
+                    // any event from the replacement connection can collide.
+                    self.shared.ready.remove(peer_id);
+                    self.shared.registry.remove(peer_id);
+                    self.shared.released_bridges.remove(peer_id);
+                    self.shared.tokens.retain(|_, purpose| {
+                        !matches!(
+                            purpose,
+                            TokenPurpose::OpenHop(_, peer)
+                                | TokenPurpose::OpenProbe(peer)
+                                | TokenPurpose::OpenReserve(peer)
+                                if peer == peer_id
+                        )
+                    });
+                    for attempt in self.attempts.values_mut() {
+                        attempt.on_peer_superseded(peer_id, &mut self.shared, now);
+                    }
+                    self.housekeeping
+                        .on_peer_superseded(peer_id, &mut self.shared, now);
+                    for circuit in self.inbound.values_mut() {
+                        circuit.on_relay_disconnected(peer_id, &mut self.shared);
+                    }
+                }
                 for attempt in self.attempts.values_mut() {
                     attempt.on_peer_connected(peer_id, &mut self.shared, now);
                 }
@@ -322,20 +356,30 @@ impl NatAgent {
                         .iter()
                         .any(|relay| relay.peer_id() == peer_id)
                     {
-                        return;
+                        // STOP is registered only for the NAT control plane.
+                        // Reject untrusted opens here instead of leaking them
+                        // to the application and leaving their stream credit
+                        // occupied until the remote closes them.
+                        self.shared.push_action(NatAction::ResetStream {
+                            peer: peer_id.clone(),
+                            stream_id: *stream_id,
+                        });
+                        handled = true;
+                    } else {
+                        // A relay is bridging an inbound circuit to us: claim
+                        // the stream and run the responder flow on it.
+                        let id = self.next_inbound_id;
+                        self.next_inbound_id += 1;
+                        self.shared
+                            .own_stream(peer_id, *stream_id, StreamRole::StopInbound(id));
+                        self.inbound.insert(
+                            id,
+                            InboundCircuit::new(peer_id.clone(), *stream_id, &self.shared, now),
+                        );
+                        handled = true;
                     }
-                    // A relay is bridging an inbound circuit to us: claim
-                    // the stream and run the responder flow on it.
-                    let id = self.next_inbound_id;
-                    self.next_inbound_id += 1;
-                    self.shared
-                        .own_stream(peer_id, *stream_id, StreamRole::StopInbound(id));
-                    self.inbound.insert(
-                        id,
-                        InboundCircuit::new(peer_id.clone(), *stream_id, &self.shared, now),
-                    );
                 } else {
-                    self.route_stream(peer_id, *stream_id, StreamInput::Ready, now);
+                    handled = self.route_stream(peer_id, *stream_id, StreamInput::Ready, now);
                 }
             }
             SwarmEvent::StreamData {
@@ -343,24 +387,27 @@ impl NatAgent {
                 stream_id,
                 data,
             } => {
-                self.route_stream(peer_id, *stream_id, StreamInput::Data(data), now);
+                handled = self.route_stream(peer_id, *stream_id, StreamInput::Data(data), now);
             }
             SwarmEvent::StreamRemoteWriteClosed { peer_id, stream_id } => {
-                self.route_stream(peer_id, *stream_id, StreamInput::RemoteWriteClosed, now);
+                handled =
+                    self.route_stream(peer_id, *stream_id, StreamInput::RemoteWriteClosed, now);
             }
             SwarmEvent::StreamClosed { peer_id, stream_id } => {
                 if let Some(id) = self.shared.take_released_bridge(peer_id, *stream_id) {
+                    handled = true;
                     if let Some(attempt) = self.attempts.get_mut(&id) {
                         attempt.on_released_bridge_closed(*stream_id, &mut self.shared, now);
                     }
                 } else {
-                    self.route_stream(peer_id, *stream_id, StreamInput::Closed, now);
+                    handled = self.route_stream(peer_id, *stream_id, StreamInput::Closed, now);
                 }
                 self.shared.release_stream(peer_id, *stream_id);
             }
             _ => {}
         }
         self.reap_done();
+        handled
     }
 
     /// Advances time-based state: stagger expiry, leg deadlines, punch
@@ -502,13 +549,19 @@ impl NatAgent {
             && self.housekeeping.is_quiet()
     }
 
-    fn route_stream(&mut self, peer: &PeerId, stream: StreamId, input: StreamInput<'_>, now: Now) {
+    fn route_stream(
+        &mut self,
+        peer: &PeerId,
+        stream: StreamId,
+        input: StreamInput<'_>,
+        now: Now,
+    ) -> bool {
         // Guardrail: streams we don't own are none of our business.
         let Some(streams) = self.shared.registry.get(peer) else {
-            return;
+            return false;
         };
         let Some(role) = streams.get(&stream).copied() else {
-            return;
+            return false;
         };
         match role {
             StreamRole::HopConnect(id) => {
@@ -526,6 +579,7 @@ impl NatAgent {
                 }
             }
         }
+        true
     }
 
     fn reap_done(&mut self) {

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -279,8 +279,10 @@ impl NatAgent {
     /// Drivers use this to consume rejected inbound control streams.
     pub fn handle_event_with_disposition(&mut self, event: &SwarmEvent, now: Now) -> bool {
         let mut handled = false;
+        let mut touched_state = false;
         match event {
             SwarmEvent::ConnectionEstablished { peer_id } => {
+                touched_state = true;
                 let superseded = !self.shared.connected.insert(peer_id.clone());
                 if superseded {
                     // The swarm's last-connection-wins policy emits a second
@@ -316,6 +318,7 @@ impl NatAgent {
                 }
             }
             SwarmEvent::ConnectionClosed { peer_id } => {
+                touched_state = true;
                 self.shared.connected.remove(peer_id);
                 self.shared.ready.remove(peer_id);
                 for attempt in self.attempts.values_mut() {
@@ -332,6 +335,7 @@ impl NatAgent {
                 self.shared.released_bridges.remove(peer_id);
             }
             SwarmEvent::PeerReady { peer_id, protocols } => {
+                touched_state = true;
                 self.shared.ready.insert(peer_id.clone(), protocols.clone());
                 for attempt in self.attempts.values_mut() {
                     attempt.on_peer_ready(peer_id, protocols, &mut self.shared, now);
@@ -386,6 +390,7 @@ impl NatAgent {
                 } else {
                     handled = self.route_stream(peer_id, *stream_id, StreamInput::Ready, now);
                 }
+                touched_state = handled;
             }
             SwarmEvent::StreamData {
                 peer_id,
@@ -393,10 +398,12 @@ impl NatAgent {
                 data,
             } => {
                 handled = self.route_stream(peer_id, *stream_id, StreamInput::Data(data), now);
+                touched_state = handled;
             }
             SwarmEvent::StreamRemoteWriteClosed { peer_id, stream_id } => {
                 handled =
                     self.route_stream(peer_id, *stream_id, StreamInput::RemoteWriteClosed, now);
+                touched_state = handled;
             }
             SwarmEvent::StreamClosed { peer_id, stream_id } => {
                 if let Some(id) = self.shared.take_released_bridge(peer_id, *stream_id) {
@@ -406,12 +413,20 @@ impl NatAgent {
                     }
                 } else {
                     handled = self.route_stream(peer_id, *stream_id, StreamInput::Closed, now);
+                    if handled {
+                        self.shared.release_stream(peer_id, *stream_id);
+                    }
                 }
-                self.shared.release_stream(peer_id, *stream_id);
+                touched_state = handled;
             }
             _ => {}
         }
-        self.reap_done();
+        // Foreign application stream events stop after their single registry
+        // lookup. Only state that actually visited a NAT machine can make an
+        // attempt or inbound circuit reapable.
+        if touched_state {
+            self.reap_done();
+        }
         handled
     }
 

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -93,6 +93,10 @@ pub(crate) struct Shared {
     pub(crate) connected: BTreeSet<PeerId>,
     /// Peers that reached `PeerReady`, with their advertised protocols.
     pub(crate) ready: BTreeMap<PeerId, Vec<String>>,
+    /// Bridges released to the application but still participating in a
+    /// direct-upgrade race. Data on these streams belongs to the app; only a
+    /// terminal close is routed back to the owning attempt.
+    released_bridges: BTreeMap<PeerId, BTreeMap<StreamId, ConnectId>>,
     /// Our validated external/listen addresses, advertised in DCUtR CONNECT.
     pub(crate) listen_addrs: Vec<Multiaddr>,
 }
@@ -129,6 +133,41 @@ impl Shared {
                 self.registry.remove(peer);
             }
         }
+    }
+
+    pub(crate) fn track_released_bridge(
+        &mut self,
+        peer: &PeerId,
+        stream: StreamId,
+        attempt: ConnectId,
+    ) {
+        self.released_bridges
+            .entry(peer.clone())
+            .or_default()
+            .insert(stream, attempt);
+    }
+
+    pub(crate) fn take_released_bridge(
+        &mut self,
+        peer: &PeerId,
+        stream: StreamId,
+    ) -> Option<ConnectId> {
+        let attempt = self
+            .released_bridges
+            .get_mut(peer)
+            .and_then(|streams| streams.remove(&stream));
+        if self
+            .released_bridges
+            .get(peer)
+            .is_some_and(BTreeMap::is_empty)
+        {
+            self.released_bridges.remove(peer);
+        }
+        attempt
+    }
+
+    pub(crate) fn forget_released_bridge(&mut self, peer: &PeerId, stream: StreamId) {
+        let _ = self.take_released_bridge(peer, stream);
     }
 }
 
@@ -169,6 +208,7 @@ impl NatAgent {
                 next_token: 0,
                 connected: BTreeSet::new(),
                 ready: BTreeMap::new(),
+                released_bridges: BTreeMap::new(),
                 listen_addrs: Vec::new(),
             },
             attempts: BTreeMap::new(),
@@ -194,6 +234,17 @@ impl NatAgent {
     pub fn connect(&mut self, peer: PeerId, direct_addrs: Vec<Multiaddr>, now: Now) -> ConnectId {
         let id = ConnectId(self.next_connect_id);
         self.next_connect_id += 1;
+        // A connection that is already identity-verified is the best path
+        // available. Do not manufacture a new race which can only waste
+        // work (and, with no candidates or relay, falsely report failure).
+        if self.shared.connected.contains(&peer) {
+            self.shared.push_event(NatEvent::PathEstablished {
+                connect_id: id,
+                peer,
+                path: crate::types::Path::DirectDialed,
+            });
+            return id;
+        }
         if let Some(attempt) = ConnectAttempt::start(id, peer, direct_addrs, &mut self.shared, now)
         {
             self.attempts.insert(id, attempt);
@@ -241,6 +292,7 @@ impl NatAgent {
                 // Streams on the closed connection are gone; drop any the
                 // attempts have not already cleaned up.
                 self.shared.registry.remove(peer_id);
+                self.shared.released_bridges.remove(peer_id);
             }
             SwarmEvent::PeerReady { peer_id, protocols } => {
                 self.shared.ready.insert(peer_id.clone(), protocols.clone());
@@ -257,6 +309,21 @@ impl NatAgent {
                 initiated_locally,
             } => {
                 if !initiated_locally && protocol_id == STOP_PROTOCOL_ID {
+                    // STOP is a relay control protocol, but registration of
+                    // its id makes it possible for any connected peer to
+                    // negotiate it. Only relays explicitly configured by
+                    // the application are trusted to request an inbound
+                    // circuit; otherwise a peer could make us punch its
+                    // chosen addresses.
+                    if !self
+                        .shared
+                        .config
+                        .relays
+                        .iter()
+                        .any(|relay| relay.peer_id() == peer_id)
+                    {
+                        return;
+                    }
                     // A relay is bridging an inbound circuit to us: claim
                     // the stream and run the responder flow on it.
                     let id = self.next_inbound_id;
@@ -282,7 +349,13 @@ impl NatAgent {
                 self.route_stream(peer_id, *stream_id, StreamInput::RemoteWriteClosed, now);
             }
             SwarmEvent::StreamClosed { peer_id, stream_id } => {
-                self.route_stream(peer_id, *stream_id, StreamInput::Closed, now);
+                if let Some(id) = self.shared.take_released_bridge(peer_id, *stream_id) {
+                    if let Some(attempt) = self.attempts.get_mut(&id) {
+                        attempt.on_released_bridge_closed(*stream_id, &mut self.shared, now);
+                    }
+                } else {
+                    self.route_stream(peer_id, *stream_id, StreamInput::Closed, now);
+                }
                 self.shared.release_stream(peer_id, *stream_id);
             }
             _ => {}

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -1,0 +1,352 @@
+use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use minip2p_core::{Multiaddr, PeerId};
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::{ConnectionId, StreamId};
+
+use crate::attempt::ConnectAttempt;
+use crate::config::NatConfig;
+use crate::events::{NatAction, NatEvent};
+use crate::types::{ConnectId, NatToken, Now, ReachabilityState};
+
+/// Roles a stream owned by the agent can play. Streams not in the registry
+/// belong to the application (`Released` is modeled as removal).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StreamRole {
+    /// Outbound HOP CONNECT stream for a dialer-side attempt; after the
+    /// relay reports `Bridged` the same stream carries the DCUtR exchange.
+    HopConnect(ConnectId),
+}
+
+/// What a pending `Dial` / `OpenStream` token was issued for.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum TokenPurpose {
+    /// Dial of a caller-supplied direct candidate.
+    DirectDial(ConnectId),
+    /// Dial of the relay itself (to start a relay leg).
+    RelayDial(ConnectId),
+    /// Simultaneous-open dial of a DCUtR observed address.
+    PunchDial(ConnectId),
+    /// HOP stream open on the relay; the peer is kept so a result arriving
+    /// after the attempt ended can still be cleaned up.
+    OpenHop(ConnectId, PeerId),
+}
+
+impl TokenPurpose {
+    fn connect_id(&self) -> ConnectId {
+        match self {
+            Self::DirectDial(id)
+            | Self::RelayDial(id)
+            | Self::PunchDial(id)
+            | Self::OpenHop(id, _) => *id,
+        }
+    }
+}
+
+/// A stream-scoped input extracted from a [`SwarmEvent`].
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum StreamInput<'a> {
+    Ready,
+    Data(&'a [u8]),
+    RemoteWriteClosed,
+    Closed,
+}
+
+/// State shared between the agent shell and its attempt state machines.
+pub(crate) struct Shared {
+    pub(crate) config: NatConfig,
+    pub(crate) actions: VecDeque<NatAction>,
+    pub(crate) events: VecDeque<NatEvent>,
+    /// Streams the agent currently owns, per peer. Peer-scoped because
+    /// stream ids are only unique within one connection.
+    pub(crate) registry: BTreeMap<PeerId, BTreeMap<StreamId, StreamRole>>,
+    pub(crate) tokens: BTreeMap<NatToken, TokenPurpose>,
+    next_token: u64,
+    /// Peers with an established (identity-verified) connection. A QUIC
+    /// supersede re-emits `ConnectionEstablished` and the retired connection
+    /// emits no `ConnectionClosed`, so set semantics absorb both.
+    pub(crate) connected: BTreeSet<PeerId>,
+    /// Peers that reached `PeerReady`, with their advertised protocols.
+    pub(crate) ready: BTreeMap<PeerId, Vec<String>>,
+    /// Our validated external/listen addresses, advertised in DCUtR CONNECT.
+    pub(crate) listen_addrs: Vec<Multiaddr>,
+}
+
+impl Shared {
+    pub(crate) fn alloc_token(&mut self, purpose: TokenPurpose) -> NatToken {
+        let token = NatToken(self.next_token);
+        self.next_token += 1;
+        self.tokens.insert(token, purpose);
+        token
+    }
+
+    pub(crate) fn push_action(&mut self, action: NatAction) {
+        self.actions.push_back(action);
+    }
+
+    pub(crate) fn push_event(&mut self, event: NatEvent) {
+        self.events.push_back(event);
+    }
+
+    /// Registers `stream` (on `peer`'s connection) as agent-owned.
+    pub(crate) fn own_stream(&mut self, peer: &PeerId, stream: StreamId, role: StreamRole) {
+        self.registry
+            .entry(peer.clone())
+            .or_default()
+            .insert(stream, role);
+    }
+
+    /// Releases `stream` back to the application (or forgets it entirely).
+    pub(crate) fn release_stream(&mut self, peer: &PeerId, stream: StreamId) {
+        if let Some(streams) = self.registry.get_mut(peer) {
+            streams.remove(&stream);
+            if streams.is_empty() {
+                self.registry.remove(peer);
+            }
+        }
+    }
+}
+
+/// Sans-I/O NAT-traversal orchestrator.
+///
+/// Inputs arrive through [`handle_event`](Self::handle_event) (swarm events,
+/// by reference), [`handle_tick`](Self::handle_tick) (time), and the
+/// synchronous driver echoes [`dial_result`](Self::dial_result) /
+/// [`stream_open_result`](Self::stream_open_result). Outputs drain through
+/// [`poll_action`](Self::poll_action) and [`poll_event`](Self::poll_event);
+/// drain both until `None` after every input, then sleep at most
+/// [`next_timeout`](Self::next_timeout) before the next tick.
+///
+/// The driver must route stream events the agent owns
+/// ([`owns_stream`](Self::owns_stream)) into the agent *only* — application
+/// code must not see them — and forward everything else untouched.
+pub struct NatAgent {
+    local_peer_id: PeerId,
+    shared: Shared,
+    attempts: BTreeMap<ConnectId, ConnectAttempt>,
+    next_connect_id: u64,
+}
+
+impl NatAgent {
+    /// Creates an agent for the node identified by `local_peer_id`.
+    pub fn new(local_peer_id: PeerId, config: NatConfig) -> Self {
+        Self {
+            local_peer_id,
+            shared: Shared {
+                config,
+                actions: VecDeque::new(),
+                events: VecDeque::new(),
+                registry: BTreeMap::new(),
+                tokens: BTreeMap::new(),
+                next_token: 0,
+                connected: BTreeSet::new(),
+                ready: BTreeMap::new(),
+                listen_addrs: Vec::new(),
+            },
+            attempts: BTreeMap::new(),
+            next_connect_id: 0,
+        }
+    }
+
+    /// The local peer id the agent was constructed with.
+    pub fn local_peer_id(&self) -> &PeerId {
+        &self.local_peer_id
+    }
+
+    /// Starts a connect attempt toward `peer`.
+    ///
+    /// `direct_addrs` are candidate transport addresses for the peer (from
+    /// discovery, config, or out-of-band exchange); they are validated and
+    /// deduplicated with the same policy as
+    /// [`minip2p_core::select_direct_candidates`]. The relay leg uses the
+    /// first configured relay in [`NatConfig::relays`].
+    pub fn connect(&mut self, peer: PeerId, direct_addrs: Vec<Multiaddr>, now: Now) -> ConnectId {
+        let id = ConnectId(self.next_connect_id);
+        self.next_connect_id += 1;
+        if let Some(attempt) = ConnectAttempt::start(id, peer, direct_addrs, &mut self.shared, now)
+        {
+            self.attempts.insert(id, attempt);
+        }
+        id
+    }
+
+    /// Abandons a connect attempt, resetting any streams it holds. No
+    /// further events are emitted for `id`.
+    pub fn cancel(&mut self, id: ConnectId, _now: Now) {
+        if let Some(mut attempt) = self.attempts.remove(&id) {
+            attempt.cancel(&mut self.shared);
+        }
+    }
+
+    /// Updates the validated addresses advertised during DCUtR exchanges.
+    pub fn set_listen_addrs(&mut self, addrs: &[Multiaddr]) {
+        self.shared.listen_addrs = addrs.to_vec();
+    }
+
+    /// Feeds one swarm event. Events for streams the agent does not own are
+    /// ignored with a single map lookup and zero clones.
+    pub fn handle_event(&mut self, event: &SwarmEvent, now: Now) {
+        match event {
+            SwarmEvent::ConnectionEstablished { peer_id } => {
+                self.shared.connected.insert(peer_id.clone());
+                for attempt in self.attempts.values_mut() {
+                    attempt.on_peer_connected(peer_id, &mut self.shared, now);
+                }
+            }
+            SwarmEvent::ConnectionClosed { peer_id } => {
+                self.shared.connected.remove(peer_id);
+                self.shared.ready.remove(peer_id);
+                for attempt in self.attempts.values_mut() {
+                    attempt.on_peer_disconnected(peer_id, &mut self.shared, now);
+                }
+                // Streams on the closed connection are gone; drop any the
+                // attempts have not already cleaned up.
+                self.shared.registry.remove(peer_id);
+            }
+            SwarmEvent::PeerReady { peer_id, protocols } => {
+                self.shared.ready.insert(peer_id.clone(), protocols.clone());
+                for attempt in self.attempts.values_mut() {
+                    attempt.on_peer_ready(peer_id, protocols, &mut self.shared, now);
+                }
+            }
+            SwarmEvent::StreamReady {
+                peer_id, stream_id, ..
+            } => {
+                self.route_stream(peer_id, *stream_id, StreamInput::Ready, now);
+            }
+            SwarmEvent::StreamData {
+                peer_id,
+                stream_id,
+                data,
+            } => {
+                self.route_stream(peer_id, *stream_id, StreamInput::Data(data), now);
+            }
+            SwarmEvent::StreamRemoteWriteClosed { peer_id, stream_id } => {
+                self.route_stream(peer_id, *stream_id, StreamInput::RemoteWriteClosed, now);
+            }
+            SwarmEvent::StreamClosed { peer_id, stream_id } => {
+                self.route_stream(peer_id, *stream_id, StreamInput::Closed, now);
+                self.shared.release_stream(peer_id, *stream_id);
+            }
+            _ => {}
+        }
+        self.reap_done();
+    }
+
+    /// Advances time-based state: stagger expiry, leg deadlines, punch
+    /// windows, connect deadlines.
+    pub fn handle_tick(&mut self, now: Now) {
+        for attempt in self.attempts.values_mut() {
+            attempt.on_tick(&mut self.shared, now);
+        }
+        self.reap_done();
+    }
+
+    /// Reports the result of a [`NatAction::Dial`] the driver executed.
+    pub fn dial_result(&mut self, token: NatToken, result: Result<ConnectionId, String>, now: Now) {
+        let Some(purpose) = self.shared.tokens.remove(&token) else {
+            return;
+        };
+        if let Some(attempt) = self.attempts.get_mut(&purpose.connect_id()) {
+            attempt.on_dial_result(&purpose, result, &mut self.shared, now);
+        }
+        self.reap_done();
+    }
+
+    /// Reports the result of a [`NatAction::OpenStream`] the driver executed.
+    pub fn stream_open_result(
+        &mut self,
+        token: NatToken,
+        result: Result<StreamId, String>,
+        now: Now,
+    ) {
+        let Some(purpose) = self.shared.tokens.remove(&token) else {
+            return;
+        };
+        let TokenPurpose::OpenHop(id, relay_peer) = purpose else {
+            return;
+        };
+        match self.attempts.get_mut(&id) {
+            Some(attempt) => {
+                attempt.on_stream_open_result(result, &mut self.shared, now);
+                self.reap_done();
+            }
+            None => {
+                // The attempt ended (won, failed, or was cancelled) while the
+                // open was in flight; don't leak the stream.
+                if let Ok(stream_id) = result {
+                    self.shared.push_action(NatAction::ResetStream {
+                        peer: relay_peer,
+                        stream_id,
+                    });
+                }
+            }
+        }
+    }
+
+    /// Returns the next queued command for the driver.
+    pub fn poll_action(&mut self) -> Option<NatAction> {
+        self.shared.actions.pop_front()
+    }
+
+    /// Returns the next application-visible event.
+    pub fn poll_event(&mut self) -> Option<NatEvent> {
+        self.shared.events.pop_front()
+    }
+
+    /// Milliseconds until the earliest pending deadline, if any. Drivers
+    /// fold this into their poll budget, mirroring `SwarmCore::next_timeout`.
+    pub fn next_timeout(&self, now_ms: u64) -> Option<u64> {
+        self.attempts
+            .values()
+            .filter_map(ConnectAttempt::next_deadline)
+            .min()
+            .map(|due| due.saturating_sub(now_ms))
+    }
+
+    /// Returns `true` if `stream_id` on `peer`'s connection currently
+    /// belongs to the agent. The driver uses this to decide whether to
+    /// consume or forward a stream event.
+    pub fn owns_stream(&self, peer: &PeerId, stream_id: StreamId) -> bool {
+        self.shared
+            .registry
+            .get(peer)
+            .is_some_and(|streams| streams.contains_key(&stream_id))
+    }
+
+    /// Our current reachability verdict. Stays
+    /// [`Unknown`](ReachabilityState::Unknown) until probing (a later
+    /// milestone) gathers confidence.
+    pub fn reachability(&self) -> ReachabilityState {
+        ReachabilityState::Unknown
+    }
+
+    /// Returns `true` when the agent has no queued outputs and no work in
+    /// flight.
+    pub fn is_idle(&self) -> bool {
+        self.shared.actions.is_empty() && self.shared.events.is_empty() && self.attempts.is_empty()
+    }
+
+    fn route_stream(&mut self, peer: &PeerId, stream: StreamId, input: StreamInput<'_>, now: Now) {
+        // Guardrail: streams we don't own are none of our business.
+        let Some(streams) = self.shared.registry.get(peer) else {
+            return;
+        };
+        let Some(role) = streams.get(&stream).copied() else {
+            return;
+        };
+        match role {
+            StreamRole::HopConnect(id) => {
+                if let Some(attempt) = self.attempts.get_mut(&id) {
+                    attempt.on_stream_input(stream, input, &mut self.shared, now);
+                }
+            }
+        }
+    }
+
+    fn reap_done(&mut self) {
+        self.attempts.retain(|_, attempt| !attempt.is_done());
+    }
+}

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -28,6 +28,9 @@ pub(crate) enum StreamRole {
     AutonatProbe,
     /// Inbound STOP stream from a relay (responder-side circuit).
     StopInbound(u64),
+    /// Inbound STOP stream from an untrusted peer. Kept owned until terminal
+    /// close so its reset lifecycle cannot leak into the application.
+    RejectedStop,
 }
 
 /// What a pending `Dial` / `OpenStream` token was issued for.
@@ -364,6 +367,8 @@ impl NatAgent {
                             peer: peer_id.clone(),
                             stream_id: *stream_id,
                         });
+                        self.shared
+                            .own_stream(peer_id, *stream_id, StreamRole::RejectedStop);
                         handled = true;
                     } else {
                         // A relay is bridging an inbound circuit to us: claim
@@ -578,6 +583,7 @@ impl NatAgent {
                     circuit.on_stream_input(stream, input, &mut self.shared, now);
                 }
             }
+            StreamRole::RejectedStop => {}
         }
         true
     }

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -9,7 +9,8 @@ use minip2p_transport::{ConnectionId, StreamId};
 use crate::attempt::ConnectAttempt;
 use crate::config::NatConfig;
 use crate::events::{NatAction, NatEvent};
-use crate::types::{ConnectId, NatToken, Now, ReachabilityState};
+use crate::housekeeping::Housekeeping;
+use crate::types::{ConnectId, NatToken, Now, ReachabilityState, ReservationInfo};
 
 /// Roles a stream owned by the agent can play. Streams not in the registry
 /// belong to the application (`Released` is modeled as removal).
@@ -18,6 +19,10 @@ pub(crate) enum StreamRole {
     /// Outbound HOP CONNECT stream for a dialer-side attempt; after the
     /// relay reports `Bridged` the same stream carries the DCUtR exchange.
     HopConnect(ConnectId),
+    /// Outbound HOP RESERVE stream (reservation manager).
+    HopReserve,
+    /// Outbound AutoNAT probe stream (reachability prober).
+    AutonatProbe,
 }
 
 /// What a pending `Dial` / `OpenStream` token was issued for.
@@ -32,15 +37,24 @@ pub(crate) enum TokenPurpose {
     /// HOP stream open on the relay; the peer is kept so a result arriving
     /// after the attempt ended can still be cleaned up.
     OpenHop(ConnectId, PeerId),
+    /// Dial of an AutoNAT server for a reachability probe.
+    ProbeDial,
+    /// AutoNAT probe stream open.
+    OpenProbe(PeerId),
+    /// Dial of the relay for a reservation.
+    ReserveDial,
+    /// HOP RESERVE stream open.
+    OpenReserve(PeerId),
 }
 
 impl TokenPurpose {
-    fn connect_id(&self) -> ConnectId {
+    fn connect_id(&self) -> Option<ConnectId> {
         match self {
             Self::DirectDial(id)
             | Self::RelayDial(id)
             | Self::PunchDial(id)
-            | Self::OpenHop(id, _) => *id,
+            | Self::OpenHop(id, _) => Some(*id),
+            _ => None,
         }
     }
 }
@@ -56,6 +70,7 @@ pub(crate) enum StreamInput<'a> {
 
 /// State shared between the agent shell and its attempt state machines.
 pub(crate) struct Shared {
+    pub(crate) local_peer_id: PeerId,
     pub(crate) config: NatConfig,
     pub(crate) actions: VecDeque<NatAction>,
     pub(crate) events: VecDeque<NatEvent>,
@@ -123,18 +138,19 @@ impl Shared {
 /// ([`owns_stream`](Self::owns_stream)) into the agent *only* — application
 /// code must not see them — and forward everything else untouched.
 pub struct NatAgent {
-    local_peer_id: PeerId,
     shared: Shared,
     attempts: BTreeMap<ConnectId, ConnectAttempt>,
+    housekeeping: Housekeeping,
     next_connect_id: u64,
 }
 
 impl NatAgent {
     /// Creates an agent for the node identified by `local_peer_id`.
     pub fn new(local_peer_id: PeerId, config: NatConfig) -> Self {
+        let housekeeping = Housekeeping::new(&config);
         Self {
-            local_peer_id,
             shared: Shared {
+                local_peer_id,
                 config,
                 actions: VecDeque::new(),
                 events: VecDeque::new(),
@@ -146,13 +162,14 @@ impl NatAgent {
                 listen_addrs: Vec::new(),
             },
             attempts: BTreeMap::new(),
+            housekeeping,
             next_connect_id: 0,
         }
     }
 
     /// The local peer id the agent was constructed with.
     pub fn local_peer_id(&self) -> &PeerId {
-        &self.local_peer_id
+        &self.shared.local_peer_id
     }
 
     /// Starts a connect attempt toward `peer`.
@@ -201,6 +218,8 @@ impl NatAgent {
                 for attempt in self.attempts.values_mut() {
                     attempt.on_peer_disconnected(peer_id, &mut self.shared, now);
                 }
+                self.housekeeping
+                    .on_peer_disconnected(peer_id, &mut self.shared, now);
                 // Streams on the closed connection are gone; drop any the
                 // attempts have not already cleaned up.
                 self.shared.registry.remove(peer_id);
@@ -210,6 +229,8 @@ impl NatAgent {
                 for attempt in self.attempts.values_mut() {
                     attempt.on_peer_ready(peer_id, protocols, &mut self.shared, now);
                 }
+                self.housekeeping
+                    .on_peer_ready(peer_id, protocols, &mut self.shared, now);
             }
             SwarmEvent::StreamReady {
                 peer_id, stream_id, ..
@@ -241,6 +262,7 @@ impl NatAgent {
         for attempt in self.attempts.values_mut() {
             attempt.on_tick(&mut self.shared, now);
         }
+        self.housekeeping.on_tick(&mut self.shared, now);
         self.reap_done();
     }
 
@@ -249,8 +271,22 @@ impl NatAgent {
         let Some(purpose) = self.shared.tokens.remove(&token) else {
             return;
         };
-        if let Some(attempt) = self.attempts.get_mut(&purpose.connect_id()) {
-            attempt.on_dial_result(&purpose, result, &mut self.shared, now);
+        match &purpose {
+            TokenPurpose::ProbeDial => {
+                self.housekeeping
+                    .on_probe_dial_result(&result, &mut self.shared, now);
+            }
+            TokenPurpose::ReserveDial => {
+                self.housekeeping
+                    .on_reserve_dial_result(&result, &mut self.shared, now);
+            }
+            _ => {
+                if let Some(id) = purpose.connect_id()
+                    && let Some(attempt) = self.attempts.get_mut(&id)
+                {
+                    attempt.on_dial_result(&purpose, result, &mut self.shared, now);
+                }
+            }
         }
         self.reap_done();
     }
@@ -265,24 +301,36 @@ impl NatAgent {
         let Some(purpose) = self.shared.tokens.remove(&token) else {
             return;
         };
-        let TokenPurpose::OpenHop(id, relay_peer) = purpose else {
-            return;
-        };
-        match self.attempts.get_mut(&id) {
-            Some(attempt) => {
-                attempt.on_stream_open_result(result, &mut self.shared, now);
-                self.reap_done();
-            }
-            None => {
-                // The attempt ended (won, failed, or was cancelled) while the
-                // open was in flight; don't leak the stream.
-                if let Ok(stream_id) = result {
-                    self.shared.push_action(NatAction::ResetStream {
-                        peer: relay_peer,
-                        stream_id,
-                    });
+        match purpose {
+            TokenPurpose::OpenHop(id, relay_peer) => match self.attempts.get_mut(&id) {
+                Some(attempt) => {
+                    attempt.on_stream_open_result(result, &mut self.shared, now);
+                    self.reap_done();
                 }
+                None => {
+                    // The attempt ended (won, failed, or was cancelled) while
+                    // the open was in flight; don't leak the stream.
+                    if let Ok(stream_id) = result {
+                        self.shared.push_action(NatAction::ResetStream {
+                            peer: relay_peer,
+                            stream_id,
+                        });
+                    }
+                }
+            },
+            TokenPurpose::OpenProbe(server_peer) => {
+                self.housekeeping
+                    .on_probe_open_result(&server_peer, result, &mut self.shared, now);
             }
+            TokenPurpose::OpenReserve(relay_peer) => {
+                self.housekeeping.on_reserve_open_result(
+                    &relay_peer,
+                    result,
+                    &mut self.shared,
+                    now,
+                );
+            }
+            _ => {}
         }
     }
 
@@ -302,6 +350,7 @@ impl NatAgent {
         self.attempts
             .values()
             .filter_map(ConnectAttempt::next_deadline)
+            .chain(self.housekeeping.next_deadline())
             .min()
             .map(|due| due.saturating_sub(now_ms))
     }
@@ -316,17 +365,25 @@ impl NatAgent {
             .is_some_and(|streams| streams.contains_key(&stream_id))
     }
 
-    /// Our current reachability verdict. Stays
-    /// [`Unknown`](ReachabilityState::Unknown) until probing (a later
-    /// milestone) gathers confidence.
+    /// Our current reachability verdict: majority-of-N confidence over the
+    /// last M probe results, so it never flips on a single probe.
     pub fn reachability(&self) -> ReachabilityState {
-        ReachabilityState::Unknown
+        self.housekeeping.reachability()
+    }
+
+    /// The relay reservation currently held, if any.
+    pub fn active_reservation(&self) -> Option<&ReservationInfo> {
+        self.housekeeping.active_reservation()
     }
 
     /// Returns `true` when the agent has no queued outputs and no work in
-    /// flight.
+    /// flight (a settled reservation or a scheduled future probe is not
+    /// "work").
     pub fn is_idle(&self) -> bool {
-        self.shared.actions.is_empty() && self.shared.events.is_empty() && self.attempts.is_empty()
+        self.shared.actions.is_empty()
+            && self.shared.events.is_empty()
+            && self.attempts.is_empty()
+            && self.housekeeping.is_quiet()
     }
 
     fn route_stream(&mut self, peer: &PeerId, stream: StreamId, input: StreamInput<'_>, now: Now) {
@@ -342,6 +399,10 @@ impl NatAgent {
                 if let Some(attempt) = self.attempts.get_mut(&id) {
                     attempt.on_stream_input(stream, input, &mut self.shared, now);
                 }
+            }
+            StreamRole::HopReserve | StreamRole::AutonatProbe => {
+                self.housekeeping
+                    .on_stream_input(role, stream, input, &mut self.shared, now);
             }
         }
     }

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -59,6 +59,9 @@ pub(crate) struct ConnectAttempt {
     bridge_released: bool,
     /// The remote write half reached EOF while the bridge was agent-owned.
     bridge_remote_write_closed: bool,
+    /// Application bytes coalesced behind the initiator-side DCUtR reply.
+    /// Drained exactly once into the first relayed `PathEstablished` event.
+    bridge_pending_data: Vec<u8>,
     punch_addrs: Vec<Multiaddr>,
     punch_dials_issued: bool,
     /// Absolute deadline of the current punch window.
@@ -107,6 +110,7 @@ impl ConnectAttempt {
             bridge_alive: false,
             bridge_released: false,
             bridge_remote_write_closed: false,
+            bridge_pending_data: Vec::new(),
             punch_addrs: Vec::new(),
             punch_dials_issued: false,
             punch_deadline: None,
@@ -715,6 +719,7 @@ impl ConnectAttempt {
             self.issue_punch_dials(shared);
         }
 
+        let relay_peer = self.relay_peer().cloned();
         if let Some(dcutr) = self.dcutr.as_mut() {
             match dcutr.handle_input(DcutrInitiatorInput::SendSync) {
                 Ok(()) => {
@@ -724,7 +729,7 @@ impl ConnectAttempt {
                             sync_frames.push(data);
                         }
                     }
-                    if let Some(relay_peer) = self.relay_peer().cloned() {
+                    if let Some(relay_peer) = relay_peer {
                         for data in sync_frames {
                             shared.push_action(NatAction::SendStream {
                                 peer: relay_peer.clone(),
@@ -733,6 +738,7 @@ impl ConnectAttempt {
                             });
                         }
                     }
+                    self.bridge_pending_data = dcutr.take_trailing_data().unwrap_or_default();
                 }
                 Err(e) => {
                     self.dcutr = None;
@@ -856,12 +862,22 @@ impl ConnectAttempt {
         let Some(relay) = self.relay_peer().cloned() else {
             return;
         };
+        let remote_write_closed = self.bridge_remote_write_closed;
         let path = Path::Relayed {
+            relay: relay.clone(),
+            stream_id: stream,
+            pending_data: core::mem::take(&mut self.bridge_pending_data),
+            remote_write_closed,
+        };
+        // `pending_data` is a one-shot handoff. Keep only stable path
+        // identity in `best`, so a later PathUpgraded event cannot surface
+        // the same bytes a second time.
+        self.best = Some(Path::Relayed {
             relay,
             stream_id: stream,
-            remote_write_closed: self.bridge_remote_write_closed,
-        };
-        self.best = Some(path.clone());
+            pending_data: Vec::new(),
+            remote_write_closed,
+        });
         shared.push_event(NatEvent::PathEstablished {
             connect_id: self.id,
             peer: self.peer.clone(),

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -181,7 +181,12 @@ impl ConnectAttempt {
         if self.done || *peer != self.peer {
             return;
         }
-        let path = if self.punch_dials_issued {
+        // `ConnectionEstablished` carries no dial/connection correlation.
+        // If one of the original candidate dials is still live, classifying
+        // this as punched would be a false claim: it may be that late
+        // candidate connection. Only call it punched when the relay race was
+        // the sole remaining source of a direct connection.
+        let path = if self.punch_dials_issued && self.direct_live == 0 {
             Path::DirectPunched
         } else {
             Path::DirectDialed
@@ -337,7 +342,16 @@ impl ConnectAttempt {
             (RelayLeg::Bridged { stream: s }, StreamInput::Data(data)) if s == stream => {
                 self.on_bridge_data(stream, data, shared, now);
             }
-            (_, StreamInput::Closed | StreamInput::RemoteWriteClosed) => {
+            (
+                RelayLeg::WaitHopReady { stream: s } | RelayLeg::AwaitHopStatus { stream: s },
+                StreamInput::RemoteWriteClosed,
+            ) if s == stream => {
+                self.on_hop_remote_write_closed(stream, shared, now);
+            }
+            (RelayLeg::Bridged { stream: s }, StreamInput::RemoteWriteClosed) if s == stream => {
+                self.on_bridge_remote_write_closed(stream, shared, now);
+            }
+            (_, StreamInput::Closed) => {
                 self.on_stream_closed(stream, shared, now);
             }
             _ => {}
@@ -491,8 +505,9 @@ impl ConnectAttempt {
         }
     }
 
-    /// The relay bridged the circuit: announce the relayed path and start
-    /// the DCUtR punch over it immediately, in parallel.
+    /// The relay bridged the circuit: start the DCUtR punch immediately.
+    /// The raw stream stays agent-owned until SYNC is sent, at which point it
+    /// becomes safe to announce as an application-usable relayed path.
     fn on_bridged(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
         let RelayLeg::AwaitHopStatus { .. } = self.leg else {
             return;
@@ -505,23 +520,13 @@ impl ConnectAttempt {
         self.bridge_alive = true;
         self.hop = None;
 
-        if self.best.is_none() {
-            let path = Path::Relayed {
-                relay: relay_peer.clone(),
-                stream_id: stream,
-            };
-            self.best = Some(path.clone());
-            shared.push_event(NatEvent::PathEstablished {
-                connect_id: self.id,
-                peer: self.peer.clone(),
-                path,
-            });
-        }
-
         let mut dcutr = DcutrInitiator::new(&shared.listen_addrs);
         if let Err(e) = dcutr.handle_input(DcutrInitiatorInput::Flush) {
             // Deferred construction error (e.g. oversized CONNECT): the
-            // punch cannot even start, but the relayed path stands.
+            // punch cannot even start, but the relayed path stands and is
+            // already safe to hand to the application.
+            self.release_bridge(shared);
+            self.announce_relay_path(stream, shared);
             self.punch_failed_permanently(shared, e.to_string(), now);
             return;
         }
@@ -553,6 +558,13 @@ impl ConnectAttempt {
             self.punch_failed_permanently(shared, e.to_string(), now);
             return;
         }
+        self.drain_dcutr_outputs(stream, shared, now);
+    }
+
+    fn drain_dcutr_outputs(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
+        let Some(dcutr) = self.dcutr.as_mut() else {
+            return;
+        };
         let mut outputs = Vec::new();
         while let Some(output) = dcutr.poll_output() {
             outputs.push(output);
@@ -575,6 +587,61 @@ impl ConnectAttempt {
                 }
             }
         }
+    }
+
+    /// A remote half-close still permits local protocol writes. Let the
+    /// sans-I/O machine consume it rather than treating it as a full circuit
+    /// teardown; it may have a complete frame buffered already.
+    fn on_hop_remote_write_closed(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
+        let Some(hop) = self.hop.as_mut() else {
+            return;
+        };
+        if let Err(e) = hop.handle_input(HopConnectInput::RemoteWriteClosed) {
+            self.fail_relay_leg(shared, NatError::Protocol(e.to_string()));
+            return;
+        }
+        let mut outputs = Vec::new();
+        while let Some(output) = hop.poll_output() {
+            outputs.push(output);
+        }
+        for output in outputs {
+            match output {
+                HopConnectOutput::Outbound(data) => {
+                    if let Some(relay_peer) = self.relay_peer().cloned() {
+                        shared.push_action(NatAction::SendStream {
+                            peer: relay_peer,
+                            stream_id: stream,
+                            data,
+                        });
+                    }
+                }
+                HopConnectOutput::Outcome(ConnectOutcome::Bridged { .. }) => {
+                    self.on_bridged(stream, shared, now);
+                }
+                HopConnectOutput::Outcome(ConnectOutcome::Refused { status, reason }) => {
+                    self.fail_relay_leg(
+                        shared,
+                        NatError::RelayRefused(format!("{status:?}: {reason}")),
+                    );
+                    return;
+                }
+                HopConnectOutput::BridgeData(bytes) => {
+                    self.on_bridge_data(stream, &bytes, shared, now);
+                }
+            }
+        }
+    }
+
+    fn on_bridge_remote_write_closed(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
+        let Some(dcutr) = self.dcutr.as_mut() else {
+            return;
+        };
+        if let Err(e) = dcutr.handle_input(DcutrInitiatorInput::RemoteWriteClosed) {
+            self.dcutr = None;
+            self.punch_failed_permanently(shared, e.to_string(), now);
+            return;
+        }
+        self.drain_dcutr_outputs(stream, shared, now);
     }
 
     /// The remote's observed addresses arrived: dial them all, send SYNC,
@@ -624,6 +691,7 @@ impl ConnectAttempt {
         // bridge belongs to the application.
         self.dcutr = None;
         self.release_bridge(shared);
+        self.announce_relay_path(stream, shared);
 
         if self.punch_addrs.is_empty() {
             self.punch_failed_permanently(
@@ -689,6 +757,14 @@ impl ConnectAttempt {
         }
         if self.bridge_alive {
             self.release_bridge(shared);
+            if let RelayLeg::Bridged { stream } = self.leg {
+                self.announce_relay_path(stream, shared);
+                // The app now owns the final relay stream outright. Stop
+                // intercepting its terminal events with this settled attempt.
+                if let Some(relay_peer) = self.relay_peer().cloned() {
+                    shared.forget_released_bridge(&relay_peer, stream);
+                }
+            }
             shared.push_event(NatEvent::FellBackToRelay {
                 connect_id: self.id,
                 peer: self.peer.clone(),
@@ -714,7 +790,27 @@ impl ConnectAttempt {
         {
             self.bridge_released = true;
             shared.release_stream(&relay_peer, stream);
+            shared.track_released_bridge(&relay_peer, stream, self.id);
         }
+    }
+
+    fn announce_relay_path(&mut self, stream: StreamId, shared: &mut Shared) {
+        if self.best.is_some() {
+            return;
+        }
+        let Some(relay) = self.relay_peer().cloned() else {
+            return;
+        };
+        let path = Path::Relayed {
+            relay,
+            stream_id: stream,
+        };
+        self.best = Some(path.clone());
+        shared.push_event(NatEvent::PathEstablished {
+            connect_id: self.id,
+            peer: self.peer.clone(),
+            path,
+        });
     }
 
     fn on_stream_closed(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
@@ -752,15 +848,31 @@ impl ConnectAttempt {
         if self.dcutr.is_some() {
             // The DCUtR exchange can never complete now.
             self.dcutr = None;
-            self.punch_failed_permanently(
-                shared,
-                "relay bridge lost during the DCUtR exchange".into(),
-                now,
-            );
+            self.punch_deadline = None;
+            if self.direct_live == 0 {
+                self.punch_failed_permanently(
+                    shared,
+                    "relay bridge lost during the DCUtR exchange".into(),
+                    now,
+                );
+            }
         }
         // If punch windows are already running, the punch itself may still
         // succeed via `ConnectionEstablished`; the window deadline settles
         // the rest.
+    }
+
+    /// Handles a terminal event for a bridge that was released to the app
+    /// while the direct-upgrade race was still active.
+    pub(crate) fn on_released_bridge_closed(
+        &mut self,
+        stream: StreamId,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        if matches!(self.leg, RelayLeg::Bridged { stream: s } if s == stream) {
+            self.on_bridge_lost(shared, now);
+        }
     }
 
     fn fail_relay_leg(&mut self, shared: &mut Shared, error: NatError) {
@@ -817,6 +929,7 @@ impl ConnectAttempt {
                         });
                     }
                     shared.release_stream(&relay_peer, stream);
+                    shared.forget_released_bridge(&relay_peer, stream);
                 }
             }
             _ => {}

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -1,0 +1,839 @@
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use minip2p_core::{Multiaddr, PeerAddr, PeerId, SansIoProtocol, select_direct_candidates};
+use minip2p_dcutr::{DcutrInitiator, DcutrInitiatorInput, DcutrInitiatorOutput, InitiatorOutcome};
+use minip2p_relay::{
+    ConnectOutcome, HOP_PROTOCOL_ID, HopConnect, HopConnectInput, HopConnectOutput,
+};
+use minip2p_transport::{ConnectionId, StreamId};
+
+use crate::agent::{Shared, StreamInput, StreamRole, TokenPurpose};
+use crate::events::{NatAction, NatEvent};
+use crate::types::{ConnectId, NatError, Now, Path};
+
+/// Progress of the relay leg of a connect attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RelayLeg {
+    /// No relay configured, or the leg was cancelled after a direct win.
+    Inactive,
+    /// Waiting out the direct leg's head start.
+    WaitStagger { until: u64 },
+    /// Relay dial issued and/or waiting for `PeerReady` on the relay.
+    WaitRelayReady,
+    /// `OpenStream` for the HOP protocol issued; waiting for the stream id.
+    OpeningHop,
+    /// HOP stream allocated; waiting for multistream negotiation.
+    WaitHopReady { stream: StreamId },
+    /// HOP CONNECT sent; waiting for the relay's STATUS response.
+    AwaitHopStatus { stream: StreamId },
+    /// Circuit bridged; the stream carries DCUtR and then application bytes.
+    Bridged { stream: StreamId },
+    /// The leg failed; only the direct leg (if any) can still win.
+    Failed,
+}
+
+/// Per-target dialer-race arbiter: direct candidate dials at `t0` racing a
+/// staggered relay leg, with a DCUtR punch attempted over the bridge as soon
+/// as it exists. The best path wins; improvements are announced as explicit
+/// upgrades.
+pub(crate) struct ConnectAttempt {
+    id: ConnectId,
+    peer: PeerId,
+    connect_deadline: u64,
+    /// Direct-candidate dials whose synchronous result has not come back as
+    /// an error. Successful dials stay "live" until the connection appears
+    /// or the connect deadline fires.
+    direct_live: u32,
+    relay: Option<PeerAddr>,
+    leg: RelayLeg,
+    /// Absolute deadline for the relay leg to reach `Bridged`.
+    relay_deadline: Option<u64>,
+    hop: Option<HopConnect>,
+    dcutr: Option<DcutrInitiator>,
+    dcutr_sent_at: Option<u64>,
+    /// The bridge exists and has not been torn down by a close/disconnect.
+    bridge_alive: bool,
+    /// The bridge stream has been handed back to the application.
+    bridge_released: bool,
+    punch_addrs: Vec<Multiaddr>,
+    punch_dials_issued: bool,
+    /// Absolute deadline of the current punch window.
+    punch_deadline: Option<u64>,
+    /// 1-based index of the current punch window.
+    punch_window: u32,
+    best: Option<Path>,
+    last_error: Option<NatError>,
+    done: bool,
+}
+
+impl ConnectAttempt {
+    /// Starts an attempt: dials every validated direct candidate now and
+    /// arms the relay leg. Returns `None` when the attempt failed instantly
+    /// (the failure event is already queued).
+    pub(crate) fn start(
+        id: ConnectId,
+        peer: PeerId,
+        direct_addrs: Vec<Multiaddr>,
+        shared: &mut Shared,
+        now: Now,
+    ) -> Option<Self> {
+        let candidates = select_direct_candidates(&direct_addrs, None, None).into_addrs();
+        let relay = shared.config.relays.first().cloned();
+
+        if candidates.is_empty() && relay.is_none() {
+            shared.push_event(NatEvent::ConnectFailed {
+                connect_id: id,
+                peer,
+                error: NatError::NoPathAvailable,
+            });
+            return None;
+        }
+
+        let mut attempt = Self {
+            id,
+            peer,
+            connect_deadline: now.mono_ms + shared.config.connect_deadline_ms,
+            direct_live: 0,
+            relay,
+            leg: RelayLeg::Inactive,
+            relay_deadline: None,
+            hop: None,
+            dcutr: None,
+            dcutr_sent_at: None,
+            bridge_alive: false,
+            bridge_released: false,
+            punch_addrs: Vec::new(),
+            punch_dials_issued: false,
+            punch_deadline: None,
+            punch_window: 0,
+            best: None,
+            last_error: None,
+            done: false,
+        };
+
+        for addr in candidates {
+            // Candidates are validated pure transport addresses, so pairing
+            // them with the target peer id cannot fail.
+            let Ok(peer_addr) = PeerAddr::new(addr, attempt.peer.clone()) else {
+                continue;
+            };
+            let token = shared.alloc_token(TokenPurpose::DirectDial(id));
+            shared.push_action(NatAction::Dial {
+                token,
+                addr: peer_addr,
+            });
+            attempt.direct_live += 1;
+        }
+
+        if attempt.relay.is_some() {
+            let stagger = shared.config.relay_stagger_ms;
+            if stagger == 0 || attempt.direct_live == 0 {
+                // Nothing to give a head start to (or none requested).
+                attempt.begin_relay_leg(shared, now);
+            } else {
+                attempt.leg = RelayLeg::WaitStagger {
+                    until: now.mono_ms + stagger,
+                };
+            }
+        }
+
+        if attempt.done {
+            return None;
+        }
+        Some(attempt)
+    }
+
+    pub(crate) fn is_done(&self) -> bool {
+        self.done
+    }
+
+    /// Earliest pending absolute deadline, for the driver's timer fold-in.
+    pub(crate) fn next_deadline(&self) -> Option<u64> {
+        if self.done {
+            return None;
+        }
+        let mut due = self.connect_deadline;
+        if let RelayLeg::WaitStagger { until } = self.leg {
+            due = due.min(until);
+        }
+        for deadline in [self.relay_deadline, self.punch_deadline]
+            .into_iter()
+            .flatten()
+        {
+            due = due.min(deadline);
+        }
+        Some(due)
+    }
+
+    /// Abandons the attempt silently, cleaning up any held streams.
+    pub(crate) fn cancel(&mut self, shared: &mut Shared) {
+        self.teardown_relay_leg(shared);
+        self.done = true;
+    }
+
+    // -----------------------------------------------------------------------
+    // Inputs routed from the agent
+    // -----------------------------------------------------------------------
+
+    pub(crate) fn on_peer_connected(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
+        if self.done || *peer != self.peer {
+            return;
+        }
+        let path = if self.punch_dials_issued {
+            Path::DirectPunched
+        } else {
+            Path::DirectDialed
+        };
+        match &self.best {
+            None => {
+                self.best = Some(path.clone());
+                shared.push_event(NatEvent::PathEstablished {
+                    connect_id: self.id,
+                    peer: self.peer.clone(),
+                    path,
+                });
+            }
+            Some(Path::Relayed { .. }) => {
+                let from = self.best.replace(path.clone()).expect("checked Some above");
+                shared.push_event(NatEvent::PathUpgraded {
+                    connect_id: self.id,
+                    peer: self.peer.clone(),
+                    from,
+                    to: path,
+                });
+            }
+            // A duplicate direct connection (QUIC supersede) — nothing new.
+            Some(_) => return,
+        }
+        let _ = now;
+        self.punch_deadline = None;
+        self.teardown_relay_leg(shared);
+        self.done = true;
+    }
+
+    pub(crate) fn on_peer_disconnected(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
+        if self.done || !self.is_relay_peer(peer) {
+            return;
+        }
+        match self.leg {
+            RelayLeg::WaitRelayReady
+            | RelayLeg::OpeningHop
+            | RelayLeg::WaitHopReady { .. }
+            | RelayLeg::AwaitHopStatus { .. } => {
+                self.fail_relay_leg(
+                    shared,
+                    NatError::DialFailed("relay connection closed".into()),
+                );
+            }
+            RelayLeg::Bridged { .. } => self.on_bridge_lost(shared, now),
+            _ => {}
+        }
+    }
+
+    pub(crate) fn on_peer_ready(
+        &mut self,
+        peer: &PeerId,
+        protocols: &[String],
+        shared: &mut Shared,
+        _now: Now,
+    ) {
+        if self.done || self.leg != RelayLeg::WaitRelayReady || !self.is_relay_peer(peer) {
+            return;
+        }
+        if protocols.iter().any(|p| p == HOP_PROTOCOL_ID) {
+            self.open_hop(shared);
+        } else {
+            self.fail_relay_leg(
+                shared,
+                NatError::Protocol("relay does not advertise the HOP protocol".into()),
+            );
+        }
+    }
+
+    pub(crate) fn on_dial_result(
+        &mut self,
+        purpose: &TokenPurpose,
+        result: Result<ConnectionId, String>,
+        shared: &mut Shared,
+        _now: Now,
+    ) {
+        if self.done {
+            return;
+        }
+        let Err(reason) = result else {
+            // A successful dial only means the handshake is under way; the
+            // connection (or the connect deadline) tells the rest.
+            return;
+        };
+        match purpose {
+            TokenPurpose::DirectDial(_) => {
+                self.direct_live = self.direct_live.saturating_sub(1);
+                self.last_error = Some(NatError::DialFailed(reason));
+                self.fail_if_no_legs_remain(shared);
+            }
+            TokenPurpose::RelayDial(_) => {
+                self.fail_relay_leg(shared, NatError::DialFailed(reason));
+            }
+            // Punch dials are expected to fail often; the punch window
+            // deadline governs the retry/fallback flow.
+            TokenPurpose::PunchDial(_) => {}
+            TokenPurpose::OpenHop(..) => {}
+        }
+    }
+
+    pub(crate) fn on_stream_open_result(
+        &mut self,
+        result: Result<StreamId, String>,
+        shared: &mut Shared,
+        _now: Now,
+    ) {
+        if self.done || self.leg != RelayLeg::OpeningHop {
+            // Stale result (leg already failed); don't leak the stream.
+            if let (Ok(stream), Some(relay_peer)) = (&result, self.relay_peer().cloned()) {
+                shared.push_action(NatAction::ResetStream {
+                    peer: relay_peer,
+                    stream_id: *stream,
+                });
+            }
+            return;
+        }
+        match result {
+            Ok(stream) => {
+                let Some(relay_peer) = self.relay_peer().cloned() else {
+                    return;
+                };
+                self.hop = Some(HopConnect::new(self.peer.to_bytes()));
+                shared.own_stream(&relay_peer, stream, StreamRole::HopConnect(self.id));
+                self.leg = RelayLeg::WaitHopReady { stream };
+            }
+            Err(reason) => {
+                self.fail_relay_leg(
+                    shared,
+                    NatError::Protocol(format!("opening HOP stream failed: {reason}")),
+                );
+            }
+        }
+    }
+
+    pub(crate) fn on_stream_input(
+        &mut self,
+        stream: StreamId,
+        input: StreamInput<'_>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        if self.done {
+            return;
+        }
+        match (self.leg, input) {
+            (RelayLeg::WaitHopReady { stream: s }, StreamInput::Ready) if s == stream => {
+                self.flush_hop_connect(stream, shared);
+            }
+            (RelayLeg::AwaitHopStatus { stream: s }, StreamInput::Data(data)) if s == stream => {
+                self.on_hop_data(stream, data, shared, now);
+            }
+            (RelayLeg::Bridged { stream: s }, StreamInput::Data(data)) if s == stream => {
+                self.on_bridge_data(stream, data, shared, now);
+            }
+            (_, StreamInput::Closed | StreamInput::RemoteWriteClosed) => {
+                self.on_stream_closed(stream, shared, now);
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn on_tick(&mut self, shared: &mut Shared, now: Now) {
+        if self.done {
+            return;
+        }
+
+        if let RelayLeg::WaitStagger { until } = self.leg
+            && now.mono_ms >= until
+        {
+            self.begin_relay_leg(shared, now);
+        }
+
+        if let Some(deadline) = self.relay_deadline
+            && now.mono_ms >= deadline
+        {
+            self.fail_relay_leg(shared, NatError::Timeout);
+        }
+
+        if let Some(deadline) = self.punch_deadline
+            && now.mono_ms >= deadline
+        {
+            self.on_punch_window_elapsed(shared, now);
+        }
+
+        if !self.done && now.mono_ms >= self.connect_deadline {
+            if self.best.is_some() {
+                // A relayed path exists but the punch never resolved; settle
+                // on the relay.
+                self.punch_deadline = None;
+                self.settle_after_punch(shared);
+            } else {
+                self.fail(shared, NatError::Timeout);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Relay leg
+    // -----------------------------------------------------------------------
+
+    fn begin_relay_leg(&mut self, shared: &mut Shared, now: Now) {
+        let Some(relay) = self.relay.clone() else {
+            self.leg = RelayLeg::Inactive;
+            return;
+        };
+        self.relay_deadline = Some(now.mono_ms + shared.config.relay_leg_deadline_ms);
+        let relay_peer = relay.peer_id().clone();
+
+        if let Some(protocols) = shared.ready.get(&relay_peer) {
+            if protocols.iter().any(|p| p == HOP_PROTOCOL_ID) {
+                self.open_hop(shared);
+            } else {
+                self.fail_relay_leg(
+                    shared,
+                    NatError::Protocol("relay does not advertise the HOP protocol".into()),
+                );
+            }
+        } else if shared.connected.contains(&relay_peer) {
+            self.leg = RelayLeg::WaitRelayReady;
+        } else {
+            let token = shared.alloc_token(TokenPurpose::RelayDial(self.id));
+            shared.push_action(NatAction::Dial { token, addr: relay });
+            self.leg = RelayLeg::WaitRelayReady;
+        }
+    }
+
+    fn open_hop(&mut self, shared: &mut Shared) {
+        let Some(relay_peer) = self.relay_peer().cloned() else {
+            return;
+        };
+        let token = shared.alloc_token(TokenPurpose::OpenHop(self.id, relay_peer.clone()));
+        shared.push_action(NatAction::OpenStream {
+            token,
+            peer: relay_peer,
+            protocol_id: HOP_PROTOCOL_ID.into(),
+        });
+        self.leg = RelayLeg::OpeningHop;
+    }
+
+    /// The HOP stream finished multistream negotiation: send CONNECT.
+    fn flush_hop_connect(&mut self, stream: StreamId, shared: &mut Shared) {
+        let Some(relay_peer) = self.relay_peer().cloned() else {
+            return;
+        };
+        let Some(hop) = self.hop.as_mut() else {
+            return;
+        };
+        if let Err(e) = hop.handle_input(HopConnectInput::Flush) {
+            let reason = e.to_string();
+            self.fail_relay_leg(shared, NatError::Protocol(reason));
+            return;
+        }
+        while let Some(output) = hop.poll_output() {
+            if let HopConnectOutput::Outbound(data) = output {
+                shared.push_action(NatAction::SendStream {
+                    peer: relay_peer.clone(),
+                    stream_id: stream,
+                    data,
+                });
+            }
+        }
+        self.leg = RelayLeg::AwaitHopStatus { stream };
+    }
+
+    fn on_hop_data(&mut self, stream: StreamId, data: &[u8], shared: &mut Shared, now: Now) {
+        let Some(hop) = self.hop.as_mut() else {
+            return;
+        };
+        if let Err(e) = hop.handle_input(HopConnectInput::Data(data.to_vec())) {
+            let reason = e.to_string();
+            self.fail_relay_leg(shared, NatError::Protocol(reason));
+            return;
+        }
+        let mut outputs = Vec::new();
+        while let Some(output) = hop.poll_output() {
+            outputs.push(output);
+        }
+        // `HopConnect` yields `Outcome(Bridged)` before any `BridgeData`, so
+        // pipelined peer bytes reach the DCUtR machine created below inside
+        // this same cascade — before any later `StreamData` event.
+        for output in outputs {
+            match output {
+                HopConnectOutput::Outbound(data) => {
+                    if let Some(relay_peer) = self.relay_peer().cloned() {
+                        shared.push_action(NatAction::SendStream {
+                            peer: relay_peer,
+                            stream_id: stream,
+                            data,
+                        });
+                    }
+                }
+                HopConnectOutput::Outcome(ConnectOutcome::Bridged { .. }) => {
+                    self.on_bridged(stream, shared, now);
+                }
+                HopConnectOutput::Outcome(ConnectOutcome::Refused { status, reason }) => {
+                    self.fail_relay_leg(
+                        shared,
+                        NatError::RelayRefused(format!("{status:?}: {reason}")),
+                    );
+                    return;
+                }
+                HopConnectOutput::BridgeData(bytes) => {
+                    self.on_bridge_data(stream, &bytes, shared, now);
+                }
+            }
+        }
+    }
+
+    /// The relay bridged the circuit: announce the relayed path and start
+    /// the DCUtR punch over it immediately, in parallel.
+    fn on_bridged(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
+        let RelayLeg::AwaitHopStatus { .. } = self.leg else {
+            return;
+        };
+        let Some(relay_peer) = self.relay_peer().cloned() else {
+            return;
+        };
+        self.leg = RelayLeg::Bridged { stream };
+        self.relay_deadline = None;
+        self.bridge_alive = true;
+        self.hop = None;
+
+        if self.best.is_none() {
+            let path = Path::Relayed {
+                relay: relay_peer.clone(),
+                stream_id: stream,
+            };
+            self.best = Some(path.clone());
+            shared.push_event(NatEvent::PathEstablished {
+                connect_id: self.id,
+                peer: self.peer.clone(),
+                path,
+            });
+        }
+
+        let mut dcutr = DcutrInitiator::new(&shared.listen_addrs);
+        if let Err(e) = dcutr.handle_input(DcutrInitiatorInput::Flush) {
+            // Deferred construction error (e.g. oversized CONNECT): the
+            // punch cannot even start, but the relayed path stands.
+            self.punch_failed_permanently(shared, e.to_string(), now);
+            return;
+        }
+        while let Some(output) = dcutr.poll_output() {
+            if let DcutrInitiatorOutput::Outbound(data) = output {
+                shared.push_action(NatAction::SendStream {
+                    peer: relay_peer.clone(),
+                    stream_id: stream,
+                    data,
+                });
+            }
+        }
+        self.dcutr_sent_at = Some(now.mono_ms);
+        self.dcutr = Some(dcutr);
+    }
+
+    fn on_bridge_data(&mut self, stream: StreamId, data: &[u8], shared: &mut Shared, now: Now) {
+        let Some(dcutr) = self.dcutr.as_mut() else {
+            return;
+        };
+        let rtt_ms = now
+            .mono_ms
+            .saturating_sub(self.dcutr_sent_at.unwrap_or(now.mono_ms));
+        if let Err(e) = dcutr.handle_input(DcutrInitiatorInput::Data {
+            bytes: data.to_vec(),
+            rtt_ms,
+        }) {
+            self.dcutr = None;
+            self.punch_failed_permanently(shared, e.to_string(), now);
+            return;
+        }
+        let mut outputs = Vec::new();
+        while let Some(output) = dcutr.poll_output() {
+            outputs.push(output);
+        }
+        for output in outputs {
+            match output {
+                DcutrInitiatorOutput::Outbound(data) => {
+                    if let Some(relay_peer) = self.relay_peer().cloned() {
+                        shared.push_action(NatAction::SendStream {
+                            peer: relay_peer,
+                            stream_id: stream,
+                            data,
+                        });
+                    }
+                }
+                DcutrInitiatorOutput::Outcome(InitiatorOutcome::DialNow {
+                    remote_addrs, ..
+                }) => {
+                    self.on_dial_now(stream, remote_addrs, shared, now);
+                }
+            }
+        }
+    }
+
+    /// The remote's observed addresses arrived: dial them all, send SYNC,
+    /// hand the bridge back to the application, and open the punch window.
+    fn on_dial_now(
+        &mut self,
+        stream: StreamId,
+        remote_addrs: Vec<Multiaddr>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        self.punch_addrs = select_direct_candidates(&remote_addrs, None, None).into_addrs();
+
+        // Per the spec the initiator dials first, then signals SYNC.
+        if !self.punch_addrs.is_empty() {
+            self.issue_punch_dials(shared);
+        }
+
+        if let Some(dcutr) = self.dcutr.as_mut() {
+            match dcutr.handle_input(DcutrInitiatorInput::SendSync) {
+                Ok(()) => {
+                    let mut sync_frames = Vec::new();
+                    while let Some(output) = dcutr.poll_output() {
+                        if let DcutrInitiatorOutput::Outbound(data) = output {
+                            sync_frames.push(data);
+                        }
+                    }
+                    if let Some(relay_peer) = self.relay_peer().cloned() {
+                        for data in sync_frames {
+                            shared.push_action(NatAction::SendStream {
+                                peer: relay_peer.clone(),
+                                stream_id: stream,
+                                data,
+                            });
+                        }
+                    }
+                }
+                Err(e) => {
+                    self.dcutr = None;
+                    self.punch_failed_permanently(shared, e.to_string(), now);
+                    return;
+                }
+            }
+        }
+
+        // No further DCUtR frames are expected: from here every byte on the
+        // bridge belongs to the application.
+        self.dcutr = None;
+        self.release_bridge(shared);
+
+        if self.punch_addrs.is_empty() {
+            self.punch_failed_permanently(
+                shared,
+                "no dialable remote addresses in DCUtR reply".into(),
+                now,
+            );
+            return;
+        }
+        self.punch_window = 1;
+        self.punch_deadline = Some(now.mono_ms + shared.config.punch_deadline_ms);
+    }
+
+    fn issue_punch_dials(&mut self, shared: &mut Shared) {
+        for addr in &self.punch_addrs {
+            let Ok(peer_addr) = PeerAddr::new(addr.clone(), self.peer.clone()) else {
+                continue;
+            };
+            let token = shared.alloc_token(TokenPurpose::PunchDial(self.id));
+            shared.push_action(NatAction::Dial {
+                token,
+                addr: peer_addr,
+            });
+        }
+        self.punch_dials_issued = true;
+    }
+
+    fn on_punch_window_elapsed(&mut self, shared: &mut Shared, now: Now) {
+        shared.push_event(NatEvent::HolePunchFailed {
+            connect_id: self.id,
+            attempt: self.punch_window,
+            reason: "hole punch window elapsed without a direct connection".into(),
+        });
+        let total_windows = 1 + shared.config.punch_max_retries;
+        if self.punch_window < total_windows {
+            self.punch_window += 1;
+            self.issue_punch_dials(shared);
+            self.punch_deadline = Some(now.mono_ms + shared.config.punch_deadline_ms);
+        } else {
+            self.punch_deadline = None;
+            self.settle_after_punch(shared);
+        }
+    }
+
+    /// The punch can never succeed (protocol error, no addresses): emit one
+    /// failure and settle immediately.
+    fn punch_failed_permanently(&mut self, shared: &mut Shared, reason: String, _now: Now) {
+        shared.push_event(NatEvent::HolePunchFailed {
+            connect_id: self.id,
+            attempt: self.punch_window.max(1),
+            reason,
+        });
+        self.punch_deadline = None;
+        self.settle_after_punch(shared);
+    }
+
+    /// The punch is over without a direct connection. If the bridge is
+    /// still standing, the relayed path is the final result; otherwise the
+    /// attempt has nothing left.
+    fn settle_after_punch(&mut self, shared: &mut Shared) {
+        if self.done {
+            return;
+        }
+        if self.bridge_alive {
+            self.release_bridge(shared);
+            shared.push_event(NatEvent::FellBackToRelay {
+                connect_id: self.id,
+                peer: self.peer.clone(),
+            });
+            self.done = true;
+        } else {
+            let error = self
+                .last_error
+                .take()
+                .unwrap_or(NatError::DialFailed("relay bridge lost".into()));
+            self.fail(shared, error);
+        }
+    }
+
+    /// Stops consuming the bridge stream; subsequent `StreamData` on it is
+    /// forwarded to the application by the driver.
+    fn release_bridge(&mut self, shared: &mut Shared) {
+        if self.bridge_released {
+            return;
+        }
+        if let RelayLeg::Bridged { stream } = self.leg
+            && let Some(relay_peer) = self.relay_peer().cloned()
+        {
+            self.bridge_released = true;
+            shared.release_stream(&relay_peer, stream);
+        }
+    }
+
+    fn on_stream_closed(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
+        match self.leg {
+            RelayLeg::WaitHopReady { stream: s } | RelayLeg::AwaitHopStatus { stream: s }
+                if s == stream =>
+            {
+                self.fail_relay_leg(
+                    shared,
+                    NatError::Protocol("HOP stream closed before the circuit was bridged".into()),
+                );
+            }
+            RelayLeg::Bridged { stream: s } if s == stream => self.on_bridge_lost(shared, now),
+            _ => {}
+        }
+    }
+
+    /// The bridge died (stream closed or relay connection lost).
+    fn on_bridge_lost(&mut self, shared: &mut Shared, now: Now) {
+        if !self.bridge_alive {
+            return;
+        }
+        self.bridge_alive = false;
+        if let RelayLeg::Bridged { stream } = self.leg
+            && !self.bridge_released
+            && let Some(relay_peer) = self.relay_peer().cloned()
+        {
+            shared.release_stream(&relay_peer, stream);
+            self.bridge_released = true;
+        }
+        self.leg = RelayLeg::Failed;
+        self.last_error = Some(NatError::DialFailed(
+            "relay bridge lost before the attempt settled".into(),
+        ));
+        if self.dcutr.is_some() {
+            // The DCUtR exchange can never complete now.
+            self.dcutr = None;
+            self.punch_failed_permanently(
+                shared,
+                "relay bridge lost during the DCUtR exchange".into(),
+                now,
+            );
+        }
+        // If punch windows are already running, the punch itself may still
+        // succeed via `ConnectionEstablished`; the window deadline settles
+        // the rest.
+    }
+
+    fn fail_relay_leg(&mut self, shared: &mut Shared, error: NatError) {
+        match self.leg {
+            RelayLeg::WaitHopReady { stream } | RelayLeg::AwaitHopStatus { stream } => {
+                if let Some(relay_peer) = self.relay_peer().cloned() {
+                    shared.push_action(NatAction::ResetStream {
+                        peer: relay_peer.clone(),
+                        stream_id: stream,
+                    });
+                    shared.release_stream(&relay_peer, stream);
+                }
+            }
+            _ => {}
+        }
+        self.leg = RelayLeg::Failed;
+        self.relay_deadline = None;
+        self.hop = None;
+        self.last_error = Some(error);
+        self.fail_if_no_legs_remain(shared);
+    }
+
+    fn fail_if_no_legs_remain(&mut self, shared: &mut Shared) {
+        let relay_leg_dead = matches!(self.leg, RelayLeg::Failed | RelayLeg::Inactive);
+        if self.best.is_none() && self.direct_live == 0 && relay_leg_dead && !self.done {
+            let error = self.last_error.take().unwrap_or(NatError::NoPathAvailable);
+            self.fail(shared, error);
+        }
+    }
+
+    fn fail(&mut self, shared: &mut Shared, error: NatError) {
+        self.teardown_relay_leg(shared);
+        shared.push_event(NatEvent::ConnectFailed {
+            connect_id: self.id,
+            peer: self.peer.clone(),
+            error,
+        });
+        self.done = true;
+    }
+
+    /// Cancels whatever the relay leg is doing and resets any stream it
+    /// still holds (including a bridge the application was told about — the
+    /// caller emits the explaining event first).
+    fn teardown_relay_leg(&mut self, shared: &mut Shared) {
+        match self.leg {
+            RelayLeg::WaitHopReady { stream }
+            | RelayLeg::AwaitHopStatus { stream }
+            | RelayLeg::Bridged { stream } => {
+                if let Some(relay_peer) = self.relay_peer().cloned() {
+                    if self.bridge_alive || !matches!(self.leg, RelayLeg::Bridged { .. }) {
+                        shared.push_action(NatAction::ResetStream {
+                            peer: relay_peer.clone(),
+                            stream_id: stream,
+                        });
+                    }
+                    shared.release_stream(&relay_peer, stream);
+                }
+            }
+            _ => {}
+        }
+        self.leg = RelayLeg::Inactive;
+        self.relay_deadline = None;
+        self.punch_deadline = None;
+        self.hop = None;
+        self.dcutr = None;
+        self.bridge_alive = false;
+    }
+
+    fn relay_peer(&self) -> Option<&PeerId> {
+        self.relay.as_ref().map(PeerAddr::peer_id)
+    }
+
+    fn is_relay_peer(&self, peer: &PeerId) -> bool {
+        self.relay_peer() == Some(peer)
+    }
+}

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -57,6 +57,8 @@ pub(crate) struct ConnectAttempt {
     bridge_alive: bool,
     /// The bridge stream has been handed back to the application.
     bridge_released: bool,
+    /// The remote write half reached EOF while the bridge was agent-owned.
+    bridge_remote_write_closed: bool,
     punch_addrs: Vec<Multiaddr>,
     punch_dials_issued: bool,
     /// Absolute deadline of the current punch window.
@@ -104,6 +106,7 @@ impl ConnectAttempt {
             dcutr_sent_at: None,
             bridge_alive: false,
             bridge_released: false,
+            bridge_remote_write_closed: false,
             punch_addrs: Vec::new(),
             punch_dials_issued: false,
             punch_deadline: None,
@@ -237,6 +240,31 @@ impl ConnectAttempt {
         }
     }
 
+    /// Invalidates relay state carried by a connection that the swarm
+    /// superseded. Unlike an ordinary close, cleanup must not emit stream
+    /// resets: peer-scoped stream ids now address the replacement connection.
+    pub(crate) fn on_peer_superseded(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
+        if self.done || !self.is_relay_peer(peer) {
+            return;
+        }
+        match self.leg {
+            RelayLeg::WaitRelayReady
+            | RelayLeg::OpeningHop
+            | RelayLeg::WaitHopReady { .. }
+            | RelayLeg::AwaitHopStatus { .. } => {
+                self.leg = RelayLeg::Failed;
+                self.relay_deadline = None;
+                self.hop = None;
+                self.last_error = Some(NatError::DialFailed(
+                    "relay connection was superseded".into(),
+                ));
+                self.fail_if_no_legs_remain(shared);
+            }
+            RelayLeg::Bridged { .. } => self.on_bridge_lost(shared, now),
+            _ => {}
+        }
+    }
+
     pub(crate) fn on_peer_ready(
         &mut self,
         peer: &PeerId,
@@ -276,7 +304,15 @@ impl ConnectAttempt {
             TokenPurpose::DirectDial(_) => {
                 self.direct_live = self.direct_live.saturating_sub(1);
                 self.last_error = Some(NatError::DialFailed(reason));
-                self.fail_if_no_legs_remain(shared);
+                if self.direct_live == 0
+                    && matches!(self.best, Some(Path::Relayed { .. }))
+                    && self.dcutr.is_none()
+                    && self.punch_deadline.is_none()
+                {
+                    self.settle_after_punch(shared);
+                } else {
+                    self.fail_if_no_legs_remain(shared);
+                }
             }
             TokenPurpose::RelayDial(_) => {
                 self.fail_relay_leg(shared, NatError::DialFailed(reason));
@@ -633,6 +669,7 @@ impl ConnectAttempt {
     }
 
     fn on_bridge_remote_write_closed(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
+        self.bridge_remote_write_closed = true;
         let Some(dcutr) = self.dcutr.as_mut() else {
             return;
         };
@@ -642,6 +679,24 @@ impl ConnectAttempt {
             return;
         }
         self.drain_dcutr_outputs(stream, shared, now);
+        if self.dcutr.is_some() {
+            // No more inbound bytes can complete the CONNECT reply. Release
+            // the still-writable relay bridge immediately, but keep original
+            // direct candidate dials alive so a late direct path can upgrade
+            // it before the connect deadline.
+            self.dcutr = None;
+            shared.push_event(NatEvent::HolePunchFailed {
+                connect_id: self.id,
+                attempt: self.punch_window.max(1),
+                reason: "relay bridge reached EOF before the DCUtR reply completed".into(),
+            });
+            self.punch_deadline = None;
+            self.release_bridge(shared);
+            self.announce_relay_path(stream, shared);
+            if self.direct_live == 0 {
+                self.settle_after_punch(shared);
+            }
+        }
     }
 
     /// The remote's observed addresses arrived: dial them all, send SYNC,
@@ -804,6 +859,7 @@ impl ConnectAttempt {
         let path = Path::Relayed {
             relay,
             stream_id: stream,
+            remote_write_closed: self.bridge_remote_write_closed,
         };
         self.best = Some(path.clone());
         shared.push_event(NatEvent::PathEstablished {

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -279,7 +279,7 @@ impl ConnectAttempt {
             // Punch dials are expected to fail often; the punch window
             // deadline governs the retry/fallback flow.
             TokenPurpose::PunchDial(_) => {}
-            TokenPurpose::OpenHop(..) => {}
+            _ => {}
         }
     }
 

--- a/crates/nat/src/config.rs
+++ b/crates/nat/src/config.rs
@@ -1,0 +1,103 @@
+use alloc::vec::Vec;
+
+use minip2p_core::PeerAddr;
+
+/// When the agent should hold a relay reservation for inbound reachability.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ReservationPolicy {
+    /// Never reserve. Outbound connects can still use per-connect relay
+    /// legs — HOP CONNECT needs the *target's* reservation, not ours.
+    Never,
+    /// Reserve while reachability is [`Private`] (or [`Unknown`] after the
+    /// first failed probe round), release when it settles [`Public`].
+    ///
+    /// [`Private`]: crate::ReachabilityState::Private
+    /// [`Unknown`]: crate::ReachabilityState::Unknown
+    /// [`Public`]: crate::ReachabilityState::Public
+    #[default]
+    WhenPrivate,
+    /// Always hold a reservation while a relay is configured.
+    Always,
+}
+
+/// Tuning knobs for [`NatAgent`](crate::NatAgent).
+///
+/// The defaults mirror the hand-rolled orchestration in `examples/peer` and
+/// common go-libp2p practice; every value can be overridden.
+#[derive(Clone, Debug)]
+pub struct NatConfig {
+    /// Relays available for circuit legs and reservations, in preference
+    /// order. Empty disables the relay leg entirely.
+    pub relays: Vec<PeerAddr>,
+    /// AutoNAT servers used for reachability probes, in preference order.
+    /// Empty leaves reachability [`Unknown`](crate::ReachabilityState::Unknown).
+    pub autonat_servers: Vec<PeerAddr>,
+    /// Head start given to the direct leg before the relay leg spins up.
+    /// `0` races both fully in parallel.
+    pub relay_stagger_ms: u64,
+    /// Overall deadline for a connect attempt.
+    pub connect_deadline_ms: u64,
+    /// Deadline for the relay leg to reach `Bridged` (measured from when the
+    /// leg starts, i.e. after the stagger).
+    pub relay_leg_deadline_ms: u64,
+    /// One hole-punch window: how long to wait for the direct connection
+    /// after dialing the remote's observed addresses.
+    pub punch_deadline_ms: u64,
+    /// Extra punch windows after the first one fails (re-dialing the same
+    /// observed addresses each time).
+    pub punch_max_retries: u32,
+    /// Cadence of responder-side random-UDP blasts during a punch.
+    pub blast_interval_ms: u64,
+    /// Payload length of each random-UDP blast packet.
+    pub blast_payload_len: usize,
+    /// Responder-side approximation of RTT/2: minimum delay between SYNC
+    /// arrival and the first blast.
+    pub responder_sync_delay_ms: u64,
+    /// Probe verdicts (out of [`confidence_window`](Self::confidence_window))
+    /// that must agree before reachability flips.
+    pub confidence_threshold: u8,
+    /// Size of the sliding window of recent probe verdicts.
+    pub confidence_window: u8,
+    /// Probe interval once reachability is settled.
+    pub probe_interval_settled_ms: u64,
+    /// Probe interval while reachability is unknown or contested.
+    pub probe_interval_unsettled_ms: u64,
+    /// Deadline for a single AutoNAT probe exchange.
+    pub probe_deadline_ms: u64,
+    /// Renew a reservation this many seconds before its `expire` timestamp.
+    pub reservation_renewal_margin_secs: u64,
+    /// Assumed reservation lifetime when the relay returns no `expire` or
+    /// the host has no wall clock.
+    pub reservation_default_ttl_secs: u64,
+    /// Backoff before retrying (or rotating relays) after a refused or
+    /// failed reservation.
+    pub reservation_retry_backoff_ms: u64,
+    /// When to hold a relay reservation.
+    pub reservation_policy: ReservationPolicy,
+}
+
+impl Default for NatConfig {
+    fn default() -> Self {
+        Self {
+            relays: Vec::new(),
+            autonat_servers: Vec::new(),
+            relay_stagger_ms: 200,
+            connect_deadline_ms: 60_000,
+            relay_leg_deadline_ms: 12_000,
+            punch_deadline_ms: 3_000,
+            punch_max_retries: 2,
+            blast_interval_ms: 100,
+            blast_payload_len: 32,
+            responder_sync_delay_ms: 50,
+            confidence_threshold: 3,
+            confidence_window: 5,
+            probe_interval_settled_ms: 90_000,
+            probe_interval_unsettled_ms: 5_000,
+            probe_deadline_ms: 20_000,
+            reservation_renewal_margin_secs: 120,
+            reservation_default_ttl_secs: 3_600,
+            reservation_retry_backoff_ms: 500,
+            reservation_policy: ReservationPolicy::WhenPrivate,
+        }
+    }
+}

--- a/crates/nat/src/events.rs
+++ b/crates/nat/src/events.rs
@@ -1,0 +1,114 @@
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use minip2p_core::{Multiaddr, PeerAddr, PeerId};
+use minip2p_transport::StreamId;
+
+use crate::types::{ConnectId, NatError, NatToken, Path, ReachabilityState};
+
+/// Commands the agent asks its driver to execute against the swarm.
+///
+/// `Dial` and `OpenStream` are synchronous swarm calls; the driver echoes
+/// their results back via [`NatAgent::dial_result`](crate::NatAgent::dial_result)
+/// and [`NatAgent::stream_open_result`](crate::NatAgent::stream_open_result)
+/// with the same token. The remaining actions are fire-and-forget.
+#[derive(Clone, Debug)]
+pub enum NatAction {
+    /// Call `Swarm::dial(&addr)` and report the result with `token`.
+    Dial { token: NatToken, addr: PeerAddr },
+    /// Call `Swarm::open_stream(&peer, &protocol_id)` and report the result
+    /// with `token`.
+    OpenStream {
+        token: NatToken,
+        peer: PeerId,
+        protocol_id: String,
+    },
+    /// Call `Swarm::send_stream(&peer, stream_id, data)`.
+    SendStream {
+        peer: PeerId,
+        stream_id: StreamId,
+        data: Vec<u8>,
+    },
+    /// Call `Swarm::close_stream_write(&peer, stream_id)`.
+    CloseStreamWrite { peer: PeerId, stream_id: StreamId },
+    /// Call `Swarm::reset_stream(&peer, stream_id)`. Failures may be
+    /// ignored — the stream is being abandoned.
+    ResetStream { peer: PeerId, stream_id: StreamId },
+    /// Call `Swarm::disconnect(&peer)`.
+    Disconnect { peer: PeerId },
+    /// Send one datagram of `payload_len` random bytes to `target` to open
+    /// our NAT mapping (responder-side hole punch). The wiring fills the
+    /// random bytes and calls the transport's raw-UDP send; transports
+    /// without one may drop the action.
+    SendRandomUdp {
+        target: Multiaddr,
+        payload_len: usize,
+    },
+}
+
+/// Events the agent surfaces to the application.
+#[derive(Clone, Debug)]
+pub enum NatEvent {
+    /// The reachability verdict flipped (majority-of-window confidence, so
+    /// this never flaps on a single probe).
+    ReachabilityChanged {
+        old: ReachabilityState,
+        new: ReachabilityState,
+    },
+    /// A relay accepted (or renewed) our reservation; we are now dialable
+    /// through it.
+    RelayReserved {
+        relay: PeerId,
+        /// Absolute expiry as reported by the relay, if any.
+        expires_unix_secs: Option<u64>,
+        /// When the agent will renew, on the driver's monotonic clock.
+        renew_at_mono_ms: u64,
+    },
+    /// The reservation lapsed or the relay connection was lost; reacquisition
+    /// starts automatically per the configured policy.
+    RelayReservationLost { relay: PeerId },
+    /// A first usable path to the peer is available.
+    PathEstablished {
+        connect_id: ConnectId,
+        peer: PeerId,
+        path: Path,
+    },
+    /// A better path replaced the previously announced one. When `from` was
+    /// [`Path::Relayed`], its bridge stream has been reset and must no
+    /// longer be used.
+    PathUpgraded {
+        connect_id: ConnectId,
+        peer: PeerId,
+        from: Path,
+        to: Path,
+    },
+    /// One hole-punch window elapsed (or the punch aborted) without a direct
+    /// connection. Informational; retries and fallback are automatic.
+    HolePunchFailed {
+        connect_id: ConnectId,
+        /// 1-based punch window index.
+        attempt: u32,
+        reason: String,
+    },
+    /// All punch windows are exhausted; the relayed path announced earlier
+    /// remains the final path for this attempt, and its bridge stream now
+    /// belongs entirely to the application.
+    FellBackToRelay { connect_id: ConnectId, peer: PeerId },
+    /// The attempt ended with no usable path.
+    ConnectFailed {
+        connect_id: ConnectId,
+        peer: PeerId,
+        error: NatError,
+    },
+    /// A remote peer opened a relay circuit to us (responder side). The
+    /// stream is a raw bridge; `pending_data` holds any bytes that arrived
+    /// pipelined behind the circuit setup.
+    InboundRelayCircuit {
+        peer: PeerId,
+        stream_id: StreamId,
+        pending_data: Vec<u8>,
+    },
+    /// An inbound circuit's hole punch succeeded; the peer is now directly
+    /// connected.
+    InboundDirectUpgrade { peer: PeerId },
+}

--- a/crates/nat/src/events.rs
+++ b/crates/nat/src/events.rs
@@ -54,7 +54,13 @@ pub enum NatEvent {
     ReachabilityChanged {
         old: ReachabilityState,
         new: ReachabilityState,
+        /// AutoNAT-confirmed public addresses associated with the new
+        /// verdict. Empty for non-public verdicts.
+        confirmed_addrs: Vec<Multiaddr>,
     },
+    /// AutoNAT confirmed a different public address set without changing the
+    /// already-public reachability verdict.
+    PublicAddressesChanged { addrs: Vec<Multiaddr> },
     /// A relay accepted (or renewed) our reservation; we are now dialable
     /// through it.
     RelayReserved {
@@ -107,6 +113,10 @@ pub enum NatEvent {
         peer: PeerId,
         stream_id: StreamId,
         pending_data: Vec<u8>,
+        /// `true` when the remote write half reached EOF before handoff. The
+        /// original swarm event was consumed by the NAT control plane and
+        /// will not be emitted again for the application.
+        remote_write_closed: bool,
     },
     /// An inbound circuit's hole punch succeeded; the peer is now directly
     /// connected.

--- a/crates/nat/src/housekeeping.rs
+++ b/crates/nat/src/housekeeping.rs
@@ -1,0 +1,929 @@
+//! Own-side housekeeping, independent of any connect attempt:
+//!
+//! - [`Prober`] — AutoNAT reachability probing with majority-of-N confidence
+//!   over a sliding window of M verdicts. `AutoNatClient` is single-shot;
+//!   the aggregation (and the never-flap-on-one-probe guarantee) lives here.
+//! - [`ReservationManager`] — holds a relay reservation per the configured
+//!   [`ReservationPolicy`], renewing ahead of the relay-reported `expire`
+//!   and rotating relays (with backoff) on refusal or loss.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use minip2p_autonat::{
+    AUTONAT_PROTOCOL_ID, AutoNatClient, AutoNatClientInput, AutoNatClientOutput, Reachability,
+};
+use minip2p_core::{PeerAddr, PeerId, SansIoProtocol};
+use minip2p_relay::{
+    HOP_PROTOCOL_ID, HopReservation, HopReservationInput, HopReservationOutput, ReservationOutcome,
+};
+use minip2p_transport::{ConnectionId, StreamId};
+
+use crate::ReservationPolicy;
+use crate::agent::{Shared, StreamInput, StreamRole, TokenPurpose};
+use crate::events::{NatAction, NatEvent};
+use crate::types::{Now, ReachabilityState, ReservationInfo};
+
+/// Progress of one outbound single-stream exchange (probe or reservation).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ExchangeStage {
+    /// Waiting for the server's connection to reach `PeerReady`
+    /// (a dial may be in flight).
+    WaitPeerReady,
+    /// `OpenStream` issued; waiting for the stream id.
+    Opening,
+    /// Stream allocated; waiting for multistream negotiation.
+    WaitStreamReady { stream: StreamId },
+    /// Request sent; waiting for the response.
+    AwaitResponse { stream: StreamId },
+}
+
+impl ExchangeStage {
+    fn stream(&self) -> Option<StreamId> {
+        match self {
+            Self::WaitStreamReady { stream } | Self::AwaitResponse { stream } => Some(*stream),
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reachability prober
+// ---------------------------------------------------------------------------
+
+/// One in-flight AutoNAT probe.
+struct ProbeFlight {
+    server: PeerAddr,
+    stage: ExchangeStage,
+    machine: Option<AutoNatClient>,
+    deadline: u64,
+}
+
+/// AutoNAT probing with an M-sample confidence window: the verdict flips
+/// only when at least N of the last M samples agree, and each flip emits
+/// exactly one [`NatEvent::ReachabilityChanged`].
+pub(crate) struct Prober {
+    verdict: ReachabilityState,
+    /// Sliding window of recent samples (`true` = public).
+    window: Vec<bool>,
+    flight: Option<ProbeFlight>,
+    next_probe_at: Option<u64>,
+    server_idx: usize,
+}
+
+impl Prober {
+    fn new(has_servers: bool) -> Self {
+        Self {
+            verdict: ReachabilityState::Unknown,
+            window: Vec::new(),
+            flight: None,
+            // Without configured servers there is nothing to schedule, and
+            // the agent must not report a phantom timeout.
+            next_probe_at: has_servers.then_some(0),
+            server_idx: 0,
+        }
+    }
+
+    fn on_tick(&mut self, shared: &mut Shared, now: Now) {
+        if let Some(flight) = &self.flight
+            && now.mono_ms >= flight.deadline
+        {
+            self.abort_flight(shared, now);
+        }
+        if self.flight.is_none()
+            && let Some(due) = self.next_probe_at
+            && now.mono_ms >= due
+        {
+            self.start_probe(shared, now);
+        }
+    }
+
+    /// Starts the next probe if the preconditions hold.
+    fn start_probe(&mut self, shared: &mut Shared, now: Now) {
+        if shared.config.autonat_servers.is_empty() || shared.listen_addrs.is_empty() {
+            // Nothing to probe (yet); check again at the unsettled cadence.
+            self.next_probe_at = Some(now.mono_ms + shared.config.probe_interval_unsettled_ms);
+            return;
+        }
+        let servers = &shared.config.autonat_servers;
+        let server = servers[self.server_idx % servers.len()].clone();
+        let deadline = now.mono_ms + shared.config.probe_deadline_ms;
+        let server_peer = server.peer_id().clone();
+
+        let stage = if let Some(protocols) = shared.ready.get(&server_peer) {
+            if protocols.iter().any(|p| p == AUTONAT_PROTOCOL_ID) {
+                let token = shared.alloc_token(TokenPurpose::OpenProbe(server_peer.clone()));
+                shared.push_action(NatAction::OpenStream {
+                    token,
+                    peer: server_peer,
+                    protocol_id: AUTONAT_PROTOCOL_ID.into(),
+                });
+                ExchangeStage::Opening
+            } else {
+                // Wrong server; rotate and try the next one soon.
+                self.server_idx += 1;
+                self.next_probe_at = Some(now.mono_ms + shared.config.probe_interval_unsettled_ms);
+                return;
+            }
+        } else if shared.connected.contains(&server_peer) {
+            ExchangeStage::WaitPeerReady
+        } else {
+            let token = shared.alloc_token(TokenPurpose::ProbeDial);
+            shared.push_action(NatAction::Dial {
+                token,
+                addr: server.clone(),
+            });
+            ExchangeStage::WaitPeerReady
+        };
+
+        self.flight = Some(ProbeFlight {
+            server,
+            stage,
+            machine: None,
+            deadline,
+        });
+        self.next_probe_at = None;
+    }
+
+    fn on_peer_ready(
+        &mut self,
+        peer: &PeerId,
+        protocols: &[String],
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        let Some(flight) = &mut self.flight else {
+            return;
+        };
+        if flight.stage != ExchangeStage::WaitPeerReady || flight.server.peer_id() != peer {
+            return;
+        }
+        if protocols.iter().any(|p| p == AUTONAT_PROTOCOL_ID) {
+            let token = shared.alloc_token(TokenPurpose::OpenProbe(peer.clone()));
+            shared.push_action(NatAction::OpenStream {
+                token,
+                peer: peer.clone(),
+                protocol_id: AUTONAT_PROTOCOL_ID.into(),
+            });
+            flight.stage = ExchangeStage::Opening;
+        } else {
+            self.abort_flight(shared, now);
+        }
+    }
+
+    fn on_peer_disconnected(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
+        if let Some(flight) = &self.flight
+            && flight.server.peer_id() == peer
+        {
+            self.abort_flight(shared, now);
+        }
+    }
+
+    fn on_dial_result(
+        &mut self,
+        result: &Result<ConnectionId, String>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        if result.is_err()
+            && self
+                .flight
+                .as_ref()
+                .is_some_and(|f| f.stage == ExchangeStage::WaitPeerReady)
+        {
+            self.abort_flight(shared, now);
+        }
+    }
+
+    fn on_stream_open_result(
+        &mut self,
+        server_peer: &PeerId,
+        result: Result<StreamId, String>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        let expecting = self.flight.as_ref().is_some_and(|f| {
+            f.stage == ExchangeStage::Opening && f.server.peer_id() == server_peer
+        });
+        if !expecting {
+            if let Ok(stream_id) = result {
+                shared.push_action(NatAction::ResetStream {
+                    peer: server_peer.clone(),
+                    stream_id,
+                });
+            }
+            return;
+        }
+        match result {
+            Ok(stream) => {
+                let flight = self.flight.as_mut().expect("checked above");
+                shared.own_stream(server_peer, stream, StreamRole::AutonatProbe);
+                flight.machine = Some(AutoNatClient::new(
+                    &shared.local_peer_id,
+                    &shared.listen_addrs,
+                ));
+                flight.stage = ExchangeStage::WaitStreamReady { stream };
+            }
+            Err(_) => self.abort_flight(shared, now),
+        }
+    }
+
+    /// Routes a probe-stream event. Returns whether the verdict flipped.
+    fn on_stream_input(
+        &mut self,
+        stream: StreamId,
+        input: StreamInput<'_>,
+        shared: &mut Shared,
+        now: Now,
+    ) -> bool {
+        let Some(flight) = &mut self.flight else {
+            return false;
+        };
+        if flight.stage.stream() != Some(stream) {
+            return false;
+        }
+        match (flight.stage, input) {
+            (ExchangeStage::WaitStreamReady { .. }, StreamInput::Ready) => {
+                let server_peer = flight.server.peer_id().clone();
+                let Some(machine) = flight.machine.as_mut() else {
+                    return false;
+                };
+                if machine.handle_input(AutoNatClientInput::Flush).is_err() {
+                    self.abort_flight(shared, now);
+                    return false;
+                }
+                while let Some(output) = machine.poll_output() {
+                    if let AutoNatClientOutput::Outbound(data) = output {
+                        shared.push_action(NatAction::SendStream {
+                            peer: server_peer.clone(),
+                            stream_id: stream,
+                            data,
+                        });
+                    }
+                }
+                flight.stage = ExchangeStage::AwaitResponse { stream };
+                false
+            }
+            (ExchangeStage::AwaitResponse { .. }, StreamInput::Data(data)) => {
+                let Some(machine) = flight.machine.as_mut() else {
+                    return false;
+                };
+                if machine
+                    .handle_input(AutoNatClientInput::Data(data.to_vec()))
+                    .is_err()
+                {
+                    self.abort_flight(shared, now);
+                    return false;
+                }
+                let mut sample = None;
+                while let Some(output) = machine.poll_output() {
+                    if let AutoNatClientOutput::Outcome(reachability) = output {
+                        sample = Some(reachability);
+                    }
+                }
+                match sample {
+                    Some(reachability) => {
+                        self.finish_flight(shared, now);
+                        self.record_sample(&reachability, shared, now)
+                    }
+                    None => false,
+                }
+            }
+            (_, StreamInput::Closed | StreamInput::RemoteWriteClosed) => {
+                self.abort_flight(shared, now);
+                false
+            }
+            _ => false,
+        }
+    }
+
+    /// Records one probe verdict and applies the N-of-M confidence rule.
+    /// Returns whether the verdict flipped.
+    fn record_sample(
+        &mut self,
+        reachability: &Reachability,
+        shared: &mut Shared,
+        _now: Now,
+    ) -> bool {
+        let sample = match reachability {
+            Reachability::Public { .. } => true,
+            Reachability::Private { .. } => false,
+            // No signal: never move the window on an inconclusive probe.
+            Reachability::Unknown { .. } => return false,
+        };
+        let window = usize::from(shared.config.confidence_window.max(1));
+        self.window.push(sample);
+        if self.window.len() > window {
+            self.window.remove(0);
+        }
+
+        let threshold = usize::from(shared.config.confidence_threshold.max(1));
+        let public_votes = self.window.iter().filter(|s| **s).count();
+        let private_votes = self.window.len() - public_votes;
+        let new = if public_votes >= threshold {
+            ReachabilityState::Public
+        } else if private_votes >= threshold {
+            ReachabilityState::Private
+        } else {
+            self.verdict
+        };
+        if new == self.verdict {
+            return false;
+        }
+        let old = core::mem::replace(&mut self.verdict, new);
+        shared.push_event(NatEvent::ReachabilityChanged { old, new });
+        true
+    }
+
+    /// Ends the current flight cleanly (response consumed) and schedules
+    /// the next probe.
+    fn finish_flight(&mut self, shared: &mut Shared, now: Now) {
+        if let Some(flight) = self.flight.take()
+            && let Some(stream) = flight.stage.stream()
+        {
+            let peer = flight.server.peer_id();
+            shared.push_action(NatAction::CloseStreamWrite {
+                peer: peer.clone(),
+                stream_id: stream,
+            });
+            shared.release_stream(peer, stream);
+        }
+        self.schedule_next(shared, now);
+    }
+
+    /// Ends the current flight without a sample (error/timeout/refusal),
+    /// rotates servers, and schedules a quick retry.
+    fn abort_flight(&mut self, shared: &mut Shared, now: Now) {
+        if let Some(flight) = self.flight.take()
+            && let Some(stream) = flight.stage.stream()
+        {
+            let peer = flight.server.peer_id();
+            shared.push_action(NatAction::ResetStream {
+                peer: peer.clone(),
+                stream_id: stream,
+            });
+            shared.release_stream(peer, stream);
+        }
+        self.server_idx += 1;
+        self.next_probe_at = Some(now.mono_ms + shared.config.probe_interval_unsettled_ms);
+    }
+
+    fn schedule_next(&mut self, shared: &mut Shared, now: Now) {
+        let interval = if self.verdict == ReachabilityState::Unknown {
+            shared.config.probe_interval_unsettled_ms
+        } else {
+            shared.config.probe_interval_settled_ms
+        };
+        self.next_probe_at = Some(now.mono_ms + interval);
+    }
+
+    fn next_deadline(&self) -> Option<u64> {
+        let flight_deadline = self.flight.as_ref().map(|f| f.deadline);
+        match (flight_deadline, self.next_probe_at) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (a, b) => a.or(b),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reservation manager
+// ---------------------------------------------------------------------------
+
+/// Where the reservation flow currently stands.
+enum ResState {
+    /// Not holding and not acquiring (policy says no, or nothing to do).
+    Idle,
+    /// Acquisition (or renewal) exchange in flight.
+    Acquiring {
+        relay: PeerAddr,
+        stage: ExchangeStage,
+        machine: Option<HopReservation>,
+        deadline: u64,
+    },
+    /// Reservation held; renewal fires at `info.renew_at_mono_ms`.
+    Reserved {
+        relay: PeerAddr,
+        info: ReservationInfo,
+    },
+    /// Waiting out a failure/refusal before trying the (rotated) relay.
+    Backoff { until: u64 },
+}
+
+/// Holds a relay reservation according to policy: `Wanted ↔ Reserved`, with
+/// renewal scheduled from the relay's absolute `expire`, a default-TTL
+/// fallback for missing expiries or clockless hosts, and relay rotation
+/// plus backoff on refusal.
+pub(crate) struct ReservationManager {
+    state: ResState,
+    relay_idx: usize,
+    /// Set while renewing or reconnecting so a failure emits
+    /// [`NatEvent::RelayReservationLost`] exactly once.
+    held: Option<PeerId>,
+}
+
+impl ReservationManager {
+    fn new() -> Self {
+        Self {
+            state: ResState::Idle,
+            relay_idx: 0,
+            held: None,
+        }
+    }
+
+    fn wanted(&self, shared: &Shared, verdict: ReachabilityState) -> bool {
+        if shared.config.relays.is_empty() {
+            return false;
+        }
+        match shared.config.reservation_policy {
+            ReservationPolicy::Never => false,
+            ReservationPolicy::Always => true,
+            // Reserve unless we are confidently public: a NAT'd listener
+            // must be dialable while evidence is still being gathered.
+            ReservationPolicy::WhenPrivate => verdict != ReachabilityState::Public,
+        }
+    }
+
+    /// Reconciles the state machine with the policy and clock.
+    fn sync(&mut self, verdict: ReachabilityState, shared: &mut Shared, now: Now) {
+        let wanted = self.wanted(shared, verdict);
+        if !wanted {
+            self.release(shared);
+            return;
+        }
+        match &self.state {
+            ResState::Idle => self.begin_acquire(shared, now),
+            ResState::Backoff { until } if now.mono_ms >= *until => {
+                self.begin_acquire(shared, now);
+            }
+            ResState::Reserved { info, .. } if now.mono_ms >= info.renew_at_mono_ms => {
+                let relay_peer = info.relay.clone();
+                self.held = Some(relay_peer);
+                self.begin_acquire(shared, now);
+            }
+            ResState::Acquiring { deadline, .. } if now.mono_ms >= *deadline => {
+                self.fail_acquire(shared, now);
+            }
+            _ => {}
+        }
+    }
+
+    /// Drops any held reservation and stops acquiring (policy says no).
+    fn release(&mut self, shared: &mut Shared) {
+        match core::mem::replace(&mut self.state, ResState::Idle) {
+            ResState::Reserved { relay, .. } => {
+                shared.push_event(NatEvent::RelayReservationLost {
+                    relay: relay.peer_id().clone(),
+                });
+            }
+            ResState::Acquiring { relay, stage, .. } => {
+                if let Some(stream) = stage.stream() {
+                    let peer = relay.peer_id();
+                    shared.push_action(NatAction::ResetStream {
+                        peer: peer.clone(),
+                        stream_id: stream,
+                    });
+                    shared.release_stream(peer, stream);
+                }
+                if let Some(held) = self.held.take() {
+                    shared.push_event(NatEvent::RelayReservationLost { relay: held });
+                }
+            }
+            _ => {}
+        }
+        self.held = None;
+    }
+
+    fn begin_acquire(&mut self, shared: &mut Shared, now: Now) {
+        let relays = &shared.config.relays;
+        if relays.is_empty() {
+            self.state = ResState::Idle;
+            return;
+        }
+        let relay = relays[self.relay_idx % relays.len()].clone();
+        let relay_peer = relay.peer_id().clone();
+        let deadline = now.mono_ms + shared.config.relay_leg_deadline_ms;
+
+        let stage = if let Some(protocols) = shared.ready.get(&relay_peer) {
+            if protocols.iter().any(|p| p == HOP_PROTOCOL_ID) {
+                let token = shared.alloc_token(TokenPurpose::OpenReserve(relay_peer.clone()));
+                shared.push_action(NatAction::OpenStream {
+                    token,
+                    peer: relay_peer,
+                    protocol_id: HOP_PROTOCOL_ID.into(),
+                });
+                ExchangeStage::Opening
+            } else {
+                self.state = ResState::Idle;
+                self.fail_acquire(shared, now);
+                return;
+            }
+        } else if shared.connected.contains(&relay_peer) {
+            ExchangeStage::WaitPeerReady
+        } else {
+            let token = shared.alloc_token(TokenPurpose::ReserveDial);
+            shared.push_action(NatAction::Dial {
+                token,
+                addr: relay.clone(),
+            });
+            ExchangeStage::WaitPeerReady
+        };
+
+        self.state = ResState::Acquiring {
+            relay,
+            stage,
+            machine: None,
+            deadline,
+        };
+    }
+
+    /// The acquisition failed (dial error, refusal, timeout, machine
+    /// error): emit `RelayReservationLost` if a reservation was being
+    /// renewed, rotate relays, and back off.
+    fn fail_acquire(&mut self, shared: &mut Shared, now: Now) {
+        if let ResState::Acquiring { relay, stage, .. } =
+            core::mem::replace(&mut self.state, ResState::Idle)
+            && let Some(stream) = stage.stream()
+        {
+            let peer = relay.peer_id();
+            shared.push_action(NatAction::ResetStream {
+                peer: peer.clone(),
+                stream_id: stream,
+            });
+            shared.release_stream(peer, stream);
+        }
+        if let Some(held) = self.held.take() {
+            shared.push_event(NatEvent::RelayReservationLost { relay: held });
+        }
+        self.relay_idx += 1;
+        self.state = ResState::Backoff {
+            until: now.mono_ms + shared.config.reservation_retry_backoff_ms,
+        };
+    }
+
+    fn on_peer_ready(
+        &mut self,
+        peer: &PeerId,
+        protocols: &[String],
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        let ResState::Acquiring { relay, stage, .. } = &mut self.state else {
+            return;
+        };
+        if *stage != ExchangeStage::WaitPeerReady || relay.peer_id() != peer {
+            return;
+        }
+        if protocols.iter().any(|p| p == HOP_PROTOCOL_ID) {
+            let token = shared.alloc_token(TokenPurpose::OpenReserve(peer.clone()));
+            shared.push_action(NatAction::OpenStream {
+                token,
+                peer: peer.clone(),
+                protocol_id: HOP_PROTOCOL_ID.into(),
+            });
+            *stage = ExchangeStage::Opening;
+        } else {
+            self.fail_acquire(shared, now);
+        }
+    }
+
+    fn on_peer_disconnected(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
+        match &self.state {
+            ResState::Reserved { relay, .. } if relay.peer_id() == peer => {
+                // The relay session carries inbound circuits; without it the
+                // reservation is useless. Reacquire after a short backoff.
+                shared.push_event(NatEvent::RelayReservationLost {
+                    relay: peer.clone(),
+                });
+                self.relay_idx += 1;
+                self.state = ResState::Backoff {
+                    until: now.mono_ms + shared.config.reservation_retry_backoff_ms,
+                };
+            }
+            ResState::Acquiring { relay, .. } if relay.peer_id() == peer => {
+                self.fail_acquire(shared, now);
+            }
+            _ => {}
+        }
+    }
+
+    fn on_dial_result(
+        &mut self,
+        result: &Result<ConnectionId, String>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        if result.is_err()
+            && matches!(
+                &self.state,
+                ResState::Acquiring {
+                    stage: ExchangeStage::WaitPeerReady,
+                    ..
+                }
+            )
+        {
+            self.fail_acquire(shared, now);
+        }
+    }
+
+    fn on_stream_open_result(
+        &mut self,
+        relay_peer: &PeerId,
+        result: Result<StreamId, String>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        let expecting = matches!(
+            &self.state,
+            ResState::Acquiring { relay, stage: ExchangeStage::Opening, .. }
+                if relay.peer_id() == relay_peer
+        );
+        if !expecting {
+            if let Ok(stream_id) = result {
+                shared.push_action(NatAction::ResetStream {
+                    peer: relay_peer.clone(),
+                    stream_id,
+                });
+            }
+            return;
+        }
+        match result {
+            Ok(stream) => {
+                shared.own_stream(relay_peer, stream, StreamRole::HopReserve);
+                if let ResState::Acquiring { stage, machine, .. } = &mut self.state {
+                    *machine = Some(HopReservation::new());
+                    *stage = ExchangeStage::WaitStreamReady { stream };
+                }
+            }
+            Err(_) => self.fail_acquire(shared, now),
+        }
+    }
+
+    fn on_stream_input(
+        &mut self,
+        stream: StreamId,
+        input: StreamInput<'_>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        let ResState::Acquiring {
+            relay,
+            stage,
+            machine,
+            ..
+        } = &mut self.state
+        else {
+            return;
+        };
+        if stage.stream() != Some(stream) {
+            return;
+        }
+        match (*stage, input) {
+            (ExchangeStage::WaitStreamReady { .. }, StreamInput::Ready) => {
+                let relay_peer = relay.peer_id().clone();
+                let Some(machine) = machine.as_mut() else {
+                    return;
+                };
+                if machine.handle_input(HopReservationInput::Flush).is_err() {
+                    self.fail_acquire(shared, now);
+                    return;
+                }
+                while let Some(output) = machine.poll_output() {
+                    if let HopReservationOutput::Outbound(data) = output {
+                        shared.push_action(NatAction::SendStream {
+                            peer: relay_peer.clone(),
+                            stream_id: stream,
+                            data,
+                        });
+                    }
+                }
+                *stage = ExchangeStage::AwaitResponse { stream };
+            }
+            (ExchangeStage::AwaitResponse { .. }, StreamInput::Data(data)) => {
+                let Some(m) = machine.as_mut() else {
+                    return;
+                };
+                if m.handle_input(HopReservationInput::Data(data.to_vec()))
+                    .is_err()
+                {
+                    self.fail_acquire(shared, now);
+                    return;
+                }
+                let mut outcome = None;
+                while let Some(output) = m.poll_output() {
+                    if let HopReservationOutput::Outcome(o) = output {
+                        outcome = Some(o);
+                    }
+                }
+                match outcome {
+                    Some(ReservationOutcome::Accepted { reservation, .. }) => {
+                        let relay = relay.clone();
+                        let expire = reservation.and_then(|r| r.expire);
+                        self.complete_acquire(relay, stream, expire, shared, now);
+                    }
+                    Some(ReservationOutcome::Refused { .. }) => {
+                        self.fail_acquire(shared, now);
+                    }
+                    None => {}
+                }
+            }
+            (_, StreamInput::Closed | StreamInput::RemoteWriteClosed) => {
+                self.fail_acquire(shared, now);
+            }
+            _ => {}
+        }
+    }
+
+    /// A reservation (initial or renewal) was accepted: compute the renewal
+    /// time and announce it.
+    fn complete_acquire(
+        &mut self,
+        relay: PeerAddr,
+        stream: StreamId,
+        expire_unix_secs: Option<u64>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        let relay_peer = relay.peer_id().clone();
+        shared.push_action(NatAction::CloseStreamWrite {
+            peer: relay_peer.clone(),
+            stream_id: stream,
+        });
+        shared.release_stream(&relay_peer, stream);
+        self.held = None;
+
+        let margin = shared.config.reservation_renewal_margin_secs;
+        let default_ttl = shared.config.reservation_default_ttl_secs;
+        // Renew `margin` seconds before the reported expiry when both the
+        // expiry and a wall clock exist; otherwise assume the default TTL.
+        // Clockless renewal is approximate by design.
+        let renew_in_secs = match (expire_unix_secs, now.unix_secs) {
+            (Some(expire), Some(unix_now)) => {
+                let remaining = expire.saturating_sub(unix_now);
+                remaining.saturating_sub(margin).max(1)
+            }
+            _ => default_ttl.saturating_sub(margin).max(1),
+        };
+        let info = ReservationInfo {
+            relay: relay_peer.clone(),
+            expires_unix_secs: expire_unix_secs,
+            renew_at_mono_ms: now.mono_ms + renew_in_secs * 1_000,
+        };
+        shared.push_event(NatEvent::RelayReserved {
+            relay: relay_peer,
+            expires_unix_secs: info.expires_unix_secs,
+            renew_at_mono_ms: info.renew_at_mono_ms,
+        });
+        self.state = ResState::Reserved { relay, info };
+    }
+
+    fn active(&self) -> Option<&ReservationInfo> {
+        match &self.state {
+            ResState::Reserved { info, .. } => Some(info),
+            _ => None,
+        }
+    }
+
+    fn next_deadline(&self) -> Option<u64> {
+        match &self.state {
+            ResState::Idle => None,
+            ResState::Acquiring { deadline, .. } => Some(*deadline),
+            ResState::Reserved { info, .. } => Some(info.renew_at_mono_ms),
+            ResState::Backoff { until } => Some(*until),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Composition
+// ---------------------------------------------------------------------------
+
+/// The agent's own-side housekeeping, running independently of connect
+/// attempts.
+pub(crate) struct Housekeeping {
+    prober: Prober,
+    reservations: ReservationManager,
+}
+
+impl Housekeeping {
+    pub(crate) fn new(config: &crate::NatConfig) -> Self {
+        Self {
+            prober: Prober::new(!config.autonat_servers.is_empty()),
+            reservations: ReservationManager::new(),
+        }
+    }
+
+    pub(crate) fn reachability(&self) -> ReachabilityState {
+        self.prober.verdict
+    }
+
+    pub(crate) fn active_reservation(&self) -> Option<&ReservationInfo> {
+        self.reservations.active()
+    }
+
+    pub(crate) fn on_tick(&mut self, shared: &mut Shared, now: Now) {
+        self.prober.on_tick(shared, now);
+        self.reservations.sync(self.prober.verdict, shared, now);
+    }
+
+    pub(crate) fn on_peer_ready(
+        &mut self,
+        peer: &PeerId,
+        protocols: &[String],
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        self.prober.on_peer_ready(peer, protocols, shared, now);
+        self.reservations
+            .on_peer_ready(peer, protocols, shared, now);
+    }
+
+    pub(crate) fn on_peer_disconnected(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
+        self.prober.on_peer_disconnected(peer, shared, now);
+        self.reservations.on_peer_disconnected(peer, shared, now);
+    }
+
+    pub(crate) fn on_probe_dial_result(
+        &mut self,
+        result: &Result<ConnectionId, String>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        self.prober.on_dial_result(result, shared, now);
+    }
+
+    pub(crate) fn on_reserve_dial_result(
+        &mut self,
+        result: &Result<ConnectionId, String>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        self.reservations.on_dial_result(result, shared, now);
+    }
+
+    pub(crate) fn on_probe_open_result(
+        &mut self,
+        server_peer: &PeerId,
+        result: Result<StreamId, String>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        self.prober
+            .on_stream_open_result(server_peer, result, shared, now);
+    }
+
+    pub(crate) fn on_reserve_open_result(
+        &mut self,
+        relay_peer: &PeerId,
+        result: Result<StreamId, String>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        self.reservations
+            .on_stream_open_result(relay_peer, result, shared, now);
+    }
+
+    pub(crate) fn on_stream_input(
+        &mut self,
+        role: StreamRole,
+        stream: StreamId,
+        input: StreamInput<'_>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        match role {
+            StreamRole::AutonatProbe => {
+                if self.prober.on_stream_input(stream, input, shared, now) {
+                    // A verdict flip can change what the reservation policy
+                    // wants; reconcile inside the same cascade.
+                    self.reservations.sync(self.prober.verdict, shared, now);
+                }
+            }
+            StreamRole::HopReserve => {
+                self.reservations
+                    .on_stream_input(stream, input, shared, now);
+            }
+            StreamRole::HopConnect(_) => {}
+        }
+    }
+
+    pub(crate) fn next_deadline(&self) -> Option<u64> {
+        match (
+            self.prober.next_deadline(),
+            self.reservations.next_deadline(),
+        ) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (a, b) => a.or(b),
+        }
+    }
+
+    /// `true` when nothing is actively in flight (scheduled future probes
+    /// don't count as work).
+    pub(crate) fn is_quiet(&self) -> bool {
+        self.prober.flight.is_none()
+            && matches!(
+                self.reservations.state,
+                ResState::Idle | ResState::Reserved { .. }
+            )
+    }
+}

--- a/crates/nat/src/housekeeping.rs
+++ b/crates/nat/src/housekeeping.rs
@@ -289,7 +289,32 @@ impl Prober {
                     None => false,
                 }
             }
-            (_, StreamInput::Closed | StreamInput::RemoteWriteClosed) => {
+            (ExchangeStage::AwaitResponse { .. }, StreamInput::RemoteWriteClosed) => {
+                let Some(machine) = flight.machine.as_mut() else {
+                    return false;
+                };
+                if machine
+                    .handle_input(AutoNatClientInput::RemoteWriteClosed)
+                    .is_err()
+                {
+                    self.abort_flight(shared, now);
+                    return false;
+                }
+                let mut sample = None;
+                while let Some(output) = machine.poll_output() {
+                    if let AutoNatClientOutput::Outcome(reachability) = output {
+                        sample = Some(reachability);
+                    }
+                }
+                match sample {
+                    Some(reachability) => {
+                        self.finish_flight(shared, now);
+                        self.record_sample(&reachability, shared, now)
+                    }
+                    None => false,
+                }
+            }
+            (_, StreamInput::Closed) => {
                 self.abort_flight(shared, now);
                 false
             }
@@ -317,7 +342,10 @@ impl Prober {
             self.window.remove(0);
         }
 
-        let threshold = usize::from(shared.config.confidence_threshold.max(1));
+        // A threshold above the bounded window can never be reached. Treat
+        // it as unanimity for the configured window instead of leaving
+        // reachability permanently Unknown.
+        let threshold = usize::from(shared.config.confidence_threshold.max(1)).min(window);
         let public_votes = self.window.iter().filter(|s| **s).count();
         let private_votes = self.window.len() - public_votes;
         let new = if public_votes >= threshold {
@@ -727,7 +755,35 @@ impl ReservationManager {
                     None => {}
                 }
             }
-            (_, StreamInput::Closed | StreamInput::RemoteWriteClosed) => {
+            (ExchangeStage::AwaitResponse { .. }, StreamInput::RemoteWriteClosed) => {
+                let Some(m) = machine.as_mut() else {
+                    return;
+                };
+                if m.handle_input(HopReservationInput::RemoteWriteClosed)
+                    .is_err()
+                {
+                    self.fail_acquire(shared, now);
+                    return;
+                }
+                let mut outcome = None;
+                while let Some(output) = m.poll_output() {
+                    if let HopReservationOutput::Outcome(o) = output {
+                        outcome = Some(o);
+                    }
+                }
+                match outcome {
+                    Some(ReservationOutcome::Accepted { reservation, .. }) => {
+                        let relay = relay.clone();
+                        let expire = reservation.and_then(|r| r.expire);
+                        self.complete_acquire(relay, stream, expire, shared, now);
+                    }
+                    Some(ReservationOutcome::Refused { .. }) => {
+                        self.fail_acquire(shared, now);
+                    }
+                    None => {}
+                }
+            }
+            (_, StreamInput::Closed) => {
                 self.fail_acquire(shared, now);
             }
             _ => {}
@@ -767,7 +823,11 @@ impl ReservationManager {
         let info = ReservationInfo {
             relay: relay_peer.clone(),
             expires_unix_secs: expire_unix_secs,
-            renew_at_mono_ms: now.mono_ms + renew_in_secs * 1_000,
+            // The relay controls `expire`, so this conversion must not let a
+            // large value wrap the monotonic renewal deadline.
+            renew_at_mono_ms: now
+                .mono_ms
+                .saturating_add(renew_in_secs.saturating_mul(1_000)),
         };
         shared.push_event(NatEvent::RelayReserved {
             relay: relay_peer,

--- a/crates/nat/src/housekeeping.rs
+++ b/crates/nat/src/housekeeping.rs
@@ -348,10 +348,18 @@ impl Prober {
         _now: Now,
     ) -> bool {
         let (sample, sample_addrs) = match reachability {
-            Reachability::Public { addrs, .. } => (
-                true,
-                select_direct_candidates(addrs, None, None).into_addrs(),
-            ),
+            Reachability::Public { addrs, .. } => {
+                let selected = select_direct_candidates(addrs, None, None);
+                // A successful dial-back is useful public evidence only when
+                // it leaves the application with an address this QUIC-only
+                // stack can actually advertise and accept. Counting an empty
+                // selection could release a WhenPrivate reservation while
+                // providing no direct replacement path.
+                if selected.is_empty() {
+                    return false;
+                }
+                (true, selected.into_addrs())
+            }
             Reachability::Private { .. } => (false, Vec::new()),
             // No signal: never move the window on an inconclusive probe.
             Reachability::Unknown { .. } => return false,
@@ -683,6 +691,13 @@ impl ReservationManager {
             }
             ResState::Acquiring { relay, .. } if relay.peer_id() == peer => {
                 // Do not reset the retired stream id on the new connection.
+                // A renewal keeps the old reservation in `held` while its
+                // replacement exchange runs. Superseding the relay connection
+                // invalidates that reservation even though the exchange did
+                // not fail through the normal stream path.
+                if let Some(held) = self.held.take() {
+                    shared.push_event(NatEvent::RelayReservationLost { relay: held });
+                }
                 self.relay_idx += 1;
                 self.state = ResState::Backoff {
                     until: now.mono_ms + shared.config.reservation_retry_backoff_ms,
@@ -1025,7 +1040,7 @@ impl Housekeeping {
                 self.reservations
                     .on_stream_input(stream, input, shared, now);
             }
-            StreamRole::HopConnect(_) | StreamRole::StopInbound(_) => {}
+            StreamRole::HopConnect(_) | StreamRole::StopInbound(_) | StreamRole::RejectedStop => {}
         }
     }
 

--- a/crates/nat/src/housekeeping.rs
+++ b/crates/nat/src/housekeeping.rs
@@ -488,16 +488,21 @@ enum ResState {
 pub(crate) struct ReservationManager {
     state: ResState,
     relay_idx: usize,
+    /// The initial policy reconciliation is an immediate timer source. Once
+    /// it runs, later policy flips call `sync` directly from probe handling.
+    needs_sync: bool,
     /// Set while renewing or reconnecting so a failure emits
     /// [`NatEvent::RelayReservationLost`] exactly once.
     held: Option<PeerId>,
 }
 
 impl ReservationManager {
-    fn new() -> Self {
+    fn new(config: &crate::NatConfig) -> Self {
         Self {
             state: ResState::Idle,
             relay_idx: 0,
+            needs_sync: !config.relays.is_empty()
+                && config.reservation_policy != ReservationPolicy::Never,
             held: None,
         }
     }
@@ -517,6 +522,7 @@ impl ReservationManager {
 
     /// Reconciles the state machine with the policy and clock.
     fn sync(&mut self, verdict: ReachabilityState, shared: &mut Shared, now: Now) {
+        self.needs_sync = false;
         let wanted = self.wanted(shared, verdict);
         if !wanted {
             self.release(shared);
@@ -918,6 +924,7 @@ impl ReservationManager {
 
     fn next_deadline(&self) -> Option<u64> {
         match &self.state {
+            ResState::Idle if self.needs_sync => Some(0),
             ResState::Idle => None,
             ResState::Acquiring { deadline, .. } => Some(*deadline),
             ResState::Reserved { info, .. } => Some(info.renew_at_mono_ms),
@@ -941,7 +948,7 @@ impl Housekeeping {
     pub(crate) fn new(config: &crate::NatConfig) -> Self {
         Self {
             prober: Prober::new(!config.autonat_servers.is_empty()),
-            reservations: ReservationManager::new(),
+            reservations: ReservationManager::new(config),
         }
     }
 

--- a/crates/nat/src/housekeeping.rs
+++ b/crates/nat/src/housekeeping.rs
@@ -13,7 +13,7 @@ use alloc::vec::Vec;
 use minip2p_autonat::{
     AUTONAT_PROTOCOL_ID, AutoNatClient, AutoNatClientInput, AutoNatClientOutput, Reachability,
 };
-use minip2p_core::{PeerAddr, PeerId, SansIoProtocol};
+use minip2p_core::{Multiaddr, PeerAddr, PeerId, SansIoProtocol, select_direct_candidates};
 use minip2p_relay::{
     HOP_PROTOCOL_ID, HopReservation, HopReservationInput, HopReservationOutput, ReservationOutcome,
 };
@@ -66,6 +66,8 @@ pub(crate) struct Prober {
     verdict: ReachabilityState,
     /// Sliding window of recent samples (`true` = public).
     window: Vec<bool>,
+    /// Most recently confirmed, directly dialable public addresses.
+    public_addrs: Vec<Multiaddr>,
     flight: Option<ProbeFlight>,
     next_probe_at: Option<u64>,
     server_idx: usize,
@@ -76,6 +78,7 @@ impl Prober {
         Self {
             verdict: ReachabilityState::Unknown,
             window: Vec::new(),
+            public_addrs: Vec::new(),
             flight: None,
             // Without configured servers there is nothing to schedule, and
             // the agent must not report a phantom timeout.
@@ -176,6 +179,20 @@ impl Prober {
             && flight.server.peer_id() == peer
         {
             self.abort_flight(shared, now);
+        }
+    }
+
+    fn on_peer_superseded(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
+        if self
+            .flight
+            .as_ref()
+            .is_some_and(|flight| flight.server.peer_id() == peer)
+        {
+            // The old connection's stream ids are invalid, but resetting
+            // them would target the replacement connection.
+            self.flight = None;
+            self.server_idx += 1;
+            self.next_probe_at = Some(now.mono_ms + shared.config.probe_interval_unsettled_ms);
         }
     }
 
@@ -330,9 +347,12 @@ impl Prober {
         shared: &mut Shared,
         _now: Now,
     ) -> bool {
-        let sample = match reachability {
-            Reachability::Public { .. } => true,
-            Reachability::Private { .. } => false,
+        let (sample, sample_addrs) = match reachability {
+            Reachability::Public { addrs, .. } => (
+                true,
+                select_direct_candidates(addrs, None, None).into_addrs(),
+            ),
+            Reachability::Private { .. } => (false, Vec::new()),
             // No signal: never move the window on an inconclusive probe.
             Reachability::Unknown { .. } => return false,
         };
@@ -356,10 +376,25 @@ impl Prober {
             self.verdict
         };
         if new == self.verdict {
+            if new == ReachabilityState::Public && sample && sample_addrs != self.public_addrs {
+                self.public_addrs = sample_addrs.clone();
+                shared.push_event(NatEvent::PublicAddressesChanged {
+                    addrs: sample_addrs,
+                });
+            }
             return false;
         }
         let old = core::mem::replace(&mut self.verdict, new);
-        shared.push_event(NatEvent::ReachabilityChanged { old, new });
+        self.public_addrs = if new == ReachabilityState::Public && sample {
+            sample_addrs
+        } else {
+            Vec::new()
+        };
+        shared.push_event(NatEvent::ReachabilityChanged {
+            old,
+            new,
+            confirmed_addrs: self.public_addrs.clone(),
+        });
         true
     }
 
@@ -635,6 +670,28 @@ impl ReservationManager {
         }
     }
 
+    fn on_peer_superseded(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
+        match &self.state {
+            ResState::Reserved { relay, .. } if relay.peer_id() == peer => {
+                shared.push_event(NatEvent::RelayReservationLost {
+                    relay: peer.clone(),
+                });
+                self.relay_idx += 1;
+                self.state = ResState::Backoff {
+                    until: now.mono_ms + shared.config.reservation_retry_backoff_ms,
+                };
+            }
+            ResState::Acquiring { relay, .. } if relay.peer_id() == peer => {
+                // Do not reset the retired stream id on the new connection.
+                self.relay_idx += 1;
+                self.state = ResState::Backoff {
+                    until: now.mono_ms + shared.config.reservation_retry_backoff_ms,
+                };
+            }
+            _ => {}
+        }
+    }
+
     fn on_dial_result(
         &mut self,
         result: &Result<ConnectionId, String>,
@@ -901,6 +958,11 @@ impl Housekeeping {
     pub(crate) fn on_peer_disconnected(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
         self.prober.on_peer_disconnected(peer, shared, now);
         self.reservations.on_peer_disconnected(peer, shared, now);
+    }
+
+    pub(crate) fn on_peer_superseded(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
+        self.prober.on_peer_superseded(peer, shared, now);
+        self.reservations.on_peer_superseded(peer, shared, now);
     }
 
     pub(crate) fn on_probe_dial_result(

--- a/crates/nat/src/housekeeping.rs
+++ b/crates/nat/src/housekeeping.rs
@@ -903,7 +903,7 @@ impl Housekeeping {
                 self.reservations
                     .on_stream_input(stream, input, shared, now);
             }
-            StreamRole::HopConnect(_) => {}
+            StreamRole::HopConnect(_) | StreamRole::StopInbound(_) => {}
         }
     }
 

--- a/crates/nat/src/inbound.rs
+++ b/crates/nat/src/inbound.rs
@@ -1,0 +1,380 @@
+//! Responder-side hole punching: a NAT'd listener holding a relay
+//! reservation accepts inbound STOP circuits, answers the initiator's DCUtR
+//! exchange, and punches back — dialing the initiator's observed addresses
+//! and blasting random UDP datagrams to open its own NAT mapping.
+//!
+//! ```text
+//! relay opens STOP stream ──▶ CONNECT ──▶ auto-Accept (STATUS:OK)
+//!   ──▶ DCUtR CONNECT arrives ──▶ reply with our observed addresses
+//!   ──▶ SYNC arrives ──▶ dial initiator's addrs + schedule UDP blasts,
+//!       release the bridge to the app (InboundRelayCircuit)
+//! direct connection appears ──▶ cancel blasts, InboundDirectUpgrade
+//! ```
+
+use alloc::vec::Vec;
+
+use minip2p_core::{Multiaddr, PeerAddr, PeerId, SansIoProtocol, select_direct_candidates};
+use minip2p_dcutr::{DcutrResponder, DcutrResponderInput, DcutrResponderOutput, ResponderEvent};
+use minip2p_relay::{Status, StopResponder, StopResponderInput, StopResponderOutput};
+use minip2p_transport::StreamId;
+
+use crate::agent::{Shared, StreamInput, TokenPurpose};
+use crate::events::{NatAction, NatEvent};
+use crate::types::Now;
+
+/// Responder-side UDP blast schedule during the punch window.
+struct BlastSchedule {
+    addrs: Vec<Multiaddr>,
+    next_at: u64,
+    until: u64,
+}
+
+/// One inbound relay circuit: STOP acceptance, DCUtR responder exchange,
+/// and the punch-back (dials + UDP blasts).
+pub(crate) struct InboundCircuit {
+    /// The peer that opened the STOP stream to us (the relay).
+    relay: PeerId,
+    stream: StreamId,
+    /// The initiating peer, once the STOP CONNECT names it.
+    source: Option<PeerId>,
+    stop: Option<StopResponder>,
+    dcutr: Option<DcutrResponder>,
+    remote_addrs: Vec<Multiaddr>,
+    /// Deadline for the STOP + DCUtR exchange to finish; after it the
+    /// bridge is released to the app punch-less rather than abandoned.
+    exchange_deadline: u64,
+    blast: Option<BlastSchedule>,
+    /// Keep the circuit alive for upgrade detection until this instant
+    /// (covers the initiator's full retry window, not just our blasts).
+    linger_until: Option<u64>,
+    /// The bridge stream has been handed to the application.
+    released: bool,
+    done: bool,
+}
+
+impl InboundCircuit {
+    /// Claims a freshly negotiated inbound STOP stream.
+    pub(crate) fn new(relay: PeerId, stream: StreamId, shared: &Shared, now: Now) -> Self {
+        Self {
+            relay,
+            stream,
+            source: None,
+            stop: Some(StopResponder::new()),
+            dcutr: None,
+            remote_addrs: Vec::new(),
+            exchange_deadline: now.mono_ms + shared.config.relay_leg_deadline_ms,
+            blast: None,
+            linger_until: None,
+            released: false,
+            done: false,
+        }
+    }
+
+    pub(crate) fn is_done(&self) -> bool {
+        self.done
+    }
+
+    pub(crate) fn next_deadline(&self) -> Option<u64> {
+        if self.done {
+            return None;
+        }
+        let mut due: Option<u64> = None;
+        if !self.released {
+            due = Some(self.exchange_deadline);
+        }
+        if let Some(blast) = &self.blast {
+            let next = blast.next_at.min(blast.until);
+            due = Some(due.map_or(next, |d| d.min(next)));
+        }
+        if let Some(linger) = self.linger_until {
+            due = Some(due.map_or(linger, |d| d.min(linger)));
+        }
+        due
+    }
+
+    pub(crate) fn on_stream_input(
+        &mut self,
+        stream: StreamId,
+        input: StreamInput<'_>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        if self.done || stream != self.stream {
+            return;
+        }
+        match input {
+            StreamInput::Data(data) => {
+                if self.source.is_none() {
+                    self.on_stop_data(data, shared, now);
+                } else {
+                    self.on_bridge_data(data, shared, now);
+                }
+            }
+            StreamInput::Closed | StreamInput::RemoteWriteClosed => {
+                // The circuit died before the app took over.
+                self.abandon(shared, false);
+            }
+            StreamInput::Ready => {}
+        }
+    }
+
+    /// Feeds bytes into the STOP responder until the CONNECT request is
+    /// decoded, then auto-accepts and starts the DCUtR responder.
+    fn on_stop_data(&mut self, data: &[u8], shared: &mut Shared, now: Now) {
+        let Some(stop) = self.stop.as_mut() else {
+            return;
+        };
+        if stop
+            .handle_input(StopResponderInput::Data(data.to_vec()))
+            .is_err()
+        {
+            self.abandon(shared, true);
+            return;
+        }
+        let request = loop {
+            match stop.poll_output() {
+                Some(StopResponderOutput::Request(request)) => break Some(request),
+                Some(_) => {}
+                None => break None,
+            }
+        };
+        let Some(request) = request else {
+            return;
+        };
+
+        let Ok(source) = PeerId::from_bytes(&request.source_peer_id) else {
+            // Unusable source identity: reject and drop the circuit.
+            let _ = stop.handle_input(StopResponderInput::Reject(Status::MalformedMessage));
+            let mut outbound = Vec::new();
+            while let Some(output) = stop.poll_output() {
+                if let StopResponderOutput::Outbound(bytes) = output {
+                    outbound.push(bytes);
+                }
+            }
+            for bytes in outbound {
+                shared.push_action(NatAction::SendStream {
+                    peer: self.relay.clone(),
+                    stream_id: self.stream,
+                    data: bytes,
+                });
+            }
+            self.abandon(shared, true);
+            return;
+        };
+
+        if stop.handle_input(StopResponderInput::Accept).is_err() {
+            self.abandon(shared, true);
+            return;
+        }
+        self.source = Some(source);
+
+        // STATUS:OK first, then any bytes the relay pipelined behind the
+        // CONNECT — those already belong to the DCUtR exchange and must
+        // reach the machine inside this same cascade.
+        let mut outbound = Vec::new();
+        let mut pipelined = Vec::new();
+        while let Some(output) = stop.poll_output() {
+            match output {
+                StopResponderOutput::Outbound(bytes) => outbound.push(bytes),
+                StopResponderOutput::BridgeData(bytes) => pipelined.extend(bytes),
+                StopResponderOutput::Request(_) => {}
+            }
+        }
+        self.stop = None;
+        for bytes in outbound {
+            shared.push_action(NatAction::SendStream {
+                peer: self.relay.clone(),
+                stream_id: self.stream,
+                data: bytes,
+            });
+        }
+
+        self.dcutr = Some(DcutrResponder::new(&shared.listen_addrs));
+        if !pipelined.is_empty() {
+            self.on_bridge_data(&pipelined, shared, now);
+        }
+    }
+
+    /// Feeds bridge bytes into the DCUtR responder.
+    fn on_bridge_data(&mut self, data: &[u8], shared: &mut Shared, now: Now) {
+        let Some(dcutr) = self.dcutr.as_mut() else {
+            return;
+        };
+        if dcutr
+            .handle_input(DcutrResponderInput::Data(data.to_vec()))
+            .is_err()
+        {
+            // The punch cannot proceed (malformed exchange or our own
+            // oversized reply), but the bridge itself is fine: hand it to
+            // the app without punching.
+            self.dcutr = None;
+            self.release_to_app(shared);
+            return;
+        }
+        let mut outputs = Vec::new();
+        while let Some(output) = dcutr.poll_output() {
+            outputs.push(output);
+        }
+        for output in outputs {
+            match output {
+                DcutrResponderOutput::Outbound(bytes) => {
+                    shared.push_action(NatAction::SendStream {
+                        peer: self.relay.clone(),
+                        stream_id: self.stream,
+                        data: bytes,
+                    });
+                }
+                DcutrResponderOutput::Event(ResponderEvent::ConnectReceived {
+                    remote_addrs,
+                    ..
+                }) => {
+                    self.remote_addrs =
+                        select_direct_candidates(&remote_addrs, None, None).into_addrs();
+                }
+                DcutrResponderOutput::Event(ResponderEvent::SyncReceived) => {
+                    self.on_sync(shared, now);
+                }
+            }
+        }
+    }
+
+    /// SYNC arrived: punch back (simultaneous dials + UDP blasts) and hand
+    /// the bridge to the application.
+    fn on_sync(&mut self, shared: &mut Shared, now: Now) {
+        self.dcutr = None;
+        let Some(source) = self.source.clone() else {
+            return;
+        };
+
+        for addr in &self.remote_addrs {
+            let Ok(peer_addr) = PeerAddr::new(addr.clone(), source.clone()) else {
+                continue;
+            };
+            let token = shared.alloc_token(TokenPurpose::InboundPunchDial);
+            shared.push_action(NatAction::Dial {
+                token,
+                addr: peer_addr,
+            });
+        }
+        if !self.remote_addrs.is_empty() {
+            self.blast = Some(BlastSchedule {
+                addrs: self.remote_addrs.clone(),
+                // The spec says wait ~RTT/2 after SYNC; without a measured
+                // RTT this configured floor stands in for it.
+                next_at: now.mono_ms + shared.config.responder_sync_delay_ms,
+                until: now.mono_ms + shared.config.punch_deadline_ms,
+            });
+        }
+        // Stay alive for upgrade detection across the initiator's full
+        // retry window.
+        let window =
+            shared.config.punch_deadline_ms * (1 + u64::from(shared.config.punch_max_retries));
+        self.linger_until = Some(now.mono_ms + window);
+        self.release_to_app(shared);
+    }
+
+    /// Hands the bridge stream to the application, exactly once.
+    fn release_to_app(&mut self, shared: &mut Shared) {
+        if self.released {
+            return;
+        }
+        self.released = true;
+        shared.release_stream(&self.relay, self.stream);
+        if let Some(source) = &self.source {
+            shared.push_event(NatEvent::InboundRelayCircuit {
+                peer: source.clone(),
+                stream_id: self.stream,
+                // Bytes coalesced behind the SYNC frame inside one read are
+                // consumed by the DCUtR machine; in practice application
+                // data starts in later packets.
+                pending_data: Vec::new(),
+            });
+        }
+        if self.blast.is_none() && self.linger_until.is_none() {
+            self.done = true;
+        }
+    }
+
+    pub(crate) fn on_tick(&mut self, shared: &mut Shared, now: Now) {
+        if self.done {
+            return;
+        }
+        if !self.released && now.mono_ms >= self.exchange_deadline {
+            if self.source.is_some() {
+                // The punch exchange stalled, but the accepted bridge is
+                // perfectly usable: give it to the app without punching.
+                self.dcutr = None;
+                self.release_to_app(shared);
+            } else {
+                // The relay never even sent CONNECT.
+                self.abandon(shared, true);
+                return;
+            }
+        }
+        if let Some(blast) = &mut self.blast {
+            while now.mono_ms >= blast.next_at && blast.next_at <= blast.until {
+                for addr in &blast.addrs {
+                    shared.push_action(NatAction::SendRandomUdp {
+                        target: addr.clone(),
+                        payload_len: shared.config.blast_payload_len,
+                    });
+                }
+                blast.next_at += shared.config.blast_interval_ms;
+            }
+            if now.mono_ms >= blast.until {
+                self.blast = None;
+            }
+        }
+        if let Some(linger) = self.linger_until
+            && now.mono_ms >= linger
+        {
+            self.linger_until = None;
+            self.blast = None;
+            if self.released {
+                self.done = true;
+            }
+        }
+    }
+
+    /// The initiator's (or our) punch landed: the peer is directly
+    /// connected.
+    pub(crate) fn on_peer_connected(&mut self, peer: &PeerId, shared: &mut Shared, _now: Now) {
+        if self.done || self.source.as_ref() != Some(peer) {
+            return;
+        }
+        self.blast = None;
+        self.linger_until = None;
+        shared.push_event(NatEvent::InboundDirectUpgrade { peer: peer.clone() });
+        if self.released {
+            self.done = true;
+        }
+    }
+
+    /// The relay connection died. Before release the circuit is gone; after
+    /// release the app owns the (now dead) stream and the punch-back may
+    /// still land, so the circuit lingers.
+    pub(crate) fn on_relay_disconnected(&mut self, peer: &PeerId, _shared: &mut Shared) {
+        if self.done || &self.relay != peer {
+            return;
+        }
+        if !self.released {
+            // Registry entries for the dead connection are dropped by the
+            // agent; nothing to reset.
+            self.done = true;
+        }
+    }
+
+    /// Drops the circuit before the app ever saw it.
+    fn abandon(&mut self, shared: &mut Shared, reset: bool) {
+        if !self.released {
+            if reset {
+                shared.push_action(NatAction::ResetStream {
+                    peer: self.relay.clone(),
+                    stream_id: self.stream,
+                });
+            }
+            shared.release_stream(&self.relay, self.stream);
+        }
+        self.done = true;
+    }
+}

--- a/crates/nat/src/inbound.rs
+++ b/crates/nat/src/inbound.rs
@@ -43,6 +43,9 @@ pub(crate) struct InboundCircuit {
     /// Application bytes received after the final DCUtR SYNC frame in the
     /// same stream read. These must accompany the raw bridge handoff.
     pending_data: Vec<u8>,
+    /// The remote write half reached EOF while the control plane still owned
+    /// the bridge. The transport will not repeat that event after handoff.
+    remote_write_closed: bool,
     /// Deadline for the STOP + DCUtR exchange to finish; after it the
     /// bridge is released to the app punch-less rather than abandoned.
     exchange_deadline: u64,
@@ -66,6 +69,7 @@ impl InboundCircuit {
             dcutr: None,
             remote_addrs: Vec::new(),
             pending_data: Vec::new(),
+            remote_write_closed: false,
             exchange_deadline: now.mono_ms + shared.config.relay_leg_deadline_ms,
             blast: None,
             linger_until: None,
@@ -115,6 +119,7 @@ impl InboundCircuit {
                 }
             }
             StreamInput::RemoteWriteClosed => {
+                self.remote_write_closed = true;
                 // A peer can stop sending while the local write half remains
                 // usable. Let the protocol parser consume that boundary and
                 // retain the circuit until its normal exchange deadline.
@@ -254,7 +259,7 @@ impl InboundCircuit {
             }
         }
         if sync_received {
-            self.pending_data = dcutr.take_trailing_data();
+            self.pending_data = dcutr.take_trailing_data().unwrap_or_default();
             self.on_sync(shared, now);
         }
     }
@@ -306,6 +311,7 @@ impl InboundCircuit {
                 peer: source.clone(),
                 stream_id: self.stream,
                 pending_data: core::mem::take(&mut self.pending_data),
+                remote_write_closed: self.remote_write_closed,
             });
         }
         if self.blast.is_none() && self.linger_until.is_none() {

--- a/crates/nat/src/inbound.rs
+++ b/crates/nat/src/inbound.rs
@@ -40,6 +40,9 @@ pub(crate) struct InboundCircuit {
     stop: Option<StopResponder>,
     dcutr: Option<DcutrResponder>,
     remote_addrs: Vec<Multiaddr>,
+    /// Application bytes received after the final DCUtR SYNC frame in the
+    /// same stream read. These must accompany the raw bridge handoff.
+    pending_data: Vec<u8>,
     /// Deadline for the STOP + DCUtR exchange to finish; after it the
     /// bridge is released to the app punch-less rather than abandoned.
     exchange_deadline: u64,
@@ -62,6 +65,7 @@ impl InboundCircuit {
             stop: Some(StopResponder::new()),
             dcutr: None,
             remote_addrs: Vec::new(),
+            pending_data: Vec::new(),
             exchange_deadline: now.mono_ms + shared.config.relay_leg_deadline_ms,
             blast: None,
             linger_until: None,
@@ -110,7 +114,17 @@ impl InboundCircuit {
                     self.on_bridge_data(data, shared, now);
                 }
             }
-            StreamInput::Closed | StreamInput::RemoteWriteClosed => {
+            StreamInput::RemoteWriteClosed => {
+                // A peer can stop sending while the local write half remains
+                // usable. Let the protocol parser consume that boundary and
+                // retain the circuit until its normal exchange deadline.
+                if self.source.is_none() {
+                    self.on_stop_input(StopResponderInput::RemoteWriteClosed, shared, now);
+                } else {
+                    self.on_dcutr_input(DcutrResponderInput::RemoteWriteClosed, shared, now);
+                }
+            }
+            StreamInput::Closed => {
                 // The circuit died before the app took over.
                 self.abandon(shared, false);
             }
@@ -121,13 +135,14 @@ impl InboundCircuit {
     /// Feeds bytes into the STOP responder until the CONNECT request is
     /// decoded, then auto-accepts and starts the DCUtR responder.
     fn on_stop_data(&mut self, data: &[u8], shared: &mut Shared, now: Now) {
+        self.on_stop_input(StopResponderInput::Data(data.to_vec()), shared, now);
+    }
+
+    fn on_stop_input(&mut self, input: StopResponderInput, shared: &mut Shared, now: Now) {
         let Some(stop) = self.stop.as_mut() else {
             return;
         };
-        if stop
-            .handle_input(StopResponderInput::Data(data.to_vec()))
-            .is_err()
-        {
+        if stop.handle_input(input).is_err() {
             self.abandon(shared, true);
             return;
         }
@@ -197,13 +212,14 @@ impl InboundCircuit {
 
     /// Feeds bridge bytes into the DCUtR responder.
     fn on_bridge_data(&mut self, data: &[u8], shared: &mut Shared, now: Now) {
+        self.on_dcutr_input(DcutrResponderInput::Data(data.to_vec()), shared, now);
+    }
+
+    fn on_dcutr_input(&mut self, input: DcutrResponderInput, shared: &mut Shared, now: Now) {
         let Some(dcutr) = self.dcutr.as_mut() else {
             return;
         };
-        if dcutr
-            .handle_input(DcutrResponderInput::Data(data.to_vec()))
-            .is_err()
-        {
+        if dcutr.handle_input(input).is_err() {
             // The punch cannot proceed (malformed exchange or our own
             // oversized reply), but the bridge itself is fine: hand it to
             // the app without punching.
@@ -215,6 +231,7 @@ impl InboundCircuit {
         while let Some(output) = dcutr.poll_output() {
             outputs.push(output);
         }
+        let mut sync_received = false;
         for output in outputs {
             match output {
                 DcutrResponderOutput::Outbound(bytes) => {
@@ -232,9 +249,13 @@ impl InboundCircuit {
                         select_direct_candidates(&remote_addrs, None, None).into_addrs();
                 }
                 DcutrResponderOutput::Event(ResponderEvent::SyncReceived) => {
-                    self.on_sync(shared, now);
+                    sync_received = true;
                 }
             }
+        }
+        if sync_received {
+            self.pending_data = dcutr.take_trailing_data();
+            self.on_sync(shared, now);
         }
     }
 
@@ -284,10 +305,7 @@ impl InboundCircuit {
             shared.push_event(NatEvent::InboundRelayCircuit {
                 peer: source.clone(),
                 stream_id: self.stream,
-                // Bytes coalesced behind the SYNC frame inside one read are
-                // consumed by the DCUtR machine; in practice application
-                // data starts in later packets.
-                pending_data: Vec::new(),
+                pending_data: core::mem::take(&mut self.pending_data),
             });
         }
         if self.blast.is_none() && self.linger_until.is_none() {
@@ -312,6 +330,8 @@ impl InboundCircuit {
             }
         }
         if let Some(blast) = &mut self.blast {
+            let interval = shared.config.blast_interval_ms.max(1);
+            let mut exhausted = false;
             while now.mono_ms >= blast.next_at && blast.next_at <= blast.until {
                 for addr in &blast.addrs {
                     shared.push_action(NatAction::SendRandomUdp {
@@ -319,9 +339,15 @@ impl InboundCircuit {
                         payload_len: shared.config.blast_payload_len,
                     });
                 }
-                blast.next_at += shared.config.blast_interval_ms;
+                match blast.next_at.checked_add(interval) {
+                    Some(next_at) => blast.next_at = next_at,
+                    None => {
+                        exhausted = true;
+                        break;
+                    }
+                }
             }
-            if now.mono_ms >= blast.until {
+            if now.mono_ms >= blast.until || exhausted {
                 self.blast = None;
             }
         }

--- a/crates/nat/src/lib.rs
+++ b/crates/nat/src/lib.rs
@@ -40,9 +40,10 @@ mod agent;
 mod attempt;
 mod config;
 mod events;
+mod housekeeping;
 mod types;
 
 pub use agent::NatAgent;
 pub use config::{NatConfig, ReservationPolicy};
 pub use events::{NatAction, NatEvent};
-pub use types::{ConnectId, NatError, NatToken, Now, Path, ReachabilityState};
+pub use types::{ConnectId, NatError, NatToken, Now, Path, ReachabilityState, ReservationInfo};

--- a/crates/nat/src/lib.rs
+++ b/crates/nat/src/lib.rs
@@ -48,3 +48,9 @@ pub use agent::NatAgent;
 pub use config::{NatConfig, ReservationPolicy};
 pub use events::{NatAction, NatEvent};
 pub use types::{ConnectId, NatError, NatToken, Now, Path, ReachabilityState, ReservationInfo};
+
+// Protocol ids for everything the agent drives, so a driver can register
+// them without depending on each protocol crate.
+pub use minip2p_autonat::AUTONAT_PROTOCOL_ID;
+pub use minip2p_dcutr::DCUTR_PROTOCOL_ID;
+pub use minip2p_relay::{HOP_PROTOCOL_ID, STOP_PROTOCOL_ID};

--- a/crates/nat/src/lib.rs
+++ b/crates/nat/src/lib.rs
@@ -13,8 +13,8 @@
 //! t0      direct leg: dial every validated candidate address
 //! t0+δ    relay leg (stagger δ, 0 = fully parallel):
 //!           ensure relay session → HOP CONNECT(target)
-//!           → Bridged ⇒ PathEstablished(Relayed) (usable NOW)
-//!           → immediately start a DCUtR punch over the bridge, in parallel
+//!           → Bridged ⇒ start a DCUtR punch over the bridge
+//!           → after SYNC, release bridge ⇒ PathEstablished(Relayed)
 //! first usable path wins; a better path later ⇒ explicit PathUpgraded
 //! "fallback" is not a phase — it is what remains when the punch leg
 //! exhausts (FellBackToRelay)

--- a/crates/nat/src/lib.rs
+++ b/crates/nat/src/lib.rs
@@ -41,6 +41,7 @@ mod attempt;
 mod config;
 mod events;
 mod housekeeping;
+mod inbound;
 mod types;
 
 pub use agent::NatAgent;

--- a/crates/nat/src/lib.rs
+++ b/crates/nat/src/lib.rs
@@ -1,0 +1,48 @@
+//! Sans-I/O NAT-traversal orchestrator for minip2p.
+//!
+//! The protocol machines for relay circuits ([`minip2p_relay`]), hole
+//! punching ([`minip2p_dcutr`]), and reachability probing live in their own
+//! crates; this crate provides the missing orchestrator: [`NatAgent`], a
+//! single state machine that races direct dials against a relayed circuit
+//! and upgrades to a punched direct connection when it can.
+//!
+//! Connection model — parallel racing with convergence, not sequential
+//! fallback:
+//!
+//! ```text
+//! t0      direct leg: dial every validated candidate address
+//! t0+δ    relay leg (stagger δ, 0 = fully parallel):
+//!           ensure relay session → HOP CONNECT(target)
+//!           → Bridged ⇒ PathEstablished(Relayed) (usable NOW)
+//!           → immediately start a DCUtR punch over the bridge, in parallel
+//! first usable path wins; a better path later ⇒ explicit PathUpgraded
+//! "fallback" is not a phase — it is what remains when the punch leg
+//! exhausts (FellBackToRelay)
+//! ```
+//!
+//! The agent performs no I/O and reads no clocks: feed it swarm events by
+//! reference via [`NatAgent::handle_event`], time via [`NatAgent::handle_tick`],
+//! and execute the [`NatAction`]s it emits against a [`minip2p_swarm::Swarm`]
+//! (or any equivalent runtime). Events for streams the agent does not own
+//! cost one map lookup and zero clones.
+//!
+//! The relayed path is a **raw bridge stream**, not a full swarm connection:
+//! no identify, ping, or multistream-select runs over it. See
+//! [`Path::Relayed`].
+//!
+//! `no_std` + `alloc` compatible.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+mod agent;
+mod attempt;
+mod config;
+mod events;
+mod types;
+
+pub use agent::NatAgent;
+pub use config::{NatConfig, ReservationPolicy};
+pub use events::{NatAction, NatEvent};
+pub use types::{ConnectId, NatError, NatToken, Now, Path, ReachabilityState};

--- a/crates/nat/src/types.rs
+++ b/crates/nat/src/types.rs
@@ -71,6 +71,10 @@ pub enum Path {
         relay: PeerId,
         /// The bridged stream (originally the HOP CONNECT stream).
         stream_id: StreamId,
+        /// Whether the remote write half reached EOF while the NAT control
+        /// plane still owned the bridge. When true, the original stream event
+        /// was consumed and will not be delivered again.
+        remote_write_closed: bool,
     },
 }
 

--- a/crates/nat/src/types.rs
+++ b/crates/nat/src/types.rs
@@ -1,0 +1,115 @@
+use minip2p_core::PeerId;
+use minip2p_transport::StreamId;
+
+/// Clock sample supplied by the driver with every input.
+///
+/// The agent never reads clocks itself. `mono_ms` orders all internal
+/// deadlines; `unix_secs` is only needed to schedule relay-reservation
+/// renewal from the absolute `expire` timestamp a relay returns, and may be
+/// `None` on hosts without a real-time clock (renewal then falls back to a
+/// configured default TTL).
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Now {
+    /// Monotonic milliseconds. Any epoch, as long as it never goes backward.
+    pub mono_ms: u64,
+    /// Wall-clock seconds since the unix epoch, if available.
+    pub unix_secs: Option<u64>,
+}
+
+impl Now {
+    /// A `Now` carrying only a monotonic reading.
+    pub fn from_mono(mono_ms: u64) -> Self {
+        Self {
+            mono_ms,
+            unix_secs: None,
+        }
+    }
+}
+
+/// Handle identifying one [`NatAgent::connect`](crate::NatAgent::connect)
+/// intent across its actions and events.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ConnectId(pub(crate) u64);
+
+/// Opaque correlation token for a pending [`NatAction::Dial`] or
+/// [`NatAction::OpenStream`].
+///
+/// The driver executes the synchronous swarm call and echoes the token back
+/// unchanged via [`NatAgent::dial_result`](crate::NatAgent::dial_result) /
+/// [`NatAgent::stream_open_result`](crate::NatAgent::stream_open_result).
+///
+/// [`NatAction::Dial`]: crate::NatAction::Dial
+/// [`NatAction::OpenStream`]: crate::NatAction::OpenStream
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct NatToken(pub(crate) u64);
+
+/// A usable path to a peer.
+///
+/// Ranking: [`Path::DirectDialed`] ≈ [`Path::DirectPunched`] >
+/// [`Path::Relayed`]. When a better path becomes available after a worse one
+/// was announced, the agent emits an explicit
+/// [`NatEvent::PathUpgraded`](crate::NatEvent::PathUpgraded) — never a silent
+/// switch.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Path {
+    /// A direct QUIC connection established by dialing a known candidate
+    /// address. Use the ordinary swarm APIs with the peer id.
+    DirectDialed,
+    /// A direct QUIC connection established by a DCUtR hole punch. Use the
+    /// ordinary swarm APIs with the peer id.
+    DirectPunched,
+    /// A raw bridged relay stream.
+    ///
+    /// **This is not a full swarm connection.** No identify, ping, or
+    /// multistream-select negotiation runs over the circuit; the application
+    /// exchanges raw bytes on `stream_id` (addressed to `relay`) with
+    /// `Swarm::send_stream` and receives them as ordinary `StreamData`
+    /// events. A circuit transport that makes a relayed path look like any
+    /// other connection is future work.
+    Relayed {
+        /// The relay peer the bridge stream runs through.
+        relay: PeerId,
+        /// The bridged stream (originally the HOP CONNECT stream).
+        stream_id: StreamId,
+    },
+}
+
+impl Path {
+    /// Returns `true` for direct (dialed or punched) paths.
+    pub fn is_direct(&self) -> bool {
+        !matches!(self, Self::Relayed { .. })
+    }
+}
+
+/// Our current view of this node's reachability from the public internet.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ReachabilityState {
+    /// Not enough probe evidence yet.
+    #[default]
+    Unknown,
+    /// Confidently reachable: inbound dials to our advertised addresses work.
+    Public,
+    /// Confidently unreachable: we need a relay reservation to be dialable.
+    Private,
+}
+
+/// Terminal errors for a connect attempt, carried by
+/// [`NatEvent::ConnectFailed`](crate::NatEvent::ConnectFailed).
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum NatError {
+    /// No dialable direct candidates and no relay configured.
+    #[error("no dialable candidates and no relay configured")]
+    NoPathAvailable,
+    /// The connect deadline elapsed before any path was established.
+    #[error("connect deadline elapsed before any path was established")]
+    Timeout,
+    /// A dial was rejected or a connection was lost.
+    #[error("dial failed: {0}")]
+    DialFailed(alloc::string::String),
+    /// A protocol state machine rejected the exchange.
+    #[error("protocol error: {0}")]
+    Protocol(alloc::string::String),
+    /// The relay refused the circuit.
+    #[error("relay refused: {0}")]
+    RelayRefused(alloc::string::String),
+}

--- a/crates/nat/src/types.rs
+++ b/crates/nat/src/types.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use minip2p_core::PeerId;
 use minip2p_transport::StreamId;
 
@@ -71,6 +73,11 @@ pub enum Path {
         relay: PeerId,
         /// The bridged stream (originally the HOP CONNECT stream).
         stream_id: StreamId,
+        /// Application bytes received in the same transport read after the
+        /// final initiator-side DCUtR frame. Consume these before waiting for
+        /// later `StreamData` events; they are surfaced exactly once on the
+        /// original relayed `PathEstablished` event.
+        pending_data: Vec<u8>,
         /// Whether the remote write half reached EOF while the NAT control
         /// plane still owned the bridge. When true, the original stream event
         /// was consumed and will not be delivered again.

--- a/crates/nat/src/types.rs
+++ b/crates/nat/src/types.rs
@@ -93,6 +93,18 @@ pub enum ReachabilityState {
     Private,
 }
 
+/// A currently held relay reservation, as reported by
+/// [`NatAgent::active_reservation`](crate::NatAgent::active_reservation).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReservationInfo {
+    /// The relay holding the reservation.
+    pub relay: PeerId,
+    /// Absolute expiry reported by the relay, if any.
+    pub expires_unix_secs: Option<u64>,
+    /// When renewal fires, on the driver's monotonic clock.
+    pub renew_at_mono_ms: u64,
+}
+
 /// Terminal errors for a connect attempt, carried by
 /// [`NatEvent::ConnectFailed`](crate::NatEvent::ConnectFailed).
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -209,7 +209,7 @@ fn unconfigured_peer_cannot_claim_an_inbound_stop_stream() {
     let mut h = Harness::without_relay(NatConfig::default());
     let attacker = peer(b"untrusted-peer");
     let stream = StreamId::new(88);
-    h.agent.handle_event(
+    let handled = h.agent.handle_event_with_disposition(
         &SwarmEvent::StreamReady {
             peer_id: attacker.clone(),
             stream_id: stream,
@@ -219,7 +219,9 @@ fn unconfigured_peer_cannot_claim_an_inbound_stop_stream() {
         at(0),
     );
 
+    assert!(handled, "rejected NAT control streams stay internal");
     assert!(!h.agent.owns_stream(&attacker, stream));
+    assert!(has_reset_for(&drain_actions(&mut h.agent), stream));
     h.agent.handle_event(
         &SwarmEvent::StreamData {
             peer_id: attacker,
@@ -233,9 +235,9 @@ fn unconfigured_peer_cannot_claim_an_inbound_stop_stream() {
 }
 
 #[test]
-fn remote_write_close_during_dcutr_is_not_a_full_bridge_close() {
+fn remote_write_close_during_dcutr_releases_relay_and_keeps_direct_dials_live() {
     let mut h = Harness::with_relay(NatConfig::default());
-    let (_, stream) = drive_to_bridged(&mut h, 0);
+    let (id, stream) = drive_to_bridged(&mut h, 0);
     drain_actions(&mut h.agent);
 
     h.agent.handle_event(
@@ -246,7 +248,68 @@ fn remote_write_close_during_dcutr_is_not_a_full_bridge_close() {
         at(310),
     );
 
+    assert!(!h.agent.owns_stream(&h.relay, stream));
+    assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [
+            NatEvent::HolePunchFailed { connect_id: failed, .. },
+            NatEvent::PathEstablished {
+                connect_id,
+                path: Path::Relayed {
+                    remote_write_closed: true,
+                    ..
+                },
+                ..
+            }
+        ] if *failed == id && *connect_id == id
+    ));
+
+    h.target_connected(at(320));
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::PathUpgraded {
+            connect_id,
+            from: Path::Relayed {
+                remote_write_closed: true,
+                ..
+            },
+            to: Path::DirectDialed,
+            ..
+        }] if *connect_id == id
+    ));
+}
+
+#[test]
+fn relay_supersede_scrubs_old_stream_ids_without_resetting_the_new_connection() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (_, stream) = drive_to_bridged(&mut h, 0);
+    drain_actions(&mut h.agent);
     assert!(h.agent.owns_stream(&h.relay, stream));
+
+    h.agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            peer_id: h.relay.clone(),
+        },
+        at(310),
+    );
+
+    assert!(!h.agent.owns_stream(&h.relay, stream));
+    assert!(
+        !has_reset_for(&drain_actions(&mut h.agent), stream),
+        "a stale stream id must never reset a colliding stream on the replacement connection"
+    );
+
+    // The replacement connection may reuse the same stream id. Its event
+    // must not be routed into the retired attempt.
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            peer_id: h.relay.clone(),
+            stream_id: stream,
+            data: b"new connection data".to_vec(),
+        },
+        at(311),
+    );
     assert!(drain_actions(&mut h.agent).is_empty());
     assert!(drain_events(&mut h.agent).is_empty());
 }

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -534,7 +534,7 @@ fn relay_refusal_fails_when_no_direct_leg_remains() {
 }
 
 #[test]
-fn pipelined_bridge_bytes_reach_dcutr_before_any_later_event() {
+fn initiator_reply_coalesced_with_application_data_preserves_remainder() {
     let mut h = Harness::with_relay(NatConfig::default());
     let id = h.agent.connect(h.target.clone(), Vec::new(), at(0));
     let actions = drain_actions(&mut h.agent);
@@ -553,14 +553,20 @@ fn pipelined_bridge_bytes_reach_dcutr_before_any_later_event() {
     // STATUS:OK and the responder's DCUtR CONNECT coalesced in one read:
     // the pipelined bytes must feed the just-created DCUtR machine inside
     // the same cascade.
+    let app_data = b"application bytes after dcutr reply";
     let mut coalesced = hop_status(Status::Ok);
     coalesced.extend(dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]));
+    coalesced.extend_from_slice(app_data);
     h.stream_data(stream, coalesced, at(100));
 
     let events = drain_events(&mut h.agent);
     assert!(matches!(
         events.as_slice(),
-        [NatEvent::PathEstablished { connect_id, path: Path::Relayed { .. }, .. }] if *connect_id == id
+        [NatEvent::PathEstablished {
+            connect_id,
+            path: Path::Relayed { pending_data, .. },
+            ..
+        }] if *connect_id == id && pending_data == app_data
     ));
     let actions = drain_actions(&mut h.agent);
     assert_eq!(
@@ -574,6 +580,17 @@ fn pipelined_bridge_bytes_reach_dcutr_before_any_later_event() {
         "DCUtR CONNECT and SYNC both go out"
     );
     assert!(!h.agent.owns_stream(&h.relay, stream));
+
+    h.target_connected(at(110));
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::PathUpgraded {
+            connect_id,
+            from: Path::Relayed { pending_data, .. },
+            to: Path::DirectPunched,
+            ..
+        }] if *connect_id == id && pending_data.is_empty()
+    ));
 }
 
 #[test]

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -220,16 +220,35 @@ fn unconfigured_peer_cannot_claim_an_inbound_stop_stream() {
     );
 
     assert!(handled, "rejected NAT control streams stay internal");
-    assert!(!h.agent.owns_stream(&attacker, stream));
+    assert!(
+        h.agent.owns_stream(&attacker, stream),
+        "rejected stream remains owned until terminal close"
+    );
     assert!(has_reset_for(&drain_actions(&mut h.agent), stream));
-    h.agent.handle_event(
+
+    assert!(h.agent.handle_event_with_disposition(
         &SwarmEvent::StreamData {
-            peer_id: attacker,
+            peer_id: attacker.clone(),
             stream_id: stream,
             data: stop_connect(&h.target),
         },
         at(1),
-    );
+    ));
+    assert!(h.agent.handle_event_with_disposition(
+        &SwarmEvent::StreamRemoteWriteClosed {
+            peer_id: attacker.clone(),
+            stream_id: stream,
+        },
+        at(2),
+    ));
+    assert!(h.agent.handle_event_with_disposition(
+        &SwarmEvent::StreamClosed {
+            peer_id: attacker.clone(),
+            stream_id: stream,
+        },
+        at(3),
+    ));
+    assert!(!h.agent.owns_stream(&attacker, stream));
     assert!(drain_actions(&mut h.agent).is_empty());
     assert!(drain_events(&mut h.agent).is_empty());
 }

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -1,0 +1,545 @@
+//! Scripted dialer-race tests: no I/O, no clocks — every input is fed by
+//! hand and every action/event asserted.
+
+mod common;
+
+use common::*;
+
+use minip2p_core::Multiaddr;
+use minip2p_nat::{ConnectId, NatAction, NatConfig, NatError, NatEvent, Path};
+use minip2p_relay::Status;
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::{ConnectionId, StreamId};
+
+/// Drives a fresh connect attempt (with one direct candidate) through the
+/// relay leg up to `Bridged`: direct dial at t0, stagger, relay dial, HOP
+/// open/negotiate/CONNECT, STATUS:OK at t0+300.
+///
+/// Leaves the `PathEstablished(Relayed)` event and the DCUtR CONNECT send
+/// action queued for the caller to drain.
+fn drive_to_bridged(h: &mut Harness, t0: u64) -> (ConnectId, StreamId) {
+    let id = h
+        .agent
+        .connect(h.target.clone(), vec![maddr(TARGET_ADDR)], at(t0));
+    let actions = drain_actions(&mut h.agent);
+    let direct_token = dial_token_for(&actions, &h.target);
+    h.agent
+        .dial_result(direct_token, Ok(ConnectionId::new(1)), at(t0 + 5));
+
+    h.agent.handle_tick(at(t0 + 200));
+    let actions = drain_actions(&mut h.agent);
+    let relay_token = dial_token_for(&actions, &h.relay);
+    h.agent
+        .dial_result(relay_token, Ok(ConnectionId::new(2)), at(t0 + 205));
+    h.relay_session_ready(at(t0 + 210));
+
+    let actions = drain_actions(&mut h.agent);
+    let open_token = open_stream_token(&actions);
+    let stream = StreamId::new(7);
+    h.agent
+        .stream_open_result(open_token, Ok(stream), at(t0 + 215));
+    assert!(h.agent.owns_stream(&h.relay, stream));
+
+    h.stream_ready(stream, at(t0 + 220));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(send_stream_count(&actions), 1, "HOP CONNECT must be sent");
+
+    h.stream_data(stream, hop_status(Status::Ok), at(t0 + 300));
+    (id, stream)
+}
+
+/// Continues a bridged attempt through the DCUtR reply: punch dial + SYNC
+/// go out and the bridge is handed back to the application.
+fn drive_to_sync(h: &mut Harness, stream: StreamId, now_ms: u64) -> Vec<NatAction> {
+    h.stream_data(
+        stream,
+        dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]),
+        at(now_ms),
+    );
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(
+        dial_count_for(&actions, &h.target),
+        1,
+        "one punch dial for the observed address"
+    );
+    assert_eq!(send_stream_count(&actions), 1, "SYNC must be sent");
+    assert!(
+        !h.agent.owns_stream(&h.relay, stream),
+        "bridge belongs to the app once SYNC is out"
+    );
+    actions
+}
+
+#[test]
+fn direct_win_before_stagger_never_touches_the_relay() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let id = h
+        .agent
+        .connect(h.target.clone(), vec![maddr(TARGET_ADDR)], at(0));
+
+    let actions = drain_actions(&mut h.agent);
+    let token = dial_token_for(&actions, &h.target);
+    assert_eq!(dial_count_for(&actions, &h.relay), 0);
+    assert!(!has_hop_open(&actions));
+
+    h.agent.dial_result(token, Ok(ConnectionId::new(1)), at(10));
+    h.target_connected(at(50));
+
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::PathEstablished { connect_id, path: Path::DirectDialed, .. }] if *connect_id == id
+    ));
+
+    // Ticking far past the stagger must not wake a relay leg.
+    h.agent.handle_tick(at(1_000));
+    let actions = drain_actions(&mut h.agent);
+    assert!(
+        actions.is_empty(),
+        "no relay actions after a direct win: {actions:?}"
+    );
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn stagger_delays_the_relay_leg() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    h.agent
+        .connect(h.target.clone(), vec![maddr(TARGET_ADDR)], at(0));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(dial_count_for(&actions, &h.target), 1);
+    assert_eq!(dial_count_for(&actions, &h.relay), 0);
+
+    // The stagger is the earliest pending deadline.
+    assert_eq!(h.agent.next_timeout(0), Some(200));
+
+    h.agent.handle_tick(at(199));
+    assert!(drain_actions(&mut h.agent).is_empty());
+
+    h.agent.handle_tick(at(200));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(dial_count_for(&actions, &h.relay), 1);
+}
+
+#[test]
+fn zero_stagger_races_both_legs_in_parallel() {
+    let mut h = Harness::with_relay(NatConfig {
+        relay_stagger_ms: 0,
+        ..NatConfig::default()
+    });
+    h.agent
+        .connect(h.target.clone(), vec![maddr(TARGET_ADDR)], at(0));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(dial_count_for(&actions, &h.target), 1);
+    assert_eq!(dial_count_for(&actions, &h.relay), 1);
+}
+
+#[test]
+fn no_direct_candidates_skip_the_stagger() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    h.agent.connect(h.target.clone(), Vec::new(), at(0));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(
+        dial_count_for(&actions, &h.relay),
+        1,
+        "relay leg starts immediately when there is nothing to stagger against"
+    );
+}
+
+#[test]
+fn relayed_path_upgrades_to_punched_direct() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (id, stream) = drive_to_bridged(&mut h, 0);
+
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::PathEstablished { connect_id, path: Path::Relayed { stream_id, .. }, .. }]
+            if *connect_id == id && *stream_id == stream
+    ));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(
+        send_stream_count(&actions),
+        1,
+        "DCUtR CONNECT goes out on the bridge"
+    );
+
+    drive_to_sync(&mut h, stream, 350);
+
+    // The punch lands: the direct connection appears.
+    h.target_connected(at(600));
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::PathUpgraded {
+            connect_id,
+            from: Path::Relayed { .. },
+            to: Path::DirectPunched,
+            ..
+        }] if *connect_id == id
+    ));
+    let actions = drain_actions(&mut h.agent);
+    assert!(
+        has_reset_for(&actions, stream),
+        "the superseded bridge must be reset, never silently leaked"
+    );
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn punch_exhaustion_falls_back_to_the_relay() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (id, stream) = drive_to_bridged(&mut h, 0);
+    drain_events(&mut h.agent);
+    drain_actions(&mut h.agent);
+    drive_to_sync(&mut h, stream, 350);
+
+    // Default config: one window + two retries, 3s each.
+    for (tick_ms, window) in [(3_350, 1u32), (6_350, 2)] {
+        h.agent.handle_tick(at(tick_ms));
+        let events = drain_events(&mut h.agent);
+        assert!(matches!(
+            events.as_slice(),
+            [NatEvent::HolePunchFailed { attempt, .. }] if *attempt == window
+        ));
+        let actions = drain_actions(&mut h.agent);
+        assert_eq!(
+            dial_count_for(&actions, &h.target),
+            1,
+            "each retry re-dials the observed address"
+        );
+    }
+
+    h.agent.handle_tick(at(9_350));
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [
+            NatEvent::HolePunchFailed { attempt: 3, .. },
+            NatEvent::FellBackToRelay { connect_id, .. },
+        ] if *connect_id == id
+    ));
+    let actions = drain_actions(&mut h.agent);
+    assert!(
+        !has_reset_for(&actions, stream),
+        "the surviving relayed path must not be reset"
+    );
+    assert!(!h.agent.owns_stream(&h.relay, stream));
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn all_legs_failing_reports_connect_failed() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    h.agent
+        .connect(h.target.clone(), vec![maddr(TARGET_ADDR)], at(0));
+    let actions = drain_actions(&mut h.agent);
+    let direct_token = dial_token_for(&actions, &h.target);
+
+    // Direct dial rejected synchronously; the relay leg is still pending.
+    h.agent
+        .dial_result(direct_token, Err("connection refused".into()), at(10));
+    assert!(drain_events(&mut h.agent).is_empty());
+
+    h.agent.handle_tick(at(200));
+    let actions = drain_actions(&mut h.agent);
+    let relay_token = dial_token_for(&actions, &h.relay);
+    h.agent
+        .dial_result(relay_token, Err("relay unreachable".into()), at(210));
+
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::ConnectFailed {
+            error: NatError::DialFailed(_),
+            ..
+        }]
+    ));
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn malformed_hop_response_fails_with_protocol_error() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    h.agent.connect(h.target.clone(), Vec::new(), at(0));
+    let actions = drain_actions(&mut h.agent);
+    let relay_token = dial_token_for(&actions, &h.relay);
+    h.agent
+        .dial_result(relay_token, Ok(ConnectionId::new(2)), at(5));
+    h.relay_session_ready(at(10));
+
+    let actions = drain_actions(&mut h.agent);
+    let open_token = open_stream_token(&actions);
+    let stream = StreamId::new(3);
+    h.agent.stream_open_result(open_token, Ok(stream), at(15));
+    h.stream_ready(stream, at(20));
+    drain_actions(&mut h.agent);
+
+    // A complete frame whose payload is not a valid HopMessage.
+    h.stream_data(stream, vec![0x05, b'j', b'u', b'n', b'k', b'!'], at(30));
+
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::ConnectFailed {
+            error: NatError::Protocol(_),
+            ..
+        }]
+    ));
+    let actions = drain_actions(&mut h.agent);
+    assert!(
+        has_reset_for(&actions, stream),
+        "the dead HOP stream is reset"
+    );
+    assert!(!h.agent.owns_stream(&h.relay, stream));
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn relay_refusal_fails_when_no_direct_leg_remains() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    h.agent.connect(h.target.clone(), Vec::new(), at(0));
+    let actions = drain_actions(&mut h.agent);
+    let relay_token = dial_token_for(&actions, &h.relay);
+    h.agent
+        .dial_result(relay_token, Ok(ConnectionId::new(2)), at(5));
+    h.relay_session_ready(at(10));
+
+    let actions = drain_actions(&mut h.agent);
+    let open_token = open_stream_token(&actions);
+    let stream = StreamId::new(3);
+    h.agent.stream_open_result(open_token, Ok(stream), at(15));
+    h.stream_ready(stream, at(20));
+    drain_actions(&mut h.agent);
+
+    h.stream_data(stream, hop_status(Status::NoReservation), at(30));
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::ConnectFailed {
+            error: NatError::RelayRefused(_),
+            ..
+        }]
+    ));
+    let actions = drain_actions(&mut h.agent);
+    assert!(
+        has_reset_for(&actions, stream),
+        "the refused HOP stream is reset"
+    );
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn pipelined_bridge_bytes_reach_dcutr_before_any_later_event() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let id = h.agent.connect(h.target.clone(), Vec::new(), at(0));
+    let actions = drain_actions(&mut h.agent);
+    let relay_token = dial_token_for(&actions, &h.relay);
+    h.agent
+        .dial_result(relay_token, Ok(ConnectionId::new(2)), at(5));
+    h.relay_session_ready(at(10));
+
+    let actions = drain_actions(&mut h.agent);
+    let open_token = open_stream_token(&actions);
+    let stream = StreamId::new(9);
+    h.agent.stream_open_result(open_token, Ok(stream), at(15));
+    h.stream_ready(stream, at(20));
+    drain_actions(&mut h.agent);
+
+    // STATUS:OK and the responder's DCUtR CONNECT coalesced in one read:
+    // the pipelined bytes must feed the just-created DCUtR machine inside
+    // the same cascade.
+    let mut coalesced = hop_status(Status::Ok);
+    coalesced.extend(dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]));
+    h.stream_data(stream, coalesced, at(100));
+
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::PathEstablished { connect_id, path: Path::Relayed { .. }, .. }] if *connect_id == id
+    ));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(
+        dial_count_for(&actions, &h.target),
+        1,
+        "punch dial issued from the pipelined reply"
+    );
+    assert_eq!(
+        send_stream_count(&actions),
+        2,
+        "DCUtR CONNECT and SYNC both go out"
+    );
+    assert!(!h.agent.owns_stream(&h.relay, stream));
+}
+
+#[test]
+fn oversized_dcutr_connect_falls_back_to_relay() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    // Enough distinct addresses that the encoded DCUtR CONNECT exceeds the
+    // 4 KiB frame cap, tripping the machine's deferred construction error.
+    let addrs: Vec<Multiaddr> = (1u16..=400)
+        .map(|port| maddr(&format!("/ip4/198.51.100.5/udp/{port}/quic-v1")))
+        .collect();
+    h.agent.set_listen_addrs(&addrs);
+
+    let (id, stream) = drive_to_bridged(&mut h, 0);
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [
+            NatEvent::PathEstablished { path: Path::Relayed { .. }, .. },
+            NatEvent::HolePunchFailed { .. },
+            NatEvent::FellBackToRelay { connect_id, .. },
+        ] if *connect_id == id
+    ));
+    assert!(!h.agent.owns_stream(&h.relay, stream));
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn foreign_stream_events_are_ignored_without_state_changes() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (_, stream) = drive_to_bridged(&mut h, 0);
+    drain_events(&mut h.agent);
+    drain_actions(&mut h.agent);
+
+    // A stream the agent never opened — same peer, different id.
+    let foreign = StreamId::new(1_234);
+    assert!(!h.agent.owns_stream(&h.relay, foreign));
+    h.stream_data(foreign, b"app data".to_vec(), at(320));
+
+    // Same id as the bridge but on a different peer's connection.
+    assert!(!h.agent.owns_stream(&h.target, stream));
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            peer_id: h.target.clone(),
+            stream_id: stream,
+            data: b"app data".to_vec(),
+        },
+        at(321),
+    );
+
+    assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(
+        h.agent.owns_stream(&h.relay, stream),
+        "bridge is still owned"
+    );
+}
+
+#[test]
+fn duplicate_direct_connection_does_not_double_report() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    h.agent
+        .connect(h.target.clone(), vec![maddr(TARGET_ADDR)], at(0));
+    drain_actions(&mut h.agent);
+    h.target_connected(at(50));
+    assert_eq!(drain_events(&mut h.agent).len(), 1);
+
+    // A QUIC supersede re-emits ConnectionEstablished for the same peer.
+    h.target_connected(at(60));
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(drain_actions(&mut h.agent).is_empty());
+}
+
+#[test]
+fn cancel_mid_race_resets_streams_and_goes_quiet() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (id, stream) = drive_to_bridged(&mut h, 0);
+    drain_events(&mut h.agent);
+    drain_actions(&mut h.agent);
+
+    h.agent.cancel(id, at(320));
+    let actions = drain_actions(&mut h.agent);
+    assert!(has_reset_for(&actions, stream));
+    assert!(drain_events(&mut h.agent).is_empty(), "cancel is silent");
+    assert!(!h.agent.owns_stream(&h.relay, stream));
+
+    // Late inputs for the dead attempt change nothing.
+    h.stream_data(stream, hop_status(Status::Ok), at(330));
+    h.target_connected(at(340));
+    assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn relay_leg_deadline_fails_a_stalled_leg() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    h.agent.connect(h.target.clone(), Vec::new(), at(0));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(dial_count_for(&actions, &h.relay), 1);
+
+    // The relay never answers.
+    h.agent.handle_tick(at(11_999));
+    assert!(drain_events(&mut h.agent).is_empty());
+    h.agent.handle_tick(at(12_000));
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::ConnectFailed {
+            error: NatError::Timeout,
+            ..
+        }]
+    ));
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn connect_deadline_fails_an_attempt_with_no_path() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    h.agent
+        .connect(h.target.clone(), vec![maddr(TARGET_ADDR)], at(0));
+    let actions = drain_actions(&mut h.agent);
+    let token = dial_token_for(&actions, &h.target);
+    // The dial is accepted but the handshake never completes.
+    h.agent.dial_result(token, Ok(ConnectionId::new(1)), at(5));
+
+    h.agent.handle_tick(at(59_999));
+    assert!(drain_events(&mut h.agent).is_empty());
+    h.agent.handle_tick(at(60_000));
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::ConnectFailed {
+            error: NatError::Timeout,
+            ..
+        }]
+    ));
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn no_candidates_and_no_relay_fails_immediately() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    let id = h.agent.connect(h.target.clone(), Vec::new(), at(0));
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::ConnectFailed { connect_id, error: NatError::NoPathAvailable, .. }]
+            if *connect_id == id
+    ));
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn wildcard_and_non_quic_candidates_are_filtered() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    h.agent.connect(
+        h.target.clone(),
+        vec![
+            maddr("/ip4/0.0.0.0/udp/4001/quic-v1"),
+            maddr("/ip4/192.0.2.10/udp/4001"),
+            maddr(TARGET_ADDR),
+            maddr(TARGET_ADDR),
+        ],
+        at(0),
+    );
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(
+        dial_count_for(&actions, &h.target),
+        1,
+        "wildcards, non-QUIC shapes, and duplicates never get dialed"
+    );
+}

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -15,8 +15,8 @@ use minip2p_transport::{ConnectionId, StreamId};
 /// relay leg up to `Bridged`: direct dial at t0, stagger, relay dial, HOP
 /// open/negotiate/CONNECT, STATUS:OK at t0+300.
 ///
-/// Leaves the `PathEstablished(Relayed)` event and the DCUtR CONNECT send
-/// action queued for the caller to drain.
+/// Leaves the DCUtR CONNECT send action queued for the caller to drain. The
+/// relay stream remains agent-owned until DCUtR has sent SYNC.
 fn drive_to_bridged(h: &mut Harness, t0: u64) -> (ConnectId, StreamId) {
     let id = h
         .agent
@@ -49,7 +49,7 @@ fn drive_to_bridged(h: &mut Harness, t0: u64) -> (ConnectId, StreamId) {
 }
 
 /// Continues a bridged attempt through the DCUtR reply: punch dial + SYNC
-/// go out and the bridge is handed back to the application.
+/// go out, then the bridge is handed back to the application and announced.
 fn drive_to_sync(h: &mut Harness, stream: StreamId, now_ms: u64) -> Vec<NatAction> {
     h.stream_data(
         stream,
@@ -67,6 +67,12 @@ fn drive_to_sync(h: &mut Harness, stream: StreamId, now_ms: u64) -> Vec<NatActio
         !h.agent.owns_stream(&h.relay, stream),
         "bridge belongs to the app once SYNC is out"
     );
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::PathEstablished { path: Path::Relayed { stream_id, .. }, .. }]
+            if *stream_id == stream
+    ));
     actions
 }
 
@@ -148,16 +154,12 @@ fn no_direct_candidates_skip_the_stagger() {
 }
 
 #[test]
-fn relayed_path_upgrades_to_punched_direct() {
+fn relayed_path_upgrades_to_direct_without_misattribution() {
     let mut h = Harness::with_relay(NatConfig::default());
     let (id, stream) = drive_to_bridged(&mut h, 0);
 
-    let events = drain_events(&mut h.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [NatEvent::PathEstablished { connect_id, path: Path::Relayed { stream_id, .. }, .. }]
-            if *connect_id == id && *stream_id == stream
-    ));
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(h.agent.owns_stream(&h.relay, stream));
     let actions = drain_actions(&mut h.agent);
     assert_eq!(
         send_stream_count(&actions),
@@ -175,7 +177,7 @@ fn relayed_path_upgrades_to_punched_direct() {
         [NatEvent::PathUpgraded {
             connect_id,
             from: Path::Relayed { .. },
-            to: Path::DirectPunched,
+            to: Path::DirectDialed,
             ..
         }] if *connect_id == id
     ));
@@ -188,10 +190,129 @@ fn relayed_path_upgrades_to_punched_direct() {
 }
 
 #[test]
+fn already_connected_peer_is_reported_without_starting_a_race() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    h.target_connected(at(0));
+    let id = h.agent.connect(h.target.clone(), Vec::new(), at(1));
+
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::PathEstablished { connect_id, peer, path: Path::DirectDialed }]
+            if *connect_id == id && *peer == h.target
+    ));
+    assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn unconfigured_peer_cannot_claim_an_inbound_stop_stream() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    let attacker = peer(b"untrusted-peer");
+    let stream = StreamId::new(88);
+    h.agent.handle_event(
+        &SwarmEvent::StreamReady {
+            peer_id: attacker.clone(),
+            stream_id: stream,
+            protocol_id: minip2p_relay::STOP_PROTOCOL_ID.to_string(),
+            initiated_locally: false,
+        },
+        at(0),
+    );
+
+    assert!(!h.agent.owns_stream(&attacker, stream));
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            peer_id: attacker,
+            stream_id: stream,
+            data: stop_connect(&h.target),
+        },
+        at(1),
+    );
+    assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(drain_events(&mut h.agent).is_empty());
+}
+
+#[test]
+fn remote_write_close_during_dcutr_is_not_a_full_bridge_close() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (_, stream) = drive_to_bridged(&mut h, 0);
+    drain_actions(&mut h.agent);
+
+    h.agent.handle_event(
+        &SwarmEvent::StreamRemoteWriteClosed {
+            peer_id: h.relay.clone(),
+            stream_id: stream,
+        },
+        at(310),
+    );
+
+    assert!(h.agent.owns_stream(&h.relay, stream));
+    assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(drain_events(&mut h.agent).is_empty());
+}
+
+#[test]
+fn bridge_close_before_dcutr_finishes_waits_for_live_direct_dials() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (id, stream) = drive_to_bridged(&mut h, 0);
+    drain_actions(&mut h.agent);
+
+    h.agent.handle_event(
+        &SwarmEvent::StreamClosed {
+            peer_id: h.relay.clone(),
+            stream_id: stream,
+        },
+        at(310),
+    );
+    assert!(drain_events(&mut h.agent).is_empty());
+
+    h.target_connected(at(320));
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::PathEstablished { connect_id, path: Path::DirectDialed, .. }]
+            if *connect_id == id
+    ));
+}
+
+#[test]
+fn released_bridge_close_cannot_be_reported_as_a_relay_fallback() {
+    let mut h = Harness::with_relay(NatConfig {
+        punch_max_retries: 0,
+        ..NatConfig::default()
+    });
+    let (id, stream) = drive_to_bridged(&mut h, 0);
+    drain_actions(&mut h.agent);
+    drive_to_sync(&mut h, stream, 350);
+
+    // The raw stream is application-owned, but the agent still observes its
+    // terminal event to keep the direct-upgrade race honest.
+    h.agent.handle_event(
+        &SwarmEvent::StreamClosed {
+            peer_id: h.relay.clone(),
+            stream_id: stream,
+        },
+        at(400),
+    );
+    h.agent.handle_tick(at(3_350));
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [
+            NatEvent::HolePunchFailed { .. },
+            NatEvent::ConnectFailed { connect_id, .. },
+        ] if *connect_id == id
+    ));
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, NatEvent::FellBackToRelay { .. }))
+    );
+}
+
+#[test]
 fn punch_exhaustion_falls_back_to_the_relay() {
     let mut h = Harness::with_relay(NatConfig::default());
     let (id, stream) = drive_to_bridged(&mut h, 0);
-    drain_events(&mut h.agent);
     drain_actions(&mut h.agent);
     drive_to_sync(&mut h, stream, 350);
 

--- a/crates/nat/tests/common/mod.rs
+++ b/crates/nat/tests/common/mod.rs
@@ -10,8 +10,8 @@ use minip2p_core::{Multiaddr, PeerAddr, PeerId, SansIoProtocol};
 use minip2p_dcutr::{HolePunch, HolePunchType, encode_frame as dcutr_encode_frame};
 use minip2p_nat::{NatAction, NatAgent, NatConfig, NatEvent, NatToken, Now, ReservationPolicy};
 use minip2p_relay::{
-    HOP_PROTOCOL_ID, HopMessage, HopMessageType, Reservation, Status,
-    encode_frame as relay_encode_frame,
+    HOP_PROTOCOL_ID, HopMessage, HopMessageType, Peer, Reservation, Status, StopMessage,
+    StopMessageType, encode_frame as relay_encode_frame,
 };
 use minip2p_swarm::SwarmEvent;
 use minip2p_transport::StreamId;
@@ -68,6 +68,42 @@ pub fn dcutr_connect_reply(addrs: &[Multiaddr]) -> Vec<u8> {
         obs_addrs: addrs.iter().map(Multiaddr::to_bytes).collect(),
     };
     dcutr_encode_frame(&msg.encode())
+}
+
+/// A framed STOP CONNECT from a relay, naming `source_peer_id` (raw bytes).
+pub fn stop_connect_raw(source_peer_id: Vec<u8>) -> Vec<u8> {
+    let msg = StopMessage {
+        kind: StopMessageType::Connect,
+        peer: Some(Peer {
+            id: source_peer_id,
+            addrs: Vec::new(),
+        }),
+        limit: None,
+        status: None,
+    };
+    relay_encode_frame(&msg.encode())
+}
+
+/// A framed STOP CONNECT from a relay, naming `source` as the initiator.
+pub fn stop_connect(source: &PeerId) -> Vec<u8> {
+    stop_connect_raw(source.to_bytes())
+}
+
+/// A framed DCUtR SYNC.
+pub fn dcutr_sync() -> Vec<u8> {
+    let msg = HolePunch {
+        kind: HolePunchType::Sync,
+        obs_addrs: Vec::new(),
+    };
+    dcutr_encode_frame(&msg.encode())
+}
+
+/// Counts `SendRandomUdp` actions.
+pub fn blast_count(actions: &[NatAction]) -> usize {
+    actions
+        .iter()
+        .filter(|action| matches!(action, NatAction::SendRandomUdp { .. }))
+        .count()
 }
 
 /// A framed HOP STATUS:OK reservation response with an optional expiry.

--- a/crates/nat/tests/common/mod.rs
+++ b/crates/nat/tests/common/mod.rs
@@ -5,11 +5,13 @@
 // uses a different subset of the helpers.
 #![allow(dead_code)]
 
-use minip2p_core::{Multiaddr, PeerAddr, PeerId};
+use minip2p_autonat::{AutoNatServer, AutoNatServerInput, AutoNatServerOutput, ResponseStatus};
+use minip2p_core::{Multiaddr, PeerAddr, PeerId, SansIoProtocol};
 use minip2p_dcutr::{HolePunch, HolePunchType, encode_frame as dcutr_encode_frame};
-use minip2p_nat::{NatAction, NatAgent, NatConfig, NatEvent, NatToken, Now};
+use minip2p_nat::{NatAction, NatAgent, NatConfig, NatEvent, NatToken, Now, ReservationPolicy};
 use minip2p_relay::{
-    HOP_PROTOCOL_ID, HopMessage, HopMessageType, Status, encode_frame as relay_encode_frame,
+    HOP_PROTOCOL_ID, HopMessage, HopMessageType, Reservation, Status,
+    encode_frame as relay_encode_frame,
 };
 use minip2p_swarm::SwarmEvent;
 use minip2p_transport::StreamId;
@@ -29,6 +31,13 @@ pub fn maddr(s: &str) -> Multiaddr {
 
 pub fn at(ms: u64) -> Now {
     Now::from_mono(ms)
+}
+
+pub fn at_unix(ms: u64, secs: u64) -> Now {
+    Now {
+        mono_ms: ms,
+        unix_secs: Some(secs),
+    }
 }
 
 pub fn drain_actions(agent: &mut NatAgent) -> Vec<NatAction> {
@@ -61,6 +70,62 @@ pub fn dcutr_connect_reply(addrs: &[Multiaddr]) -> Vec<u8> {
     dcutr_encode_frame(&msg.encode())
 }
 
+/// A framed HOP STATUS:OK reservation response with an optional expiry.
+pub fn hop_reserve_ok(expire_unix_secs: Option<u64>) -> Vec<u8> {
+    let msg = HopMessage {
+        kind: HopMessageType::Status,
+        peer: None,
+        reservation: Some(Reservation {
+            expire: expire_unix_secs,
+            addrs: Vec::new(),
+            voucher: None,
+        }),
+        limit: None,
+        status: Some(Status::Ok),
+    };
+    relay_encode_frame(&msg.encode())
+}
+
+/// Runs `request_bytes` through a real [`AutoNatServer`] and returns the
+/// wire bytes of the given response — public with `addrs`, or a dial error.
+pub fn autonat_response(request_bytes: &[u8], public_addrs: Option<&[Multiaddr]>) -> Vec<u8> {
+    let mut server = AutoNatServer::new();
+    server
+        .handle_input(AutoNatServerInput::Data(request_bytes.to_vec()))
+        .expect("well-formed AutoNAT request");
+    assert!(matches!(
+        server.poll_output(),
+        Some(AutoNatServerOutput::Request(_))
+    ));
+    let response = match public_addrs {
+        Some(addrs) => AutoNatServerInput::RespondPublic {
+            addrs: addrs.to_vec(),
+        },
+        None => AutoNatServerInput::RespondError {
+            status: ResponseStatus::DialError,
+            reason: "dial-back failed".into(),
+        },
+    };
+    server.handle_input(response).expect("respond");
+    match server.poll_output() {
+        Some(AutoNatServerOutput::Outbound(bytes)) => bytes,
+        other => panic!("expected outbound response, got {other:?}"),
+    }
+}
+
+/// Extracts the payload of the single `SendStream` action on `stream`.
+pub fn sent_data_on(actions: &[NatAction], stream: StreamId) -> Vec<u8> {
+    let mut found = actions.iter().filter_map(|action| match action {
+        NatAction::SendStream {
+            stream_id, data, ..
+        } if *stream_id == stream => Some(data.clone()),
+        _ => None,
+    });
+    let data = found.next().expect("expected a SendStream on the stream");
+    assert!(found.next().is_none(), "more than one SendStream");
+    data
+}
+
 /// Finds the token of the single `Dial` action targeting `peer`.
 pub fn dial_token_for(actions: &[NatAction], peer: &PeerId) -> NatToken {
     let mut tokens = actions.iter().filter_map(|action| match action {
@@ -78,6 +143,19 @@ pub fn dial_count_for(actions: &[NatAction], peer: &PeerId) -> usize {
         .iter()
         .filter(|action| matches!(action, NatAction::Dial { addr, .. } if addr.peer_id() == peer))
         .count()
+}
+
+/// Finds the token of the single `OpenStream` action targeting `peer`.
+pub fn open_stream_token_for(actions: &[NatAction], peer: &PeerId) -> NatToken {
+    let mut tokens = actions.iter().filter_map(|action| match action {
+        NatAction::OpenStream { token, peer: p, .. } if p == peer => Some(*token),
+        _ => None,
+    });
+    let token = tokens
+        .next()
+        .expect("expected an OpenStream action for the peer");
+    assert!(tokens.next().is_none(), "more than one OpenStream for peer");
+    token
 }
 
 /// Finds the token of the single `OpenStream` action.
@@ -125,6 +203,10 @@ pub struct Harness {
 
 impl Harness {
     /// An agent with one relay configured and a validated listen address.
+    ///
+    /// Reservation housekeeping is disabled: this harness scripts the
+    /// dialer-side race in isolation. Housekeeping tests configure their
+    /// own policy explicitly.
     pub fn with_relay(mut config: NatConfig) -> Self {
         let local = peer(b"local-peer");
         let target = peer(b"target-peer");
@@ -132,6 +214,7 @@ impl Harness {
         let relay_addr =
             PeerAddr::new(maddr(RELAY_TRANSPORT_ADDR), relay.clone()).expect("valid relay addr");
         config.relays = vec![relay_addr.clone()];
+        config.reservation_policy = ReservationPolicy::Never;
         let mut agent = NatAgent::new(local.clone(), config);
         agent.set_listen_addrs(&[maddr(LISTEN_ADDR)]);
         Self {

--- a/crates/nat/tests/common/mod.rs
+++ b/crates/nat/tests/common/mod.rs
@@ -1,0 +1,213 @@
+//! Shared scripted-test harness: a fake clock, canned peers, and frame
+//! builders for driving a [`NatAgent`] with no I/O.
+
+// Each integration-test binary compiles its own copy of this module and
+// uses a different subset of the helpers.
+#![allow(dead_code)]
+
+use minip2p_core::{Multiaddr, PeerAddr, PeerId};
+use minip2p_dcutr::{HolePunch, HolePunchType, encode_frame as dcutr_encode_frame};
+use minip2p_nat::{NatAction, NatAgent, NatConfig, NatEvent, NatToken, Now};
+use minip2p_relay::{
+    HOP_PROTOCOL_ID, HopMessage, HopMessageType, Status, encode_frame as relay_encode_frame,
+};
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::StreamId;
+
+pub const TARGET_ADDR: &str = "/ip4/192.0.2.10/udp/4001/quic-v1";
+pub const RELAY_TRANSPORT_ADDR: &str = "/ip4/203.0.113.1/udp/4001/quic-v1";
+pub const LISTEN_ADDR: &str = "/ip4/198.51.100.5/udp/4500/quic-v1";
+pub const REMOTE_OBSERVED_ADDR: &str = "/ip4/192.0.2.99/udp/4002/quic-v1";
+
+pub fn peer(tag: &[u8]) -> PeerId {
+    PeerId::from_public_key_protobuf(tag)
+}
+
+pub fn maddr(s: &str) -> Multiaddr {
+    s.parse().expect("valid multiaddr")
+}
+
+pub fn at(ms: u64) -> Now {
+    Now::from_mono(ms)
+}
+
+pub fn drain_actions(agent: &mut NatAgent) -> Vec<NatAction> {
+    core::iter::from_fn(|| agent.poll_action()).collect()
+}
+
+pub fn drain_events(agent: &mut NatAgent) -> Vec<NatEvent> {
+    core::iter::from_fn(|| agent.poll_event()).collect()
+}
+
+/// A framed HOP STATUS response carrying `status`.
+pub fn hop_status(status: Status) -> Vec<u8> {
+    let msg = HopMessage {
+        kind: HopMessageType::Status,
+        peer: None,
+        reservation: None,
+        limit: None,
+        status: Some(status),
+    };
+    relay_encode_frame(&msg.encode())
+}
+
+/// A framed DCUtR CONNECT (the responder's reply) advertising `addrs`.
+/// Observed addresses travel as binary multiaddrs on the wire.
+pub fn dcutr_connect_reply(addrs: &[Multiaddr]) -> Vec<u8> {
+    let msg = HolePunch {
+        kind: HolePunchType::Connect,
+        obs_addrs: addrs.iter().map(Multiaddr::to_bytes).collect(),
+    };
+    dcutr_encode_frame(&msg.encode())
+}
+
+/// Finds the token of the single `Dial` action targeting `peer`.
+pub fn dial_token_for(actions: &[NatAction], peer: &PeerId) -> NatToken {
+    let mut tokens = actions.iter().filter_map(|action| match action {
+        NatAction::Dial { token, addr } if addr.peer_id() == peer => Some(*token),
+        _ => None,
+    });
+    let token = tokens.next().expect("expected a Dial action for the peer");
+    assert!(tokens.next().is_none(), "more than one Dial for the peer");
+    token
+}
+
+/// Counts `Dial` actions targeting `peer`.
+pub fn dial_count_for(actions: &[NatAction], peer: &PeerId) -> usize {
+    actions
+        .iter()
+        .filter(|action| matches!(action, NatAction::Dial { addr, .. } if addr.peer_id() == peer))
+        .count()
+}
+
+/// Finds the token of the single `OpenStream` action.
+pub fn open_stream_token(actions: &[NatAction]) -> NatToken {
+    let mut tokens = actions.iter().filter_map(|action| match action {
+        NatAction::OpenStream { token, .. } => Some(*token),
+        _ => None,
+    });
+    let token = tokens.next().expect("expected an OpenStream action");
+    assert!(tokens.next().is_none(), "more than one OpenStream action");
+    token
+}
+
+pub fn has_hop_open(actions: &[NatAction]) -> bool {
+    actions.iter().any(|action| {
+        matches!(
+            action,
+            NatAction::OpenStream { protocol_id, .. } if protocol_id == HOP_PROTOCOL_ID
+        )
+    })
+}
+
+pub fn send_stream_count(actions: &[NatAction]) -> usize {
+    actions
+        .iter()
+        .filter(|action| matches!(action, NatAction::SendStream { .. }))
+        .count()
+}
+
+pub fn has_reset_for(actions: &[NatAction], stream: StreamId) -> bool {
+    actions.iter().any(
+        |action| matches!(action, NatAction::ResetStream { stream_id, .. } if *stream_id == stream),
+    )
+}
+
+/// Scripted world around one agent: a local node, a target peer, and one
+/// configured relay.
+pub struct Harness {
+    pub agent: NatAgent,
+    pub local: PeerId,
+    pub target: PeerId,
+    pub relay: PeerId,
+    pub relay_addr: PeerAddr,
+}
+
+impl Harness {
+    /// An agent with one relay configured and a validated listen address.
+    pub fn with_relay(mut config: NatConfig) -> Self {
+        let local = peer(b"local-peer");
+        let target = peer(b"target-peer");
+        let relay = peer(b"relay-peer");
+        let relay_addr =
+            PeerAddr::new(maddr(RELAY_TRANSPORT_ADDR), relay.clone()).expect("valid relay addr");
+        config.relays = vec![relay_addr.clone()];
+        let mut agent = NatAgent::new(local.clone(), config);
+        agent.set_listen_addrs(&[maddr(LISTEN_ADDR)]);
+        Self {
+            agent,
+            local,
+            target,
+            relay,
+            relay_addr,
+        }
+    }
+
+    /// An agent with no relay configured.
+    pub fn without_relay(config: NatConfig) -> Self {
+        let local = peer(b"local-peer");
+        let target = peer(b"target-peer");
+        let relay = peer(b"relay-peer");
+        let relay_addr =
+            PeerAddr::new(maddr(RELAY_TRANSPORT_ADDR), relay.clone()).expect("valid relay addr");
+        let mut agent = NatAgent::new(local.clone(), config);
+        agent.set_listen_addrs(&[maddr(LISTEN_ADDR)]);
+        Self {
+            agent,
+            local,
+            target,
+            relay,
+            relay_addr,
+        }
+    }
+
+    /// Marks the relay connection as established and identify-complete
+    /// (advertising the HOP protocol).
+    pub fn relay_session_ready(&mut self, now: Now) {
+        self.agent.handle_event(
+            &SwarmEvent::ConnectionEstablished {
+                peer_id: self.relay.clone(),
+            },
+            now,
+        );
+        self.agent.handle_event(
+            &SwarmEvent::PeerReady {
+                peer_id: self.relay.clone(),
+                protocols: vec![HOP_PROTOCOL_ID.to_string()],
+            },
+            now,
+        );
+    }
+
+    pub fn stream_ready(&mut self, stream: StreamId, now: Now) {
+        self.agent.handle_event(
+            &SwarmEvent::StreamReady {
+                peer_id: self.relay.clone(),
+                stream_id: stream,
+                protocol_id: HOP_PROTOCOL_ID.to_string(),
+                initiated_locally: true,
+            },
+            now,
+        );
+    }
+
+    pub fn stream_data(&mut self, stream: StreamId, data: Vec<u8>, now: Now) {
+        self.agent.handle_event(
+            &SwarmEvent::StreamData {
+                peer_id: self.relay.clone(),
+                stream_id: stream,
+                data,
+            },
+            now,
+        );
+    }
+
+    pub fn target_connected(&mut self, now: Now) {
+        self.agent.handle_event(
+            &SwarmEvent::ConnectionEstablished {
+                peer_id: self.target.clone(),
+            },
+            now,
+        );
+    }
+}

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -28,6 +28,15 @@ struct Hk {
 }
 
 fn build(policy: ReservationPolicy, relay_count: usize, server_count: usize) -> Hk {
+    build_with_config(policy, relay_count, server_count, |_| {})
+}
+
+fn build_with_config(
+    policy: ReservationPolicy,
+    relay_count: usize,
+    server_count: usize,
+    configure: impl FnOnce(&mut NatConfig),
+) -> Hk {
     let relay = peer(b"relay-peer");
     let relay2 = peer(b"relay-peer-2");
     let server = peer(b"autonat-server");
@@ -48,12 +57,13 @@ fn build(policy: ReservationPolicy, relay_count: usize, server_count: usize) -> 
         autonat_servers.push(PeerAddr::new(maddr(SERVER2_ADDR), server2.clone()).unwrap());
     }
 
-    let config = NatConfig {
+    let mut config = NatConfig {
         reservation_policy: policy,
         relays,
         autonat_servers,
         ..NatConfig::default()
     };
+    configure(&mut config);
     let mut agent = NatAgent::new(peer(b"local-peer"), config);
     agent.set_listen_addrs(&[maddr(LISTEN_ADDR)]);
     Hk {
@@ -217,6 +227,34 @@ fn confidence_window_flips_once_and_never_flaps_on_one_probe() {
 }
 
 #[test]
+fn confidence_threshold_above_window_clamps_to_unanimity() {
+    let mut hk = build_with_config(ReservationPolicy::Never, 0, 1, |config| {
+        config.confidence_window = 3;
+        config.confidence_threshold = 9;
+    });
+
+    // Bootstrap the AutoNAT session, then collect a full (three-vote)
+    // unanimous window. An unclamped threshold could never settle here.
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    let dial = dial_token_for(&actions, &hk.server);
+    hk.agent.dial_result(dial, Ok(ConnectionId::new(50)), at(1));
+    let server = hk.server.clone();
+    hk.session_ready(&server, &[AUTONAT_PROTOCOL_ID], at(2));
+    assert!(hk.finish_probe(true, 3).is_empty());
+    assert!(hk.run_probe(true, 6_000).is_empty());
+
+    let events = hk.run_probe(true, 12_000);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::ReachabilityChanged {
+            old: ReachabilityState::Unknown,
+            new: ReachabilityState::Public,
+        }]
+    ));
+}
+
+#[test]
 fn probe_timeout_rotates_to_the_next_server() {
     let mut hk = build(ReservationPolicy::Never, 0, 2);
 
@@ -303,6 +341,27 @@ fn reservation_renews_at_expire_minus_margin() {
             ..
         }]
     ));
+}
+
+#[test]
+fn enormous_relay_expiry_saturates_the_renewal_deadline() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+    let (events, _) = reserve_via_relay(&mut hk, hop_reserve_ok(Some(u64::MAX)), at_unix(10, 0));
+
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::RelayReserved {
+            renew_at_mono_ms: u64::MAX,
+            ..
+        }]
+    ));
+    assert_eq!(
+        hk.agent
+            .active_reservation()
+            .expect("reservation held")
+            .renew_at_mono_ms,
+        u64::MAX
+    );
 }
 
 #[test]

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -124,7 +124,11 @@ impl Hk {
 
     /// Completes a probe exchange whose `OpenStream` is already queued.
     /// Responds public or private and returns the events it produced.
-    fn finish_probe(&mut self, public: bool, t: u64) -> Vec<NatEvent> {
+    fn finish_probe_with_addrs(
+        &mut self,
+        public_addrs: Option<&[minip2p_core::Multiaddr]>,
+        t: u64,
+    ) -> Vec<NatEvent> {
         let server = self.server.clone();
         let actions = drain_actions(&mut self.agent);
         let token = open_stream_token_for(&actions, &server);
@@ -133,10 +137,14 @@ impl Hk {
         self.stream_ready(&server.clone(), stream, AUTONAT_PROTOCOL_ID, at(t + 1));
         let actions = drain_actions(&mut self.agent);
         let request = sent_data_on(&actions, stream);
-        let public_addrs = [maddr(LISTEN_ADDR)];
-        let response = autonat_response(&request, public.then_some(&public_addrs[..]));
+        let response = autonat_response(&request, public_addrs);
         self.stream_data(&server, stream, response, at(t + 2));
         drain_events(&mut self.agent)
+    }
+
+    fn finish_probe(&mut self, public: bool, t: u64) -> Vec<NatEvent> {
+        let public_addrs = [maddr(LISTEN_ADDR)];
+        self.finish_probe_with_addrs(public.then_some(&public_addrs), t)
     }
 
     /// Ticks to start the next probe (the server session must be ready),
@@ -255,6 +263,48 @@ fn confidence_threshold_above_window_clamps_to_unanimity() {
             ..
         }]
     ));
+}
+
+#[test]
+fn public_probe_without_a_usable_quic_addr_is_inconclusive() {
+    let mut hk = build_with_config(ReservationPolicy::WhenPrivate, 1, 1, |config| {
+        config.confidence_window = 1;
+        config.confidence_threshold = 1;
+    });
+
+    // Establish both housekeeping sessions, then hold a relay reservation
+    // while reachability is still Unknown.
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    let relay_dial = dial_token_for(&actions, &hk.relay);
+    let server_dial = dial_token_for(&actions, &hk.server);
+    hk.agent
+        .dial_result(relay_dial, Ok(ConnectionId::new(60)), at(1));
+    hk.agent
+        .dial_result(server_dial, Ok(ConnectionId::new(61)), at(1));
+    let relay = hk.relay.clone();
+    hk.session_ready(&relay, &[HOP_PROTOCOL_ID], at(2));
+    let (events, _) = hk.finish_reserve(hop_reserve_ok(None), at(3));
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::RelayReserved { .. }]
+    ));
+    assert!(hk.agent.active_reservation().is_some());
+
+    let server = hk.server.clone();
+    hk.session_ready(&server, &[AUTONAT_PROTOCOL_ID], at(4));
+    let wildcard_only = [maddr("/ip4/0.0.0.0/udp/4001/quic-v1")];
+    let events = hk.finish_probe_with_addrs(Some(&wildcard_only), 5);
+
+    assert!(
+        events.is_empty(),
+        "unusable public evidence is inconclusive"
+    );
+    assert_eq!(hk.agent.reachability(), ReachabilityState::Unknown);
+    assert!(
+        hk.agent.active_reservation().is_some(),
+        "WhenPrivate must retain its only advertised path"
+    );
 }
 
 #[test]
@@ -445,6 +495,43 @@ fn lost_relay_connection_emits_lost_and_reacquires() {
     hk.agent.handle_tick(at(5_600));
     let actions = drain_actions(&mut hk.agent);
     assert_eq!(dial_count_for(&actions, &hk.relay), 1);
+}
+
+#[test]
+fn relay_supersede_during_renewal_emits_reservation_lost() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+    let (events, _) = reserve_via_relay(&mut hk, hop_reserve_ok(Some(1_900)), at_unix(10, 1_000));
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::RelayReserved { .. }]
+    ));
+    drain_actions(&mut hk.agent); // completed exchange's close-write
+
+    // Start renewal, then replace the relay connection before the new
+    // reservation exchange completes. The old reservation died with the
+    // retired connection and must be withdrawn immediately.
+    let renew_at = 10 + 780 * 1_000;
+    hk.agent.handle_tick(at_unix(renew_at, 1_790));
+    let relay = hk.relay.clone();
+    hk.agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            peer_id: relay.clone(),
+        },
+        at_unix(renew_at + 1, 1_790),
+    );
+
+    let events = drain_events(&mut hk.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::RelayReservationLost { relay: lost }] if *lost == relay
+    ));
+    assert!(hk.agent.active_reservation().is_none());
+    assert!(
+        !drain_actions(&mut hk.agent)
+            .iter()
+            .any(|action| matches!(action, NatAction::ResetStream { .. })),
+        "supersede cleanup must not reset a stream id on the replacement connection"
+    );
 }
 
 #[test]

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -181,6 +181,18 @@ impl Hk {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn initial_reservation_policy_arms_only_the_needed_tick() {
+    let mut wanted = build(ReservationPolicy::Always, 1, 0);
+    assert_eq!(wanted.agent.next_timeout(0), Some(0));
+    wanted.agent.handle_tick(at(0));
+    let relay = wanted.relay.clone();
+    assert_eq!(dial_count_for(&drain_actions(&mut wanted.agent), &relay), 1);
+
+    let not_wanted = build(ReservationPolicy::Never, 1, 0);
+    assert_eq!(not_wanted.agent.next_timeout(0), None);
+}
+
+#[test]
 fn confidence_window_flips_once_and_never_flaps_on_one_probe() {
     let mut hk = build(ReservationPolicy::Never, 0, 1);
     assert_eq!(hk.agent.reachability(), ReachabilityState::Unknown);

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -199,7 +199,8 @@ fn confidence_window_flips_once_and_never_flaps_on_one_probe() {
         [NatEvent::ReachabilityChanged {
             old: ReachabilityState::Unknown,
             new: ReachabilityState::Public,
-        }]
+            confirmed_addrs,
+        }] if *confirmed_addrs == vec![maddr(LISTEN_ADDR)]
     ));
     assert_eq!(hk.agent.reachability(), ReachabilityState::Public);
 
@@ -221,7 +222,8 @@ fn confidence_window_flips_once_and_never_flaps_on_one_probe() {
         [NatEvent::ReachabilityChanged {
             old: ReachabilityState::Public,
             new: ReachabilityState::Private,
-        }]
+            confirmed_addrs,
+        }] if confirmed_addrs.is_empty()
     ));
     assert_eq!(hk.agent.reachability(), ReachabilityState::Private);
 }
@@ -250,6 +252,7 @@ fn confidence_threshold_above_window_clamps_to_unanimity() {
         [NatEvent::ReachabilityChanged {
             old: ReachabilityState::Unknown,
             new: ReachabilityState::Public,
+            ..
         }]
     ));
 }

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -1,0 +1,460 @@
+//! Scripted housekeeping tests: AutoNAT confidence aggregation and relay
+//! reservation lifecycle, with a fake clock and no I/O.
+
+mod common;
+
+use common::*;
+
+use minip2p_autonat::AUTONAT_PROTOCOL_ID;
+use minip2p_core::{PeerAddr, PeerId};
+use minip2p_nat::{
+    NatAction, NatAgent, NatConfig, NatEvent, Now, ReachabilityState, ReservationPolicy,
+};
+use minip2p_relay::{HOP_PROTOCOL_ID, Status};
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::{ConnectionId, StreamId};
+
+const SERVER_ADDR: &str = "/ip4/203.0.113.50/udp/4001/quic-v1";
+const SERVER2_ADDR: &str = "/ip4/203.0.113.51/udp/4001/quic-v1";
+const RELAY2_TRANSPORT_ADDR: &str = "/ip4/203.0.113.2/udp/4001/quic-v1";
+
+struct Hk {
+    agent: NatAgent,
+    relay: PeerId,
+    relay2: PeerId,
+    server: PeerId,
+    server2: PeerId,
+    next_stream: u64,
+}
+
+fn build(policy: ReservationPolicy, relay_count: usize, server_count: usize) -> Hk {
+    let relay = peer(b"relay-peer");
+    let relay2 = peer(b"relay-peer-2");
+    let server = peer(b"autonat-server");
+    let server2 = peer(b"autonat-server-2");
+
+    let mut relays = Vec::new();
+    if relay_count >= 1 {
+        relays.push(PeerAddr::new(maddr(RELAY_TRANSPORT_ADDR), relay.clone()).unwrap());
+    }
+    if relay_count >= 2 {
+        relays.push(PeerAddr::new(maddr(RELAY2_TRANSPORT_ADDR), relay2.clone()).unwrap());
+    }
+    let mut autonat_servers = Vec::new();
+    if server_count >= 1 {
+        autonat_servers.push(PeerAddr::new(maddr(SERVER_ADDR), server.clone()).unwrap());
+    }
+    if server_count >= 2 {
+        autonat_servers.push(PeerAddr::new(maddr(SERVER2_ADDR), server2.clone()).unwrap());
+    }
+
+    let config = NatConfig {
+        reservation_policy: policy,
+        relays,
+        autonat_servers,
+        ..NatConfig::default()
+    };
+    let mut agent = NatAgent::new(peer(b"local-peer"), config);
+    agent.set_listen_addrs(&[maddr(LISTEN_ADDR)]);
+    Hk {
+        agent,
+        relay,
+        relay2,
+        server,
+        server2,
+        next_stream: 100,
+    }
+}
+
+impl Hk {
+    fn fresh_stream(&mut self) -> StreamId {
+        self.next_stream += 1;
+        StreamId::new(self.next_stream)
+    }
+
+    /// Connection established + PeerReady advertising `protocols`.
+    fn session_ready(&mut self, peer: &PeerId, protocols: &[&str], now: Now) {
+        self.agent.handle_event(
+            &SwarmEvent::ConnectionEstablished {
+                peer_id: peer.clone(),
+            },
+            now,
+        );
+        self.agent.handle_event(
+            &SwarmEvent::PeerReady {
+                peer_id: peer.clone(),
+                protocols: protocols.iter().map(|p| p.to_string()).collect(),
+            },
+            now,
+        );
+    }
+
+    fn stream_ready(&mut self, peer: &PeerId, stream: StreamId, protocol: &str, now: Now) {
+        self.agent.handle_event(
+            &SwarmEvent::StreamReady {
+                peer_id: peer.clone(),
+                stream_id: stream,
+                protocol_id: protocol.to_string(),
+                initiated_locally: true,
+            },
+            now,
+        );
+    }
+
+    fn stream_data(&mut self, peer: &PeerId, stream: StreamId, data: Vec<u8>, now: Now) {
+        self.agent.handle_event(
+            &SwarmEvent::StreamData {
+                peer_id: peer.clone(),
+                stream_id: stream,
+                data,
+            },
+            now,
+        );
+    }
+
+    /// Completes a probe exchange whose `OpenStream` is already queued.
+    /// Responds public or private and returns the events it produced.
+    fn finish_probe(&mut self, public: bool, t: u64) -> Vec<NatEvent> {
+        let server = self.server.clone();
+        let actions = drain_actions(&mut self.agent);
+        let token = open_stream_token_for(&actions, &server);
+        let stream = self.fresh_stream();
+        self.agent.stream_open_result(token, Ok(stream), at(t));
+        self.stream_ready(&server.clone(), stream, AUTONAT_PROTOCOL_ID, at(t + 1));
+        let actions = drain_actions(&mut self.agent);
+        let request = sent_data_on(&actions, stream);
+        let public_addrs = [maddr(LISTEN_ADDR)];
+        let response = autonat_response(&request, public.then_some(&public_addrs[..]));
+        self.stream_data(&server, stream, response, at(t + 2));
+        drain_events(&mut self.agent)
+    }
+
+    /// Ticks to start the next probe (the server session must be ready),
+    /// then completes it.
+    fn run_probe(&mut self, public: bool, t: u64) -> Vec<NatEvent> {
+        self.agent.handle_tick(at(t));
+        self.finish_probe(public, t + 1)
+    }
+
+    /// Completes a reservation exchange whose `OpenStream` is already
+    /// queued, feeding `response`. Returns (events, stream id).
+    fn finish_reserve(&mut self, response: Vec<u8>, now: Now) -> (Vec<NatEvent>, StreamId) {
+        let relay = self.relay_for_current();
+        let actions = drain_actions(&mut self.agent);
+        let token = open_stream_token_for(&actions, &relay);
+        let stream = self.fresh_stream();
+        self.agent.stream_open_result(token, Ok(stream), now);
+        self.stream_ready(&relay.clone(), stream, HOP_PROTOCOL_ID, now);
+        let actions = drain_actions(&mut self.agent);
+        let _request = sent_data_on(&actions, stream);
+        self.stream_data(&relay, stream, response, now);
+        (drain_events(&mut self.agent), stream)
+    }
+
+    fn relay_for_current(&self) -> PeerId {
+        // Tests drive one relay at a time; the current one is whichever has
+        // a queued OpenStream. Defaults to the primary relay.
+        self.relay.clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reachability confidence
+// ---------------------------------------------------------------------------
+
+#[test]
+fn confidence_window_flips_once_and_never_flaps_on_one_probe() {
+    let mut hk = build(ReservationPolicy::Never, 0, 1);
+    assert_eq!(hk.agent.reachability(), ReachabilityState::Unknown);
+
+    // First probe bootstraps the server session.
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    let dial = dial_token_for(&actions, &hk.server);
+    hk.agent.dial_result(dial, Ok(ConnectionId::new(50)), at(1));
+    let server = hk.server.clone();
+    hk.session_ready(&server, &[AUTONAT_PROTOCOL_ID], at(2));
+    assert!(hk.finish_probe(true, 3).is_empty(), "1 vote of 3: no flip");
+    assert_eq!(hk.agent.reachability(), ReachabilityState::Unknown);
+
+    // Unsettled cadence is 5s.
+    assert!(
+        hk.run_probe(true, 6_000).is_empty(),
+        "2 votes of 3: no flip"
+    );
+
+    let events = hk.run_probe(true, 12_000);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::ReachabilityChanged {
+            old: ReachabilityState::Unknown,
+            new: ReachabilityState::Public,
+        }]
+    ));
+    assert_eq!(hk.agent.reachability(), ReachabilityState::Public);
+
+    // Settled cadence is 90s; more agreement changes nothing.
+    assert!(hk.run_probe(true, 110_000).is_empty());
+
+    // One disagreeing probe must never flap the verdict.
+    assert!(
+        hk.run_probe(false, 210_000).is_empty(),
+        "single private probe in a public window: no flip"
+    );
+    assert_eq!(hk.agent.reachability(), ReachabilityState::Public);
+
+    // A private majority (3 of the last 5) flips exactly once.
+    assert!(hk.run_probe(false, 310_000).is_empty());
+    let events = hk.run_probe(false, 410_000);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::ReachabilityChanged {
+            old: ReachabilityState::Public,
+            new: ReachabilityState::Private,
+        }]
+    ));
+    assert_eq!(hk.agent.reachability(), ReachabilityState::Private);
+}
+
+#[test]
+fn probe_timeout_rotates_to_the_next_server() {
+    let mut hk = build(ReservationPolicy::Never, 0, 2);
+
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    let dial = dial_token_for(&actions, &hk.server);
+    hk.agent.dial_result(dial, Ok(ConnectionId::new(50)), at(1));
+    let server = hk.server.clone();
+    hk.session_ready(&server, &[AUTONAT_PROTOCOL_ID], at(2));
+    let actions = drain_actions(&mut hk.agent);
+    let token = open_stream_token_for(&actions, &server);
+    let stream = hk.fresh_stream();
+    hk.agent.stream_open_result(token, Ok(stream), at(3));
+    hk.stream_ready(&server.clone(), stream, AUTONAT_PROTOCOL_ID, at(4));
+    drain_actions(&mut hk.agent);
+
+    // The server never answers: the probe deadline (20s) aborts the flight.
+    hk.agent.handle_tick(at(20_004));
+    let actions = drain_actions(&mut hk.agent);
+    assert!(
+        has_reset_for(&actions, stream),
+        "stalled probe stream reset"
+    );
+    assert!(drain_events(&mut hk.agent).is_empty(), "no sample recorded");
+
+    // The retry goes to the *other* server.
+    hk.agent.handle_tick(at(25_004));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(dial_count_for(&actions, &hk.server2), 1);
+    assert_eq!(dial_count_for(&actions, &hk.server), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Reservation lifecycle
+// ---------------------------------------------------------------------------
+
+/// Bootstraps the relay session and completes the first reservation.
+fn reserve_via_relay(hk: &mut Hk, response: Vec<u8>, now: Now) -> (Vec<NatEvent>, StreamId) {
+    hk.agent.handle_tick(now);
+    let actions = drain_actions(&mut hk.agent);
+    let dial = dial_token_for(&actions, &hk.relay);
+    hk.agent.dial_result(dial, Ok(ConnectionId::new(60)), now);
+    let relay = hk.relay.clone();
+    hk.session_ready(&relay, &[HOP_PROTOCOL_ID], now);
+    hk.finish_reserve(response, now)
+}
+
+#[test]
+fn reservation_renews_at_expire_minus_margin() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+
+    // Relay reports expiry at unix 1900; the clock says unix 1000 at mono 10.
+    let (events, _) = reserve_via_relay(&mut hk, hop_reserve_ok(Some(1_900)), at_unix(10, 1_000));
+    // remaining 900s − margin 120s = 780s after mono 10.
+    let expected_renew = 10 + 780 * 1_000;
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::RelayReserved {
+            expires_unix_secs: Some(1_900),
+            renew_at_mono_ms,
+            ..
+        }] if *renew_at_mono_ms == expected_renew
+    ));
+    let info = hk.agent.active_reservation().expect("reservation held");
+    assert_eq!(info.renew_at_mono_ms, expected_renew);
+    assert_eq!(hk.agent.next_timeout(10_000), Some(expected_renew - 10_000));
+    // The completed exchange closes its write side; drain it.
+    drain_actions(&mut hk.agent);
+
+    // Too early: nothing happens.
+    hk.agent.handle_tick(at_unix(700_000, 1_700));
+    assert!(drain_actions(&mut hk.agent).is_empty());
+
+    // At renew time a fresh RESERVE goes out on the still-ready session.
+    hk.agent.handle_tick(at_unix(expected_renew, 1_790));
+    let (events, _) = hk.finish_reserve(
+        hop_reserve_ok(Some(2_700)),
+        at_unix(expected_renew + 5, 1_790),
+    );
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::RelayReserved {
+            expires_unix_secs: Some(2_700),
+            ..
+        }]
+    ));
+}
+
+#[test]
+fn reservation_without_expire_uses_default_ttl() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+    let (events, _) = reserve_via_relay(&mut hk, hop_reserve_ok(None), at_unix(10, 1_000));
+    // default TTL 3600s − margin 120s = 3480s.
+    let expected_renew = 10 + 3_480 * 1_000;
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::RelayReserved {
+            expires_unix_secs: None,
+            renew_at_mono_ms,
+            ..
+        }] if *renew_at_mono_ms == expected_renew
+    ));
+}
+
+#[test]
+fn reservation_on_clockless_host_uses_default_ttl() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+    // The relay reports an expiry, but we have no wall clock to compare.
+    let (events, _) = reserve_via_relay(&mut hk, hop_reserve_ok(Some(1_900)), at(10));
+    let expected_renew = 10 + 3_480 * 1_000;
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::RelayReserved {
+            expires_unix_secs: Some(1_900),
+            renew_at_mono_ms,
+            ..
+        }] if *renew_at_mono_ms == expected_renew
+    ));
+}
+
+#[test]
+fn refused_reservation_rotates_relay_after_backoff() {
+    let mut hk = build(ReservationPolicy::Always, 2, 0);
+
+    let (events, stream) =
+        reserve_via_relay(&mut hk, hop_status(Status::ReservationRefused), at(10));
+    assert!(events.is_empty(), "refusal before holding emits nothing");
+    let actions = drain_actions(&mut hk.agent);
+    assert!(has_reset_for(&actions, stream));
+    assert!(hk.agent.active_reservation().is_none());
+
+    // Still inside the 500ms backoff: quiet.
+    hk.agent.handle_tick(at(400));
+    assert!(drain_actions(&mut hk.agent).is_empty());
+
+    // After the backoff the manager tries the *other* relay.
+    hk.agent.handle_tick(at(600));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(dial_count_for(&actions, &hk.relay2), 1);
+    assert_eq!(dial_count_for(&actions, &hk.relay), 0);
+}
+
+#[test]
+fn lost_relay_connection_emits_lost_and_reacquires() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+    let (events, _) = reserve_via_relay(&mut hk, hop_reserve_ok(None), at_unix(10, 1_000));
+    assert_eq!(events.len(), 1);
+
+    let relay = hk.relay.clone();
+    hk.agent.handle_event(
+        &SwarmEvent::ConnectionClosed {
+            peer_id: relay.clone(),
+        },
+        at(5_000),
+    );
+    let events = drain_events(&mut hk.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::RelayReservationLost { relay: r }] if *r == relay
+    ));
+    assert!(hk.agent.active_reservation().is_none());
+
+    // After the backoff the (single) relay is dialed again.
+    hk.agent.handle_tick(at(5_600));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(dial_count_for(&actions, &hk.relay), 1);
+}
+
+#[test]
+fn when_private_policy_follows_the_reachability_verdict() {
+    let mut hk = build(ReservationPolicy::WhenPrivate, 1, 1);
+
+    // While reachability is Unknown, both housekeeping flows start: a
+    // reservation (dialable now) and a probe (gather evidence).
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    let relay_dial = dial_token_for(&actions, &hk.relay);
+    let server_dial = dial_token_for(&actions, &hk.server);
+    hk.agent
+        .dial_result(relay_dial, Ok(ConnectionId::new(60)), at(1));
+    hk.agent
+        .dial_result(server_dial, Ok(ConnectionId::new(61)), at(1));
+    let relay = hk.relay.clone();
+    let server = hk.server.clone();
+    hk.session_ready(&relay, &[HOP_PROTOCOL_ID], at(2));
+    let (events, _) = hk.finish_reserve(hop_reserve_ok(None), at(3));
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::RelayReserved { .. }]
+    ));
+
+    hk.session_ready(&server, &[AUTONAT_PROTOCOL_ID], at(4));
+    assert!(hk.finish_probe(true, 5).is_empty());
+    assert!(hk.run_probe(true, 6_000).is_empty());
+
+    // Third public probe: the verdict flips and, in the same cascade, the
+    // now-unneeded reservation is released.
+    let events = hk.run_probe(true, 12_000);
+    assert!(matches!(
+        events.as_slice(),
+        [
+            NatEvent::ReachabilityChanged {
+                new: ReachabilityState::Public,
+                ..
+            },
+            NatEvent::RelayReservationLost { .. },
+        ]
+    ));
+    assert!(hk.agent.active_reservation().is_none());
+
+    // Service the next scheduled probe, then verify quiet ticks stay quiet:
+    // no reservation reacquisition while confidently public.
+    assert!(hk.run_probe(true, 50_000).is_empty());
+    drain_actions(&mut hk.agent); // the finished probe's close-write
+    hk.agent.handle_tick(at(100_000));
+    let actions = drain_actions(&mut hk.agent);
+    assert!(
+        actions.is_empty(),
+        "no reservation while confidently public: {actions:?}"
+    );
+
+    // Flip back to Private: reacquisition begins in the same cascade.
+    assert!(hk.run_probe(false, 145_000).is_empty());
+    assert!(hk.run_probe(false, 236_000).is_empty());
+    hk.agent.handle_tick(at(330_000));
+    let events = hk.finish_probe(false, 330_001);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::ReachabilityChanged {
+            new: ReachabilityState::Private,
+            ..
+        }]
+    ));
+    let actions = drain_actions(&mut hk.agent);
+    assert!(
+        actions
+            .iter()
+            .any(|a| matches!(a, NatAction::OpenStream { protocol_id, .. } if protocol_id == HOP_PROTOCOL_ID)),
+        "reservation reacquired once private: {actions:?}"
+    );
+}

--- a/crates/nat/tests/inbound.rs
+++ b/crates/nat/tests/inbound.rs
@@ -1,0 +1,228 @@
+//! Scripted responder-side tests: inbound STOP circuits, the DCUtR
+//! responder exchange, punch-back dials, and the UDP blast schedule.
+
+mod common;
+
+use common::*;
+
+use minip2p_nat::{NatAction, NatConfig, NatEvent};
+use minip2p_relay::STOP_PROTOCOL_ID;
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::StreamId;
+
+const STOP_STREAM: u64 = 40;
+
+/// Delivers an inbound STOP `StreamReady` (relay-initiated) to the agent.
+fn inbound_stop_stream(h: &mut Harness, stream: StreamId, t: u64) {
+    h.agent.handle_event(
+        &SwarmEvent::StreamReady {
+            peer_id: h.relay.clone(),
+            stream_id: stream,
+            protocol_id: STOP_PROTOCOL_ID.to_string(),
+            initiated_locally: false,
+        },
+        at(t),
+    );
+}
+
+/// Drives a claimed circuit through CONNECT-accept and the DCUtR exchange
+/// up to (but not including) SYNC.
+fn drive_to_sync_ready(h: &mut Harness, stream: StreamId) {
+    let target = h.target.clone();
+    h.stream_data(stream, stop_connect(&target), at(10));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(send_stream_count(&actions), 1, "STATUS:OK must be sent");
+
+    // The initiator's DCUtR CONNECT (same shape as a reply).
+    h.stream_data(
+        stream,
+        dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]),
+        at(20),
+    );
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(
+        send_stream_count(&actions),
+        1,
+        "our DCUtR CONNECT reply must be sent"
+    );
+}
+
+#[test]
+fn full_inbound_flow_punches_back_and_upgrades() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    let stream = StreamId::new(STOP_STREAM);
+
+    inbound_stop_stream(&mut h, stream, 0);
+    assert!(h.agent.owns_stream(&h.relay, stream), "STOP stream claimed");
+
+    drive_to_sync_ready(&mut h, stream);
+
+    h.stream_data(stream, dcutr_sync(), at(30));
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::InboundRelayCircuit { peer, stream_id, .. }]
+            if *peer == h.target && *stream_id == stream
+    ));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(
+        dial_count_for(&actions, &h.target),
+        1,
+        "simultaneous-open dial toward the initiator's observed address"
+    );
+    assert!(
+        !h.agent.owns_stream(&h.relay, stream),
+        "bridge belongs to the app after SYNC"
+    );
+
+    // First blast waits out the configured sync delay (50ms after SYNC).
+    h.agent.handle_tick(at(79));
+    assert_eq!(blast_count(&drain_actions(&mut h.agent)), 0);
+    h.agent.handle_tick(at(80));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(blast_count(&actions), 1);
+    assert!(actions.iter().any(|a| matches!(
+        a,
+        NatAction::SendRandomUdp { target, payload_len: 32 }
+            if *target == maddr(REMOTE_OBSERVED_ADDR)
+    )));
+    h.agent.handle_tick(at(180));
+    assert_eq!(
+        blast_count(&drain_actions(&mut h.agent)),
+        1,
+        "100ms cadence"
+    );
+
+    // The punch lands: blasts stop, the upgrade is announced.
+    h.target_connected(at(250));
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::InboundDirectUpgrade { peer }] if *peer == h.target
+    ));
+    h.agent.handle_tick(at(400));
+    assert_eq!(blast_count(&drain_actions(&mut h.agent)), 0);
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn blast_schedule_exhausts_at_the_punch_deadline() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+    drive_to_sync_ready(&mut h, stream);
+    h.stream_data(stream, dcutr_sync(), at(30));
+    drain_events(&mut h.agent);
+    drain_actions(&mut h.agent);
+
+    // Catch up through the whole window (deadline 30 + 3000).
+    h.agent.handle_tick(at(3_100));
+    assert!(blast_count(&drain_actions(&mut h.agent)) > 0);
+    h.agent.handle_tick(at(3_200));
+    assert_eq!(
+        blast_count(&drain_actions(&mut h.agent)),
+        0,
+        "no blasts after the punch window"
+    );
+
+    // No direct connection ever arrives: the circuit lingers through the
+    // initiator's retry window, then retires with no further events.
+    h.agent.handle_tick(at(9_030));
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn stalled_exchange_still_releases_the_bridge() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+    let target = h.target.clone();
+    h.stream_data(stream, stop_connect(&target), at(10));
+    drain_actions(&mut h.agent);
+
+    // The initiator never starts DCUtR; at the exchange deadline the
+    // accepted bridge goes to the app punch-less.
+    h.agent.handle_tick(at(12_000));
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::InboundRelayCircuit { peer, .. }] if *peer == h.target
+    ));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(dial_count_for(&actions, &h.target), 0);
+    assert_eq!(blast_count(&actions), 0);
+    assert!(!h.agent.owns_stream(&h.relay, stream));
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn malformed_stop_connect_tears_the_circuit_down() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+
+    // A STATUS frame where a CONNECT is required.
+    h.stream_data(stream, hop_status(minip2p_relay::Status::Ok), at(10));
+    let actions = drain_actions(&mut h.agent);
+    assert!(has_reset_for(&actions, stream));
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(!h.agent.owns_stream(&h.relay, stream));
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn unparsable_source_peer_id_is_rejected() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+
+    h.stream_data(stream, stop_connect_raw(vec![0xFF, 0x00, 0x01]), at(10));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(
+        send_stream_count(&actions),
+        1,
+        "a rejection STATUS goes back to the relay"
+    );
+    assert!(has_reset_for(&actions, stream));
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn inbound_application_streams_are_never_claimed() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    let stream = StreamId::new(STOP_STREAM);
+    h.agent.handle_event(
+        &SwarmEvent::StreamReady {
+            peer_id: h.relay.clone(),
+            stream_id: stream,
+            protocol_id: "/my-app/1.0.0".to_string(),
+            initiated_locally: false,
+        },
+        at(0),
+    );
+    assert!(!h.agent.owns_stream(&h.relay, stream));
+    assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn relay_disconnect_before_release_drops_the_circuit() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+    let target = h.target.clone();
+    h.stream_data(stream, stop_connect(&target), at(10));
+    drain_actions(&mut h.agent);
+
+    h.agent.handle_event(
+        &SwarmEvent::ConnectionClosed {
+            peer_id: h.relay.clone(),
+        },
+        at(20),
+    );
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(!h.agent.owns_stream(&h.relay, stream));
+    assert!(h.agent.is_idle());
+}

--- a/crates/nat/tests/inbound.rs
+++ b/crates/nat/tests/inbound.rs
@@ -142,8 +142,10 @@ fn sync_coalesced_with_application_data_preserves_the_bridge_remainder() {
 
 #[test]
 fn zero_blast_interval_is_clamped_to_one_millisecond() {
-    let mut config = NatConfig::default();
-    config.blast_interval_ms = 0;
+    let config = NatConfig {
+        blast_interval_ms: 0,
+        ..NatConfig::default()
+    };
     let mut h = inbound_harness(config);
     let stream = StreamId::new(STOP_STREAM);
     inbound_stop_stream(&mut h, stream, 0);

--- a/crates/nat/tests/inbound.rs
+++ b/crates/nat/tests/inbound.rs
@@ -136,6 +136,7 @@ fn sync_coalesced_with_application_data_preserves_the_bridge_remainder() {
             peer,
             stream_id,
             pending_data,
+            ..
         }] if *peer == h.target && *stream_id == stream && *pending_data == app_data
     ));
 }
@@ -237,7 +238,11 @@ fn remote_write_close_keeps_an_accepted_bridge_alive_until_handoff() {
     h.agent.handle_tick(at(12_000));
     assert!(matches!(
         drain_events(&mut h.agent).as_slice(),
-        [NatEvent::InboundRelayCircuit { peer, .. }] if *peer == h.target
+        [NatEvent::InboundRelayCircuit {
+            peer,
+            remote_write_closed: true,
+            ..
+        }] if *peer == h.target
     ));
 }
 

--- a/crates/nat/tests/inbound.rs
+++ b/crates/nat/tests/inbound.rs
@@ -5,12 +5,24 @@ mod common;
 
 use common::*;
 
+use minip2p_core::PeerAddr;
 use minip2p_nat::{NatAction, NatConfig, NatEvent};
 use minip2p_relay::STOP_PROTOCOL_ID;
 use minip2p_swarm::SwarmEvent;
 use minip2p_transport::StreamId;
 
 const STOP_STREAM: u64 = 40;
+
+/// Inbound STOP is accepted only from a relay explicitly configured by the
+/// application. The scripted responder tests use the harness's relay peer.
+fn inbound_harness(mut config: NatConfig) -> Harness {
+    config.reservation_policy = minip2p_nat::ReservationPolicy::Never;
+    config.relays.push(
+        PeerAddr::new(maddr(RELAY_TRANSPORT_ADDR), peer(b"relay-peer"))
+            .expect("valid configured relay"),
+    );
+    Harness::without_relay(config)
+}
 
 /// Delivers an inbound STOP `StreamReady` (relay-initiated) to the agent.
 fn inbound_stop_stream(h: &mut Harness, stream: StreamId, t: u64) {
@@ -49,7 +61,7 @@ fn drive_to_sync_ready(h: &mut Harness, stream: StreamId) {
 
 #[test]
 fn full_inbound_flow_punches_back_and_upgrades() {
-    let mut h = Harness::without_relay(NatConfig::default());
+    let mut h = inbound_harness(NatConfig::default());
     let stream = StreamId::new(STOP_STREAM);
 
     inbound_stop_stream(&mut h, stream, 0);
@@ -106,8 +118,51 @@ fn full_inbound_flow_punches_back_and_upgrades() {
 }
 
 #[test]
+fn sync_coalesced_with_application_data_preserves_the_bridge_remainder() {
+    let mut h = inbound_harness(NatConfig::default());
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+    drive_to_sync_ready(&mut h, stream);
+
+    let app_data = b"first application bytes".to_vec();
+    let mut coalesced = dcutr_sync();
+    coalesced.extend_from_slice(&app_data);
+    h.stream_data(stream, coalesced, at(30));
+
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::InboundRelayCircuit {
+            peer,
+            stream_id,
+            pending_data,
+        }] if *peer == h.target && *stream_id == stream && *pending_data == app_data
+    ));
+}
+
+#[test]
+fn zero_blast_interval_is_clamped_to_one_millisecond() {
+    let mut config = NatConfig::default();
+    config.blast_interval_ms = 0;
+    let mut h = inbound_harness(config);
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+    drive_to_sync_ready(&mut h, stream);
+    h.stream_data(stream, dcutr_sync(), at(30));
+    drain_events(&mut h.agent);
+    drain_actions(&mut h.agent);
+
+    // The first due tick completes promptly (rather than repeatedly
+    // scheduling the same instant forever), then the clamped cadence is 1ms.
+    h.agent.handle_tick(at(80));
+    assert_eq!(blast_count(&drain_actions(&mut h.agent)), 1);
+    h.agent.handle_tick(at(81));
+    assert_eq!(blast_count(&drain_actions(&mut h.agent)), 1);
+}
+
+#[test]
 fn blast_schedule_exhausts_at_the_punch_deadline() {
-    let mut h = Harness::without_relay(NatConfig::default());
+    let mut h = inbound_harness(NatConfig::default());
     let stream = StreamId::new(STOP_STREAM);
     inbound_stop_stream(&mut h, stream, 0);
     drive_to_sync_ready(&mut h, stream);
@@ -134,7 +189,7 @@ fn blast_schedule_exhausts_at_the_punch_deadline() {
 
 #[test]
 fn stalled_exchange_still_releases_the_bridge() {
-    let mut h = Harness::without_relay(NatConfig::default());
+    let mut h = inbound_harness(NatConfig::default());
     let stream = StreamId::new(STOP_STREAM);
     inbound_stop_stream(&mut h, stream, 0);
     let target = h.target.clone();
@@ -157,8 +212,36 @@ fn stalled_exchange_still_releases_the_bridge() {
 }
 
 #[test]
+fn remote_write_close_keeps_an_accepted_bridge_alive_until_handoff() {
+    let mut h = inbound_harness(NatConfig::default());
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+    let target = h.target.clone();
+    h.stream_data(stream, stop_connect(&target), at(10));
+    drain_actions(&mut h.agent);
+
+    h.agent.handle_event(
+        &SwarmEvent::StreamRemoteWriteClosed {
+            peer_id: h.relay.clone(),
+            stream_id: stream,
+        },
+        at(20),
+    );
+    assert!(h.agent.owns_stream(&h.relay, stream));
+    assert!(!has_reset_for(&drain_actions(&mut h.agent), stream));
+
+    // The half-close does not kill the local write half; hand the accepted
+    // bridge to the app once the DCUtR exchange deadline expires.
+    h.agent.handle_tick(at(12_000));
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::InboundRelayCircuit { peer, .. }] if *peer == h.target
+    ));
+}
+
+#[test]
 fn malformed_stop_connect_tears_the_circuit_down() {
-    let mut h = Harness::without_relay(NatConfig::default());
+    let mut h = inbound_harness(NatConfig::default());
     let stream = StreamId::new(STOP_STREAM);
     inbound_stop_stream(&mut h, stream, 0);
 
@@ -173,7 +256,7 @@ fn malformed_stop_connect_tears_the_circuit_down() {
 
 #[test]
 fn unparsable_source_peer_id_is_rejected() {
-    let mut h = Harness::without_relay(NatConfig::default());
+    let mut h = inbound_harness(NatConfig::default());
     let stream = StreamId::new(STOP_STREAM);
     inbound_stop_stream(&mut h, stream, 0);
 
@@ -191,7 +274,7 @@ fn unparsable_source_peer_id_is_rejected() {
 
 #[test]
 fn inbound_application_streams_are_never_claimed() {
-    let mut h = Harness::without_relay(NatConfig::default());
+    let mut h = inbound_harness(NatConfig::default());
     let stream = StreamId::new(STOP_STREAM);
     h.agent.handle_event(
         &SwarmEvent::StreamReady {
@@ -209,7 +292,7 @@ fn inbound_application_streams_are_never_claimed() {
 
 #[test]
 fn relay_disconnect_before_release_drops_the_circuit() {
-    let mut h = Harness::without_relay(NatConfig::default());
+    let mut h = inbound_harness(NatConfig::default());
     let stream = StreamId::new(STOP_STREAM);
     inbound_stop_stream(&mut h, stream, 0);
     let target = h.target.clone();

--- a/crates/nat/tests/two_agents.rs
+++ b/crates/nat/tests/two_agents.rs
@@ -13,11 +13,9 @@ use common::{LISTEN_ADDR, at, drain_events, maddr, peer};
 
 use minip2p_core::{PeerAddr, PeerId};
 use minip2p_nat::{ConnectId, NatAction, NatAgent, NatConfig, NatEvent, Path, ReservationPolicy};
-use minip2p_relay::{
-    FrameDecode, HOP_PROTOCOL_ID, HopMessage, HopMessageType, Peer, Reservation, STOP_PROTOCOL_ID,
-    Status, StopMessage, StopMessageType, decode_frame, encode_frame,
-};
+use minip2p_relay::{HOP_PROTOCOL_ID, STOP_PROTOCOL_ID};
 use minip2p_swarm::SwarmEvent;
+use minip2p_test_support::{ConnectRequestOutcome, RelayEmulator};
 use minip2p_transport::{ConnectionId, StreamId};
 
 const A_LISTEN: &str = "/ip4/198.51.100.10/udp/4100/quic-v1";
@@ -49,8 +47,7 @@ struct World {
     now: u64,
     next_stream: u64,
     next_conn: u64,
-    /// Peers holding a reservation on the emulated relay.
-    reservations: Vec<PeerId>,
+    relay_emulator: RelayEmulator,
     /// Roles of relay-facing streams, per side.
     streams: Vec<(Side, StreamId, EmuStream)>,
     /// (A's bridge stream, B's stop stream) once the STOP handshake ran.
@@ -101,7 +98,7 @@ impl World {
             now: 0,
             next_stream: 0,
             next_conn: 0,
-            reservations: Vec::new(),
+            relay_emulator: RelayEmulator::new(),
             streams: Vec::new(),
             bridge: None,
             bridged: false,
@@ -240,90 +237,65 @@ impl World {
             .find(|(s, id, _)| *s == side && *id == stream)
             .map(|(_, _, role)| *role);
         match role {
-            Some(EmuStream::Hop) => {
-                let FrameDecode::Complete { payload, consumed } = decode_frame(&data) else {
-                    panic!("agents write whole frames");
-                };
-                let msg = HopMessage::decode(payload).expect("valid HOP frame");
-                let trailing = data[consumed..].to_vec();
-                match msg.kind {
-                    HopMessageType::Reserve => {
-                        self.reservations.push(self.peer_of(side));
-                        let response = HopMessage {
-                            kind: HopMessageType::Status,
-                            peer: None,
-                            reservation: Some(Reservation {
-                                expire: Some(9_999_999_999),
-                                addrs: Vec::new(),
-                                voucher: None,
-                            }),
-                            limit: None,
-                            status: Some(Status::Ok),
-                        };
-                        self.deliver(side, stream, encode_frame(&response.encode()));
-                    }
-                    HopMessageType::Connect => {
-                        let target = PeerId::from_bytes(&msg.peer.expect("target").id)
-                            .expect("valid target peer id");
-                        assert!(
-                            self.reservations.contains(&target),
-                            "HOP CONNECT requires the target's reservation"
-                        );
-                        assert_eq!(side, Side::A, "only A connects in this scenario");
-                        // Mark A's stream as the relay side of the bridge
-                        // and open the STOP stream toward B.
-                        self.set_role(side, stream, EmuStream::HopBridge);
-                        self.next_stream += 1;
-                        let stop_stream = StreamId::new(self.next_stream);
-                        self.streams.push((Side::B, stop_stream, EmuStream::Stop));
-                        self.bridge = Some((stream, stop_stream));
-
-                        let relay = self.relay_id.clone();
-                        self.b.handle_event(
-                            &SwarmEvent::StreamReady {
-                                peer_id: relay,
-                                stream_id: stop_stream,
-                                protocol_id: STOP_PROTOCOL_ID.to_string(),
-                                initiated_locally: false,
-                            },
-                            at(self.now),
-                        );
-                        let connect = StopMessage {
-                            kind: StopMessageType::Connect,
-                            peer: Some(Peer {
-                                id: self.a_id.to_bytes(),
-                                addrs: Vec::new(),
-                            }),
-                            limit: None,
-                            status: None,
-                        };
-                        self.deliver(Side::B, stop_stream, encode_frame(&connect.encode()));
-                        assert!(trailing.is_empty(), "no pipelining before the bridge");
-                    }
-                    HopMessageType::Status => panic!("clients never send HOP STATUS"),
+            Some(EmuStream::Hop) => match side {
+                Side::B => {
+                    let reserver = self.peer_of(side);
+                    let trailing = self
+                        .relay_emulator
+                        .on_reserve_request(&reserver, &data)
+                        .expect("valid RESERVE request");
+                    assert!(trailing.is_empty(), "no bytes follow RESERVE");
+                    let response = self.relay_emulator.drain_hop_bytes_for(&reserver);
+                    self.deliver(side, stream, response);
                 }
-            }
+                Side::A => {
+                    let initiator = self.peer_of(side);
+                    let mut initiator_inbox = Vec::new();
+                    let outcome = self
+                        .relay_emulator
+                        .on_connect_request(&initiator, &data, &mut initiator_inbox)
+                        .expect("valid CONNECT request");
+                    let ConnectRequestOutcome::Bridging { target, trailing } = outcome else {
+                        panic!("B must already hold a reservation");
+                    };
+                    assert_eq!(target, self.b_id);
+                    assert!(trailing.is_empty(), "no pipelining before the bridge");
+                    assert!(initiator_inbox.is_empty(), "bridge awaits STOP ack");
+
+                    // Mark A's stream as the relay side of the bridge and
+                    // open the queued STOP stream toward B.
+                    self.set_role(side, stream, EmuStream::HopBridge);
+                    self.next_stream += 1;
+                    let stop_stream = StreamId::new(self.next_stream);
+                    self.streams.push((Side::B, stop_stream, EmuStream::Stop));
+                    self.bridge = Some((stream, stop_stream));
+
+                    let relay = self.relay_id.clone();
+                    self.b.handle_event(
+                        &SwarmEvent::StreamReady {
+                            peer_id: relay,
+                            stream_id: stop_stream,
+                            protocol_id: STOP_PROTOCOL_ID.to_string(),
+                            initiated_locally: false,
+                        },
+                        at(self.now),
+                    );
+                    let stop_connect = self.relay_emulator.drain_stop_bytes_for(&target);
+                    self.deliver(Side::B, stop_stream, stop_connect);
+                }
+            },
             Some(EmuStream::Stop) if !self.bridged => {
                 // B's answer to STOP CONNECT.
-                let FrameDecode::Complete { payload, consumed } = decode_frame(&data) else {
-                    panic!("whole frame expected");
-                };
-                let msg = StopMessage::decode(payload).expect("valid STOP frame");
-                assert_eq!(msg.kind, StopMessageType::Status);
-                assert_eq!(msg.status, Some(Status::Ok), "B auto-accepts");
+                let mut initiator_inbox = Vec::new();
+                let trailing = self
+                    .relay_emulator
+                    .on_stop_ack_from_target(&data, &mut initiator_inbox)
+                    .expect("B auto-accepts with STOP STATUS:OK");
                 self.bridged = true;
                 let (a_bridge, _) = self.bridge.expect("bridge pending");
-                let status = HopMessage {
-                    kind: HopMessageType::Status,
-                    peer: None,
-                    reservation: None,
-                    limit: None,
-                    status: Some(Status::Ok),
-                };
-                self.deliver(Side::A, a_bridge, encode_frame(&status.encode()));
+                self.deliver(Side::A, a_bridge, initiator_inbox);
                 // Anything B pipelined behind its STATUS already belongs to
                 // the bridge.
-                let trailing = data[consumed..].to_vec();
                 if !trailing.is_empty() {
                     self.deliver(Side::A, a_bridge, trailing);
                 }

--- a/crates/nat/tests/two_agents.rs
+++ b/crates/nat/tests/two_agents.rs
@@ -1,0 +1,487 @@
+//! End-to-end integration of two `NatAgent`s over an in-memory relay
+//! emulator: B reserves, A connects through the relay, DCUtR runs over the
+//! real bridged bytes on both sides, and the race settles either
+//! `DirectPunched` (when the "network" lets the punch land) or `Relayed`
+//! (when it withholds the direct connection).
+//!
+//! No QUIC, no UDP — the emulator speaks the actual HOP/STOP wire format
+//! and pipes bridge bytes between the two agents.
+
+mod common;
+
+use common::{LISTEN_ADDR, at, drain_events, maddr, peer};
+
+use minip2p_core::{PeerAddr, PeerId};
+use minip2p_nat::{ConnectId, NatAction, NatAgent, NatConfig, NatEvent, Path, ReservationPolicy};
+use minip2p_relay::{
+    FrameDecode, HOP_PROTOCOL_ID, HopMessage, HopMessageType, Peer, Reservation, STOP_PROTOCOL_ID,
+    Status, StopMessage, StopMessageType, decode_frame, encode_frame,
+};
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::{ConnectionId, StreamId};
+
+const A_LISTEN: &str = "/ip4/198.51.100.10/udp/4100/quic-v1";
+const RELAY_ADDR: &str = "/ip4/203.0.113.1/udp/4001/quic-v1";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Side {
+    A,
+    B,
+}
+
+/// What the emulated relay knows about one agent-side stream.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EmuStream {
+    /// Fresh HOP stream; the first frame decides RESERVE vs CONNECT.
+    Hop,
+    /// A's HOP stream after CONNECT: relay side of the (pending) bridge.
+    HopBridge,
+    /// B's inbound STOP stream.
+    Stop,
+}
+
+struct World {
+    a: NatAgent,
+    b: NatAgent,
+    a_id: PeerId,
+    b_id: PeerId,
+    relay_id: PeerId,
+    now: u64,
+    next_stream: u64,
+    next_conn: u64,
+    /// Peers holding a reservation on the emulated relay.
+    reservations: Vec<PeerId>,
+    /// Roles of relay-facing streams, per side.
+    streams: Vec<(Side, StreamId, EmuStream)>,
+    /// (A's bridge stream, B's stop stream) once the STOP handshake ran.
+    bridge: Option<(StreamId, StreamId)>,
+    bridged: bool,
+    /// Whether dials between A and B produce connections.
+    deliver_direct: bool,
+    /// Sides that have an emulated relay session.
+    relay_sessions: Vec<Side>,
+    blasts_from_b: usize,
+    punch_dials_from_a: usize,
+    punch_dials_from_b: usize,
+}
+
+impl World {
+    fn new() -> Self {
+        let a_id = peer(b"agent-a");
+        let b_id = peer(b"agent-b");
+        let relay_id = peer(b"relay-peer");
+        let relay_addr = PeerAddr::new(maddr(RELAY_ADDR), relay_id.clone()).unwrap();
+
+        let mut a = NatAgent::new(
+            a_id.clone(),
+            NatConfig {
+                relays: vec![relay_addr.clone()],
+                reservation_policy: ReservationPolicy::Never,
+                ..NatConfig::default()
+            },
+        );
+        a.set_listen_addrs(&[maddr(A_LISTEN)]);
+
+        let mut b = NatAgent::new(
+            b_id.clone(),
+            NatConfig {
+                relays: vec![relay_addr],
+                reservation_policy: ReservationPolicy::Always,
+                ..NatConfig::default()
+            },
+        );
+        b.set_listen_addrs(&[maddr(LISTEN_ADDR)]);
+
+        Self {
+            a,
+            b,
+            a_id,
+            b_id,
+            relay_id,
+            now: 0,
+            next_stream: 0,
+            next_conn: 0,
+            reservations: Vec::new(),
+            streams: Vec::new(),
+            bridge: None,
+            bridged: false,
+            deliver_direct: false,
+            relay_sessions: Vec::new(),
+            blasts_from_b: 0,
+            punch_dials_from_a: 0,
+            punch_dials_from_b: 0,
+        }
+    }
+
+    fn agent(&mut self, side: Side) -> &mut NatAgent {
+        match side {
+            Side::A => &mut self.a,
+            Side::B => &mut self.b,
+        }
+    }
+
+    fn peer_of(&self, side: Side) -> PeerId {
+        match side {
+            Side::A => self.a_id.clone(),
+            Side::B => self.b_id.clone(),
+        }
+    }
+
+    /// Runs both agents until neither has pending actions.
+    fn pump(&mut self) {
+        loop {
+            let mut progressed = false;
+            for side in [Side::A, Side::B] {
+                while let Some(action) = self.agent(side).poll_action() {
+                    self.process(side, action);
+                    progressed = true;
+                }
+            }
+            if !progressed {
+                break;
+            }
+        }
+    }
+
+    /// Advances the shared clock and ticks both agents.
+    fn advance(&mut self, ms: u64) {
+        self.now += ms;
+        let now = at(self.now);
+        self.a.handle_tick(now);
+        self.b.handle_tick(now);
+        self.pump();
+    }
+
+    fn process(&mut self, side: Side, action: NatAction) {
+        let now = at(self.now);
+        match action {
+            NatAction::Dial { token, addr } => {
+                if addr.peer_id() == &self.relay_id {
+                    self.next_conn += 1;
+                    let conn = ConnectionId::new(self.next_conn);
+                    self.agent(side).dial_result(token, Ok(conn), now);
+                    if !self.relay_sessions.contains(&side) {
+                        self.relay_sessions.push(side);
+                        let relay = self.relay_id.clone();
+                        let agent = self.agent(side);
+                        agent.handle_event(
+                            &SwarmEvent::ConnectionEstablished {
+                                peer_id: relay.clone(),
+                            },
+                            now,
+                        );
+                        agent.handle_event(
+                            &SwarmEvent::PeerReady {
+                                peer_id: relay,
+                                protocols: vec![
+                                    HOP_PROTOCOL_ID.to_string(),
+                                    STOP_PROTOCOL_ID.to_string(),
+                                ],
+                            },
+                            now,
+                        );
+                    }
+                } else {
+                    // A dial toward the other agent.
+                    match side {
+                        Side::A => self.punch_dials_from_a += 1,
+                        Side::B => self.punch_dials_from_b += 1,
+                    }
+                    self.next_conn += 1;
+                    let conn = ConnectionId::new(self.next_conn);
+                    self.agent(side).dial_result(token, Ok(conn), now);
+                    if self.deliver_direct {
+                        self.establish_direct();
+                    }
+                }
+            }
+            NatAction::OpenStream {
+                token,
+                peer,
+                protocol_id,
+            } => {
+                assert_eq!(peer, self.relay_id, "agents only open streams to the relay");
+                assert_eq!(protocol_id, HOP_PROTOCOL_ID);
+                self.next_stream += 1;
+                let stream = StreamId::new(self.next_stream);
+                self.streams.push((side, stream, EmuStream::Hop));
+                let relay = self.relay_id.clone();
+                let agent = self.agent(side);
+                agent.stream_open_result(token, Ok(stream), now);
+                agent.handle_event(
+                    &SwarmEvent::StreamReady {
+                        peer_id: relay,
+                        stream_id: stream,
+                        protocol_id,
+                        initiated_locally: true,
+                    },
+                    now,
+                );
+            }
+            NatAction::SendStream {
+                stream_id, data, ..
+            } => self.on_relay_bytes(side, stream_id, data),
+            NatAction::SendRandomUdp { .. } => {
+                if side == Side::B {
+                    self.blasts_from_b += 1;
+                }
+            }
+            NatAction::CloseStreamWrite { .. }
+            | NatAction::ResetStream { .. }
+            | NatAction::Disconnect { .. } => {}
+        }
+    }
+
+    /// The emulated relay's byte handling.
+    fn on_relay_bytes(&mut self, side: Side, stream: StreamId, data: Vec<u8>) {
+        let role = self
+            .streams
+            .iter()
+            .find(|(s, id, _)| *s == side && *id == stream)
+            .map(|(_, _, role)| *role);
+        match role {
+            Some(EmuStream::Hop) => {
+                let FrameDecode::Complete { payload, consumed } = decode_frame(&data) else {
+                    panic!("agents write whole frames");
+                };
+                let msg = HopMessage::decode(payload).expect("valid HOP frame");
+                let trailing = data[consumed..].to_vec();
+                match msg.kind {
+                    HopMessageType::Reserve => {
+                        self.reservations.push(self.peer_of(side));
+                        let response = HopMessage {
+                            kind: HopMessageType::Status,
+                            peer: None,
+                            reservation: Some(Reservation {
+                                expire: Some(9_999_999_999),
+                                addrs: Vec::new(),
+                                voucher: None,
+                            }),
+                            limit: None,
+                            status: Some(Status::Ok),
+                        };
+                        self.deliver(side, stream, encode_frame(&response.encode()));
+                    }
+                    HopMessageType::Connect => {
+                        let target = PeerId::from_bytes(&msg.peer.expect("target").id)
+                            .expect("valid target peer id");
+                        assert!(
+                            self.reservations.contains(&target),
+                            "HOP CONNECT requires the target's reservation"
+                        );
+                        assert_eq!(side, Side::A, "only A connects in this scenario");
+                        // Mark A's stream as the relay side of the bridge
+                        // and open the STOP stream toward B.
+                        self.set_role(side, stream, EmuStream::HopBridge);
+                        self.next_stream += 1;
+                        let stop_stream = StreamId::new(self.next_stream);
+                        self.streams.push((Side::B, stop_stream, EmuStream::Stop));
+                        self.bridge = Some((stream, stop_stream));
+
+                        let relay = self.relay_id.clone();
+                        self.b.handle_event(
+                            &SwarmEvent::StreamReady {
+                                peer_id: relay,
+                                stream_id: stop_stream,
+                                protocol_id: STOP_PROTOCOL_ID.to_string(),
+                                initiated_locally: false,
+                            },
+                            at(self.now),
+                        );
+                        let connect = StopMessage {
+                            kind: StopMessageType::Connect,
+                            peer: Some(Peer {
+                                id: self.a_id.to_bytes(),
+                                addrs: Vec::new(),
+                            }),
+                            limit: None,
+                            status: None,
+                        };
+                        self.deliver(Side::B, stop_stream, encode_frame(&connect.encode()));
+                        assert!(trailing.is_empty(), "no pipelining before the bridge");
+                    }
+                    HopMessageType::Status => panic!("clients never send HOP STATUS"),
+                }
+            }
+            Some(EmuStream::Stop) if !self.bridged => {
+                // B's answer to STOP CONNECT.
+                let FrameDecode::Complete { payload, consumed } = decode_frame(&data) else {
+                    panic!("whole frame expected");
+                };
+                let msg = StopMessage::decode(payload).expect("valid STOP frame");
+                assert_eq!(msg.kind, StopMessageType::Status);
+                assert_eq!(msg.status, Some(Status::Ok), "B auto-accepts");
+                self.bridged = true;
+                let (a_bridge, _) = self.bridge.expect("bridge pending");
+                let status = HopMessage {
+                    kind: HopMessageType::Status,
+                    peer: None,
+                    reservation: None,
+                    limit: None,
+                    status: Some(Status::Ok),
+                };
+                self.deliver(Side::A, a_bridge, encode_frame(&status.encode()));
+                // Anything B pipelined behind its STATUS already belongs to
+                // the bridge.
+                let trailing = data[consumed..].to_vec();
+                if !trailing.is_empty() {
+                    self.deliver(Side::A, a_bridge, trailing);
+                }
+            }
+            Some(EmuStream::HopBridge) if self.bridged => {
+                let (_, b_stop) = self.bridge.expect("bridged");
+                self.deliver(Side::B, b_stop, data);
+            }
+            Some(EmuStream::Stop) => {
+                // Post-bridge bytes from B flow to A's bridge stream.
+                let (a_bridge, _) = self.bridge.expect("bridged");
+                self.deliver(Side::A, a_bridge, data);
+            }
+            Some(EmuStream::HopBridge) => {
+                panic!("A wrote bridge bytes before the relay bridged")
+            }
+            None => panic!("write on an unknown stream"),
+        }
+    }
+
+    fn set_role(&mut self, side: Side, stream: StreamId, role: EmuStream) {
+        for entry in &mut self.streams {
+            if entry.0 == side && entry.1 == stream {
+                entry.2 = role;
+            }
+        }
+    }
+
+    fn deliver(&mut self, side: Side, stream: StreamId, data: Vec<u8>) {
+        let relay = self.relay_id.clone();
+        let now = at(self.now);
+        self.agent(side).handle_event(
+            &SwarmEvent::StreamData {
+                peer_id: relay,
+                stream_id: stream,
+                data,
+            },
+            now,
+        );
+    }
+
+    /// The punch "lands": both sides observe the direct connection.
+    fn establish_direct(&mut self) {
+        let (a_id, b_id) = (self.a_id.clone(), self.b_id.clone());
+        let now = at(self.now);
+        self.a
+            .handle_event(&SwarmEvent::ConnectionEstablished { peer_id: b_id }, now);
+        self.b
+            .handle_event(&SwarmEvent::ConnectionEstablished { peer_id: a_id }, now);
+    }
+
+    /// B acquires its reservation through the emulated relay.
+    fn settle_reservation(&mut self) {
+        self.advance(1);
+        let events = drain_events(&mut self.b);
+        assert!(
+            matches!(events.as_slice(), [NatEvent::RelayReserved { .. }]),
+            "B must hold a reservation, got {events:?}"
+        );
+    }
+
+    /// A starts connecting to B (relay leg only — no direct candidates).
+    fn start_connect(&mut self) -> ConnectId {
+        let id = self.a.connect(self.b_id.clone(), Vec::new(), at(self.now));
+        self.pump();
+        id
+    }
+}
+
+#[test]
+fn two_agents_punch_to_a_direct_connection() {
+    let mut world = World::new();
+    world.settle_reservation();
+
+    let id = world.start_connect();
+    // The whole circuit + DCUtR exchange ran inside the pump; A holds a
+    // relayed path and has already dialed B's observed address.
+    let events = drain_events(&mut world.a);
+    assert!(
+        matches!(
+            events.as_slice(),
+            [NatEvent::PathEstablished { connect_id, path: Path::Relayed { .. }, .. }]
+                if *connect_id == id
+        ),
+        "A settles a relayed path first, got {events:?}"
+    );
+    assert_eq!(world.punch_dials_from_a, 1, "A dialed B's observed address");
+    let events = drain_events(&mut world.b);
+    assert!(
+        matches!(
+            events.as_slice(),
+            [NatEvent::InboundRelayCircuit { peer, .. }] if *peer == world.a_id
+        ),
+        "B released the inbound bridge, got {events:?}"
+    );
+
+    // B's punch-back: simultaneous dial plus UDP blasts after the sync
+    // delay.
+    assert_eq!(world.punch_dials_from_b, 1, "B dialed A's observed address");
+    world.advance(100);
+    assert!(world.blasts_from_b > 0, "B blasts random UDP");
+
+    // Now the network lets a dial land: both sides converge on direct.
+    world.deliver_direct = true;
+    world.establish_direct();
+    world.pump();
+
+    let events = drain_events(&mut world.a);
+    assert!(
+        matches!(
+            events.as_slice(),
+            [NatEvent::PathUpgraded {
+                from: Path::Relayed { .. },
+                to: Path::DirectPunched,
+                ..
+            }]
+        ),
+        "A upgrades explicitly, got {events:?}"
+    );
+    let events = drain_events(&mut world.b);
+    assert!(
+        matches!(events.as_slice(), [NatEvent::InboundDirectUpgrade { peer }] if *peer == world.a_id),
+        "B reports the inbound upgrade, got {events:?}"
+    );
+}
+
+#[test]
+fn two_agents_fall_back_to_the_relay_when_the_punch_never_lands() {
+    let mut world = World::new();
+    world.settle_reservation();
+
+    let id = world.start_connect();
+    drain_events(&mut world.a);
+    drain_events(&mut world.b);
+
+    // Walk through all three punch windows (3s each) with no direct
+    // connection ever appearing; B's blasts run and exhaust meanwhile.
+    let mut a_events = Vec::new();
+    for _ in 0..10 {
+        world.advance(1_000);
+        a_events.extend(drain_events(&mut world.a));
+    }
+    assert!(world.blasts_from_b > 0, "B blasted during its window");
+
+    let failures = a_events
+        .iter()
+        .filter(|e| matches!(e, NatEvent::HolePunchFailed { .. }))
+        .count();
+    assert_eq!(failures, 3, "one failure per punch window: {a_events:?}");
+    assert!(
+        matches!(
+            a_events.last(),
+            Some(NatEvent::FellBackToRelay { connect_id, .. }) if *connect_id == id
+        ),
+        "the relayed path is the final result: {a_events:?}"
+    );
+    // Neither side emits anything further; the bridge belongs to the apps.
+    assert!(drain_events(&mut world.b).is_empty());
+    world.advance(60_000);
+    assert!(drain_events(&mut world.a).is_empty());
+}

--- a/crates/nat/tests/two_agents.rs
+++ b/crates/nat/tests/two_agents.rs
@@ -15,7 +15,7 @@ use minip2p_core::{PeerAddr, PeerId};
 use minip2p_nat::{ConnectId, NatAction, NatAgent, NatConfig, NatEvent, Path, ReservationPolicy};
 use minip2p_relay::{HOP_PROTOCOL_ID, STOP_PROTOCOL_ID};
 use minip2p_swarm::SwarmEvent;
-use minip2p_test_support::{ConnectRequestOutcome, RelayEmulator};
+use minip2p_test_support::{ConnectRequestOutcome, PendingConnectId, RelayEmulator};
 use minip2p_transport::{ConnectionId, StreamId};
 
 const A_LISTEN: &str = "/ip4/198.51.100.10/udp/4100/quic-v1";
@@ -50,8 +50,9 @@ struct World {
     relay_emulator: RelayEmulator,
     /// Roles of relay-facing streams, per side.
     streams: Vec<(Side, StreamId, EmuStream)>,
-    /// (A's bridge stream, B's stop stream) once the STOP handshake ran.
-    bridge: Option<(StreamId, StreamId)>,
+    /// (A's bridge stream, B's stop stream, pending CONNECT) while the relay
+    /// coordinates the STOP handshake.
+    bridge: Option<(StreamId, StreamId, PendingConnectId)>,
     bridged: bool,
     /// Whether dials between A and B produce connections.
     deliver_direct: bool,
@@ -255,7 +256,12 @@ impl World {
                         .relay_emulator
                         .on_connect_request(&initiator, &data, &mut initiator_inbox)
                         .expect("valid CONNECT request");
-                    let ConnectRequestOutcome::Bridging { target, trailing } = outcome else {
+                    let ConnectRequestOutcome::Bridging {
+                        pending_id,
+                        target,
+                        trailing,
+                    } = outcome
+                    else {
                         panic!("B must already hold a reservation");
                     };
                     assert_eq!(target, self.b_id);
@@ -268,7 +274,7 @@ impl World {
                     self.next_stream += 1;
                     let stop_stream = StreamId::new(self.next_stream);
                     self.streams.push((Side::B, stop_stream, EmuStream::Stop));
-                    self.bridge = Some((stream, stop_stream));
+                    self.bridge = Some((stream, stop_stream, pending_id));
 
                     let relay = self.relay_id.clone();
                     self.b.handle_event(
@@ -287,12 +293,12 @@ impl World {
             Some(EmuStream::Stop) if !self.bridged => {
                 // B's answer to STOP CONNECT.
                 let mut initiator_inbox = Vec::new();
+                let (a_bridge, _, pending_id) = self.bridge.expect("bridge pending");
                 let trailing = self
                     .relay_emulator
-                    .on_stop_ack_from_target(&data, &mut initiator_inbox)
+                    .on_stop_ack_from_target(pending_id, &self.b_id, &data, &mut initiator_inbox)
                     .expect("B auto-accepts with STOP STATUS:OK");
                 self.bridged = true;
-                let (a_bridge, _) = self.bridge.expect("bridge pending");
                 self.deliver(Side::A, a_bridge, initiator_inbox);
                 // Anything B pipelined behind its STATUS already belongs to
                 // the bridge.
@@ -301,12 +307,12 @@ impl World {
                 }
             }
             Some(EmuStream::HopBridge) if self.bridged => {
-                let (_, b_stop) = self.bridge.expect("bridged");
+                let (_, b_stop, _) = self.bridge.expect("bridged");
                 self.deliver(Side::B, b_stop, data);
             }
             Some(EmuStream::Stop) => {
                 // Post-bridge bytes from B flow to A's bridge stream.
-                let (a_bridge, _) = self.bridge.expect("bridged");
+                let (a_bridge, _, _) = self.bridge.expect("bridged");
                 self.deliver(Side::A, a_bridge, data);
             }
             Some(EmuStream::HopBridge) => {

--- a/crates/swarm/Cargo.toml
+++ b/crates/swarm/Cargo.toml
@@ -33,3 +33,4 @@ getrandom = { version = "0.4.3", optional = true }
 [dev-dependencies]
 minip2p-relay = { path = "../relay" }
 minip2p-dcutr = { path = "../dcutr" }
+minip2p-test-support = { path = "../test-support" }

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -216,6 +216,11 @@ impl SwarmCore {
         self.local_addresses = addrs;
     }
 
+    /// The current snapshot of addresses Identify will advertise.
+    pub fn local_addresses(&self) -> &[Multiaddr] {
+        &self.local_addresses
+    }
+
     /// Registers an application protocol id that this swarm will accept on
     /// inbound streams and allow for outbound opens via
     /// [`Self::open_stream`].

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -92,6 +92,24 @@ impl Deadline {
         Deadline(Some(instant))
     }
 
+    /// Whether the deadline has already passed. [`Deadline::NEVER`] never
+    /// passes.
+    pub fn has_passed(self) -> bool {
+        self.is_expired_at(Instant::now())
+    }
+
+    /// The earlier of two deadlines ([`Deadline::NEVER`] is latest).
+    ///
+    /// Lets callers fold an extra timer source into a wait without access
+    /// to the deadline's internals, mirroring how [`Swarm::poll_next`]
+    /// folds the core's protocol timers into its budget.
+    pub fn earliest(self, other: Deadline) -> Deadline {
+        match (self.0, other.0) {
+            (Some(a), Some(b)) => Deadline(Some(a.min(b))),
+            (a, b) => Deadline(a.or(b)),
+        }
+    }
+
     /// Whether the deadline has passed at `now`.
     fn is_expired_at(self, now: Instant) -> bool {
         self.0.is_some_and(|deadline| now >= deadline)
@@ -168,6 +186,11 @@ pub struct Swarm<T: Transport> {
     /// when the buffer drains.
     event_buffer: VecDeque<SwarmEvent>,
 
+    /// Externally validated addresses advertised through Identify in
+    /// addition to the transport's bound set. See
+    /// [`Swarm::set_external_addresses`].
+    external_addresses: Vec<Multiaddr>,
+
     /// Logical clock used to drive Sans-I/O timers.
     clock: Arc<dyn Clock>,
 }
@@ -210,8 +233,20 @@ impl<T: Transport> Swarm<T> {
             core: SwarmCore::new(identify_config, ping_config),
             local_peer_id,
             event_buffer: VecDeque::new(),
+            external_addresses: Vec::new(),
             clock,
         }
+    }
+
+    /// Sets externally validated addresses (e.g. AutoNAT-confirmed public
+    /// addresses or relay circuit addresses) to advertise through Identify
+    /// alongside the transport's bound addresses.
+    ///
+    /// Replaces the previous external set; pass an empty vector to stop
+    /// advertising extras. Duplicates of transport-bound addresses are
+    /// dropped.
+    pub fn set_external_addresses(&mut self, addrs: Vec<Multiaddr>) {
+        self.external_addresses = addrs;
     }
 
     /// Returns a reference to the underlying transport.
@@ -462,10 +497,15 @@ impl<T: Transport> Swarm<T> {
         let now_ms = self.now_ms();
 
         // 0. Refresh the core's snapshot of our listening addresses so
-        //    Identify advertises the current bound set. Cheap -- a
-        //    handful of multiaddrs at most.
-        self.core
-            .set_local_addresses(self.transport.local_addresses());
+        //    Identify advertises the current bound set plus any validated
+        //    external addresses. Cheap -- a handful of multiaddrs at most.
+        let mut local_addresses = self.transport.local_addresses();
+        for addr in &self.external_addresses {
+            if !local_addresses.contains(addr) {
+                local_addresses.push(addr.clone());
+            }
+        }
+        self.core.set_local_addresses(local_addresses);
 
         // 1. Feed transport events to the core.
         let events = self.transport.poll()?;
@@ -950,6 +990,37 @@ mod tests {
             PingConfig::default(),
             keypair.peer_id(),
         )
+    }
+
+    #[test]
+    fn external_addresses_merge_into_the_identify_snapshot() {
+        let mut swarm = idle_swarm();
+        let external: Multiaddr = "/ip4/203.0.113.9/udp/4001/quic-v1".parse().unwrap();
+        let circuit: Multiaddr = "/ip4/203.0.113.1/udp/4001/quic-v1/p2p-circuit"
+            .parse()
+            .unwrap();
+
+        swarm.set_external_addresses(vec![external.clone(), circuit.clone()]);
+        swarm.poll().unwrap();
+        // IdleTransport binds nothing, so the snapshot is exactly the
+        // external set.
+        assert_eq!(swarm.core().local_addresses(), &[external.clone(), circuit]);
+
+        // Replacing the set (here: clearing it) stops advertising extras.
+        swarm.set_external_addresses(Vec::new());
+        swarm.poll().unwrap();
+        assert!(swarm.core().local_addresses().is_empty());
+    }
+
+    #[test]
+    fn deadline_earliest_picks_the_sooner_deadline() {
+        let soon = Deadline::from(Duration::from_millis(10));
+        let later = Deadline::from(Duration::from_secs(60));
+        assert_eq!(soon.earliest(later), soon);
+        assert_eq!(later.earliest(soon), soon);
+        assert_eq!(Deadline::NEVER.earliest(soon), soon);
+        assert_eq!(soon.earliest(Deadline::NEVER), soon);
+        assert_eq!(Deadline::NEVER.earliest(Deadline::NEVER), Deadline::NEVER);
     }
 
     #[test]

--- a/crates/swarm/tests/relay_holepunch_flow.rs
+++ b/crates/swarm/tests/relay_holepunch_flow.rs
@@ -22,230 +22,21 @@
 //!   |   (both peers ready to dial each other directly)        |
 //! ```
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::str::FromStr;
 
-use minip2p_core::{Multiaddr, PeerId, SansIoProtocol};
+use minip2p_core::{Multiaddr, SansIoProtocol};
 use minip2p_dcutr::{
     DcutrInitiator, DcutrInitiatorInput, DcutrInitiatorOutput, DcutrResponder, DcutrResponderInput,
     DcutrResponderOutput, InitiatorOutcome, ResponderEvent, decode_frame as dcutr_decode_frame,
 };
 use minip2p_identity::Ed25519Keypair;
 use minip2p_relay::{
-    FrameDecode, HopConnect, HopConnectInput, HopConnectOutput, HopMessage, HopMessageType,
-    HopReservation, HopReservationInput, HopReservationOutput, Peer, Reservation,
-    ReservationOutcome, Status, StopMessage, StopMessageType, StopResponder, StopResponderInput,
-    StopResponderOutput, decode_frame as relay_decode_frame, encode_frame as relay_encode_frame,
+    HopConnect, HopConnectInput, HopConnectOutput, HopReservation, HopReservationInput,
+    HopReservationOutput, ReservationOutcome, Status, StopResponder, StopResponderInput,
+    StopResponderOutput,
 };
-
-// ---------------------------------------------------------------------------
-// In-memory relay emulator (the absolute minimum needed to bridge the test)
-// ---------------------------------------------------------------------------
-
-/// A minimal in-memory relay that handles RESERVE and CONNECT over HOP, plus
-/// the paired STOP exchange. It owns a per-peer inbox of bytes the client
-/// would receive on their HOP stream.
-struct RelayEmulator {
-    /// HOP -> reserved peer id.
-    reservations: HashMap<PeerId, ReservationChannels>,
-    /// Events observed during processing, for test assertions.
-    events: Vec<RelayEvent>,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum RelayEvent {
-    ReservationStored { peer: PeerId },
-    ConnectBridgedBetween { initiator: PeerId, target: PeerId },
-    StatusOkSentToInitiator,
-}
-
-/// Channels representing a reserved peer's HOP stream (for STATUS replies)
-/// and an optional STOP stream we will open toward them on CONNECT.
-struct ReservationChannels {
-    /// Bytes the relay sends back to the reserving peer on its HOP stream.
-    hop_inbox: Vec<u8>,
-    /// Bytes the relay sends to the reserving peer on the STOP stream opened
-    /// when another peer requests a CONNECT targeting this peer.
-    stop_inbox: Vec<u8>,
-}
-
-impl RelayEmulator {
-    fn new() -> Self {
-        Self {
-            reservations: HashMap::new(),
-            events: Vec::new(),
-        }
-    }
-
-    /// The reserving peer sends raw bytes on its HOP stream. We parse them
-    /// and queue the appropriate response to the peer's HOP inbox.
-    fn on_reserve_request(
-        &mut self,
-        reserver: &PeerId,
-        bytes: &[u8],
-    ) -> Result<(), RelayEmulatorError> {
-        let msg = decode_hop_message(bytes)?;
-        if msg.kind != HopMessageType::Reserve {
-            return Err(RelayEmulatorError::Unexpected("expected RESERVE"));
-        }
-
-        // Prepare the reservation.
-        let channels = self
-            .reservations
-            .entry(reserver.clone())
-            .or_insert_with(|| ReservationChannels {
-                hop_inbox: Vec::new(),
-                stop_inbox: Vec::new(),
-            });
-
-        let response = HopMessage {
-            kind: HopMessageType::Status,
-            peer: None,
-            reservation: Some(Reservation {
-                expire: Some(9_999_999_999),
-                addrs: Vec::new(),
-                voucher: None,
-            }),
-            limit: None,
-            status: Some(Status::Ok),
-        };
-        channels
-            .hop_inbox
-            .extend(relay_encode_frame(&response.encode()));
-        self.events.push(RelayEvent::ReservationStored {
-            peer: reserver.clone(),
-        });
-        Ok(())
-    }
-
-    /// Drain queued HOP bytes for a reserved peer.
-    fn drain_hop_bytes_for(&mut self, peer: &PeerId) -> Vec<u8> {
-        self.reservations
-            .get_mut(peer)
-            .map(|r| core::mem::take(&mut r.hop_inbox))
-            .unwrap_or_default()
-    }
-
-    /// Drain queued STOP bytes for a reserved peer.
-    fn drain_stop_bytes_for(&mut self, peer: &PeerId) -> Vec<u8> {
-        self.reservations
-            .get_mut(peer)
-            .map(|r| core::mem::take(&mut r.stop_inbox))
-            .unwrap_or_default()
-    }
-
-    /// An initiator peer sends a HOP CONNECT targeting `target`. We verify
-    /// the target is reserved, then open a virtual STOP stream to them and
-    /// forward a STOP CONNECT message.
-    ///
-    /// The initiator's responses (STATUS after the target acks) are tracked
-    /// via `pending_initiator_responses`.
-    fn on_connect_request(
-        &mut self,
-        initiator: &PeerId,
-        bytes: &[u8],
-        pending_initiator_responses: &mut Vec<u8>,
-    ) -> Result<(), RelayEmulatorError> {
-        let msg = decode_hop_message(bytes)?;
-        if msg.kind != HopMessageType::Connect {
-            return Err(RelayEmulatorError::Unexpected("expected CONNECT"));
-        }
-        let target_bytes = msg
-            .peer
-            .as_ref()
-            .map(|p| p.id.clone())
-            .ok_or(RelayEmulatorError::Unexpected("missing peer field"))?;
-
-        let target = PeerId::from_bytes(&target_bytes)
-            .map_err(|_| RelayEmulatorError::Unexpected("invalid target peer id"))?;
-
-        if !self.reservations.contains_key(&target) {
-            let refusal = HopMessage {
-                kind: HopMessageType::Status,
-                peer: None,
-                reservation: None,
-                limit: None,
-                status: Some(Status::NoReservation),
-            };
-            pending_initiator_responses.extend(relay_encode_frame(&refusal.encode()));
-            return Ok(());
-        }
-
-        // Open a STOP stream to the target: queue a STOP CONNECT with the
-        // initiator's peer id as the source.
-        let stop_connect = StopMessage {
-            kind: StopMessageType::Connect,
-            peer: Some(Peer {
-                id: initiator.to_bytes(),
-                addrs: Vec::new(),
-            }),
-            limit: None,
-            status: None,
-        };
-        self.reservations
-            .get_mut(&target)
-            .expect("checked above")
-            .stop_inbox
-            .extend(relay_encode_frame(&stop_connect.encode()));
-
-        self.events.push(RelayEvent::ConnectBridgedBetween {
-            initiator: initiator.clone(),
-            target,
-        });
-
-        Ok(())
-    }
-
-    /// The target peer replies on its STOP stream with STATUS:OK. We forward
-    /// a HOP STATUS:OK to the initiator.
-    fn on_stop_ack_from_target(
-        &mut self,
-        bytes: &[u8],
-        initiator_inbox: &mut Vec<u8>,
-    ) -> Result<(), RelayEmulatorError> {
-        let msg = decode_stop_message(bytes)?;
-        if msg.kind != StopMessageType::Status || msg.status != Some(Status::Ok) {
-            return Err(RelayEmulatorError::Unexpected("expected STOP STATUS:OK"));
-        }
-
-        let ok = HopMessage {
-            kind: HopMessageType::Status,
-            peer: None,
-            reservation: None,
-            limit: None,
-            status: Some(Status::Ok),
-        };
-        initiator_inbox.extend(relay_encode_frame(&ok.encode()));
-        self.events.push(RelayEvent::StatusOkSentToInitiator);
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-#[allow(dead_code)] // the &'static str is only for diagnostic messages surfaced via Debug.
-enum RelayEmulatorError {
-    Unexpected(&'static str),
-}
-
-/// Parse a single HOP frame from the front of `bytes` and return the decoded message.
-fn decode_hop_message(bytes: &[u8]) -> Result<HopMessage, RelayEmulatorError> {
-    match relay_decode_frame(bytes) {
-        FrameDecode::Complete { payload, .. } => {
-            HopMessage::decode(payload).map_err(|_| RelayEmulatorError::Unexpected("bad HOP"))
-        }
-        _ => Err(RelayEmulatorError::Unexpected("incomplete HOP frame")),
-    }
-}
-
-/// Parse a single STOP frame from the front of `bytes` and return the decoded message.
-fn decode_stop_message(bytes: &[u8]) -> Result<StopMessage, RelayEmulatorError> {
-    match relay_decode_frame(bytes) {
-        FrameDecode::Complete { payload, .. } => {
-            StopMessage::decode(payload).map_err(|_| RelayEmulatorError::Unexpected("bad STOP"))
-        }
-        _ => Err(RelayEmulatorError::Unexpected("incomplete STOP frame")),
-    }
-}
+use minip2p_test_support::{ConnectRequestOutcome, RelayEmulator, RelayEvent};
 
 // ---------------------------------------------------------------------------
 // The actual test
@@ -267,7 +58,12 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
 
     // B sends RESERVE. Relay stores reservation and responds with STATUS:OK.
     let reserve_bytes = reserve_flush(&mut b_reservation);
-    relay.on_reserve_request(&peer_b, &reserve_bytes).unwrap();
+    assert!(
+        relay
+            .on_reserve_request(&peer_b, &reserve_bytes)
+            .unwrap()
+            .is_empty()
+    );
 
     // B receives the relay's response on its HOP stream.
     let relay_to_b = relay.drain_hop_bytes_for(&peer_b);
@@ -294,9 +90,14 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
     // The relay forwards a STOP CONNECT to B and remembers to send A a
     // STATUS:OK once B acks.
     let mut initiator_inbox: Vec<u8> = Vec::new();
-    relay
+    let connect_request = relay
         .on_connect_request(&peer_a, &connect_bytes, &mut initiator_inbox)
         .unwrap();
+    assert!(matches!(
+        connect_request,
+        ConnectRequestOutcome::Bridging { target, trailing }
+            if target == peer_b && trailing.is_empty()
+    ));
     assert_eq!(initiator_inbox, Vec::<u8>::new(), "no refusal expected");
 
     // ---- Step 3: B receives STOP CONNECT, accepts, relay bridges ---------
@@ -311,9 +112,10 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
     let b_stop_ok = stop_accept_flush(&mut b_stop);
 
     // Relay forwards the ack to A as HOP STATUS:OK.
-    relay
+    let stop_trailing = relay
         .on_stop_ack_from_target(&b_stop_ok, &mut initiator_inbox)
         .unwrap();
+    assert!(stop_trailing.is_empty());
 
     // A receives the HOP STATUS:OK: the stream is now bridged.
     let connect_outcome = connect_feed(&mut a_connect, initiator_inbox);
@@ -413,9 +215,13 @@ fn connect_refused_when_target_not_reserved() {
     let connect_bytes = connect_flush(&mut a_connect);
 
     let mut initiator_inbox: Vec<u8> = Vec::new();
-    relay
+    let connect_request = relay
         .on_connect_request(&peer_a, &connect_bytes, &mut initiator_inbox)
         .unwrap();
+    assert!(matches!(
+        connect_request,
+        ConnectRequestOutcome::Refused { trailing } if trailing.is_empty()
+    ));
 
     let outcome = connect_feed(&mut a_connect, initiator_inbox);
 

--- a/crates/swarm/tests/relay_holepunch_flow.rs
+++ b/crates/swarm/tests/relay_holepunch_flow.rs
@@ -94,9 +94,9 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
         .on_connect_request(&peer_a, &connect_bytes, &mut initiator_inbox)
         .unwrap();
     assert!(matches!(
-        connect_request,
-        ConnectRequestOutcome::Bridging { target, trailing }
-            if target == peer_b && trailing.is_empty()
+        &connect_request,
+        ConnectRequestOutcome::Bridging { target, trailing, .. }
+            if target == &peer_b && trailing.is_empty()
     ));
     assert_eq!(initiator_inbox, Vec::<u8>::new(), "no refusal expected");
 
@@ -112,8 +112,11 @@ fn full_relay_plus_hole_punch_flow_succeeds() {
     let b_stop_ok = stop_accept_flush(&mut b_stop);
 
     // Relay forwards the ack to A as HOP STATUS:OK.
+    let ConnectRequestOutcome::Bridging { pending_id, .. } = connect_request else {
+        unreachable!("CONNECT was checked as bridging above")
+    };
     let stop_trailing = relay
-        .on_stop_ack_from_target(&b_stop_ok, &mut initiator_inbox)
+        .on_stop_ack_from_target(pending_id, &peer_b, &b_stop_ok, &mut initiator_inbox)
         .unwrap();
     assert!(stop_trailing.is_empty());
 

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "minip2p-test-support"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+minip2p-core = { path = "../core" }
+minip2p-relay = { path = "../relay" }

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -15,6 +15,8 @@ use minip2p_relay::{
 pub enum ConnectRequestOutcome {
     /// The target held a reservation and a STOP CONNECT was queued for it.
     Bridging {
+        /// Opaque token tying the STOP response to this CONNECT request.
+        pending_id: PendingConnectId,
         target: PeerId,
         /// Bytes pipelined behind the HOP CONNECT frame.
         trailing: Vec<u8>,
@@ -35,6 +37,10 @@ pub enum RelayEvent {
     StatusOkSentToInitiator,
 }
 
+/// Opaque identity for a HOP CONNECT awaiting its target's STOP response.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct PendingConnectId(u64);
+
 /// Minimal in-memory HOP/STOP relay used by protocol and NAT-agent tests.
 ///
 /// It validates real framed relay messages, stores reservations, queues STOP
@@ -42,7 +48,14 @@ pub enum RelayEvent {
 #[derive(Default)]
 pub struct RelayEmulator {
     reservations: HashMap<PeerId, ReservationChannels>,
+    pending_connects: HashMap<PendingConnectId, PendingConnect>,
+    next_connect_id: u64,
     pub events: Vec<RelayEvent>,
+}
+
+struct PendingConnect {
+    initiator: PeerId,
+    target: PeerId,
 }
 
 #[derive(Default)]
@@ -147,17 +160,31 @@ impl RelayEmulator {
         channels
             .stop_inbox
             .extend(encode_frame(&stop_connect.encode()));
-        self.events.push(RelayEvent::ConnectBridgedBetween {
-            initiator: initiator.clone(),
-            target: target.clone(),
-        });
-        Ok(ConnectRequestOutcome::Bridging { target, trailing })
+        let pending_id = PendingConnectId(self.next_connect_id);
+        self.next_connect_id = self.next_connect_id.wrapping_add(1);
+        self.pending_connects.insert(
+            pending_id,
+            PendingConnect {
+                initiator: initiator.clone(),
+                target: target.clone(),
+            },
+        );
+        Ok(ConnectRequestOutcome::Bridging {
+            pending_id,
+            target,
+            trailing,
+        })
     }
 
-    /// Handles a complete STOP STATUS:OK frame, queues HOP STATUS:OK for the
-    /// initiator, and returns any bytes already belonging to the bridge.
+    /// Handles the target's STOP response for one pending HOP CONNECT.
+    ///
+    /// The pending token and target must identify the same CONNECT. On a
+    /// successful STOP STATUS:OK, this queues HOP STATUS:OK for the initiator
+    /// and returns any bytes already belonging to the bridge.
     pub fn on_stop_ack_from_target(
         &mut self,
+        pending_id: PendingConnectId,
+        target: &PeerId,
         bytes: &[u8],
         initiator_inbox: &mut Vec<u8>,
     ) -> Result<Vec<u8>, RelayEmulatorError> {
@@ -165,6 +192,22 @@ impl RelayEmulator {
         if msg.kind != StopMessageType::Status || msg.status != Some(Status::Ok) {
             return Err(RelayEmulatorError::Unexpected("expected STOP STATUS:OK"));
         }
+
+        let pending =
+            self.pending_connects
+                .get(&pending_id)
+                .ok_or(RelayEmulatorError::Unexpected(
+                    "no matching pending CONNECT",
+                ))?;
+        if &pending.target != target {
+            return Err(RelayEmulatorError::Unexpected(
+                "STOP response target does not match pending CONNECT",
+            ));
+        }
+        let pending = self
+            .pending_connects
+            .remove(&pending_id)
+            .expect("pending CONNECT was checked above");
 
         let ok = HopMessage {
             kind: HopMessageType::Status,
@@ -174,6 +217,10 @@ impl RelayEmulator {
             status: Some(Status::Ok),
         };
         initiator_inbox.extend(encode_frame(&ok.encode()));
+        self.events.push(RelayEvent::ConnectBridgedBetween {
+            initiator: pending.initiator,
+            target: pending.target,
+        });
         self.events.push(RelayEvent::StatusOkSentToInitiator);
         Ok(bytes[consumed..].to_vec())
     }
@@ -209,5 +256,133 @@ fn decode_stop_message(bytes: &[u8]) -> Result<(StopMessage, usize), RelayEmulat
             .map(|message| (message, consumed))
             .map_err(|_| RelayEmulatorError::Unexpected("bad STOP")),
         _ => Err(RelayEmulatorError::Unexpected("incomplete STOP frame")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer(tag: &[u8]) -> PeerId {
+        PeerId::from_public_key_protobuf(tag)
+    }
+
+    fn reserve(relay: &mut RelayEmulator, target: &PeerId) {
+        let request = HopMessage {
+            kind: HopMessageType::Reserve,
+            peer: None,
+            reservation: None,
+            limit: None,
+            status: None,
+        };
+        relay
+            .on_reserve_request(target, &encode_frame(&request.encode()))
+            .unwrap();
+        relay.events.clear();
+    }
+
+    fn connect(relay: &mut RelayEmulator, initiator: &PeerId, target: &PeerId) -> PendingConnectId {
+        let request = HopMessage {
+            kind: HopMessageType::Connect,
+            peer: Some(Peer {
+                id: target.to_bytes(),
+                addrs: Vec::new(),
+            }),
+            reservation: None,
+            limit: None,
+            status: None,
+        };
+        let mut inbox = Vec::new();
+        let outcome = relay
+            .on_connect_request(initiator, &encode_frame(&request.encode()), &mut inbox)
+            .unwrap();
+        assert!(inbox.is_empty());
+        match outcome {
+            ConnectRequestOutcome::Bridging { pending_id, .. } => pending_id,
+            ConnectRequestOutcome::Refused { .. } => panic!("reserved target was refused"),
+        }
+    }
+
+    fn stop_ok() -> Vec<u8> {
+        encode_frame(
+            &StopMessage {
+                kind: StopMessageType::Status,
+                peer: None,
+                limit: None,
+                status: Some(Status::Ok),
+            }
+            .encode(),
+        )
+    }
+
+    #[test]
+    fn bridge_event_is_emitted_only_after_stop_accepts() {
+        let initiator = peer(b"initiator");
+        let target = peer(b"target");
+        let mut relay = RelayEmulator::new();
+        reserve(&mut relay, &target);
+
+        let pending_id = connect(&mut relay, &initiator, &target);
+        assert!(relay.events.is_empty(), "CONNECT is still pending STOP ACK");
+
+        let mut inbox = Vec::new();
+        relay
+            .on_stop_ack_from_target(pending_id, &target, &stop_ok(), &mut inbox)
+            .unwrap();
+        assert!(!inbox.is_empty(), "initiator receives HOP STATUS:OK");
+        assert_eq!(
+            relay.events,
+            [
+                RelayEvent::ConnectBridgedBetween { initiator, target },
+                RelayEvent::StatusOkSentToInitiator,
+            ]
+        );
+    }
+
+    #[test]
+    fn stop_ack_must_match_pending_connect_context() {
+        let initiator_a = peer(b"initiator-a");
+        let initiator_b = peer(b"initiator-b");
+        let target_a = peer(b"target-a");
+        let target_b = peer(b"target-b");
+        let mut relay = RelayEmulator::new();
+        reserve(&mut relay, &target_a);
+        reserve(&mut relay, &target_b);
+        let pending_a = connect(&mut relay, &initiator_a, &target_a);
+        let pending_b = connect(&mut relay, &initiator_b, &target_b);
+        let ack = stop_ok();
+
+        let mut inbox = Vec::new();
+        let wrong_circuit = relay
+            .on_stop_ack_from_target(pending_a, &target_b, &ack, &mut inbox)
+            .unwrap_err();
+        assert_eq!(
+            wrong_circuit,
+            RelayEmulatorError::Unexpected("STOP response target does not match pending CONNECT")
+        );
+        assert!(inbox.is_empty());
+        assert!(relay.events.is_empty());
+
+        relay
+            .on_stop_ack_from_target(pending_a, &target_a, &ack, &mut inbox)
+            .unwrap();
+        inbox.clear();
+        let already_consumed = relay
+            .on_stop_ack_from_target(pending_a, &target_a, &ack, &mut inbox)
+            .unwrap_err();
+        assert_eq!(
+            already_consumed,
+            RelayEmulatorError::Unexpected("no matching pending CONNECT")
+        );
+        assert!(inbox.is_empty());
+
+        relay
+            .on_stop_ack_from_target(pending_b, &target_b, &ack, &mut inbox)
+            .unwrap();
+        assert!(relay.events.iter().any(|event| matches!(
+            event,
+            RelayEvent::ConnectBridgedBetween { initiator, target }
+                if initiator == &initiator_b && target == &target_b
+        )));
     }
 }

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -1,0 +1,213 @@
+//! Shared protocol-faithful test fixtures for the minip2p workspace.
+//!
+//! This crate is `publish = false` and is used only through dev-dependencies.
+
+use std::collections::HashMap;
+
+use minip2p_core::PeerId;
+use minip2p_relay::{
+    FrameDecode, HopMessage, HopMessageType, Peer, Reservation, Status, StopMessage,
+    StopMessageType, decode_frame, encode_frame,
+};
+
+/// Result of handling one HOP CONNECT request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ConnectRequestOutcome {
+    /// The target held a reservation and a STOP CONNECT was queued for it.
+    Bridging {
+        target: PeerId,
+        /// Bytes pipelined behind the HOP CONNECT frame.
+        trailing: Vec<u8>,
+    },
+    /// The target held no reservation and a refusal was queued for the
+    /// initiator.
+    Refused {
+        /// Bytes pipelined behind the HOP CONNECT frame.
+        trailing: Vec<u8>,
+    },
+}
+
+/// Events retained by [`RelayEmulator`] for test assertions.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RelayEvent {
+    ReservationStored { peer: PeerId },
+    ConnectBridgedBetween { initiator: PeerId, target: PeerId },
+    StatusOkSentToInitiator,
+}
+
+/// Minimal in-memory HOP/STOP relay used by protocol and NAT-agent tests.
+///
+/// It validates real framed relay messages, stores reservations, queues STOP
+/// CONNECT requests, and turns an accepted STOP response into HOP STATUS:OK.
+#[derive(Default)]
+pub struct RelayEmulator {
+    reservations: HashMap<PeerId, ReservationChannels>,
+    pub events: Vec<RelayEvent>,
+}
+
+#[derive(Default)]
+struct ReservationChannels {
+    hop_inbox: Vec<u8>,
+    stop_inbox: Vec<u8>,
+}
+
+impl RelayEmulator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Handles a complete HOP RESERVE frame and returns any bytes pipelined
+    /// behind it.
+    pub fn on_reserve_request(
+        &mut self,
+        reserver: &PeerId,
+        bytes: &[u8],
+    ) -> Result<Vec<u8>, RelayEmulatorError> {
+        let (msg, consumed) = decode_hop_message(bytes)?;
+        if msg.kind != HopMessageType::Reserve {
+            return Err(RelayEmulatorError::Unexpected("expected RESERVE"));
+        }
+
+        let channels = self.reservations.entry(reserver.clone()).or_default();
+        let response = HopMessage {
+            kind: HopMessageType::Status,
+            peer: None,
+            reservation: Some(Reservation {
+                expire: Some(9_999_999_999),
+                addrs: Vec::new(),
+                voucher: None,
+            }),
+            limit: None,
+            status: Some(Status::Ok),
+        };
+        channels.hop_inbox.extend(encode_frame(&response.encode()));
+        self.events.push(RelayEvent::ReservationStored {
+            peer: reserver.clone(),
+        });
+        Ok(bytes[consumed..].to_vec())
+    }
+
+    pub fn drain_hop_bytes_for(&mut self, peer: &PeerId) -> Vec<u8> {
+        self.reservations
+            .get_mut(peer)
+            .map(|channels| core::mem::take(&mut channels.hop_inbox))
+            .unwrap_or_default()
+    }
+
+    pub fn drain_stop_bytes_for(&mut self, peer: &PeerId) -> Vec<u8> {
+        self.reservations
+            .get_mut(peer)
+            .map(|channels| core::mem::take(&mut channels.stop_inbox))
+            .unwrap_or_default()
+    }
+
+    /// Handles a complete HOP CONNECT frame. A reserved target receives a
+    /// queued STOP CONNECT; an unreserved target produces a refusal in
+    /// `initiator_inbox`.
+    pub fn on_connect_request(
+        &mut self,
+        initiator: &PeerId,
+        bytes: &[u8],
+        initiator_inbox: &mut Vec<u8>,
+    ) -> Result<ConnectRequestOutcome, RelayEmulatorError> {
+        let (msg, consumed) = decode_hop_message(bytes)?;
+        if msg.kind != HopMessageType::Connect {
+            return Err(RelayEmulatorError::Unexpected("expected CONNECT"));
+        }
+        let target_bytes = msg
+            .peer
+            .as_ref()
+            .map(|peer| peer.id.clone())
+            .ok_or(RelayEmulatorError::Unexpected("missing peer field"))?;
+        let target = PeerId::from_bytes(&target_bytes)
+            .map_err(|_| RelayEmulatorError::Unexpected("invalid target peer id"))?;
+        let trailing = bytes[consumed..].to_vec();
+
+        let Some(channels) = self.reservations.get_mut(&target) else {
+            let refusal = HopMessage {
+                kind: HopMessageType::Status,
+                peer: None,
+                reservation: None,
+                limit: None,
+                status: Some(Status::NoReservation),
+            };
+            initiator_inbox.extend(encode_frame(&refusal.encode()));
+            return Ok(ConnectRequestOutcome::Refused { trailing });
+        };
+
+        let stop_connect = StopMessage {
+            kind: StopMessageType::Connect,
+            peer: Some(Peer {
+                id: initiator.to_bytes(),
+                addrs: Vec::new(),
+            }),
+            limit: None,
+            status: None,
+        };
+        channels
+            .stop_inbox
+            .extend(encode_frame(&stop_connect.encode()));
+        self.events.push(RelayEvent::ConnectBridgedBetween {
+            initiator: initiator.clone(),
+            target: target.clone(),
+        });
+        Ok(ConnectRequestOutcome::Bridging { target, trailing })
+    }
+
+    /// Handles a complete STOP STATUS:OK frame, queues HOP STATUS:OK for the
+    /// initiator, and returns any bytes already belonging to the bridge.
+    pub fn on_stop_ack_from_target(
+        &mut self,
+        bytes: &[u8],
+        initiator_inbox: &mut Vec<u8>,
+    ) -> Result<Vec<u8>, RelayEmulatorError> {
+        let (msg, consumed) = decode_stop_message(bytes)?;
+        if msg.kind != StopMessageType::Status || msg.status != Some(Status::Ok) {
+            return Err(RelayEmulatorError::Unexpected("expected STOP STATUS:OK"));
+        }
+
+        let ok = HopMessage {
+            kind: HopMessageType::Status,
+            peer: None,
+            reservation: None,
+            limit: None,
+            status: Some(Status::Ok),
+        };
+        initiator_inbox.extend(encode_frame(&ok.encode()));
+        self.events.push(RelayEvent::StatusOkSentToInitiator);
+        Ok(bytes[consumed..].to_vec())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RelayEmulatorError {
+    Unexpected(&'static str),
+}
+
+impl core::fmt::Display for RelayEmulatorError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Unexpected(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for RelayEmulatorError {}
+
+fn decode_hop_message(bytes: &[u8]) -> Result<(HopMessage, usize), RelayEmulatorError> {
+    match decode_frame(bytes) {
+        FrameDecode::Complete { payload, consumed } => HopMessage::decode(payload)
+            .map(|message| (message, consumed))
+            .map_err(|_| RelayEmulatorError::Unexpected("bad HOP")),
+        _ => Err(RelayEmulatorError::Unexpected("incomplete HOP frame")),
+    }
+}
+
+fn decode_stop_message(bytes: &[u8]) -> Result<(StopMessage, usize), RelayEmulatorError> {
+    match decode_frame(bytes) {
+        FrameDecode::Complete { payload, consumed } => StopMessage::decode(payload)
+            .map(|message| (message, consumed))
+            .map_err(|_| RelayEmulatorError::Unexpected("bad STOP")),
+        _ => Err(RelayEmulatorError::Unexpected("incomplete STOP frame")),
+    }
+}

--- a/justfile
+++ b/justfile
@@ -14,6 +14,7 @@ clippy:
 
 test:
     cargo test
+    cargo test -p minip2p --features nat
 
 check-nostd:
     rustup target add thumbv7em-none-eabi

--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ test:
 
 check-nostd:
     rustup target add thumbv7em-none-eabi
-    cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm
+    cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm -p minip2p-nat
 
 peer-direct:
     cargo test -p minip2p-peer --test direct


### PR DESCRIPTION
## Summary

Adds `minip2p-nat`, a new `no_std + alloc` sans-I/O crate that orchestrates the existing relay/DCUtR/AutoNAT machines into a complete NAT-traversal agent, and wires it into the `minip2p::Endpoint` facade behind an opt-in `nat` cargo feature. Five stacked commits, one per milestone, each of which passed the full gate independently.

**Connection model — parallel racing with convergence, not sequential fallback:**

```
t0      direct leg: dial every validated candidate address
t0+δ    relay leg (stagger δ=200ms default, 0 = fully parallel):
          ensure relay session → HOP CONNECT(target)
          → Bridged ⇒ PathEstablished(Relayed)   (usable immediately)
          → DCUtR punch starts over the bridge, in parallel
first usable path wins; a better path later ⇒ explicit PathUpgraded
punch exhausted ⇒ FellBackToRelay (bridge stream handed to the app)
```

### Commits

1. **`Protocol::P2pCircuit`** — the `/p2p-circuit` multiaddr component (multicodec 0x0122): codec, Display/FromStr, round-trip tests with a hand-derived reference vector.
2. **`crates/nat` + dialer race** — `NatAgent` (bespoke inherent API: `handle_event(&SwarmEvent, now)` so foreign stream events cost one map lookup and zero clones) and `ConnectAttempt` (race arbiter). Connection state is event-derived, so a QUIC supersede can never double-report a path.
3. **Housekeeping** — AutoNAT probing with majority-of-N confidence (flips only on ≥3 of the last 5 samples; one flaky probe never flaps `ReachabilityChanged`) and the reservation manager (renewal at `expire − margin`, default-TTL fallback for clockless hosts, rotation + backoff on refusal, reacquire on loss, `WhenPrivate` policy follows the verdict).
4. **Responder side** — inbound STOP circuits auto-accepted, DCUtR answered, punch-back on SYNC (simultaneous dials + `SendRandomUdp` blasts at the configured cadence), `InboundRelayCircuit` / `InboundDirectUpgrade` events. Includes a two-agent end-to-end test over an in-memory relay emulator speaking the real HOP/STOP wire format.
5. **Facade wiring** — `Swarm::set_external_addresses` + `Deadline::earliest`/`has_passed`; the `nat` feature on `minip2p`: builder `relay()`/`autonat_server()`/`nat_config()`, `Endpoint::connect`/`wait_path`/`take_nat_events`/`reachability`/`active_reservation`, agent timers folded into event waits, circuit-address advertising while reserved, loopback QUIC e2e. The feature-off API is byte-identical.

### Deviations from the plan (docs/plan discussion)

- Stream registry keyed **(peer, stream)**, not bare `StreamId` — QUIC stream ids are only unique per connection, so every connection's first stream would collide.
- `NatAction::Dial` carries `PeerAddr`, matching `Swarm::dial`'s real signature.
- An oversized DCUtR CONNECT (deferred `MessageTooLarge`) yields `HolePunchFailed` + `FellBackToRelay` — the bridge is still perfectly usable — rather than `ConnectFailed`; `ConnectFailed(Protocol)` is covered via the malformed-HOP-response path instead.

### Known caveats (documented on the types)

- `Path::Relayed` is a **raw bridge stream**, not a full swarm connection — no identify/ping/multistream over the circuit. A circuit-transport adapter is future work, as is collapsing `examples/peer/relay.rs` onto the agent.
- Automated relay-path coverage tops out at the in-memory emulator; there is no relay server in-repo, so the live path stays manual against a rust-libp2p relay.

## Testing

- 35 scripted no-I/O agent tests (`arbitration` / `housekeeping` / `inbound` / `two_agents`) driving real wire bytes through the actual protocol machines, plus 3 loopback-QUIC e2e tests behind `--features nat`.
- Full gate per commit: `cargo test --workspace`, `cargo test -p minip2p --features nat`, `cargo clippy --workspace --all-targets -- -D warnings` (plus the fuzz manifest and the `nat`-feature clippy), `cargo fmt --check`, `cargo doc --workspace --no-deps` (zero warnings), and `cargo check --no-default-features --target thumbv7em-none-eabi` including `minip2p-nat`. CI and the justfile now cover the new crate and feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `minip2p-nat`, a sans-I/O NAT traversal orchestrator that races direct dials against a relay circuit, upgrades via DCUtR, and integrates with `minip2p::Endpoint` behind an opt-in `nat` feature. Also adds the `/p2p-circuit` multiaddr and small swarm/driver helpers; updates preserve initiator trailing bytes, reduce event-loop overhead, share a relay emulator, harden DCUtR handoff/test sequencing, and release DCUtR input after a reply failure.

- **New Features**
  - New crate `minip2p-nat` (`no_std + alloc`): orchestrates Relay v2, DCUtR, and AutoNAT; emits establish/upgrade/fallback events; includes responder handling and a reservation manager.
  - `minip2p` wiring (`features = ["nat"]`): builder `relay()`, `autonat_server()`, `nat_config()`; methods `connect[...]`, `wait_path`, `take_nat_events`, `reachability`, `active_reservation`; advertises `/…/p2p/<relay>/p2p-circuit` while reserved.
  - Core: `/p2p-circuit` (`Protocol::P2pCircuit`) parse/format/codec; `Swarm::set_external_addresses` and `SwarmCore::local_addresses()`; `Deadline::earliest()` and `has_passed()`.
  - Tests/CI: shared relay emulator in `minip2p-test-support` used by NAT and swarm tests; CI runs clippy/tests for `-p minip2p --features nat` and floats action tags.

- **Bug Fixes**
  - Fixed `wait_path` buffering and stream handoff in the NAT driver to keep stream ownership ordered and avoid dropping app events.
  - AutoNAT client now handles a remote write‑half close to finish decoding; DCUtR initiator preserves bytes coalesced behind CONNECT via `take_trailing_data`; DCUtR bridge-to-app handoff and relay test sequencing hardened to avoid races.
  - Hardened reservation manager and inbound STOP circuit lifecycle to correctly renew/rotate reservations and accept/reset STOP streams across edge cases.
  - Reduced NAT loop overhead by cutting extra wakes and processing stream events around agent runs for fewer polls.
  - DCUtR now releases its input after a reply failure to avoid retaining buffered state and unblock subsequent processing.

<sup>Written for commit 1d39a68583c8dae34f0923600c47f53b3c150735. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

