### PR TITLE
Fix three NAT bugs found in live relay testing

### DIFF
--- a/crates/nat/README.md
+++ b/crates/nat/README.md
@@ -117,9 +117,10 @@ Independent of connect attempts, the agent also runs:
 A NAT'd listener holding a reservation handles inbound circuits
 automatically: the relay's STOP CONNECT is auto-accepted, the initiator's
 DCUtR exchange is answered with our validated addresses, and on SYNC the
-agent punches back — dialing the initiator's observed addresses and
-emitting `SendRandomUdp` blasts (first after `responder_sync_delay_ms`,
-then every `blast_interval_ms` until `punch_deadline_ms`). The bridge
+agent emits `SendRandomUdp` blasts at the initiator's observed addresses
+to open its own NAT mapping (first after `responder_sync_delay_ms`, then
+every `blast_interval_ms` until `punch_deadline_ms`). Per DCUtR for QUIC
+only the initiator dials — the blasts make that dial land. The bridge
 stream is handed to the application via `InboundRelayCircuit`; a landed
 punch is announced with `InboundDirectUpgrade`.
 
@@ -129,6 +130,6 @@ punch is announced with `InboundDirectUpgrade`.
   covered by scripted no-I/O tests in `tests/arbitration.rs`.
 - Housekeeping (AutoNAT confidence aggregation, relay reservation renewal):
   implemented, covered by `tests/housekeeping.rs`.
-- Responder side (inbound STOP circuits, punch-back, UDP blasts):
+- Responder side (inbound STOP circuits, punch-window UDP blasts):
   implemented, covered by `tests/inbound.rs` plus a two-agent end-to-end
   exchange over an in-memory relay emulator (`tests/two_agents.rs`).

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -2,7 +2,7 @@ use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use minip2p_core::{Multiaddr, PeerId, select_direct_candidates};
+use minip2p_core::{Multiaddr, PeerAddr, PeerId, select_direct_candidates};
 use minip2p_swarm::SwarmEvent;
 use minip2p_transport::{ConnectionId, StreamId};
 
@@ -109,6 +109,14 @@ pub(crate) struct Shared {
     /// reporting peer disconnects, which keeps the map bounded by the
     /// configured-peer count.
     observed_addrs: BTreeMap<PeerId, Multiaddr>,
+    /// Session dials in flight: relay-leg, reservation, and probe dials whose
+    /// connection has not yet established. Concurrent machines targeting the
+    /// same infrastructure peer wait on the first dial instead of issuing
+    /// their own — a second connection to the same peer supersedes the first,
+    /// and the supersede scrubs the winner's streams. Values carry the dialed
+    /// peer and an expiry (`mono_ms`) so a handshake that never completes
+    /// cannot suppress dialing forever.
+    pending_session_dials: BTreeMap<NatToken, (PeerId, u64)>,
 }
 
 impl Shared {
@@ -121,6 +129,30 @@ impl Shared {
 
     pub(crate) fn push_action(&mut self, action: NatAction) {
         self.actions.push_back(action);
+    }
+
+    /// Issues a session dial: allocates the token, records the in-flight
+    /// entry consulted by [`Shared::session_dial_pending`], and pushes the
+    /// `Dial` action. Punch dials must not go through here — simultaneous
+    /// open intentionally dials a peer that is about to be connected.
+    pub(crate) fn push_session_dial(&mut self, purpose: TokenPurpose, addr: PeerAddr, now: Now) {
+        // Expired entries only accumulate when handshakes silently die;
+        // prune them here so the map stays bounded without a timer.
+        self.pending_session_dials
+            .retain(|_, (_, expires)| *expires > now.mono_ms);
+        let token = self.alloc_token(purpose);
+        let expires = now.mono_ms + self.config.relay_leg_deadline_ms;
+        self.pending_session_dials
+            .insert(token, (addr.peer_id().clone(), expires));
+        self.push_action(NatAction::Dial { token, addr });
+    }
+
+    /// Whether a session dial toward `peer` is still in flight (issued, not
+    /// yet established, expiry not passed).
+    pub(crate) fn session_dial_pending(&self, peer: &PeerId, now: Now) -> bool {
+        self.pending_session_dials
+            .values()
+            .any(|(dialed, expires)| dialed == peer && *expires > now.mono_ms)
     }
 
     pub(crate) fn push_event(&mut self, event: NatEvent) {
@@ -260,6 +292,7 @@ impl NatAgent {
                 released_bridges: BTreeMap::new(),
                 listen_addrs: Vec::new(),
                 observed_addrs: BTreeMap::new(),
+                pending_session_dials: BTreeMap::new(),
             },
             attempts: BTreeMap::new(),
             housekeeping,
@@ -330,6 +363,12 @@ impl NatAgent {
         match event {
             SwarmEvent::ConnectionEstablished { peer_id } => {
                 touched_state = true;
+                // Any session dial toward this peer has done its job (ours
+                // landed, or another machine's did — either way the peer is
+                // reachable now and further dials would supersede).
+                self.shared
+                    .pending_session_dials
+                    .retain(|_, (dialed, _)| dialed != peer_id);
                 let superseded = !self.shared.connected.insert(peer_id.clone());
                 if superseded {
                     // The swarm's last-connection-wins policy emits a second
@@ -381,6 +420,9 @@ impl NatAgent {
                 self.shared.registry.remove(peer_id);
                 self.shared.released_bridges.remove(peer_id);
                 self.shared.observed_addrs.remove(peer_id);
+                self.shared
+                    .pending_session_dials
+                    .retain(|_, (dialed, _)| dialed != peer_id);
             }
             SwarmEvent::IdentifyReceived { peer_id, info } => {
                 // The remote reports the transport address it sees us from.
@@ -506,6 +548,11 @@ impl NatAgent {
         let Some(purpose) = self.shared.tokens.remove(&token) else {
             return;
         };
+        if result.is_err() {
+            // A rejected session dial is no longer in flight; waiters fall
+            // back to their own deadlines.
+            self.shared.pending_session_dials.remove(&token);
+        }
         match &purpose {
             TokenPurpose::ProbeDial => {
                 self.housekeeping

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -132,13 +132,24 @@ impl Shared {
     /// entry consulted by [`Shared::session_dial_pending`], and pushes the
     /// `Dial` action. Punch dials must not go through here — simultaneous
     /// open intentionally dials a peer that is about to be connected.
-    pub(crate) fn push_session_dial(&mut self, purpose: TokenPurpose, addr: PeerAddr, now: Now) {
+    ///
+    /// `deadline_ms` is the owning machine's flight deadline for this dial.
+    /// The entry must stay visible for as long as the owner is still
+    /// legitimately waiting — expiring earlier re-opens the duplicate-dial
+    /// window this map exists to close.
+    pub(crate) fn push_session_dial(
+        &mut self,
+        purpose: TokenPurpose,
+        addr: PeerAddr,
+        now: Now,
+        deadline_ms: u64,
+    ) {
         // Expired entries only accumulate when handshakes silently die;
         // prune them here so the map stays bounded without a timer.
         self.pending_session_dials
             .retain(|_, (_, expires)| *expires > now.mono_ms);
         let token = self.alloc_token(purpose);
-        let expires = now.mono_ms + self.config.relay_leg_deadline_ms;
+        let expires = now.mono_ms + deadline_ms;
         self.pending_session_dials
             .insert(token, (addr.peer_id().clone(), expires));
         self.push_action(NatAction::Dial { token, addr });
@@ -545,10 +556,21 @@ impl NatAgent {
         let Some(purpose) = self.shared.tokens.remove(&token) else {
             return;
         };
-        if result.is_err() {
-            // A rejected session dial is no longer in flight; waiters fall
-            // back to their own deadlines.
-            self.shared.pending_session_dials.remove(&token);
+        if result.is_err()
+            && let Some((peer, _)) = self.shared.pending_session_dials.remove(&token)
+        {
+            // A rejected session dial is no longer in flight. Attempts that
+            // were sharing it must issue their own dial now: nothing else
+            // re-enters a waiting relay leg, so they would otherwise burn
+            // their leg deadline on a dial that already failed. The owner
+            // learns through its own routing below, and housekeeping
+            // waiters fall back to their acquire/probe deadlines.
+            let owner = purpose.connect_id();
+            for (id, attempt) in self.attempts.iter_mut() {
+                if owner.as_ref() != Some(id) {
+                    attempt.on_session_dial_failed(&peer, &mut self.shared, now);
+                }
+            }
         }
         match &purpose {
             TokenPurpose::ProbeDial => {

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -53,9 +53,6 @@ pub(crate) enum TokenPurpose {
     ReserveDial,
     /// HOP RESERVE stream open.
     OpenReserve(PeerId),
-    /// Responder-side simultaneous-open dial of an initiator's observed
-    /// address. Results are ignored; the punch window governs.
-    InboundPunchDial,
 }
 
 impl TokenPurpose {

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -454,11 +454,14 @@ impl ConnectAttempt {
                     NatError::Protocol("relay does not advertise the HOP protocol".into()),
                 );
             }
-        } else if shared.connected.contains(&relay_peer) {
+        } else if shared.connected.contains(&relay_peer)
+            || shared.session_dial_pending(&relay_peer, now)
+        {
+            // Connected, or another machine (reservation, probe) is already
+            // dialing this relay: wait for `PeerReady` on that connection.
             self.leg = RelayLeg::WaitRelayReady;
         } else {
-            let token = shared.alloc_token(TokenPurpose::RelayDial(self.id));
-            shared.push_action(NatAction::Dial { token, addr: relay });
+            shared.push_session_dial(TokenPurpose::RelayDial(self.id), relay, now);
             self.leg = RelayLeg::WaitRelayReady;
         }
     }

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -289,6 +289,28 @@ impl ConnectAttempt {
         }
     }
 
+    /// A shared session dial toward this attempt's relay — owned by another
+    /// machine — failed while this attempt was waiting on it. Re-issue the
+    /// dial: nothing else re-enters the relay leg, so waiting out the leg
+    /// deadline would forfeit the relay path over a dial that already
+    /// failed. The pending-dial gate collapses simultaneous re-dials from
+    /// several waiters back into one.
+    pub(crate) fn on_session_dial_failed(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
+        if self.done || self.leg != RelayLeg::WaitRelayReady || !self.is_relay_peer(peer) {
+            return;
+        }
+        if shared.connected.contains(peer) || shared.session_dial_pending(peer, now) {
+            // The shared connection landed anyway, or an earlier-woken
+            // waiter already re-dialed; keep waiting on that.
+            return;
+        }
+        let Some(relay) = self.relay.clone() else {
+            return;
+        };
+        let deadline_ms = shared.config.relay_leg_deadline_ms;
+        shared.push_session_dial(TokenPurpose::RelayDial(self.id), relay, now, deadline_ms);
+    }
+
     pub(crate) fn on_dial_result(
         &mut self,
         purpose: &TokenPurpose,
@@ -461,7 +483,8 @@ impl ConnectAttempt {
             // dialing this relay: wait for `PeerReady` on that connection.
             self.leg = RelayLeg::WaitRelayReady;
         } else {
-            shared.push_session_dial(TokenPurpose::RelayDial(self.id), relay, now);
+            let deadline_ms = shared.config.relay_leg_deadline_ms;
+            shared.push_session_dial(TokenPurpose::RelayDial(self.id), relay, now, deadline_ms);
             self.leg = RelayLeg::WaitRelayReady;
         }
     }

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -296,17 +296,43 @@ impl ConnectAttempt {
     /// failed. The pending-dial gate collapses simultaneous re-dials from
     /// several waiters back into one.
     pub(crate) fn on_session_dial_failed(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
-        if self.done || self.leg != RelayLeg::WaitRelayReady || !self.is_relay_peer(peer) {
+        if self.done || !self.is_relay_peer(peer) {
             return;
         }
-        if shared.connected.contains(peer) || shared.session_dial_pending(peer, now) {
-            // The shared connection landed anyway, or an earlier-woken
-            // waiter already re-dialed; keep waiting on that.
+        self.redrive_relay_leg(shared, now);
+    }
+
+    /// Re-issues the relay dial when the leg waits on a connection that no
+    /// longer has a dial in flight — the shared dial failed, or its owner
+    /// stalled and the entry expired. No-op while a dial is still pending,
+    /// once the relay is connected, and past the leg's own deadline (the
+    /// tick is about to fail the leg; a fresh dial would only gate other
+    /// machines on a connection nobody is waiting for).
+    fn redrive_relay_leg(&mut self, shared: &mut Shared, now: Now) {
+        if self.done || self.leg != RelayLeg::WaitRelayReady {
+            return;
+        }
+        if self
+            .relay_deadline
+            .is_none_or(|deadline| now.mono_ms >= deadline)
+        {
             return;
         }
         let Some(relay) = self.relay.clone() else {
             return;
         };
+        let relay_peer = relay.peer_id();
+        if shared.connected.contains(relay_peer) || shared.session_dial_pending(relay_peer, now) {
+            // The shared connection landed anyway, or an earlier-woken
+            // waiter already re-dialed; keep waiting on that.
+            return;
+        }
+        // The entry gets the full dial-flight lifetime even when this leg's
+        // own deadline is nearer: it models the handshake in flight, not
+        // the attempt's patience. A connection landing after the leg gives
+        // up still lifts the gate (`ConnectionEstablished` clears the
+        // peer's entries), whereas a shorter lifetime would re-open the
+        // duplicate-dial window while the handshake is still under way.
         let deadline_ms = shared.config.relay_leg_deadline_ms;
         shared.push_session_dial(TokenPurpose::RelayDial(self.id), relay, now, deadline_ms);
     }
@@ -436,6 +462,12 @@ impl ConnectAttempt {
         {
             self.fail_relay_leg(shared, NatError::Timeout);
         }
+
+        // A shared dial the leg was waiting on can vanish without a result
+        // when its owner stalls: the entry expires exactly at the owner's
+        // own flight deadline, so a tick is guaranteed to run then — this
+        // re-drive is what keeps a stalled owner from stranding the leg.
+        self.redrive_relay_leg(shared, now);
 
         if let Some(deadline) = self.punch_deadline
             && now.mono_ms >= deadline

--- a/crates/nat/src/housekeeping.rs
+++ b/crates/nat/src/housekeeping.rs
@@ -128,14 +128,14 @@ impl Prober {
                 self.next_probe_at = Some(now.mono_ms + shared.config.probe_interval_unsettled_ms);
                 return;
             }
-        } else if shared.connected.contains(&server_peer) {
+        } else if shared.connected.contains(&server_peer)
+            || shared.session_dial_pending(&server_peer, now)
+        {
+            // Connected, or another machine is already dialing this peer
+            // (an AutoNAT server can double as the configured relay).
             ExchangeStage::WaitPeerReady
         } else {
-            let token = shared.alloc_token(TokenPurpose::ProbeDial);
-            shared.push_action(NatAction::Dial {
-                token,
-                addr: server.clone(),
-            });
+            shared.push_session_dial(TokenPurpose::ProbeDial, server.clone(), now);
             ExchangeStage::WaitPeerReady
         };
 
@@ -595,14 +595,14 @@ impl ReservationManager {
                 self.fail_acquire(shared, now);
                 return;
             }
-        } else if shared.connected.contains(&relay_peer) {
+        } else if shared.connected.contains(&relay_peer)
+            || shared.session_dial_pending(&relay_peer, now)
+        {
+            // Connected, or a connect attempt's relay leg is already dialing
+            // this relay: share that connection instead of superseding it.
             ExchangeStage::WaitPeerReady
         } else {
-            let token = shared.alloc_token(TokenPurpose::ReserveDial);
-            shared.push_action(NatAction::Dial {
-                token,
-                addr: relay.clone(),
-            });
+            shared.push_session_dial(TokenPurpose::ReserveDial, relay.clone(), now);
             ExchangeStage::WaitPeerReady
         };
 

--- a/crates/nat/src/housekeeping.rs
+++ b/crates/nat/src/housekeeping.rs
@@ -135,7 +135,8 @@ impl Prober {
             // (an AutoNAT server can double as the configured relay).
             ExchangeStage::WaitPeerReady
         } else {
-            shared.push_session_dial(TokenPurpose::ProbeDial, server.clone(), now);
+            let deadline_ms = shared.config.probe_deadline_ms;
+            shared.push_session_dial(TokenPurpose::ProbeDial, server.clone(), now, deadline_ms);
             ExchangeStage::WaitPeerReady
         };
 
@@ -602,7 +603,8 @@ impl ReservationManager {
             // this relay: share that connection instead of superseding it.
             ExchangeStage::WaitPeerReady
         } else {
-            shared.push_session_dial(TokenPurpose::ReserveDial, relay.clone(), now);
+            let deadline_ms = shared.config.relay_leg_deadline_ms;
+            shared.push_session_dial(TokenPurpose::ReserveDial, relay.clone(), now, deadline_ms);
             ExchangeStage::WaitPeerReady
         };
 

--- a/crates/nat/src/inbound.rs
+++ b/crates/nat/src/inbound.rs
@@ -1,24 +1,25 @@
 //! Responder-side hole punching: a NAT'd listener holding a relay
 //! reservation accepts inbound STOP circuits, answers the initiator's DCUtR
-//! exchange, and punches back — dialing the initiator's observed addresses
-//! and blasting random UDP datagrams to open its own NAT mapping.
+//! exchange, and blasts random UDP datagrams at the initiator's observed
+//! addresses to open its own NAT mapping. Only the initiator dials (DCUtR
+//! for QUIC): the blasts make that dial land.
 //!
 //! ```text
 //! relay opens STOP stream ──▶ CONNECT ──▶ auto-Accept (STATUS:OK)
 //!   ──▶ DCUtR CONNECT arrives ──▶ reply with our observed addresses
-//!   ──▶ SYNC arrives ──▶ dial initiator's addrs + schedule UDP blasts,
+//!   ──▶ SYNC arrives ──▶ schedule UDP blasts,
 //!       release the bridge to the app (InboundRelayCircuit)
-//! direct connection appears ──▶ cancel blasts, InboundDirectUpgrade
+//! initiator's dial lands ──▶ cancel blasts, InboundDirectUpgrade
 //! ```
 
 use alloc::vec::Vec;
 
-use minip2p_core::{Multiaddr, PeerAddr, PeerId, SansIoProtocol, select_direct_candidates};
+use minip2p_core::{Multiaddr, PeerId, SansIoProtocol, select_direct_candidates};
 use minip2p_dcutr::{DcutrResponder, DcutrResponderInput, DcutrResponderOutput, ResponderEvent};
 use minip2p_relay::{Status, StopResponder, StopResponderInput, StopResponderOutput};
 use minip2p_transport::StreamId;
 
-use crate::agent::{Shared, StreamInput, TokenPurpose};
+use crate::agent::{Shared, StreamInput};
 use crate::events::{NatAction, NatEvent};
 use crate::types::Now;
 
@@ -30,7 +31,7 @@ struct BlastSchedule {
 }
 
 /// One inbound relay circuit: STOP acceptance, DCUtR responder exchange,
-/// and the punch-back (dials + UDP blasts).
+/// and the punch-window UDP blasts.
 pub(crate) struct InboundCircuit {
     /// The peer that opened the STOP stream to us (the relay).
     relay: PeerId,
@@ -264,24 +265,20 @@ impl InboundCircuit {
         }
     }
 
-    /// SYNC arrived: punch back (simultaneous dials + UDP blasts) and hand
+    /// SYNC arrived: open our NAT mapping with random-UDP blasts and hand
     /// the bridge to the application.
+    ///
+    /// Per the DCUtR spec for QUIC, only the initiator dials. A responder
+    /// dial would race the initiator's — when both land (guaranteed
+    /// without NATs, common with cone NATs) the second connection
+    /// supersedes the first and the supersede scrubs every stream the
+    /// application just opened on the announced path.
     fn on_sync(&mut self, shared: &mut Shared, now: Now) {
         self.dcutr = None;
-        let Some(source) = self.source.clone() else {
+        if self.source.is_none() {
             return;
-        };
-
-        for addr in &self.remote_addrs {
-            let Ok(peer_addr) = PeerAddr::new(addr.clone(), source.clone()) else {
-                continue;
-            };
-            let token = shared.alloc_token(TokenPurpose::InboundPunchDial);
-            shared.push_action(NatAction::Dial {
-                token,
-                addr: peer_addr,
-            });
         }
+
         if !self.remote_addrs.is_empty() {
             self.blast = Some(BlastSchedule {
                 addrs: self.remote_addrs.clone(),
@@ -384,8 +381,8 @@ impl InboundCircuit {
     }
 
     /// The relay connection died. Before release the circuit is gone; after
-    /// release the app owns the (now dead) stream and the punch-back may
-    /// still land, so the circuit lingers.
+    /// release the app owns the (now dead) stream and the initiator's punch
+    /// dial may still land, so the circuit lingers.
     pub(crate) fn on_relay_disconnected(&mut self, peer: &PeerId, _shared: &mut Shared) {
         if self.done || &self.relay != peer {
             return;

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -704,6 +704,71 @@ fn concurrent_reservation_and_connect_share_one_relay_dial() {
     );
 }
 
+/// The in-flight entry must live as long as the owning machine's own flight
+/// deadline. A probe dial is legitimate for `probe_deadline_ms` (20s); if
+/// the entry expired at the relay-leg deadline (12s) instead, a connect
+/// attempt arriving in between would dial the same peer a second time —
+/// recreating the supersede this map exists to prevent.
+#[test]
+fn pending_probe_dial_covers_the_probe_deadline_not_the_relay_legs() {
+    // The AutoNAT server doubles as the configured relay, so the probe's
+    // dial and the attempt's relay leg target the same peer.
+    let mut hk = build_with_config(ReservationPolicy::Never, 1, 0, |config| {
+        config.autonat_servers =
+            vec![PeerAddr::new(maddr(RELAY_TRANSPORT_ADDR), peer(b"relay-peer")).unwrap()];
+    });
+    let relay = hk.relay.clone();
+
+    // The probe dials the server; the handshake is slow but still within
+    // the probe's own deadline.
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(dial_count_for(&actions, &relay), 1, "{actions:?}");
+
+    // A connect starts past the relay-leg deadline but inside the probe
+    // deadline: the probe's dial is still in flight, so the relay leg must
+    // join it rather than open a superseding second connection.
+    hk.agent
+        .connect(peer(b"target-peer"), Vec::new(), at(15_000));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(
+        dial_count_for(&actions, &relay),
+        0,
+        "the relay leg must wait on the probe's in-flight dial: {actions:?}"
+    );
+}
+
+/// When the owner of a shared session dial reports failure, waiting
+/// attempts must issue their own dial immediately. Nothing else re-enters
+/// a waiting relay leg: without the wake-up the attempt would burn its
+/// whole leg deadline on a dial that already failed and could time out
+/// without ever trying the relay.
+#[test]
+fn waiting_attempt_redials_when_the_shared_dial_fails() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+    let relay = hk.relay.clone();
+
+    // The reservation manager owns the relay dial.
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    let reserve_dial = dial_token_for(&actions, &relay);
+
+    // A connect attempt joins the pending dial.
+    hk.agent.connect(peer(b"target-peer"), Vec::new(), at(10));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(dial_count_for(&actions, &relay), 0, "{actions:?}");
+
+    // The shared dial fails: the waiting attempt re-dials at once.
+    hk.agent
+        .dial_result(reserve_dial, Err("connection refused".into()), at(500));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(
+        dial_count_for(&actions, &relay),
+        1,
+        "the waiting attempt must issue its own dial: {actions:?}"
+    );
+}
+
 /// A session dial whose handshake never completes must not suppress dialing
 /// forever: once the reservation deadline fails the acquisition, the retry
 /// issues a fresh dial (the stale in-flight entry has expired).

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -498,39 +498,6 @@ fn hop_open_count(actions: &[NatAction], peer: &PeerId) -> usize {
 }
 
 #[test]
-fn concurrent_connect_joins_the_pending_reservation_dial() {
-    let mut hk = build(ReservationPolicy::Always, 1, 0);
-
-    // The reservation manager dials the relay first.
-    hk.agent.handle_tick(at(0));
-    let actions = drain_actions(&mut hk.agent);
-    let token = dial_token_for(&actions, &hk.relay);
-    hk.agent.dial_result(token, Ok(ConnectionId::new(60)), at(5));
-
-    // A connect starts while that handshake is still in flight. Its relay
-    // leg must join the pending dial: a second connection to the same peer
-    // would supersede the first, scrubbing both machines' streams.
-    hk.agent.connect(peer(b"target-peer"), Vec::new(), at(100));
-    hk.agent.handle_tick(at(400));
-    let actions = drain_actions(&mut hk.agent);
-    assert_eq!(
-        dial_count_for(&actions, &hk.relay),
-        0,
-        "the connect raced a second relay dial"
-    );
-
-    // The single connection lands; both machines proceed on it.
-    let relay = hk.relay.clone();
-    hk.session_ready(&relay, &[HOP_PROTOCOL_ID], at(500));
-    let actions = drain_actions(&mut hk.agent);
-    assert_eq!(
-        hop_open_count(&actions, &relay),
-        2,
-        "reserve and connect legs must share the connection"
-    );
-}
-
-#[test]
 fn connect_and_reservation_racing_in_one_tick_share_one_dial() {
     let mut hk = build(ReservationPolicy::Always, 1, 0);
 
@@ -549,28 +516,6 @@ fn connect_and_reservation_racing_in_one_tick_share_one_dial() {
     hk.session_ready(&relay, &[HOP_PROTOCOL_ID], at(300));
     let actions = drain_actions(&mut hk.agent);
     assert_eq!(hop_open_count(&actions, &relay), 2);
-}
-
-#[test]
-fn expired_session_dial_does_not_suppress_the_retry() {
-    let mut hk = build(ReservationPolicy::Always, 1, 0);
-    hk.agent.handle_tick(at(0));
-    let actions = drain_actions(&mut hk.agent);
-    assert_eq!(dial_count_for(&actions, &hk.relay), 1);
-
-    // The handshake never completes and no dial result ever arrives. The
-    // acquire deadline fails the exchange, and once the backoff elapses the
-    // retry must dial again — the stale pending entry has expired and must
-    // not suppress it forever.
-    let mut redials = 0;
-    for t in [12_050, 12_650, 13_300] {
-        hk.agent.handle_tick(at(t));
-        redials += dial_count_for(&drain_actions(&mut hk.agent), &hk.relay);
-    }
-    assert_eq!(
-        redials, 1,
-        "expired pending dial must not suppress the retry"
-    );
 }
 
 #[test]

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -769,6 +769,68 @@ fn waiting_attempt_redials_when_the_shared_dial_fails() {
     );
 }
 
+/// When the owner of a shared dial stalls (no result ever arrives), its
+/// entry expires at the owner's own flight deadline — and the tick running
+/// at that moment must re-drive waiting relay legs. Without the re-drive
+/// the attempt idles until its own later deadline and fails without ever
+/// dialing the relay itself.
+#[test]
+fn waiting_attempt_redials_when_the_shared_dial_expires() {
+    let mut hk = build_with_config(ReservationPolicy::Never, 1, 0, |config| {
+        config.autonat_servers =
+            vec![PeerAddr::new(maddr(RELAY_TRANSPORT_ADDR), peer(b"relay-peer")).unwrap()];
+    });
+    let relay = hk.relay.clone();
+
+    // The probe owns the dial (20s flight); the handshake stalls silently.
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(dial_count_for(&actions, &relay), 1, "{actions:?}");
+
+    // A connect joins the pending dial mid-flight.
+    hk.agent
+        .connect(peer(b"target-peer"), Vec::new(), at(15_000));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(dial_count_for(&actions, &relay), 0, "{actions:?}");
+
+    // The probe's flight deadline: the entry expires and the same tick must
+    // re-drive the waiting relay leg (whose own deadline, 27s, is live).
+    hk.agent.handle_tick(at(20_000));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(
+        dial_count_for(&actions, &relay),
+        1,
+        "the waiting attempt must re-dial when the stalled entry expires: {actions:?}"
+    );
+}
+
+/// A shared-dial failure arriving after the leg's own deadline (with no
+/// tick in between) must not trigger a re-dial: the next tick fails the
+/// leg, so a fresh entry would only gate the reservation manager's and
+/// prober's dials on a connection nobody is waiting for.
+#[test]
+fn late_shared_dial_failure_does_not_redial_a_dead_leg() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+    let relay = hk.relay.clone();
+
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    let reserve_dial = dial_token_for(&actions, &relay);
+
+    hk.agent.connect(peer(b"target-peer"), Vec::new(), at(10));
+    drain_actions(&mut hk.agent);
+
+    // The failure lands past the attempt's relay-leg deadline (10 + 12s).
+    hk.agent
+        .dial_result(reserve_dial, Err("timed out".into()), at(12_500));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(
+        dial_count_for(&actions, &relay),
+        0,
+        "no re-dial past the leg deadline: {actions:?}"
+    );
+}
+
 /// A session dial whose handshake never completes must not suppress dialing
 /// forever: once the reservation deadline fails the acquisition, the retry
 /// issues a fresh dial (the stale in-flight entry has expired).

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -483,6 +483,96 @@ fn refused_reservation_rotates_relay_after_backoff() {
     assert_eq!(dial_count_for(&actions, &hk.relay), 0);
 }
 
+/// Counts HOP `OpenStream` actions targeting `peer`.
+fn hop_open_count(actions: &[NatAction], peer: &PeerId) -> usize {
+    actions
+        .iter()
+        .filter(|action| {
+            matches!(
+                action,
+                NatAction::OpenStream { peer: p, protocol_id, .. }
+                    if p == peer && protocol_id == HOP_PROTOCOL_ID
+            )
+        })
+        .count()
+}
+
+#[test]
+fn concurrent_connect_joins_the_pending_reservation_dial() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+
+    // The reservation manager dials the relay first.
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    let token = dial_token_for(&actions, &hk.relay);
+    hk.agent.dial_result(token, Ok(ConnectionId::new(60)), at(5));
+
+    // A connect starts while that handshake is still in flight. Its relay
+    // leg must join the pending dial: a second connection to the same peer
+    // would supersede the first, scrubbing both machines' streams.
+    hk.agent.connect(peer(b"target-peer"), Vec::new(), at(100));
+    hk.agent.handle_tick(at(400));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(
+        dial_count_for(&actions, &hk.relay),
+        0,
+        "the connect raced a second relay dial"
+    );
+
+    // The single connection lands; both machines proceed on it.
+    let relay = hk.relay.clone();
+    hk.session_ready(&relay, &[HOP_PROTOCOL_ID], at(500));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(
+        hop_open_count(&actions, &relay),
+        2,
+        "reserve and connect legs must share the connection"
+    );
+}
+
+#[test]
+fn connect_and_reservation_racing_in_one_tick_share_one_dial() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+
+    // Whatever internal order the machines run in, only one dial may reach
+    // the relay.
+    hk.agent.connect(peer(b"target-peer"), Vec::new(), at(0));
+    hk.agent.handle_tick(at(250));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(
+        dial_count_for(&actions, &hk.relay),
+        1,
+        "exactly one shared relay dial"
+    );
+
+    let relay = hk.relay.clone();
+    hk.session_ready(&relay, &[HOP_PROTOCOL_ID], at(300));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(hop_open_count(&actions, &relay), 2);
+}
+
+#[test]
+fn expired_session_dial_does_not_suppress_the_retry() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(dial_count_for(&actions, &hk.relay), 1);
+
+    // The handshake never completes and no dial result ever arrives. The
+    // acquire deadline fails the exchange, and once the backoff elapses the
+    // retry must dial again — the stale pending entry has expired and must
+    // not suppress it forever.
+    let mut redials = 0;
+    for t in [12_050, 12_650, 13_300] {
+        hk.agent.handle_tick(at(t));
+        redials += dial_count_for(&drain_actions(&mut hk.agent), &hk.relay);
+    }
+    assert_eq!(
+        redials, 1,
+        "expired pending dial must not suppress the retry"
+    );
+}
+
 #[test]
 fn lost_relay_connection_emits_lost_and_reacquires() {
     let mut hk = build(ReservationPolicy::Always, 1, 0);
@@ -617,5 +707,81 @@ fn when_private_policy_follows_the_reachability_verdict() {
             .iter()
             .any(|a| matches!(a, NatAction::OpenStream { protocol_id, .. } if protocol_id == HOP_PROTOCOL_ID)),
         "reservation reacquired once private: {actions:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Session-dial sharing
+// ---------------------------------------------------------------------------
+
+/// Regression test for a failure first seen against a live relay: the
+/// reservation manager and a connect attempt's relay leg both dialed the
+/// relay while the first handshake was still in flight (real-network RTT),
+/// producing two connections — and the second superseded the first, killing
+/// the attempt with "relay connection was superseded".
+#[test]
+fn concurrent_reservation_and_connect_share_one_relay_dial() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+    let relay = hk.relay.clone();
+
+    // The reservation manager dials the relay first.
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    let reserve_dial = dial_token_for(&actions, &relay);
+
+    // A connect starts while that dial is still handshaking; its relay leg
+    // must wait on the pending connection instead of dialing again.
+    let _id = hk.agent.connect(peer(b"target-peer"), Vec::new(), at(10));
+    hk.agent.handle_tick(at(300));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(
+        dial_count_for(&actions, &relay),
+        0,
+        "a second relay dial supersedes the first connection: {actions:?}"
+    );
+
+    // The shared connection comes up: both machines proceed, each opening
+    // its own HOP stream on it.
+    hk.agent
+        .dial_result(reserve_dial, Ok(ConnectionId::new(9)), at(400));
+    hk.session_ready(&relay, &[HOP_PROTOCOL_ID], at(410));
+    let actions = drain_actions(&mut hk.agent);
+    let hop_opens = actions
+        .iter()
+        .filter(|a| {
+            matches!(a, NatAction::OpenStream { protocol_id, .. } if protocol_id == HOP_PROTOCOL_ID)
+        })
+        .count();
+    assert_eq!(
+        hop_opens, 2,
+        "reservation and connect attempt must each open a HOP stream on \
+         the shared connection: {actions:?}"
+    );
+}
+
+/// A session dial whose handshake never completes must not suppress dialing
+/// forever: once the reservation deadline fails the acquisition, the retry
+/// issues a fresh dial (the stale in-flight entry has expired).
+#[test]
+fn stalled_session_dial_expires_and_the_retry_redials() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+    let relay = hk.relay.clone();
+
+    hk.agent.handle_tick(at(0));
+    let actions = drain_actions(&mut hk.agent);
+    assert_eq!(dial_count_for(&actions, &relay), 1);
+    // No dial_result, no connection: the handshake silently stalls.
+
+    // Past the acquisition deadline (relay_leg_deadline_ms) and the retry
+    // backoff, the manager tries again — with a real dial, not a wait on
+    // the dead one.
+    hk.agent.handle_tick(at(12_600));
+    let mut actions = drain_actions(&mut hk.agent);
+    hk.agent.handle_tick(at(13_500));
+    actions.extend(drain_actions(&mut hk.agent));
+    assert_eq!(
+        dial_count_for(&actions, &relay),
+        1,
+        "the retry must redial the relay: {actions:?}"
     );
 }

--- a/crates/nat/tests/inbound.rs
+++ b/crates/nat/tests/inbound.rs
@@ -1,5 +1,5 @@
 //! Scripted responder-side tests: inbound STOP circuits, the DCUtR
-//! responder exchange, punch-back dials, and the UDP blast schedule.
+//! responder exchange, and the UDP blast schedule.
 
 mod common;
 
@@ -60,7 +60,7 @@ fn drive_to_sync_ready(h: &mut Harness, stream: StreamId) {
 }
 
 #[test]
-fn full_inbound_flow_punches_back_and_upgrades() {
+fn full_inbound_flow_blasts_and_upgrades() {
     let mut h = inbound_harness(NatConfig::default());
     let stream = StreamId::new(STOP_STREAM);
 
@@ -79,8 +79,9 @@ fn full_inbound_flow_punches_back_and_upgrades() {
     let actions = drain_actions(&mut h.agent);
     assert_eq!(
         dial_count_for(&actions, &h.target),
-        1,
-        "simultaneous-open dial toward the initiator's observed address"
+        0,
+        "only the initiator dials; a responder dial would race it and the \
+         superseded connection would lose its streams"
     );
     assert!(
         !h.agent.owns_stream(&h.relay, stream),

--- a/crates/nat/tests/two_agents.rs
+++ b/crates/nat/tests/two_agents.rs
@@ -427,15 +427,12 @@ fn two_agents_punch_to_a_direct_connection() {
         "B released the inbound bridge, got {events:?}"
     );
 
-    // B's punch-back: simultaneous dial plus UDP blasts after the sync
-    // delay.
+    // B's punch-back is blast-only (DCUtR for QUIC: the initiator dials).
+    // A responder dial would race A's — when both land, the second
+    // connection supersedes the first and scrubs its streams.
     assert_eq!(
-        world.punch_dials_from_b, 2,
-        "B dialed A's listen address and A's relay-observed public mapping"
-    );
-    assert!(
-        world.punch_dial_addrs_from_b.contains(&maddr(A_PUBLIC)),
-        "B's punch-back targets A's public mapping: {:?}",
+        world.punch_dials_from_b, 0,
+        "the responder must not dial: {:?}",
         world.punch_dial_addrs_from_b
     );
     world.advance(100);

--- a/transports/quic/src/connection.rs
+++ b/transports/quic/src/connection.rs
@@ -605,12 +605,14 @@ impl QuicConnection {
                     });
                     break;
                 }
-                Err(e) => {
-                    return Err(TransportError::CloseFailed {
-                        id: self.id,
-                        reason: format!("udp send error: {e}"),
-                    });
-                }
+                // Any other send error (EHOSTUNREACH after a route flap,
+                // ICMP-driven ECONNREFUSED, ...) affects only this
+                // connection's path, so it must not abort the whole
+                // endpoint's poll. Treat the packet as lost -- quiche's
+                // loss recovery retransmits it, and a path that stays dead
+                // ends in this connection's idle timeout. Stop draining so
+                // a dead route is not hammered within one flush.
+                Err(_) => break,
             }
         }
         Ok(())

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -975,10 +975,12 @@ impl QuicTransport {
                     self.pending_datagrams.pop_front();
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
-                Err(e) => {
-                    return Err(TransportError::PollError {
-                        reason: format!("queued udp send failed: {e}"),
-                    });
+                // Queued datagrams may target different destinations, so a
+                // dead route for one must neither abort the poll nor block
+                // the rest: drop the packet (loss recovery retransmits
+                // anything that mattered) and keep flushing.
+                Err(_) => {
+                    self.pending_datagrams.pop_front();
                 }
             }
         }
@@ -1935,7 +1937,7 @@ mod tests {
     }
 
     #[test]
-    fn queued_events_survive_an_errored_poll() {
+    fn poisoned_queued_datagram_is_dropped_without_failing_the_poll() {
         let mut transport =
             QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("bind");
         let addr = transport.local_multiaddr().expect("multiaddr");
@@ -1943,30 +1945,25 @@ mod tests {
             .pending_events
             .push(TransportEvent::Listening { addr: addr.clone() });
 
-        // An IPv6 destination on an IPv4 socket makes the datagram flush fail
-        // with a hard error before any events would be returned.
+        // An IPv6 destination on an IPv4 socket makes the datagram send fail
+        // with a hard error. A dead route affects only that packet's
+        // destination, so the poll must drop it and carry on rather than
+        // abort the whole endpoint.
         let bad_destination: SocketAddr = "[::1]:9".parse().expect("socket addr");
         transport.queue_datagram_best_effort(&[0u8; 4], bad_destination);
+        let good_destination = transport.local_addr().expect("local addr");
+        transport.queue_datagram_best_effort(&[0u8; 4], good_destination);
 
-        let error = transport
-            .poll()
-            .expect_err("hard send failure must surface");
-        assert!(matches!(error, TransportError::PollError { .. }));
-        assert!(
-            transport
-                .pending_events
-                .iter()
-                .any(|event| matches!(event, TransportEvent::Listening { addr: a } if *a == addr)),
-            "events queued before the failed poll must remain queued"
-        );
-
-        // Once the poisoned datagram is gone the next poll delivers the batch.
-        transport.pending_datagrams.clear();
         let events = transport.poll().expect("poll");
         assert!(
             events
                 .iter()
-                .any(|event| matches!(event, TransportEvent::Listening { addr: a } if *a == addr))
+                .any(|event| matches!(event, TransportEvent::Listening { addr: a } if *a == addr)),
+            "events queued before the poisoned datagram must still be delivered"
+        );
+        assert!(
+            transport.pending_datagrams.is_empty(),
+            "the poisoned datagram must be dropped and the one behind it sent"
         );
     }
 


### PR DESCRIPTION
## Context

Live testing PR #20's demo against a real rust-libp2p 0.48 relay (Circuit Relay v2 + DCUtR over IPv6 QUIC, ~130 ms RTT) surfaced three bugs that loopback tests and the emulator cannot reproduce — all three are fixed here. Each one was found as a failing live run and re-validated live after the fix, including a cross-internet hole punch where an AWS-hosted dialer punched through a real stateful home-router firewall to reach the listener (8/8 pongs, relayed ~105 ms → direct 55 ms, unbroken seq).

## Fixes

### 1. Share in-flight session dials instead of racing them

**Symptom:** `ConnectFailed: dial failed: relay connection was superseded`.

A connect attempt's relay leg and the reservation manager both dialed the relay concurrently. Over a real RTT the handshakes overlap, two QUIC connections land, and the swarm's last-connection-wins policy scrubs the first — killing the attempt. Infrastructure dials (relay / reserve / probe) to the same peer now join a shared pending dial (`Shared::pending_session_dials`, with expiry so a stalled dial never suppresses retries). Punch dials are exempt: simultaneous open is intentional there.

### 2. Remove the responder's punch dial

**Symptom:** after `nat-path-upgraded to=direct-punched`, the fresh echo stream died (`echo stream never became ready`).

Both sides punch-dialed after the DCUtR SYNC. When both dials land (guaranteed without NATs, common with cone NATs), the second connection supersedes the first and scrubs the stream the application just opened. Per the DCUtR spec for QUIC, only the initiator dials; the responder now only sends random-UDP blasts to open its NAT mapping. The cross-internet test above proves the blast path: the AWS initiator's dial could only reach the NAT'd listener through the pinhole its blasts opened.

### 3. Treat UDP send errors as packet loss instead of failing the endpoint

**Symptom:** the listener process died with `error: swarm poll: close failed for 2: udp send error: No route to host (os error 65)`.

A route flap (a VPN grabbing the IPv6 default route, macOS rotating temporary addresses) made `send_to` fail with `EHOSTUNREACH`, and the transport propagated that as fatal to the whole endpoint — one dead path took down every connection. Send failures now drop the datagram: quiche's loss recovery retransmits it, and a path that stays dead ends in that one connection's idle timeout. Retained (`WouldBlock`) datagrams get the same treatment, since one dead destination must not block or abort the rest.

## Testing

- Housekeeping tests: a connect and a reservation racing to the same relay produce exactly one dial (in-flight and same-tick variants); a stalled dial expires and the retry re-dials.
- Inbound/two-agent tests: the responder emits zero dials after SYNC and blasts instead; the initiator still dials both candidates; the full inbound flow upgrades on the initiator's connection.
- Transport test: a poisoned queued datagram is dropped without failing the poll, and queued events still deliver.
- Full gate: fmt, clippy `-D warnings`, all workspace suites.
- Live: two end-to-end runs against the real relay (same-host peers, then AWS dialer → NAT'd listener), both exiting 0 with unbroken seq and visible relayed→direct RTT drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three NAT issues found in live relay testing: dedupes in-flight session dials with per-purpose lifetimes, enforces initiator-only QUIC DCUtR punching, and treats UDP send errors as packet loss. This prevents relay supersedes, preserves streams on upgrade, and avoids endpoint crashes during route flaps.

- **Bug Fixes**
  - Share in-flight session dials (relay leg/reservation/probe) with per-purpose lifetimes; clear on connect/close/error/expiry; wake waiters on failure and re-drive them on tick if the shared dial expires; punch dials are exempt.
  - Remove responder punch dial for QUIC DCUtR; responder now only sends UDP blasts after SYNC to open its NAT mapping, aligning with spec and preventing supersedes that scrub app streams; docs updated.
  - Treat UDP send failures as packet loss in `transports/quic`: drop failed `send_to` and queued datagrams instead of aborting the poll/endpoint; stop draining after a send error; quiche handles retransmits.

<sup>Written for commit ce76f1a6d1b303d64e147dbb53ef16386b1598e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

