### PR TITLE
Feed identify observed addresses into DCUtR punch candidates

### DIFF
--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -102,11 +102,12 @@ pub(crate) struct Shared {
     released_bridges: BTreeMap<PeerId, BTreeMap<StreamId, ConnectId>>,
     /// Our validated external/listen addresses, advertised in DCUtR CONNECT.
     pub(crate) listen_addrs: Vec<Multiaddr>,
-    /// Our transport address as observed by each connected peer (Identify's
-    /// `observedAddr`). Behind a NAT this is the public mapping of our QUIC
-    /// socket — the address that makes cross-NAT hole punching possible.
-    /// Entries are dropped when the reporting peer disconnects, which keeps
-    /// the map bounded by the connection count.
+    /// Our transport address as observed by trusted reporters (Identify's
+    /// `observedAddr` from configured relays and AutoNAT servers). Behind a
+    /// NAT this is the public mapping of our QUIC socket — the address that
+    /// makes cross-NAT hole punching possible. Entries are dropped when the
+    /// reporting peer disconnects, which keeps the map bounded by the
+    /// configured-peer count.
     observed_addrs: BTreeMap<PeerId, Multiaddr>,
 }
 
@@ -177,6 +178,33 @@ impl Shared {
 
     pub(crate) fn forget_released_bridge(&mut self, peer: &PeerId, stream: StreamId) {
         let _ = self.take_released_bridge(peer, stream);
+    }
+
+    /// Records `reporter`'s Identify claim of our transport address.
+    ///
+    /// Punch candidates are advertised to third parties, who dial them and
+    /// blast random UDP at them during a punch — so only operator-configured
+    /// peers (relays and AutoNAT servers) are believed. An arbitrary
+    /// connected peer must not be able to plant an attacker-chosen address
+    /// here; observed addresses are never dial-back verified the way AutoNAT
+    /// addresses are.
+    fn record_observed_addr(&mut self, reporter: &PeerId, observed: Option<&[u8]>) {
+        let trusted = self
+            .config
+            .relays
+            .iter()
+            .chain(self.config.autonat_servers.iter())
+            .any(|peer| peer.peer_id() == reporter);
+        if !trusted {
+            return;
+        }
+        let Some(Ok(addr)) = observed.map(Multiaddr::from_bytes) else {
+            return;
+        };
+        let validated = select_direct_candidates(&[], Some(addr), None);
+        if let Some(addr) = validated.into_addrs().pop() {
+            self.observed_addrs.insert(reporter.clone(), addr);
+        }
     }
 
     /// Addresses advertised in DCUtR exchanges: the validated listen/external
@@ -361,12 +389,8 @@ impl NatAgent {
                 // The event stays application-visible (`handled` = false),
                 // and nothing here can complete a machine (`touched_state`
                 // stays false).
-                if let Some(Ok(addr)) = info.observed_addr.as_deref().map(Multiaddr::from_bytes) {
-                    let validated = select_direct_candidates(&[], Some(addr), None);
-                    if let Some(addr) = validated.into_addrs().pop() {
-                        self.shared.observed_addrs.insert(peer_id.clone(), addr);
-                    }
-                }
+                self.shared
+                    .record_observed_addr(peer_id, info.observed_addr.as_deref());
             }
             SwarmEvent::PeerReady { peer_id, protocols } => {
                 touched_state = true;

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -2,7 +2,7 @@ use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use minip2p_core::{Multiaddr, PeerId};
+use minip2p_core::{Multiaddr, PeerId, select_direct_candidates};
 use minip2p_swarm::SwarmEvent;
 use minip2p_transport::{ConnectionId, StreamId};
 
@@ -102,6 +102,12 @@ pub(crate) struct Shared {
     released_bridges: BTreeMap<PeerId, BTreeMap<StreamId, ConnectId>>,
     /// Our validated external/listen addresses, advertised in DCUtR CONNECT.
     pub(crate) listen_addrs: Vec<Multiaddr>,
+    /// Our transport address as observed by each connected peer (Identify's
+    /// `observedAddr`). Behind a NAT this is the public mapping of our QUIC
+    /// socket — the address that makes cross-NAT hole punching possible.
+    /// Entries are dropped when the reporting peer disconnects, which keeps
+    /// the map bounded by the connection count.
+    observed_addrs: BTreeMap<PeerId, Multiaddr>,
 }
 
 impl Shared {
@@ -172,6 +178,18 @@ impl Shared {
     pub(crate) fn forget_released_bridge(&mut self, peer: &PeerId, stream: StreamId) {
         let _ = self.take_released_bridge(peer, stream);
     }
+
+    /// Addresses advertised in DCUtR exchanges: the validated listen/external
+    /// set plus our peer-observed public mappings, deduplicated.
+    pub(crate) fn punch_candidates(&self) -> Vec<Multiaddr> {
+        let mut addrs = self.listen_addrs.clone();
+        for addr in self.observed_addrs.values() {
+            if !addrs.contains(addr) {
+                addrs.push(addr.clone());
+            }
+        }
+        addrs
+    }
 }
 
 /// Sans-I/O NAT-traversal orchestrator.
@@ -213,6 +231,7 @@ impl NatAgent {
                 ready: BTreeMap::new(),
                 released_bridges: BTreeMap::new(),
                 listen_addrs: Vec::new(),
+                observed_addrs: BTreeMap::new(),
             },
             attempts: BTreeMap::new(),
             housekeeping,
@@ -333,6 +352,21 @@ impl NatAgent {
                 // attempts have not already cleaned up.
                 self.shared.registry.remove(peer_id);
                 self.shared.released_bridges.remove(peer_id);
+                self.shared.observed_addrs.remove(peer_id);
+            }
+            SwarmEvent::IdentifyReceived { peer_id, info } => {
+                // The remote reports the transport address it sees us from.
+                // Behind a NAT that is our public mapping — the only usable
+                // DCUtR punch candidate, since bound addresses are private.
+                // The event stays application-visible (`handled` = false),
+                // and nothing here can complete a machine (`touched_state`
+                // stays false).
+                if let Some(Ok(addr)) = info.observed_addr.as_deref().map(Multiaddr::from_bytes) {
+                    let validated = select_direct_candidates(&[], Some(addr), None);
+                    if let Some(addr) = validated.into_addrs().pop() {
+                        self.shared.observed_addrs.insert(peer_id.clone(), addr);
+                    }
+                }
             }
             SwarmEvent::PeerReady { peer_id, protocols } => {
                 touched_state = true;

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -560,7 +560,7 @@ impl ConnectAttempt {
         self.bridge_alive = true;
         self.hop = None;
 
-        let mut dcutr = DcutrInitiator::new(&shared.listen_addrs);
+        let mut dcutr = DcutrInitiator::new(&shared.punch_candidates());
         if let Err(e) = dcutr.handle_input(DcutrInitiatorInput::Flush) {
             // Deferred construction error (e.g. oversized CONNECT): the
             // punch cannot even start, but the relayed path stands and is

--- a/crates/nat/src/events.rs
+++ b/crates/nat/src/events.rs
@@ -110,7 +110,12 @@ pub enum NatEvent {
     /// stream is a raw bridge; `pending_data` holds any bytes that arrived
     /// pipelined behind the circuit setup.
     InboundRelayCircuit {
+        /// The initiating peer on the far end of the circuit.
         peer: PeerId,
+        /// The relay the bridge runs through. The bridge stream lives on the
+        /// connection to this peer: `send_stream` / `close_stream_write` on
+        /// `stream_id` must address `relay`, not `peer`.
+        relay: PeerId,
         stream_id: StreamId,
         pending_data: Vec<u8>,
         /// `true` when the remote write half reached EOF before handoff. The

--- a/crates/nat/src/inbound.rs
+++ b/crates/nat/src/inbound.rs
@@ -209,7 +209,7 @@ impl InboundCircuit {
             });
         }
 
-        self.dcutr = Some(DcutrResponder::new(&shared.listen_addrs));
+        self.dcutr = Some(DcutrResponder::new(&shared.punch_candidates()));
         if !pipelined.is_empty() {
             self.on_bridge_data(&pipelined, shared, now);
         }
@@ -309,6 +309,7 @@ impl InboundCircuit {
         if let Some(source) = &self.source {
             shared.push_event(NatEvent::InboundRelayCircuit {
                 peer: source.clone(),
+                relay: self.relay.clone(),
                 stream_id: self.stream,
                 pending_data: core::mem::take(&mut self.pending_data),
                 remote_write_closed: self.remote_write_closed,

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -5,7 +5,7 @@ mod common;
 
 use common::*;
 
-use minip2p_core::Multiaddr;
+use minip2p_core::{Multiaddr, PeerAddr};
 use minip2p_nat::{ConnectId, NatAction, NatConfig, NatError, NatEvent, Path};
 use minip2p_relay::Status;
 use minip2p_swarm::SwarmEvent;
@@ -789,37 +789,94 @@ fn identify_observed_addr_joins_dcutr_connect() {
 }
 
 #[test]
-fn latest_observation_per_peer_wins_and_disconnect_drops_it() {
+fn latest_observation_per_reporter_wins() {
     let stale = "/ip4/203.0.113.77/udp/1111/quic-v1";
-    let departed = "/ip4/203.0.113.88/udp/2222/quic-v1";
     let mut h = Harness::with_relay(NatConfig::default());
 
     // Same reporter twice: only the fresh observation survives.
-    let target = h.target.clone();
-    identify_observed(&mut h.agent, &target, &maddr(stale), at(0));
-    identify_observed(&mut h.agent, &target, &maddr(OUR_OBSERVED_ADDR), at(1));
-    // A reporter whose connection closes takes its observation along.
-    let other = peer(b"other-peer");
-    identify_observed(&mut h.agent, &other, &maddr(departed), at(2));
-    h.agent
-        .handle_event(&SwarmEvent::ConnectionClosed { peer_id: other }, at(3));
+    let relay = h.relay.clone();
+    identify_observed(&mut h.agent, &relay, &maddr(stale), at(0));
+    identify_observed(&mut h.agent, &relay, &maddr(OUR_OBSERVED_ADDR), at(1));
 
     let (_id, stream) = drive_to_bridged(&mut h, 10);
     let actions = drain_actions(&mut h.agent);
     let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
     assert!(obs.contains(&maddr(OUR_OBSERVED_ADDR)));
     assert!(!obs.contains(&maddr(stale)), "replaced observation leaks");
-    assert!(!obs.contains(&maddr(departed)), "dropped observation leaks");
 }
 
 #[test]
-fn invalid_or_non_quic_observed_addrs_are_ignored() {
+fn reporter_disconnect_drops_its_observation() {
+    let departed = "/ip4/203.0.113.88/udp/2222/quic-v1";
     let mut h = Harness::with_relay(NatConfig::default());
-    // Undecodable observed_addr bytes.
+
+    // The relay reports a mapping, then its connection closes; the attempt
+    // reconnects the relay, but the stale observation must not come back.
+    let relay = h.relay.clone();
+    identify_observed(&mut h.agent, &relay, &maddr(departed), at(0));
+    h.agent
+        .handle_event(&SwarmEvent::ConnectionClosed { peer_id: relay }, at(1));
+
+    let (_id, stream) = drive_to_bridged(&mut h, 10);
+    let actions = drain_actions(&mut h.agent);
+    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    assert_eq!(
+        obs,
+        vec![maddr(LISTEN_ADDR)],
+        "dropped observation leaks into the CONNECT"
+    );
+}
+
+#[test]
+fn observed_addrs_from_untrusted_peers_are_ignored() {
+    let attacker_chosen = "/ip4/198.51.100.200/udp/53/quic-v1";
+    let mut h = Harness::with_relay(NatConfig::default());
+
+    // Valid QUIC shapes, but neither reporter is a configured relay or
+    // AutoNAT server — believing them would let any connected peer aim
+    // punch-time UDP blasts at an address of its choosing.
+    let target = h.target.clone();
+    identify_observed(&mut h.agent, &target, &maddr(attacker_chosen), at(0));
+    let other = peer(b"other-peer");
+    identify_observed(&mut h.agent, &other, &maddr(attacker_chosen), at(1));
+
+    let (_id, stream) = drive_to_bridged(&mut h, 10);
+    let actions = drain_actions(&mut h.agent);
+    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    assert_eq!(
+        obs,
+        vec![maddr(LISTEN_ADDR)],
+        "untrusted observation reached the CONNECT"
+    );
+}
+
+#[test]
+fn autonat_server_is_a_trusted_reporter() {
+    let autonat = peer(b"autonat-server");
+    let autonat_addr = PeerAddr::new(maddr("/ip4/203.0.113.60/udp/4009/quic-v1"), autonat.clone())
+        .expect("valid autonat addr");
+    let mut h = Harness::with_relay(NatConfig {
+        autonat_servers: vec![autonat_addr],
+        ..NatConfig::default()
+    });
+    identify_observed(&mut h.agent, &autonat, &maddr(OUR_OBSERVED_ADDR), at(0));
+
+    let (_id, stream) = drive_to_bridged(&mut h, 10);
+    let actions = drain_actions(&mut h.agent);
+    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    assert!(
+        obs.contains(&maddr(OUR_OBSERVED_ADDR)),
+        "a configured AutoNAT server's observation must be usable"
+    );
+}
+
+#[test]
+fn undecodable_observed_addr_bytes_are_ignored() {
+    let mut h = Harness::with_relay(NatConfig::default());
     let relay = h.relay.clone();
     h.agent.handle_event(
         &SwarmEvent::IdentifyReceived {
-            peer_id: relay.clone(),
+            peer_id: relay,
             info: minip2p_swarm::IdentifyMessage {
                 observed_addr: Some(vec![0xff, 0xff, 0xff]),
                 ..minip2p_swarm::IdentifyMessage::default()
@@ -827,12 +884,26 @@ fn invalid_or_non_quic_observed_addrs_are_ignored() {
         },
         at(0),
     );
+
+    let (_id, stream) = drive_to_bridged(&mut h, 10);
+    let actions = drain_actions(&mut h.agent);
+    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    assert_eq!(
+        obs,
+        vec![maddr(LISTEN_ADDR)],
+        "only the validated bound address may be advertised"
+    );
+}
+
+#[test]
+fn non_quic_observed_addr_is_ignored() {
+    let mut h = Harness::with_relay(NatConfig::default());
     // Well-formed but not a dialable QUIC transport.
     identify_observed(
         &mut h.agent,
-        &relay,
+        &h.relay.clone(),
         &maddr("/ip4/203.0.113.9/udp/4001"),
-        at(1),
+        at(0),
     );
 
     let (_id, stream) = drive_to_bridged(&mut h, 10);

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -763,3 +763,84 @@ fn wildcard_and_non_quic_candidates_are_filtered() {
         "wildcards, non-QUIC shapes, and duplicates never get dialed"
     );
 }
+
+#[test]
+fn identify_observed_addr_joins_dcutr_connect() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    // The relay's identify tells us our public mapping before any attempt.
+    identify_observed(
+        &mut h.agent,
+        &h.relay.clone(),
+        &maddr(OUR_OBSERVED_ADDR),
+        at(0),
+    );
+
+    let (_id, stream) = drive_to_bridged(&mut h, 10);
+    let actions = drain_actions(&mut h.agent);
+    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    assert!(
+        obs.contains(&maddr(LISTEN_ADDR)),
+        "bound addresses stay in the CONNECT"
+    );
+    assert!(
+        obs.contains(&maddr(OUR_OBSERVED_ADDR)),
+        "the peer-observed public mapping must be advertised for the punch"
+    );
+}
+
+#[test]
+fn latest_observation_per_peer_wins_and_disconnect_drops_it() {
+    let stale = "/ip4/203.0.113.77/udp/1111/quic-v1";
+    let departed = "/ip4/203.0.113.88/udp/2222/quic-v1";
+    let mut h = Harness::with_relay(NatConfig::default());
+
+    // Same reporter twice: only the fresh observation survives.
+    let target = h.target.clone();
+    identify_observed(&mut h.agent, &target, &maddr(stale), at(0));
+    identify_observed(&mut h.agent, &target, &maddr(OUR_OBSERVED_ADDR), at(1));
+    // A reporter whose connection closes takes its observation along.
+    let other = peer(b"other-peer");
+    identify_observed(&mut h.agent, &other, &maddr(departed), at(2));
+    h.agent
+        .handle_event(&SwarmEvent::ConnectionClosed { peer_id: other }, at(3));
+
+    let (_id, stream) = drive_to_bridged(&mut h, 10);
+    let actions = drain_actions(&mut h.agent);
+    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    assert!(obs.contains(&maddr(OUR_OBSERVED_ADDR)));
+    assert!(!obs.contains(&maddr(stale)), "replaced observation leaks");
+    assert!(!obs.contains(&maddr(departed)), "dropped observation leaks");
+}
+
+#[test]
+fn invalid_or_non_quic_observed_addrs_are_ignored() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    // Undecodable observed_addr bytes.
+    let relay = h.relay.clone();
+    h.agent.handle_event(
+        &SwarmEvent::IdentifyReceived {
+            peer_id: relay.clone(),
+            info: minip2p_swarm::IdentifyMessage {
+                observed_addr: Some(vec![0xff, 0xff, 0xff]),
+                ..minip2p_swarm::IdentifyMessage::default()
+            },
+        },
+        at(0),
+    );
+    // Well-formed but not a dialable QUIC transport.
+    identify_observed(
+        &mut h.agent,
+        &relay,
+        &maddr("/ip4/203.0.113.9/udp/4001"),
+        at(1),
+    );
+
+    let (_id, stream) = drive_to_bridged(&mut h, 10);
+    let actions = drain_actions(&mut h.agent);
+    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    assert_eq!(
+        obs,
+        vec![maddr(LISTEN_ADDR)],
+        "only the validated bound address may be advertised"
+    );
+}

--- a/crates/nat/tests/common/mod.rs
+++ b/crates/nat/tests/common/mod.rs
@@ -7,19 +7,24 @@
 
 use minip2p_autonat::{AutoNatServer, AutoNatServerInput, AutoNatServerOutput, ResponseStatus};
 use minip2p_core::{Multiaddr, PeerAddr, PeerId, SansIoProtocol};
-use minip2p_dcutr::{HolePunch, HolePunchType, encode_frame as dcutr_encode_frame};
+use minip2p_dcutr::{
+    FrameDecode, HolePunch, HolePunchType, decode_frame as dcutr_decode_frame,
+    encode_frame as dcutr_encode_frame,
+};
 use minip2p_nat::{NatAction, NatAgent, NatConfig, NatEvent, NatToken, Now, ReservationPolicy};
 use minip2p_relay::{
     HOP_PROTOCOL_ID, HopMessage, HopMessageType, Peer, Reservation, Status, StopMessage,
     StopMessageType, encode_frame as relay_encode_frame,
 };
-use minip2p_swarm::SwarmEvent;
+use minip2p_swarm::{IdentifyMessage, SwarmEvent};
 use minip2p_transport::StreamId;
 
 pub const TARGET_ADDR: &str = "/ip4/192.0.2.10/udp/4001/quic-v1";
 pub const RELAY_TRANSPORT_ADDR: &str = "/ip4/203.0.113.1/udp/4001/quic-v1";
 pub const LISTEN_ADDR: &str = "/ip4/198.51.100.5/udp/4500/quic-v1";
 pub const REMOTE_OBSERVED_ADDR: &str = "/ip4/192.0.2.99/udp/4002/quic-v1";
+/// A public mapping of our own socket, as a peer would report it.
+pub const OUR_OBSERVED_ADDR: &str = "/ip4/203.0.113.77/udp/45678/quic-v1";
 
 pub fn peer(tag: &[u8]) -> PeerId {
     PeerId::from_public_key_protobuf(tag)
@@ -147,6 +152,33 @@ pub fn autonat_response(request_bytes: &[u8], public_addrs: Option<&[Multiaddr]>
         Some(AutoNatServerOutput::Outbound(bytes)) => bytes,
         other => panic!("expected outbound response, got {other:?}"),
     }
+}
+
+/// Feeds an `IdentifyReceived` event whose `observed_addr` is `addr`'s
+/// binary encoding, as if `reporter` told us where it sees us from.
+pub fn identify_observed(agent: &mut NatAgent, reporter: &PeerId, addr: &Multiaddr, now: Now) {
+    agent.handle_event(
+        &SwarmEvent::IdentifyReceived {
+            peer_id: reporter.clone(),
+            info: IdentifyMessage {
+                observed_addr: Some(addr.to_bytes()),
+                ..IdentifyMessage::default()
+            },
+        },
+        now,
+    );
+}
+
+/// Decodes the observed addresses out of a framed DCUtR message.
+pub fn dcutr_obs_addrs(frame: &[u8]) -> Vec<Multiaddr> {
+    let FrameDecode::Complete { payload, .. } = dcutr_decode_frame(frame) else {
+        panic!("expected a complete DCUtR frame");
+    };
+    let msg = HolePunch::decode(payload).expect("valid HolePunch message");
+    msg.obs_addrs
+        .iter()
+        .map(|bytes| Multiaddr::from_bytes(bytes).expect("valid multiaddr"))
+        .collect()
 }
 
 /// Extracts the payload of the single `SendStream` action on `stream`.

--- a/crates/nat/tests/inbound.rs
+++ b/crates/nat/tests/inbound.rs
@@ -73,8 +73,8 @@ fn full_inbound_flow_punches_back_and_upgrades() {
     let events = drain_events(&mut h.agent);
     assert!(matches!(
         events.as_slice(),
-        [NatEvent::InboundRelayCircuit { peer, stream_id, .. }]
-            if *peer == h.target && *stream_id == stream
+        [NatEvent::InboundRelayCircuit { peer, relay, stream_id, .. }]
+            if *peer == h.target && *relay == h.relay && *stream_id == stream
     ));
     let actions = drain_actions(&mut h.agent);
     assert_eq!(
@@ -315,4 +315,34 @@ fn relay_disconnect_before_release_drops_the_circuit() {
     assert!(drain_events(&mut h.agent).is_empty());
     assert!(!h.agent.owns_stream(&h.relay, stream));
     assert!(h.agent.is_idle());
+}
+
+#[test]
+fn responder_reply_advertises_peer_observed_mapping() {
+    let mut h = inbound_harness(NatConfig::default());
+    // The relay's identify told us our public mapping earlier in the session.
+    let relay = h.relay.clone();
+    identify_observed(&mut h.agent, &relay, &maddr(OUR_OBSERVED_ADDR), at(0));
+
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 1);
+    let target = h.target.clone();
+    h.stream_data(stream, stop_connect(&target), at(10));
+    drain_actions(&mut h.agent);
+
+    h.stream_data(
+        stream,
+        dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]),
+        at(20),
+    );
+    let actions = drain_actions(&mut h.agent);
+    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    assert!(
+        obs.contains(&maddr(LISTEN_ADDR)),
+        "bound addresses stay in the reply"
+    );
+    assert!(
+        obs.contains(&maddr(OUR_OBSERVED_ADDR)),
+        "the reply must advertise our observed public mapping"
+    );
 }

--- a/crates/nat/tests/two_agents.rs
+++ b/crates/nat/tests/two_agents.rs
@@ -9,9 +9,9 @@
 
 mod common;
 
-use common::{LISTEN_ADDR, at, drain_events, maddr, peer};
+use common::{LISTEN_ADDR, at, drain_events, identify_observed, maddr, peer};
 
-use minip2p_core::{PeerAddr, PeerId};
+use minip2p_core::{Multiaddr, PeerAddr, PeerId};
 use minip2p_nat::{ConnectId, NatAction, NatAgent, NatConfig, NatEvent, Path, ReservationPolicy};
 use minip2p_relay::{HOP_PROTOCOL_ID, STOP_PROTOCOL_ID};
 use minip2p_swarm::SwarmEvent;
@@ -20,6 +20,9 @@ use minip2p_transport::{ConnectionId, StreamId};
 
 const A_LISTEN: &str = "/ip4/198.51.100.10/udp/4100/quic-v1";
 const RELAY_ADDR: &str = "/ip4/203.0.113.1/udp/4001/quic-v1";
+/// Each side's public NAT mapping, as the relay's identify reports it.
+const A_PUBLIC: &str = "/ip4/203.0.113.201/udp/40001/quic-v1";
+const B_PUBLIC: &str = "/ip4/203.0.113.202/udp/40002/quic-v1";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Side {
@@ -61,6 +64,8 @@ struct World {
     blasts_from_b: usize,
     punch_dials_from_a: usize,
     punch_dials_from_b: usize,
+    punch_dial_addrs_from_a: Vec<Multiaddr>,
+    punch_dial_addrs_from_b: Vec<Multiaddr>,
 }
 
 impl World {
@@ -108,6 +113,8 @@ impl World {
             blasts_from_b: 0,
             punch_dials_from_a: 0,
             punch_dials_from_b: 0,
+            punch_dial_addrs_from_a: Vec::new(),
+            punch_dial_addrs_from_b: Vec::new(),
         }
     }
 
@@ -170,7 +177,7 @@ impl World {
                         );
                         agent.handle_event(
                             &SwarmEvent::PeerReady {
-                                peer_id: relay,
+                                peer_id: relay.clone(),
                                 protocols: vec![
                                     HOP_PROTOCOL_ID.to_string(),
                                     STOP_PROTOCOL_ID.to_string(),
@@ -178,12 +185,26 @@ impl World {
                             },
                             now,
                         );
+                        // Identify over the relay connection reports the
+                        // side's public mapping — the real-world source of
+                        // cross-NAT punch candidates.
+                        let public = match side {
+                            Side::A => A_PUBLIC,
+                            Side::B => B_PUBLIC,
+                        };
+                        identify_observed(agent, &relay, &maddr(public), now);
                     }
                 } else {
                     // A dial toward the other agent.
                     match side {
-                        Side::A => self.punch_dials_from_a += 1,
-                        Side::B => self.punch_dials_from_b += 1,
+                        Side::A => {
+                            self.punch_dials_from_a += 1;
+                            self.punch_dial_addrs_from_a.push(addr.transport().clone());
+                        }
+                        Side::B => {
+                            self.punch_dials_from_b += 1;
+                            self.punch_dial_addrs_from_b.push(addr.transport().clone());
+                        }
                     }
                     self.next_conn += 1;
                     let conn = ConnectionId::new(self.next_conn);
@@ -388,7 +409,15 @@ fn two_agents_punch_to_a_direct_connection() {
         ),
         "A settles a relayed path first, got {events:?}"
     );
-    assert_eq!(world.punch_dials_from_a, 1, "A dialed B's observed address");
+    assert_eq!(
+        world.punch_dials_from_a, 2,
+        "A dialed B's listen address and B's relay-observed public mapping"
+    );
+    assert!(
+        world.punch_dial_addrs_from_a.contains(&maddr(B_PUBLIC)),
+        "A's punch targets B's public mapping: {:?}",
+        world.punch_dial_addrs_from_a
+    );
     let events = drain_events(&mut world.b);
     assert!(
         matches!(
@@ -400,7 +429,15 @@ fn two_agents_punch_to_a_direct_connection() {
 
     // B's punch-back: simultaneous dial plus UDP blasts after the sync
     // delay.
-    assert_eq!(world.punch_dials_from_b, 1, "B dialed A's observed address");
+    assert_eq!(
+        world.punch_dials_from_b, 2,
+        "B dialed A's listen address and A's relay-observed public mapping"
+    );
+    assert!(
+        world.punch_dial_addrs_from_b.contains(&maddr(A_PUBLIC)),
+        "B's punch-back targets A's public mapping: {:?}",
+        world.punch_dial_addrs_from_b
+    );
     world.advance(100);
     assert!(world.blasts_from_b > 0, "B blasts random UDP");
 

--- a/crates/swarm/src/lib.rs
+++ b/crates/swarm/src/lib.rs
@@ -42,6 +42,9 @@ pub use crate::events::{
     OpenStreamToken, SwarmAction, SwarmError, SwarmErrorKind, SwarmEvent, SwarmInput, SwarmOutput,
     SwarmRuntimeError,
 };
+// Part of `SwarmEvent::IdentifyReceived`'s public shape; re-exported so
+// consumers can name the type without depending on `minip2p-identify`.
+pub use minip2p_identify::IdentifyMessage;
 
 #[cfg(feature = "std")]
 pub use crate::builder::SwarmBuilder;


### PR DESCRIPTION
## Why

Cross-NAT hole punching requires each peer to advertise its **public** NAT mapping in the DCUtR exchange — an address only remote peers can report (Identify's `observedAddr`). The wire plumbing existed end to end (the identify crate carries it, the swarm sends and delivers it), but the NAT agent never read it: DCUtR candidates came only from locally bound (private) addresses, so a punch between two NATs always fell back to the relay.

## What

- **`NatAgent` now consumes `SwarmEvent::IdentifyReceived`**: the reported `observed_addr` is decoded, validated through `select_direct_candidates` (QUIC-shape filter), and stored per reporting peer (latest observation wins; entries drop when the reporter disconnects). Only operator-configured peers — relays and AutoNAT servers — are believed as reporters: punch candidates are dialed and UDP-blasted by third parties, so an arbitrary connected peer must not be able to plant an attacker-chosen address (same trust boundary as the existing STOP-stream check). The event stays application-visible and the arm preserves the foreign-event efficiency gating.
- **Both DCUtR machines seed from `punch_candidates()`** — bound/external addresses plus the observed mappings, deduplicated — on the dialer (`DcutrInitiator`) and responder (`DcutrResponder`) sides. Observations are punch-only: Identify advertisement stays AutoNAT-confirmed / relay-circuit, as before.
- **`NatEvent::InboundRelayCircuit` gains a `relay: PeerId` field.** The bridge stream lives on the connection to the relay, not the initiator, so a responder app could not previously address `send_stream` from the event alone. (Breaking enum change, per project policy.)
- **`minip2p-swarm` re-exports `IdentifyMessage`**, which is part of `SwarmEvent::IdentifyReceived`'s public shape and was previously unnameable without a direct `minip2p-identify` dependency.

## Tests

- Dialer: observed mapping joins the DCUtR CONNECT; latest-per-reporter replacement; disconnect drops the observation; untrusted reporters ignored; AutoNAT servers accepted; garbage bytes and non-QUIC shapes each filtered independently.
- Responder: the DCUtR reply advertises the observed mapping; `InboundRelayCircuit.relay` asserted.
- Two-agent emulator: both sides now punch at each other's relay-observed public mappings (dial targets asserted).

Verified end to end with a standalone consumer of the public API driving real HOP/STOP/DCUtR wire frames: the CONNECT/reply bytes on the bridge carry the observed public mapping on both sides, and invalid observations never surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
DCUtR now includes peer-observed public addresses from Identify, enabling direct cross-NAT hole punching instead of falling back to relays. Also adds a `relay` field to `NatEvent::InboundRelayCircuit` and re-exports `IdentifyMessage` from `minip2p-swarm`.

- New Features
  - DCUtR initiator/responder seed from `punch_candidates()` = `listen_addrs` + peer-observed public addrs (QUIC-only, deduped).
  - `NatAgent` records the latest valid `observed_addr` per peer from `SwarmEvent::IdentifyReceived`; drops it on disconnect.
  - `NatEvent::InboundRelayCircuit` now includes `relay: PeerId` to address the bridge stream on the relay connection.
  - `minip2p-swarm` re-exports `IdentifyMessage` for consumers of `SwarmEvent::IdentifyReceived`.

- Migration
  - Update matches for `NatEvent::InboundRelayCircuit { peer, relay, stream_id, ... }`.
  - Use `relay` (not `peer`) when sending or closing `stream_id`.

<sup>Written for commit a69777eff373998336a079954528f8b7c1b621b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


