### PR TITLE
M5 live-validation fixes: chat keepalive, opaque seqnos, --allow-unsigned

### DIFF
--- a/crates/pubsub/src/agent.rs
+++ b/crates/pubsub/src/agent.rs
@@ -268,7 +268,7 @@ impl FloodsubAgent {
         }
         self.next_seqno = self.next_seqno.wrapping_add(1);
 
-        let id: MessageId = (self.local_peer_id.to_bytes(), seqno.to_be_bytes());
+        let id: MessageId = (self.local_peer_id.to_bytes(), seqno.to_be_bytes().to_vec());
         self.seen.insert(
             id,
             now_ms,
@@ -871,7 +871,7 @@ impl FloodsubAgent {
             }
         };
 
-        let id: MessageId = (from.to_bytes(), seqno.to_be_bytes());
+        let id: MessageId = (from.to_bytes(), seqno.clone());
         if self.seen.contains(&id) {
             return; // duplicate: silent
         }

--- a/crates/pubsub/src/events.rs
+++ b/crates/pubsub/src/events.rs
@@ -62,8 +62,10 @@ pub enum PubsubEvent {
         topics: Vec<String>,
         /// Application payload.
         data: Vec<u8>,
-        /// The publisher's sequence number.
-        seqno: u64,
+        /// The publisher's sequence number, as opaque bytes: go peers emit
+        /// 8 big-endian bytes, rust-libp2p floodsub 20 random bytes.
+        /// Together with `from` it identifies the message for dedup.
+        seqno: Vec<u8>,
     },
     /// A peer announced a subscription.
     PeerSubscribed {

--- a/crates/pubsub/src/message.rs
+++ b/crates/pubsub/src/message.rs
@@ -23,6 +23,12 @@ pub const MAX_RPC_SIZE: usize = 65536;
 /// Maximum topic length in bytes, enforced on subscribe and publish alike.
 pub const MAX_TOPIC_LEN: usize = 1024;
 
+/// Maximum accepted `seqno` length in bytes. Implementations disagree on
+/// the format (go: 8 big-endian bytes, rust-libp2p floodsub: 20 random
+/// bytes), so the seqno is treated as opaque; the cap bounds what the
+/// seen-cache stores per message id.
+pub const MAX_SEQNO_LEN: usize = 64;
+
 /// Domain-separation prefix for StrictSign signatures.
 const SIGN_PREFIX: &[u8] = b"libp2p-pubsub:";
 
@@ -124,8 +130,9 @@ pub enum MessageVerifyError {
     /// The `from` field does not parse as a peer id.
     #[error("message from field is not a valid peer id")]
     InvalidFrom,
-    /// The `seqno` field is missing or not exactly 8 bytes.
-    #[error("message seqno must be exactly 8 bytes")]
+    /// The `seqno` field is missing, empty, or longer than
+    /// [`MAX_SEQNO_LEN`] bytes.
+    #[error("message seqno must be 1..=64 bytes")]
     InvalidSeqno,
     /// The message carries no signature and unsigned messages are refused.
     #[error("message is unsigned")]
@@ -298,17 +305,20 @@ impl RawMessage {
     }
 
     /// Verifies this message per StrictSign and returns its publisher and
-    /// dedup seqno.
+    /// dedup seqno bytes.
     ///
     /// Rules (see the crate README for the interop rationale):
-    /// - `from` must parse as a peer id; `seqno` must be exactly 8 bytes —
+    /// - `from` must parse as a peer id; `seqno` must be 1..=64 bytes —
     ///   required even for unsigned messages, they form the dedup id.
+    ///   Length varies by implementation (go emits 8 big-endian bytes,
+    ///   rust-libp2p floodsub 20 random bytes), so the seqno is opaque
+    ///   bytes; the cap only bounds the seen-cache's per-id memory.
     /// - A present signature is always verified, `allow_unsigned` or not.
     /// - `key` without `signature` is invalid.
     /// - The signing key must round-trip to `from`
     ///   (`PeerId::from_public_key(key) == from`) whether it came from the
     ///   `key` field or was recovered from an inline-Ed25519 `from`.
-    pub fn verify(&self, allow_unsigned: bool) -> Result<(PeerId, u64), MessageVerifyError> {
+    pub fn verify(&self, allow_unsigned: bool) -> Result<(PeerId, Vec<u8>), MessageVerifyError> {
         let from_bytes = self
             .from
             .as_deref()
@@ -318,10 +328,10 @@ impl RawMessage {
             .seqno
             .as_deref()
             .ok_or(MessageVerifyError::InvalidSeqno)?;
-        let seqno_array: [u8; 8] = seqno_bytes
-            .try_into()
-            .map_err(|_| MessageVerifyError::InvalidSeqno)?;
-        let seqno = u64::from_be_bytes(seqno_array);
+        if seqno_bytes.is_empty() || seqno_bytes.len() > MAX_SEQNO_LEN {
+            return Err(MessageVerifyError::InvalidSeqno);
+        }
+        let seqno = seqno_bytes.to_vec();
 
         let Some(signature) = self.signature.as_deref() else {
             if self.key.is_some() {
@@ -809,7 +819,7 @@ mod tests {
         assert!(message.key.is_none(), "key must be omitted on the wire");
         let (from, seqno) = message.verify(false).expect("verify");
         assert_eq!(from, kp.peer_id());
-        assert_eq!(seqno, 42);
+        assert_eq!(seqno, 42u64.to_be_bytes().to_vec());
     }
 
     #[test]
@@ -888,16 +898,28 @@ mod tests {
         );
         let (from, seqno) = unsigned.verify(true).expect("allow_unsigned accepts");
         assert_eq!(from, kp.peer_id());
-        assert_eq!(seqno, 9);
+        assert_eq!(seqno, 9u64.to_be_bytes().to_vec());
 
-        // Even unsigned, the dedup id fields stay mandatory.
+        // Seqno length is implementation-defined: rust-libp2p floodsub
+        // emits 20 random bytes. Anything 1..=64 is accepted.
+        let mut rust_seqno = unsigned.clone();
+        rust_seqno.seqno = Some(vec![7; 20]);
+        assert!(rust_seqno.verify(true).is_ok(), "20-byte seqno verifies");
+
+        // Even unsigned, the dedup id fields stay mandatory and bounded.
         let mut no_from = unsigned.clone();
         no_from.from = None;
         assert_eq!(no_from.verify(true), Err(MessageVerifyError::MissingFrom));
-        let mut short_seqno = unsigned.clone();
-        short_seqno.seqno = Some(vec![1, 2, 3]);
+        let mut empty_seqno = unsigned.clone();
+        empty_seqno.seqno = Some(Vec::new());
         assert_eq!(
-            short_seqno.verify(true),
+            empty_seqno.verify(true),
+            Err(MessageVerifyError::InvalidSeqno)
+        );
+        let mut huge_seqno = unsigned.clone();
+        huge_seqno.seqno = Some(vec![0; MAX_SEQNO_LEN + 1]);
+        assert_eq!(
+            huge_seqno.verify(true),
             Err(MessageVerifyError::InvalidSeqno)
         );
     }

--- a/crates/pubsub/src/seen.rs
+++ b/crates/pubsub/src/seen.rs
@@ -3,8 +3,8 @@
 use alloc::collections::{BTreeSet, VecDeque};
 use alloc::vec::Vec;
 
-/// A message's dedup identity: (`from` bytes, 8-byte `seqno`).
-pub(crate) type MessageId = (Vec<u8>, [u8; 8]);
+/// A message's dedup identity: (`from` bytes, `seqno` bytes).
+pub(crate) type MessageId = (Vec<u8>, Vec<u8>);
 
 /// Dedup cache for message ids.
 ///

--- a/crates/pubsub/tests/agent.rs
+++ b/crates/pubsub/tests/agent.rs
@@ -722,6 +722,32 @@ fn unsigned_messages_require_the_allow_unsigned_config() {
             .iter()
             .any(|e| matches!(e, PubsubEvent::Message { .. }))
     );
+
+    // Live-interop regression: rust-libp2p floodsub seqnos are 20 random
+    // bytes, not go's 8. They must deliver and round-trip in the event.
+    let rust_style_frame = {
+        let publisher = keypair(9);
+        let message = RawMessage {
+            from: Some(publisher.peer_id().to_bytes()),
+            data: Some(b"from rust".to_vec()),
+            seqno: Some(vec![7; 20]),
+            topic_ids: vec!["t".to_string()],
+            ..RawMessage::default()
+        };
+        let rpc = Rpc {
+            subscriptions: Vec::new(),
+            publish: vec![message],
+        };
+        encode_frame(&rpc.encode())
+    };
+    inbound_data(&mut lax, &b, StreamId::new(3), &rust_style_frame, 3);
+    assert!(
+        drain_events(&mut lax).iter().any(|e| matches!(
+            e,
+            PubsubEvent::Message { seqno, .. } if seqno.as_slice() == [7; 20]
+        )),
+        "a 20-byte seqno must deliver under allow_unsigned"
+    );
 }
 
 #[test]

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -68,7 +68,15 @@ connections is future work at the stack level.
 The payload is plain UTF-8, `"<nick>: <text>"`, formatted by the sender —
 trivially interoperable with any libp2p floodsub peer on the same topic
 (go/js sign by default and match this stack's StrictSign; rust-libp2p's
-floodsub is unsigned and needs `allow_unsigned`, not exposed by this CLI).
+floodsub is unsigned — pass `--allow-unsigned` to chat with it; signed
+messages are still verified). Seqnos are implementation-defined opaque
+bytes (go: 8 big-endian, rust: 20 random); anything 1..=64 bytes is
+accepted.
+
+A quiet room generates no traffic, and the QUIC transport drops
+connections after 30 s of silence — the chat loop pings every connected
+peer on a 10 s cadence to keep the room (and any relay reservation
+connection) alive through idle spells.
 
 ## Live-test recipes
 
@@ -86,3 +94,16 @@ address if v6 default routes are hijacked).
    paste the `circuit=` address and hole-punch in.
 3. **go-libp2p interop**: a go floodsub peer (Ed25519 identity) on the
    same topic chats both ways in strict mode.
+4. **rust-libp2p interop**: a rust-libp2p floodsub peer, with this side
+   started with `--allow-unsigned`. The rust peer must include a `ping`
+   behaviour (to answer this side's keepalives) or raise its
+   `idle_connection_timeout` — rust-libp2p closes connections no
+   behaviour holds open after 10 s by default, which reads as an
+   instant disconnect here.
+
+All four ran green on 2026-07-17: loopback sanity, an AWS-hosted
+open-internet star (hotspot + home-network leaves, kill/rejoin,
+75 s idle survival), a NAT'd host punched into from a hotspot
+(relayed → direct-punched upgrade, then chat over the punched path),
+and both interop directions against real go-libp2p and rust-libp2p
+peers.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -97,9 +97,9 @@ address if v6 default routes are hijacked).
 4. **rust-libp2p interop**: a rust-libp2p floodsub peer, with this side
    started with `--allow-unsigned`. The rust peer must include a `ping`
    behaviour (to answer this side's keepalives) or raise its
-   `idle_connection_timeout` — rust-libp2p closes connections no
-   behaviour holds open after 10 s by default, which reads as an
-   instant disconnect here.
+   `idle_connection_timeout` — by default rust-libp2p closes a
+   connection after 10 s when no behaviour keeps it alive, which reads
+   as an instant disconnect here.
 
 All four ran green on 2026-07-17: loopback sanity, an AWS-hosted
 open-internet star (hotspot + home-network leaves, kill/rejoin,

--- a/examples/chat/src/cli.rs
+++ b/examples/chat/src/cli.rs
@@ -55,6 +55,9 @@ pub struct ChatOptions {
     pub key_path: Option<PathBuf>,
     /// Optional QUIC listen/bind multiaddr. Defaults to dual-stack UDP/0.
     pub listen_addr: Option<Multiaddr>,
+    /// Accept unsigned messages (rust-libp2p floodsub interop; its
+    /// floodsub does not sign). Signed messages are still verified.
+    pub allow_unsigned: bool,
 }
 
 /// Parse error surfaced back to `main` so the binary exits with a readable
@@ -100,7 +103,11 @@ fn parse_join(args: Vec<String>) -> Result<Mode, CliError> {
     let mut i = 0;
     while i < args.len() {
         let arg = &args[i];
-        if arg.starts_with("--") {
+        if arg == "--allow-unsigned" {
+            // Boolean flag: no value follows.
+            rest.push(arg.clone());
+            i += 1;
+        } else if arg.starts_with("--") {
             rest.push(arg.clone());
             let value = args
                 .get(i + 1)
@@ -181,6 +188,11 @@ impl Flags {
             let key = &args[i];
 
             match key.as_str() {
+                "--allow-unsigned" => {
+                    chat.allow_unsigned = true;
+                    i += 1;
+                    continue;
+                }
                 "--topic" => {
                     let value = flag_value(args, i, key)?;
                     if chat.topic.is_some() {
@@ -285,6 +297,10 @@ NOTES:
     --relay   relay peer-addr for NAT traversal / reservations
     --key     persistent Ed25519 raw-secret file (hex)
     --listen  bind multiaddr; default is dual-stack UDP/0
+
+    --allow-unsigned
+              accept unsigned messages (rust-libp2p floodsub interop;
+              signed messages are still verified)
 
     Type lines on stdin to chat; EOF (Ctrl-D) exits.
 

--- a/examples/chat/src/modes.rs
+++ b/examples/chat/src/modes.rs
@@ -8,8 +8,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use minip2p::{
-    Endpoint, Event, NatConfig, NatEvent, Path, PeerAddr, PeerId, PublishError, PubsubError,
-    PubsubEvent,
+    Endpoint, Event, FloodsubConfig, NatConfig, NatEvent, Path, PeerAddr, PeerId, PublishError,
+    PubsubError, PubsubEvent,
 };
 
 use minip2p_example_common::{
@@ -40,7 +40,10 @@ fn build_endpoint(
     let mut builder = Endpoint::builder()
         .identity(keypair)
         .agent_version(AGENT)
-        .pubsub()
+        .pubsub_config(FloodsubConfig {
+            allow_unsigned: options.allow_unsigned,
+            ..FloodsubConfig::default()
+        })
         .nat_config(NatConfig::default());
     for relay in relays {
         builder = builder.relay(relay.clone());
@@ -265,7 +268,22 @@ fn run_chat(
     // under a stdin flood.
     const MAX_LINES_PER_TICK: usize = 32;
 
+    // QUIC drops a connection after 30 s of silence (the transport's idle
+    // timeout), and a quiet room generates no traffic of its own — ping
+    // every connected peer well inside that window.
+    const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
+    let mut last_keepalive = Instant::now();
+
     loop {
+        if last_keepalive.elapsed() >= KEEPALIVE_INTERVAL {
+            last_keepalive = Instant::now();
+            for peer in endpoint.connected_peers() {
+                // A peer mid-disconnect can fail the ping; the close event
+                // will surface it.
+                let _ = endpoint.ping(&peer);
+            }
+        }
+
         for _ in 0..MAX_LINES_PER_TICK {
             match input.try_recv() {
                 Ok(Some(line)) => {


### PR DESCRIPTION
Fixes from running the M5 live-validation recipes (plan milestone 5) on the real infra — AWS box, home-network zima, Mac on a mobile hotspot. All four recipes are green as of 2026-07-17; results recorded in `examples/chat/README.md`.

## Findings and fixes

### 1. Idle chat rooms disband themselves (chat keepalive)
The QUIC transport advertises a 30 s idle timeout and a quiet room generates no traffic, so every connection — including the host↔relay reservation connection — died after 30 s of nobody typing. Observed live on the open-internet star: both leaves dropped simultaneously mid-test.

Fix: the chat loop pings every `connected_peers()` entry on a 10 s cadence (3× margin, covers the relay connection too). App-level by design — the sans-I/O stack stays policy-free about which connections deserve keeping alive. Verified live: 75 s of silence with zero disconnects on both the open-internet star and the punched path.

### 2. Exact-8-byte seqnos break rust-libp2p interop (breaking change)
`RawMessage::verify` required `seqno` to be exactly 8 bytes (go's u64-BE convention). rust-libp2p floodsub emits **20 random bytes** (`layer.rs`: `rand::random::<[u8; 20]>()`), so the exact peer `allow_unsigned` exists for was rejected with a protocol violation. Upstream doesn't enforce a receive-side length; being stricter buys nothing and splits the mesh.

Fix: seqno is opaque bytes, accepted at 1..=64 (`MAX_SEQNO_LEN` bounds seen-cache memory per id; go uses 8, rust 20) and carried as bytes end-to-end. **Breaking:** `RawMessage::verify` returns `(PeerId, Vec<u8>)`, `PubsubEvent::Message.seqno` is `Vec<u8>`.

### 3. `allow_unsigned` unreachable from the chat CLI
`FloodsubConfig::allow_unsigned` existed but the example never exposed it. Added `--allow-unsigned` (signed messages are still verified; the flag only admits unsigned ones).

## Live validation summary

1. **Loopback star** — 3 peers, both directions, star-forwarding confirmed.
2. **Open-internet star** — host on AWS `:4001` (global v6), leaves on home network + mobile hotspot; kill/rejoin re-sends the subscription snapshot; 75 s idle survival.
3. **NAT'd host** — host behind NAT with the AWS relay, joiner hole-punched (`relayed → direct-punched`), chat + idle survival over the punched path.
4. **Wire interop** — real go-libp2p v0.48/pubsub v0.15 (StrictSign both ways, correct attribution) and real rust-libp2p v0.56 floodsub (signed outbound accepted by rust, unsigned 20-byte-seqno inbound accepted under `--allow-unsigned`). Note for reproducers: the rust peer needs a `ping` behaviour or a raised `idle_connection_timeout` — rust-libp2p closes behaviour-less connections after 10 s.

## Tests
- New agent regression: 20-byte-seqno unsigned message delivers under `allow_unsigned` and round-trips in the event.
- New verify-path cases: empty and >64-byte seqnos rejected, 20-byte accepted.
- Full gate green: fmt, clippy `-D warnings`, workspace tests, `minip2p --features nat,pubsub`, feature matrix, `thumbv7em-none-eabi` no_std.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps chat connections alive, fixes floodsub interop by treating seqnos as opaque bytes, and adds `--allow-unsigned` to the chat CLI. All M5 live-validation recipes pass on real infra.

- **Bug Fixes**
  - Chat: ping all `connected_peers()` every 10s to prevent 30s QUIC idle drops (keeps relay reservations alive).
  - Pubsub: treat `seqno` as opaque bytes (accept 1..=64) and carry bytes end-to-end for dedup; restores rust-libp2p floodsub interop (20-byte seqnos).
  - README: clarified `rust-libp2p` idle-timeout behavior and why a `ping` behaviour or higher timeout is needed.

- **Migration**
  - `RawMessage::verify(..) -> (PeerId, Vec<u8>)` (was `u64`).
  - `PubsubEvent::Message.seqno: Vec<u8>` (was `u64`); update any dedup keys and comparisons.

<sup>Written for commit 01d732db257fd06a27f0e1be6c74173765ff6d59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

