### PR TITLE
Add pubsub peer discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,14 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo clippy -p minip2p --features nat --all-targets -- -D warnings
       - run: cargo clippy -p minip2p --features nat,pubsub --all-targets -- -D warnings
+      - run: cargo clippy -p minip2p --features discovery --all-targets -- -D warnings
       - run: cargo clippy --manifest-path fuzz/Cargo.toml --all-targets -- -D warnings
-      - run: cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-pubsub -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm -p minip2p-nat
+      - run: cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-pubsub -p minip2p-discovery -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm -p minip2p-nat
       - run: cargo test --workspace
       - run: cargo test -p minip2p --features nat
       - run: cargo test -p minip2p --features pubsub
       - run: cargo test -p minip2p --features nat,pubsub
+      - run: cargo test -p minip2p --features discovery
       - run: cargo doc --workspace --no-deps
       - run: cargo bench -p minip2p-core --bench multiaddr --no-run
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ version = "0.1.0"
 dependencies = [
  "getrandom",
  "minip2p-core",
+ "minip2p-discovery",
  "minip2p-identify",
  "minip2p-identity",
  "minip2p-nat",
@@ -783,6 +784,15 @@ name = "minip2p-dcutr"
 version = "0.1.0"
 dependencies = [
  "minip2p-core",
+ "thiserror",
+]
+
+[[package]]
+name = "minip2p-discovery"
+version = "0.1.0"
+dependencies = [
+ "minip2p-core",
+ "minip2p-identity",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/autonat",
     "crates/core",
     "crates/dcutr",
+    "crates/discovery",
     "crates/identify",
     "crates/identity",
     "crates/minip2p",

--- a/crates/discovery/Cargo.toml
+++ b/crates/discovery/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "minip2p-discovery"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[features]
+default = ["std"]
+std = ["minip2p-core/std", "minip2p-identity/std", "thiserror/std"]
+
+[dependencies]
+minip2p-core = { path = "../core", default-features = false }
+minip2p-identity = { path = "../identity", default-features = false }
+thiserror = { version = "2.0.18", default-features = false }

--- a/crates/discovery/README.md
+++ b/crates/discovery/README.md
@@ -1,0 +1,18 @@
+# minip2p-discovery
+
+Sans-I/O peer discovery using signed pubsub presence beacons. The beacon protobuf
+and default topic are wire-compatible with js-libp2p `pubsub-peer-discovery`:
+`Peer { bytes publicKey = 1; repeated bytes addrs = 2; }` on
+`_peer-discovery._p2p._pubsub`. Policy is intentionally different: minip2p keeps
+a TTL address book and can emit automatic dial actions.
+
+The agent owns no clock, socket, stream, async task, or executor. Callers supply
+`now_ms`, drain actions/events, and report connection outcomes. Beacons must be
+carried by verified signed pubsub messages and their embedded public key must
+derive the publisher peer id.
+
+Current limitations: the facade NAT policy uses only its first configured relay;
+wildcard IP listen addresses are not announced unless Identify/AutoNAT supplies a
+usable external or circuit address. At the default 10-second cadence and the
+pubsub 120-second seen TTL, the 4096-entry seen cache supports roughly 340 peers
+(about 12 entries per peer).

--- a/crates/discovery/README.md
+++ b/crates/discovery/README.md
@@ -5,6 +5,8 @@ and default topic are wire-compatible with js-libp2p `pubsub-peer-discovery`:
 `Peer { bytes publicKey = 1; repeated bytes addrs = 2; }` on
 `_peer-discovery._p2p._pubsub`. Policy is intentionally different: minip2p keeps
 a TTL address book and can emit automatic dial actions.
+Address-less beacons still refresh peer presence, but never trigger a dial until
+a later beacon supplies at least one normalized address.
 
 The agent owns no clock, socket, stream, async task, or executor. Callers supply
 `now_ms`, drain actions/events, and report connection outcomes. Beacons must be

--- a/crates/discovery/README.md
+++ b/crates/discovery/README.md
@@ -12,6 +12,9 @@ The agent owns no clock, socket, stream, async task, or executor. Callers supply
 `now_ms`, drain actions/events, and report connection outcomes. Beacons must be
 carried by verified signed pubsub messages and their embedded public key must
 derive the publisher peer id.
+Variable-length libp2p public keys, including RSA keys, are accepted up to the
+overall beacon payload budget; identities that cannot fit are rejected when the
+agent is constructed.
 
 Current limitations: the facade NAT policy uses only its first configured relay;
 wildcard IP listen addresses are not announced unless Identify/AutoNAT supplies a

--- a/crates/discovery/src/agent.rs
+++ b/crates/discovery/src/agent.rs
@@ -156,7 +156,9 @@ impl DiscoveryAgent {
                 addrs: addrs.clone(),
             });
         }
-        self.maybe_dial(from, now_ms);
+        if !addrs.is_empty() {
+            self.maybe_dial(from, now_ms);
+        }
     }
 
     /// Reports that the swarm has a connection to a peer.
@@ -413,6 +415,33 @@ mod tests {
     }
 
     #[test]
+    fn presence_only_beacons_refresh_without_dialing() {
+        let config = DiscoveryConfig {
+            peer_ttl_ms: 5,
+            ..DiscoveryConfig::default()
+        };
+        let mut agent = agent_with(config, 1);
+        agent.handle_tick(0);
+        let _ = agent.poll_action();
+        let (peer, presence) = payload(2, &[]);
+
+        agent.handle_beacon(&peer, &presence, true, 1);
+        assert!(agent.poll_action().is_none());
+        assert_eq!(agent.known_peers().len(), 1);
+        agent.handle_beacon(&peer, &presence, true, 4);
+        assert!(agent.poll_action().is_none());
+        assert_eq!(agent.next_timeout(4), Some(5));
+
+        let (_, with_addr) = payload(2, &["/ip4/127.0.0.1/udp/9/quic-v1"]);
+        agent.handle_beacon(&peer, &with_addr, true, 5);
+        assert!(matches!(
+            agent.poll_action(),
+            Some(DiscoveryAction::Dial { peer: got, addrs })
+                if got == peer && addrs.len() == 1
+        ));
+    }
+
+    #[test]
     fn announces_suffix_filters_wildcard_and_normalizes_snapshot() {
         let config = DiscoveryConfig {
             auto_dial: false,
@@ -479,7 +508,7 @@ mod tests {
             ..DiscoveryConfig::default()
         };
         let mut agent = agent_with(config, 1);
-        let (peer, payload) = payload(2, &[]);
+        let (peer, payload) = payload(2, &["/ip4/127.0.0.1/udp/9/quic-v1"]);
         agent.handle_beacon(&peer, &payload, true, 10);
         assert!(matches!(
             agent.poll_action(),
@@ -634,7 +663,7 @@ mod tests {
             ..DiscoveryConfig::default()
         };
         let mut agent = agent_with(config, 1);
-        let (first, first_payload) = payload(2, &[]);
+        let (first, first_payload) = payload(2, &["/ip4/127.0.0.1/udp/9/quic-v1"]);
         let (second, second_payload) = payload(3, &[]);
         agent.handle_beacon(&first, &first_payload, true, 1);
         agent.handle_beacon(&second, &second_payload, true, 2);

--- a/crates/discovery/src/agent.rs
+++ b/crates/discovery/src/agent.rs
@@ -12,6 +12,7 @@ use minip2p_identity::PublicKey;
 
 use crate::{
     Beacon, DiscoveryAction, DiscoveryConfig, DiscoveryConfigError, DiscoveryEvent, KnownPeer,
+    MAX_PUBLIC_KEY_LEN,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -42,15 +43,19 @@ pub struct DiscoveryAgent {
 }
 
 impl DiscoveryAgent {
-    /// Constructs an agent after validating its configuration.
+    /// Constructs an agent after validating its configuration and identity size.
     pub fn new(
         public_key: PublicKey,
         config: DiscoveryConfig,
     ) -> Result<Self, DiscoveryConfigError> {
         config.validate()?;
+        let public_key = public_key.encode_protobuf();
+        if public_key.len() > MAX_PUBLIC_KEY_LEN {
+            return Err(DiscoveryConfigError::LocalPublicKeyTooLarge);
+        }
         Ok(Self {
-            local_peer_id: PeerId::from_public_key(&public_key),
-            public_key: public_key.encode_protobuf(),
+            local_peer_id: PeerId::from_public_key_protobuf(&public_key),
+            public_key,
             config,
             local_addrs: Vec::new(),
             next_beacon_at_ms: 0,
@@ -346,6 +351,9 @@ fn normalize_addrs(from: &PeerId, raw: Vec<Vec<u8>>, cap: usize) -> Vec<Multiadd
             Some(Protocol::P2p(_)) => continue,
             _ => addr,
         };
+        if !is_supported_addr(&addr) {
+            continue;
+        }
         if !normalized.contains(&addr) {
             normalized.push(addr);
             if normalized.len() == cap {
@@ -354,6 +362,25 @@ fn normalize_addrs(from: &PeerId, raw: Vec<Vec<u8>>, cap: usize) -> Vec<Multiadd
         }
     }
     normalized
+}
+
+fn is_supported_addr(addr: &Multiaddr) -> bool {
+    if is_wildcard_addr(addr) || addr.is_empty() {
+        return false;
+    }
+    if addr.is_quic_transport() {
+        return true;
+    }
+
+    // Keep canonical relay circuit addresses. They intentionally trigger the
+    // NAT agent's relay leg even though they are not direct QUIC candidates.
+    let protocols = addr.protocols();
+    protocols.len() == 5
+        && protocols[0].is_host()
+        && matches!(protocols[1], Protocol::Udp(_))
+        && matches!(protocols[2], Protocol::QuicV1)
+        && matches!(protocols[3], Protocol::P2p(_))
+        && matches!(protocols[4], Protocol::P2pCircuit)
 }
 
 fn is_wildcard_addr(addr: &Multiaddr) -> bool {
@@ -411,6 +438,27 @@ mod tests {
         assert!(matches!(
             agent.poll_event(),
             Some(DiscoveryEvent::PeerDiscovered { .. })
+        ));
+    }
+
+    #[test]
+    fn variable_length_keys_interoperate_and_oversized_local_keys_are_rejected() {
+        let remote_key = PublicKey::new(KeyType::Rsa, vec![7; 1_024]);
+        let remote = PeerId::from_public_key(&remote_key);
+        let payload = Beacon {
+            public_key: remote_key.encode_protobuf(),
+            addrs: vec![],
+        }
+        .encode();
+        let mut agent = agent_with(DiscoveryConfig::default(), 1);
+
+        agent.handle_beacon(&remote, &payload, true, 1);
+        assert_eq!(agent.known_peers()[0].peer, remote);
+
+        let oversized = PublicKey::new(KeyType::Rsa, vec![0; MAX_PUBLIC_KEY_LEN]);
+        assert!(matches!(
+            DiscoveryAgent::new(oversized, DiscoveryConfig::default()),
+            Err(DiscoveryConfigError::LocalPublicKeyTooLarge)
         ));
     }
 
@@ -654,6 +702,63 @@ mod tests {
         .encode();
         agent.handle_beacon(&remote, &beacon, true, 1);
         assert_eq!(agent.known_peers()[0].addrs.len(), 1);
+    }
+
+    #[test]
+    fn empty_non_quic_and_wildcard_addresses_behave_as_presence() {
+        let mut agent = agent_with(DiscoveryConfig::default(), 1);
+        let remote_key = key(2);
+        let remote = PeerId::from_public_key(&remote_key);
+        let mut non_quic = Multiaddr::from_str("/ip4/127.0.0.1/udp/9").unwrap();
+        non_quic.push(Protocol::P2p(remote.clone()));
+        let mut wildcard = Multiaddr::from_str("/ip4/0.0.0.0/udp/9/quic-v1").unwrap();
+        wildcard.push(Protocol::P2p(remote.clone()));
+        let beacon = Beacon {
+            public_key: remote_key.encode_protobuf(),
+            addrs: vec![vec![], non_quic.to_bytes(), wildcard.to_bytes()],
+        }
+        .encode();
+
+        agent.handle_beacon(&remote, &beacon, true, 1);
+
+        assert!(agent.poll_action().is_none());
+        assert!(matches!(
+            agent.poll_event(),
+            Some(DiscoveryEvent::PeerDiscovered { peer, addrs })
+                if peer == remote && addrs.is_empty()
+        ));
+        assert!(agent.known_peers()[0].addrs.is_empty());
+    }
+
+    #[test]
+    fn canonical_circuit_address_still_triggers_the_relay_leg() {
+        let mut agent = agent_with(DiscoveryConfig::default(), 1);
+        let remote_key = key(2);
+        let remote = PeerId::from_public_key(&remote_key);
+        let relay = PeerId::from_public_key(&key(3));
+        let circuit = Multiaddr::from_protocols(vec![
+            Protocol::Ip4([127, 0, 0, 1]),
+            Protocol::Udp(9),
+            Protocol::QuicV1,
+            Protocol::P2p(relay),
+            Protocol::P2pCircuit,
+            Protocol::P2p(remote.clone()),
+        ]);
+        let beacon = Beacon {
+            public_key: remote_key.encode_protobuf(),
+            addrs: vec![circuit.to_bytes()],
+        }
+        .encode();
+
+        agent.handle_beacon(&remote, &beacon, true, 1);
+
+        assert!(matches!(
+            agent.poll_action(),
+            Some(DiscoveryAction::Dial { peer, addrs })
+                if peer == remote
+                    && addrs.len() == 1
+                    && matches!(addrs[0].protocols().last(), Some(Protocol::P2pCircuit))
+        ));
     }
 
     #[test]

--- a/crates/discovery/src/agent.rs
+++ b/crates/discovery/src/agent.rs
@@ -255,7 +255,10 @@ impl DiscoveryAgent {
     }
 
     fn build_beacon(&self) -> Beacon {
-        let mut addrs = Vec::new();
+        let mut beacon = Beacon {
+            public_key: self.public_key.clone(),
+            addrs: Vec::new(),
+        };
         for addr in &self.local_addrs {
             if is_wildcard_addr(addr) {
                 continue;
@@ -263,17 +266,18 @@ impl DiscoveryAgent {
             let mut advertised = addr.clone();
             advertised.push(Protocol::P2p(self.local_peer_id.clone()));
             let bytes = advertised.to_bytes();
-            if bytes.len() <= crate::MAX_ADDR_LEN && !addrs.contains(&bytes) {
-                addrs.push(bytes);
-                if addrs.len() == self.config.max_addrs_per_peer {
+            if bytes.len() <= crate::MAX_ADDR_LEN && !beacon.addrs.contains(&bytes) {
+                beacon.addrs.push(bytes);
+                if beacon.encoded_len() > crate::MAX_BEACON_SIZE {
+                    beacon.addrs.pop();
+                    break;
+                }
+                if beacon.addrs.len() == self.config.max_addrs_per_peer {
                     break;
                 }
             }
         }
-        Beacon {
-            public_key: self.public_key.clone(),
-            addrs,
-        }
+        beacon
     }
 
     fn maybe_dial(&mut self, peer: &PeerId, now_ms: u64) {
@@ -443,6 +447,29 @@ mod tests {
             agent.known_peers()[0].addrs[0].to_string(),
             "/ip4/127.0.0.1/udp/2/quic-v1"
         );
+    }
+
+    #[test]
+    fn published_beacon_never_exceeds_decoder_limit() {
+        let mut agent = agent_with(DiscoveryConfig::default(), 1);
+        let addrs = (0..16)
+            .map(|index| {
+                Multiaddr::from_protocols(vec![
+                    Protocol::Dns(format!("{index}{}", "a".repeat(850))),
+                    Protocol::Udp(1),
+                    Protocol::QuicV1,
+                ])
+            })
+            .collect::<Vec<_>>();
+        agent.set_local_addrs(&addrs, 0);
+        agent.handle_tick(0);
+        let Some(DiscoveryAction::PublishBeacon { payload, .. }) = agent.poll_action() else {
+            panic!("expected discovery beacon");
+        };
+
+        assert!(payload.len() <= crate::MAX_BEACON_SIZE);
+        let beacon = Beacon::decode(&payload).expect("agent must publish a decodable beacon");
+        assert!(beacon.addrs.len() < addrs.len());
     }
 
     #[test]

--- a/crates/discovery/src/agent.rs
+++ b/crates/discovery/src/agent.rs
@@ -77,6 +77,7 @@ impl DiscoveryAgent {
     }
 
     /// Replaces local addresses; an actual change schedules an immediate beacon.
+    /// Unsupported, empty, and wildcard addresses are omitted when publishing.
     pub fn set_local_addrs(&mut self, addrs: &[Multiaddr], now_ms: u64) {
         if self.local_addrs != addrs {
             self.local_addrs = addrs.to_vec();
@@ -267,7 +268,7 @@ impl DiscoveryAgent {
             addrs: Vec::new(),
         };
         for addr in &self.local_addrs {
-            if is_wildcard_addr(addr) {
+            if !is_supported_addr(addr) {
                 continue;
             }
             let mut advertised = addr.clone();
@@ -490,16 +491,26 @@ mod tests {
     }
 
     #[test]
-    fn announces_suffix_filters_wildcard_and_normalizes_snapshot() {
+    fn announces_only_supported_addresses_with_publisher_suffix() {
         let config = DiscoveryConfig {
             auto_dial: false,
             ..DiscoveryConfig::default()
         };
         let mut agent = agent_with(config, 1);
+        let relay = PeerId::from_public_key(&key(3));
         agent.set_local_addrs(
             &[
+                Multiaddr::from_protocols(vec![]),
+                Multiaddr::from_str("/ip4/127.0.0.1/udp/1").unwrap(),
                 Multiaddr::from_str("/ip4/0.0.0.0/udp/1/quic-v1").unwrap(),
                 Multiaddr::from_str("/ip4/127.0.0.1/udp/2/quic-v1").unwrap(),
+                Multiaddr::from_protocols(vec![
+                    Protocol::Ip4([127, 0, 0, 1]),
+                    Protocol::Udp(3),
+                    Protocol::QuicV1,
+                    Protocol::P2p(relay),
+                    Protocol::P2pCircuit,
+                ]),
             ],
             5,
         );
@@ -511,12 +522,21 @@ mod tests {
             panic!()
         };
         let beacon = Beacon::decode(&encoded).unwrap();
-        assert_eq!(beacon.addrs.len(), 1);
-        let advertised = Multiaddr::from_bytes(&beacon.addrs[0]).unwrap();
-        assert_eq!(
-            advertised.protocols().last(),
-            Some(&Protocol::P2p(agent.local_peer_id().clone()))
-        );
+        assert_eq!(beacon.addrs.len(), 2);
+        for advertised in beacon
+            .addrs
+            .iter()
+            .map(|bytes| Multiaddr::from_bytes(bytes).unwrap())
+        {
+            assert_eq!(
+                advertised.protocols().last(),
+                Some(&Protocol::P2p(agent.local_peer_id().clone()))
+            );
+            let without_publisher = Multiaddr::from_protocols(
+                advertised.protocols()[..advertised.protocols().len() - 1].to_vec(),
+            );
+            assert!(is_supported_addr(&without_publisher));
+        }
 
         let (peer, payload) = payload(2, &["/ip4/127.0.0.1/udp/2/quic-v1"]);
         agent.handle_beacon(&peer, &payload, true, 6);

--- a/crates/discovery/src/agent.rs
+++ b/crates/discovery/src/agent.rs
@@ -1,0 +1,658 @@
+//! Deterministic discovery state machine.
+
+use alloc::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    format,
+    string::ToString,
+    vec::Vec,
+};
+
+use minip2p_core::{Multiaddr, PeerId, Protocol};
+use minip2p_identity::PublicKey;
+
+use crate::{
+    Beacon, DiscoveryAction, DiscoveryConfig, DiscoveryConfigError, DiscoveryEvent, KnownPeer,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum DialState {
+    Idle,
+    InFlight,
+    Backoff { until_ms: u64 },
+}
+
+#[derive(Clone, Debug)]
+struct PeerEntry {
+    addrs: Vec<Multiaddr>,
+    last_seen_ms: u64,
+    dial: DialState,
+}
+
+/// Sans-I/O pubsub peer-discovery state machine.
+pub struct DiscoveryAgent {
+    config: DiscoveryConfig,
+    local_peer_id: PeerId,
+    public_key: Vec<u8>,
+    local_addrs: Vec<Multiaddr>,
+    next_beacon_at_ms: u64,
+    book: BTreeMap<PeerId, PeerEntry>,
+    connected: BTreeSet<PeerId>,
+    actions: VecDeque<DiscoveryAction>,
+    events: VecDeque<DiscoveryEvent>,
+}
+
+impl DiscoveryAgent {
+    /// Constructs an agent after validating its configuration.
+    pub fn new(
+        public_key: PublicKey,
+        config: DiscoveryConfig,
+    ) -> Result<Self, DiscoveryConfigError> {
+        config.validate()?;
+        Ok(Self {
+            local_peer_id: PeerId::from_public_key(&public_key),
+            public_key: public_key.encode_protobuf(),
+            config,
+            local_addrs: Vec::new(),
+            next_beacon_at_ms: 0,
+            book: BTreeMap::new(),
+            connected: BTreeSet::new(),
+            actions: VecDeque::new(),
+            events: VecDeque::new(),
+        })
+    }
+
+    /// Returns the identity advertised by this agent.
+    pub fn local_peer_id(&self) -> &PeerId {
+        &self.local_peer_id
+    }
+
+    /// Returns the configured pubsub discovery topic.
+    pub fn topic(&self) -> &str {
+        &self.config.topic
+    }
+
+    /// Replaces local addresses; an actual change schedules an immediate beacon.
+    pub fn set_local_addrs(&mut self, addrs: &[Multiaddr], now_ms: u64) {
+        if self.local_addrs != addrs {
+            self.local_addrs = addrs.to_vec();
+            self.next_beacon_at_ms = now_ms;
+        }
+    }
+
+    /// Validates and incorporates a received pubsub beacon.
+    pub fn handle_beacon(&mut self, from: &PeerId, payload: &[u8], signed: bool, now_ms: u64) {
+        if from == &self.local_peer_id {
+            return;
+        }
+        if !signed {
+            self.violation(from, "unsigned discovery beacon");
+            return;
+        }
+        let beacon = match Beacon::decode(payload) {
+            Ok(beacon) => beacon,
+            Err(error) => {
+                self.violation(from, &error.to_string());
+                return;
+            }
+        };
+        let public_key = match PublicKey::decode_protobuf(&beacon.public_key) {
+            Ok(key) => key,
+            Err(error) => {
+                self.violation(from, &format!("invalid discovery public key: {error}"));
+                return;
+            }
+        };
+        if PeerId::from_public_key(&public_key) != *from {
+            self.violation(from, "discovery public key does not match publisher");
+            return;
+        }
+
+        let addrs = normalize_addrs(from, beacon.addrs, self.config.max_addrs_per_peer);
+        if !self.book.contains_key(from) && self.book.len() == self.config.max_known_peers {
+            let candidate = self
+                .book
+                .iter()
+                .filter(|(peer, _)| !self.connected.contains(*peer))
+                .min_by(|(a_peer, a), (b_peer, b)| {
+                    (a.last_seen_ms, *a_peer).cmp(&(b.last_seen_ms, *b_peer))
+                })
+                .map(|(peer, _)| peer.clone());
+            let Some(candidate) = candidate else {
+                return;
+            };
+            self.remove_peer(&candidate);
+        }
+
+        let mut changed = false;
+        let is_new = !self.book.contains_key(from);
+        if let Some(entry) = self.book.get_mut(from) {
+            changed = entry.addrs != addrs;
+            entry.last_seen_ms = now_ms;
+            if changed {
+                entry.addrs = addrs.clone();
+                if matches!(entry.dial, DialState::Backoff { .. }) {
+                    entry.dial = DialState::Idle;
+                }
+            }
+        } else {
+            self.book.insert(
+                from.clone(),
+                PeerEntry {
+                    addrs: addrs.clone(),
+                    last_seen_ms: now_ms,
+                    dial: DialState::Idle,
+                },
+            );
+        }
+
+        if is_new {
+            self.events.push_back(DiscoveryEvent::PeerDiscovered {
+                peer: from.clone(),
+                addrs: addrs.clone(),
+            });
+        } else if changed {
+            self.events.push_back(DiscoveryEvent::PeerUpdated {
+                peer: from.clone(),
+                addrs: addrs.clone(),
+            });
+        }
+        self.maybe_dial(from, now_ms);
+    }
+
+    /// Reports that the swarm has a connection to a peer.
+    pub fn peer_connected(&mut self, peer: &PeerId, _now_ms: u64) {
+        self.connected.insert(peer.clone());
+        if let Some(entry) = self.book.get_mut(peer) {
+            entry.dial = DialState::Idle;
+        }
+    }
+
+    /// Reports that the swarm no longer has a connection to a peer.
+    pub fn peer_disconnected(&mut self, peer: &PeerId, _now_ms: u64) {
+        self.connected.remove(peer);
+    }
+
+    /// Reports successful completion of an automatic dial.
+    pub fn dial_succeeded(&mut self, peer: &PeerId, _now_ms: u64) {
+        if let Some(entry) = self.book.get_mut(peer)
+            && matches!(entry.dial, DialState::InFlight)
+        {
+            entry.dial = DialState::Idle;
+        }
+    }
+
+    /// Reports failure of an automatic dial.
+    pub fn dial_failed(&mut self, peer: &PeerId, reason: &str, now_ms: u64) {
+        if let Some(entry) = self.book.get_mut(peer)
+            && matches!(entry.dial, DialState::InFlight)
+        {
+            entry.dial = DialState::Backoff {
+                until_ms: now_ms.saturating_add(self.config.redial_backoff_ms),
+            };
+            self.events.push_back(DiscoveryEvent::DialFailed {
+                peer: peer.clone(),
+                reason: reason.to_string(),
+            });
+        }
+    }
+
+    /// Emits a due beacon and expires stale peer records.
+    pub fn handle_tick(&mut self, now_ms: u64) {
+        if now_ms >= self.next_beacon_at_ms {
+            self.actions.push_back(DiscoveryAction::PublishBeacon {
+                topic: self.config.topic.clone(),
+                payload: self.build_beacon().encode(),
+            });
+            self.next_beacon_at_ms = now_ms.saturating_add(self.config.beacon_interval_ms);
+        }
+        let expired: Vec<PeerId> = self
+            .book
+            .iter()
+            .filter(|(_, entry)| {
+                now_ms >= entry.last_seen_ms.saturating_add(self.config.peer_ttl_ms)
+            })
+            .map(|(peer, _)| peer.clone())
+            .collect();
+        for peer in expired {
+            self.remove_peer(&peer);
+        }
+    }
+
+    /// Pops the next requested side effect.
+    pub fn poll_action(&mut self) -> Option<DiscoveryAction> {
+        self.actions.pop_front()
+    }
+
+    /// Pops the next application-facing event.
+    pub fn poll_event(&mut self) -> Option<DiscoveryEvent> {
+        self.events.pop_front()
+    }
+
+    /// Returns milliseconds until the next beacon or peer expiry.
+    pub fn next_timeout(&self, now_ms: u64) -> Option<u64> {
+        let expiry = self
+            .book
+            .values()
+            .map(|entry| entry.last_seen_ms.saturating_add(self.config.peer_ttl_ms))
+            .min();
+        let deadline = expiry
+            .map(|value| value.min(self.next_beacon_at_ms))
+            .unwrap_or(self.next_beacon_at_ms);
+        Some(deadline.saturating_sub(now_ms))
+    }
+
+    /// Returns a deterministic peer-id-ordered snapshot of the address book.
+    pub fn known_peers(&self) -> Vec<KnownPeer> {
+        self.book
+            .iter()
+            .map(|(peer, entry)| KnownPeer {
+                peer: peer.clone(),
+                addrs: entry.addrs.clone(),
+                last_seen_ms: entry.last_seen_ms,
+                connected: self.connected.contains(peer),
+            })
+            .collect()
+    }
+
+    fn build_beacon(&self) -> Beacon {
+        let mut addrs = Vec::new();
+        for addr in &self.local_addrs {
+            if is_wildcard_addr(addr) {
+                continue;
+            }
+            let mut advertised = addr.clone();
+            advertised.push(Protocol::P2p(self.local_peer_id.clone()));
+            let bytes = advertised.to_bytes();
+            if bytes.len() <= crate::MAX_ADDR_LEN && !addrs.contains(&bytes) {
+                addrs.push(bytes);
+                if addrs.len() == self.config.max_addrs_per_peer {
+                    break;
+                }
+            }
+        }
+        Beacon {
+            public_key: self.public_key.clone(),
+            addrs,
+        }
+    }
+
+    fn maybe_dial(&mut self, peer: &PeerId, now_ms: u64) {
+        if !self.config.auto_dial
+            || self.connected.contains(peer)
+            || (self.config.dial_tie_break && self.local_peer_id >= *peer)
+        {
+            return;
+        }
+        let Some(entry) = self.book.get_mut(peer) else {
+            return;
+        };
+        let permitted = match entry.dial {
+            DialState::Idle => true,
+            DialState::InFlight => false,
+            DialState::Backoff { until_ms } => now_ms >= until_ms,
+        };
+        if permitted {
+            entry.dial = DialState::InFlight;
+            self.actions.push_back(DiscoveryAction::Dial {
+                peer: peer.clone(),
+                addrs: entry.addrs.clone(),
+            });
+        }
+    }
+
+    fn remove_peer(&mut self, peer: &PeerId) {
+        let Some(entry) = self.book.remove(peer) else {
+            return;
+        };
+        self.events
+            .push_back(DiscoveryEvent::PeerExpired { peer: peer.clone() });
+        let queued = self.actions.iter().any(
+            |action| matches!(action, DiscoveryAction::Dial { peer: queued, .. } if queued == peer),
+        );
+        self.actions.retain(
+            |action| !matches!(action, DiscoveryAction::Dial { peer: queued, .. } if queued == peer),
+        );
+        if matches!(entry.dial, DialState::InFlight) || queued {
+            self.actions
+                .push_back(DiscoveryAction::CancelDial { peer: peer.clone() });
+        }
+    }
+
+    fn violation(&mut self, peer: &PeerId, reason: &str) {
+        self.events.push_back(DiscoveryEvent::ProtocolViolation {
+            peer: peer.clone(),
+            reason: reason.to_string(),
+        });
+    }
+}
+
+fn normalize_addrs(from: &PeerId, raw: Vec<Vec<u8>>, cap: usize) -> Vec<Multiaddr> {
+    let mut normalized = Vec::new();
+    for bytes in raw {
+        let Ok(addr) = Multiaddr::from_bytes(&bytes) else {
+            continue;
+        };
+        let protocols = addr.protocols();
+        let addr = match protocols.last() {
+            Some(Protocol::P2p(peer)) if peer == from => {
+                Multiaddr::from_protocols(protocols[..protocols.len() - 1].to_vec())
+            }
+            Some(Protocol::P2p(_)) => continue,
+            _ => addr,
+        };
+        if !normalized.contains(&addr) {
+            normalized.push(addr);
+            if normalized.len() == cap {
+                break;
+            }
+        }
+    }
+    normalized
+}
+
+fn is_wildcard_addr(addr: &Multiaddr) -> bool {
+    matches!(addr.protocols().first(), Some(Protocol::Ip4(ip)) if *ip == [0, 0, 0, 0])
+        || matches!(addr.protocols().first(), Some(Protocol::Ip6(ip)) if *ip == [0; 16])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::str::FromStr;
+    use minip2p_identity::{KeyType, PublicKey};
+
+    fn key(byte: u8) -> PublicKey {
+        PublicKey::new(KeyType::Ed25519, vec![byte; 32])
+    }
+
+    fn agent_with(mut config: DiscoveryConfig, local: u8) -> DiscoveryAgent {
+        config.dial_tie_break = false;
+        DiscoveryAgent::new(key(local), config).unwrap()
+    }
+
+    fn payload(remote: u8, addrs: &[&str]) -> (PeerId, Vec<u8>) {
+        let key = key(remote);
+        let peer = PeerId::from_public_key(&key);
+        let addrs = addrs
+            .iter()
+            .map(|addr| {
+                let mut addr = Multiaddr::from_str(addr).unwrap();
+                addr.push(Protocol::P2p(peer.clone()));
+                addr.to_bytes()
+            })
+            .collect();
+        (
+            peer,
+            Beacon {
+                public_key: key.encode_protobuf(),
+                addrs,
+            }
+            .encode(),
+        )
+    }
+
+    #[test]
+    fn authentication_rejects_unsigned_and_accepts_signed_sibling() {
+        let mut agent = agent_with(DiscoveryConfig::default(), 1);
+        let (peer, payload) = payload(2, &[]);
+        agent.handle_beacon(&peer, &payload, false, 1);
+        assert!(matches!(
+            agent.poll_event(),
+            Some(DiscoveryEvent::ProtocolViolation { .. })
+        ));
+        assert!(agent.known_peers().is_empty());
+        agent.handle_beacon(&peer, &payload, true, 2);
+        assert!(matches!(
+            agent.poll_event(),
+            Some(DiscoveryEvent::PeerDiscovered { .. })
+        ));
+    }
+
+    #[test]
+    fn announces_suffix_filters_wildcard_and_normalizes_snapshot() {
+        let config = DiscoveryConfig {
+            auto_dial: false,
+            ..DiscoveryConfig::default()
+        };
+        let mut agent = agent_with(config, 1);
+        agent.set_local_addrs(
+            &[
+                Multiaddr::from_str("/ip4/0.0.0.0/udp/1/quic-v1").unwrap(),
+                Multiaddr::from_str("/ip4/127.0.0.1/udp/2/quic-v1").unwrap(),
+            ],
+            5,
+        );
+        agent.handle_tick(5);
+        let Some(DiscoveryAction::PublishBeacon {
+            payload: encoded, ..
+        }) = agent.poll_action()
+        else {
+            panic!()
+        };
+        let beacon = Beacon::decode(&encoded).unwrap();
+        assert_eq!(beacon.addrs.len(), 1);
+        let advertised = Multiaddr::from_bytes(&beacon.addrs[0]).unwrap();
+        assert_eq!(
+            advertised.protocols().last(),
+            Some(&Protocol::P2p(agent.local_peer_id().clone()))
+        );
+
+        let (peer, payload) = payload(2, &["/ip4/127.0.0.1/udp/2/quic-v1"]);
+        agent.handle_beacon(&peer, &payload, true, 6);
+        assert_eq!(
+            agent.known_peers()[0].addrs[0].to_string(),
+            "/ip4/127.0.0.1/udp/2/quic-v1"
+        );
+    }
+
+    #[test]
+    fn expiry_scrubs_queued_dial_and_emits_cancel() {
+        let config = DiscoveryConfig {
+            peer_ttl_ms: 5,
+            ..DiscoveryConfig::default()
+        };
+        let mut agent = agent_with(config, 1);
+        let (peer, payload) = payload(2, &[]);
+        agent.handle_beacon(&peer, &payload, true, 10);
+        assert!(matches!(
+            agent.poll_action(),
+            Some(DiscoveryAction::Dial { .. })
+        ));
+        // Simulate a second still-queued attempt by accepting a changed snapshot after backoff.
+        agent.handle_tick(15);
+        assert!(matches!(
+            agent.poll_action(),
+            Some(DiscoveryAction::PublishBeacon { .. })
+        ));
+        assert!(
+            matches!(agent.poll_action(), Some(DiscoveryAction::CancelDial { peer: got }) if got == peer)
+        );
+        assert!(matches!(
+            agent.poll_event(),
+            Some(DiscoveryEvent::PeerDiscovered { .. })
+        ));
+        assert!(matches!(
+            agent.poll_event(),
+            Some(DiscoveryEvent::PeerExpired { .. })
+        ));
+    }
+
+    #[test]
+    fn replacement_backoff_and_connectivity_are_deterministic() {
+        let mut agent = agent_with(DiscoveryConfig::default(), 1);
+        let (peer, first) = payload(2, &["/ip4/127.0.0.1/udp/1/quic-v1"]);
+        agent.handle_beacon(&peer, &first, true, 1);
+        let _ = agent.poll_action();
+        agent.dial_failed(&peer, "no path", 2);
+        assert!(matches!(
+            agent.poll_event(),
+            Some(DiscoveryEvent::PeerDiscovered { .. })
+        ));
+        assert!(matches!(
+            agent.poll_event(),
+            Some(DiscoveryEvent::DialFailed { .. })
+        ));
+        agent.handle_beacon(&peer, &first, true, 3);
+        assert!(agent.poll_action().is_none());
+        let (_, changed) = payload(2, &["/ip4/127.0.0.1/udp/2/quic-v1"]);
+        agent.handle_beacon(&peer, &changed, true, 4);
+        assert!(matches!(
+            agent.poll_action(),
+            Some(DiscoveryAction::Dial { .. })
+        ));
+        agent.peer_connected(&peer, 5);
+        assert!(agent.known_peers()[0].connected);
+        agent.peer_disconnected(&peer, 6);
+        agent.handle_beacon(&peer, &changed, true, 7);
+        assert!(matches!(
+            agent.poll_action(),
+            Some(DiscoveryAction::Dial { .. })
+        ));
+    }
+
+    #[test]
+    fn config_validation_and_saturating_deadlines() {
+        let mut config = DiscoveryConfig::default();
+        config.topic.clear();
+        assert_eq!(config.validate(), Err(DiscoveryConfigError::EmptyTopic));
+        config = DiscoveryConfig::default();
+        config.beacon_interval_ms = 0;
+        assert_eq!(
+            config.validate(),
+            Err(DiscoveryConfigError::ZeroBeaconInterval)
+        );
+        config = DiscoveryConfig::default();
+        config.peer_ttl_ms = 0;
+        assert_eq!(config.validate(), Err(DiscoveryConfigError::ZeroPeerTtl));
+        config = DiscoveryConfig::default();
+        config.max_known_peers = 0;
+        assert_eq!(
+            config.validate(),
+            Err(DiscoveryConfigError::ZeroMaxKnownPeers)
+        );
+        config = DiscoveryConfig::default();
+        config.max_addrs_per_peer = 0;
+        assert_eq!(
+            config.validate(),
+            Err(DiscoveryConfigError::InvalidMaxAddrs)
+        );
+        config = DiscoveryConfig::default();
+        config.topic = "x".repeat(crate::MAX_TOPIC_LEN + 1);
+        assert_eq!(config.validate(), Err(DiscoveryConfigError::TopicTooLong));
+        config = DiscoveryConfig::default();
+        config.max_addrs_per_peer = crate::MAX_BEACON_ADDRS + 1;
+        assert_eq!(
+            config.validate(),
+            Err(DiscoveryConfigError::InvalidMaxAddrs)
+        );
+        let mut agent = agent_with(DiscoveryConfig::default(), 1);
+        agent.handle_tick(u64::MAX);
+        assert_eq!(agent.next_timeout(u64::MAX), Some(0));
+    }
+
+    #[test]
+    fn self_malformed_and_mismatched_identity_beacons_never_refresh() {
+        let mut agent = agent_with(DiscoveryConfig::default(), 1);
+        let local = agent.local_peer_id().clone();
+        agent.handle_beacon(&local, b"bad", false, 1);
+        assert!(agent.poll_event().is_none());
+
+        let remote = PeerId::from_public_key(&key(2));
+        agent.handle_beacon(&remote, b"bad", true, 2);
+        assert!(matches!(
+            agent.poll_event(),
+            Some(DiscoveryEvent::ProtocolViolation { .. })
+        ));
+        let forged = Beacon {
+            public_key: key(3).encode_protobuf(),
+            addrs: vec![],
+        }
+        .encode();
+        agent.handle_beacon(&remote, &forged, true, 3);
+        assert!(matches!(
+            agent.poll_event(),
+            Some(DiscoveryEvent::ProtocolViolation { .. })
+        ));
+        assert!(agent.known_peers().is_empty());
+    }
+
+    #[test]
+    fn invalid_and_mismatched_addresses_are_skipped_beside_valid_siblings() {
+        let config = DiscoveryConfig {
+            auto_dial: false,
+            ..DiscoveryConfig::default()
+        };
+        let mut agent = agent_with(config, 1);
+        let remote_key = key(2);
+        let remote = PeerId::from_public_key(&remote_key);
+        let other = PeerId::from_public_key(&key(3));
+        let valid = Multiaddr::from_str("/ip4/127.0.0.1/udp/9/quic-v1")
+            .unwrap()
+            .to_bytes();
+        let mut mismatch = Multiaddr::from_str("/ip4/127.0.0.1/udp/10/quic-v1").unwrap();
+        mismatch.push(Protocol::P2p(other));
+        let beacon = Beacon {
+            public_key: remote_key.encode_protobuf(),
+            addrs: vec![vec![0xff], mismatch.to_bytes(), valid],
+        }
+        .encode();
+        agent.handle_beacon(&remote, &beacon, true, 1);
+        assert_eq!(agent.known_peers()[0].addrs.len(), 1);
+    }
+
+    #[test]
+    fn capacity_evicts_oldest_non_connected_and_cancels_its_dial() {
+        let config = DiscoveryConfig {
+            max_known_peers: 1,
+            ..DiscoveryConfig::default()
+        };
+        let mut agent = agent_with(config, 1);
+        let (first, first_payload) = payload(2, &[]);
+        let (second, second_payload) = payload(3, &[]);
+        agent.handle_beacon(&first, &first_payload, true, 1);
+        agent.handle_beacon(&second, &second_payload, true, 2);
+        assert_eq!(agent.known_peers()[0].peer, second);
+        assert!(agent.actions.iter().any(
+            |action| matches!(action, DiscoveryAction::CancelDial { peer } if peer == &first)
+        ));
+
+        agent.peer_connected(&second, 3);
+        let (third, third_payload) = payload(4, &[]);
+        agent.handle_beacon(&third, &third_payload, true, 4);
+        assert_eq!(agent.known_peers()[0].peer, second);
+    }
+
+    #[test]
+    fn tie_break_and_beacon_rearming_follow_policy() {
+        let a_key = key(10);
+        let b_key = key(20);
+        let a = PeerId::from_public_key(&a_key);
+        let b = PeerId::from_public_key(&b_key);
+        let (local_key, remote_key) = if a < b {
+            (b_key, a_key)
+        } else {
+            (a_key, b_key)
+        };
+        let remote = PeerId::from_public_key(&remote_key);
+        let payload = Beacon {
+            public_key: remote_key.encode_protobuf(),
+            addrs: vec![],
+        }
+        .encode();
+        let mut agent = DiscoveryAgent::new(local_key, DiscoveryConfig::default()).unwrap();
+        agent.handle_beacon(&remote, &payload, true, 0);
+        assert!(
+            agent.poll_action().is_none(),
+            "higher peer id must not dial"
+        );
+
+        agent.handle_tick(0);
+        let _ = agent.poll_action();
+        assert_eq!(agent.next_timeout(1), Some(9_999));
+        agent.set_local_addrs(&[], 5);
+        assert_eq!(agent.next_timeout(5), Some(9_995));
+        let addr = Multiaddr::from_str("/ip4/127.0.0.1/udp/1/quic-v1").unwrap();
+        agent.set_local_addrs(&[addr], 6);
+        assert_eq!(agent.next_timeout(6), Some(0));
+    }
+}

--- a/crates/discovery/src/config.rs
+++ b/crates/discovery/src/config.rs
@@ -65,7 +65,7 @@ impl DiscoveryConfig {
     }
 }
 
-/// Why a [`DiscoveryConfig`] is invalid.
+/// Why a discovery agent cannot be constructed from its configuration and identity.
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum DiscoveryConfigError {
     /// The configured pubsub topic is empty.
@@ -86,4 +86,7 @@ pub enum DiscoveryConfigError {
     /// The per-peer address cap must fit the wire-format bound.
     #[error("maximum addresses per peer must be between 1 and MAX_BEACON_ADDRS")]
     InvalidMaxAddrs,
+    /// The local identity cannot fit in a discovery beacon.
+    #[error("local public key exceeds the discovery beacon payload budget")]
+    LocalPublicKeyTooLarge,
 }

--- a/crates/discovery/src/config.rs
+++ b/crates/discovery/src/config.rs
@@ -1,0 +1,89 @@
+//! Discovery policy configuration.
+
+use alloc::string::{String, ToString};
+
+use crate::{DISCOVERY_TOPIC, MAX_BEACON_ADDRS, MAX_TOPIC_LEN};
+
+/// Caller-controlled discovery cadence, address-book, and dialing policy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DiscoveryConfig {
+    /// Pubsub topic carrying discovery beacons.
+    pub topic: String,
+    /// Milliseconds between local beacons.
+    pub beacon_interval_ms: u64,
+    /// Milliseconds after the last valid beacon before a peer expires.
+    pub peer_ttl_ms: u64,
+    /// Maximum number of peer records retained.
+    pub max_known_peers: usize,
+    /// Maximum normalized addresses retained and announced per peer.
+    pub max_addrs_per_peer: usize,
+    /// Whether accepted beacons may trigger dial actions.
+    pub auto_dial: bool,
+    /// Whether only the lower peer id initiates a dial.
+    pub dial_tie_break: bool,
+    /// Delay after a failed dial before unchanged beacons can retry.
+    pub redial_backoff_ms: u64,
+}
+
+impl Default for DiscoveryConfig {
+    fn default() -> Self {
+        Self {
+            topic: DISCOVERY_TOPIC.to_string(),
+            beacon_interval_ms: 10_000,
+            peer_ttl_ms: 35_000,
+            max_known_peers: 128,
+            max_addrs_per_peer: 16,
+            auto_dial: true,
+            dial_tie_break: true,
+            redial_backoff_ms: 30_000,
+        }
+    }
+}
+
+impl DiscoveryConfig {
+    /// Validates bounds required by the codec and caller-driven timer loop.
+    pub fn validate(&self) -> Result<(), DiscoveryConfigError> {
+        if self.topic.is_empty() {
+            return Err(DiscoveryConfigError::EmptyTopic);
+        }
+        if self.topic.len() > MAX_TOPIC_LEN {
+            return Err(DiscoveryConfigError::TopicTooLong);
+        }
+        if self.beacon_interval_ms == 0 {
+            return Err(DiscoveryConfigError::ZeroBeaconInterval);
+        }
+        if self.peer_ttl_ms == 0 {
+            return Err(DiscoveryConfigError::ZeroPeerTtl);
+        }
+        if self.max_known_peers == 0 {
+            return Err(DiscoveryConfigError::ZeroMaxKnownPeers);
+        }
+        if self.max_addrs_per_peer == 0 || self.max_addrs_per_peer > MAX_BEACON_ADDRS {
+            return Err(DiscoveryConfigError::InvalidMaxAddrs);
+        }
+        Ok(())
+    }
+}
+
+/// Why a [`DiscoveryConfig`] is invalid.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum DiscoveryConfigError {
+    /// The configured pubsub topic is empty.
+    #[error("discovery topic must be non-empty")]
+    EmptyTopic,
+    /// The topic exceeds the pubsub topic bound.
+    #[error("discovery topic exceeds the maximum length")]
+    TopicTooLong,
+    /// A zero interval would livelock a quiescence loop.
+    #[error("beacon interval must be non-zero")]
+    ZeroBeaconInterval,
+    /// Peers must remain valid for a non-zero duration.
+    #[error("peer TTL must be non-zero")]
+    ZeroPeerTtl,
+    /// The address book must have room for at least one peer.
+    #[error("maximum known peers must be non-zero")]
+    ZeroMaxKnownPeers,
+    /// The per-peer address cap must fit the wire-format bound.
+    #[error("maximum addresses per peer must be between 1 and MAX_BEACON_ADDRS")]
+    InvalidMaxAddrs,
+}

--- a/crates/discovery/src/events.rs
+++ b/crates/discovery/src/events.rs
@@ -1,0 +1,79 @@
+//! Caller-facing actions, events, and address-book records.
+
+use alloc::{string::String, vec::Vec};
+use minip2p_core::{Multiaddr, PeerId};
+
+/// Work emitted by [`DiscoveryAgent`](crate::DiscoveryAgent).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DiscoveryAction {
+    /// Publish a presence beacon. Backpressure may be dropped until the next interval.
+    PublishBeacon {
+        /// Pubsub topic to publish on.
+        topic: String,
+        /// Encoded [`Beacon`](crate::Beacon) payload.
+        payload: Vec<u8>,
+    },
+    /// Start a connection attempt and report its outcome to the agent.
+    Dial {
+        /// Peer to connect to.
+        peer: PeerId,
+        /// Normalized transport-shaped candidates in sender preference order.
+        addrs: Vec<Multiaddr>,
+    },
+    /// Cancel queued or in-flight dialing because the peer was removed.
+    CancelDial {
+        /// Peer whose attempt should be cancelled.
+        peer: PeerId,
+    },
+}
+
+/// Application-facing discovery state changes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DiscoveryEvent {
+    /// A valid beacon introduced a peer.
+    PeerDiscovered {
+        /// Discovered peer.
+        peer: PeerId,
+        /// Current normalized address snapshot.
+        addrs: Vec<Multiaddr>,
+    },
+    /// A valid beacon replaced a peer's address snapshot.
+    PeerUpdated {
+        /// Updated peer.
+        peer: PeerId,
+        /// Replacement normalized address snapshot.
+        addrs: Vec<Multiaddr>,
+    },
+    /// A peer expired or was evicted from the bounded book.
+    PeerExpired {
+        /// Removed peer.
+        peer: PeerId,
+    },
+    /// An automatic dial failed.
+    DialFailed {
+        /// Peer that could not be reached.
+        peer: PeerId,
+        /// Human-readable failure cause.
+        reason: String,
+    },
+    /// A beacon failed wire or identity validation.
+    ProtocolViolation {
+        /// Publisher of the rejected pubsub message.
+        peer: PeerId,
+        /// Human-readable rejection cause.
+        reason: String,
+    },
+}
+
+/// Snapshot of one entry in the discovery address book.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KnownPeer {
+    /// Peer identity authenticated by its beacon public key.
+    pub peer: PeerId,
+    /// Most recently advertised normalized addresses.
+    pub addrs: Vec<Multiaddr>,
+    /// Caller-supplied timestamp of the last valid beacon.
+    pub last_seen_ms: u64,
+    /// Whether the surrounding swarm currently has a connection.
+    pub connected: bool,
+}

--- a/crates/discovery/src/lib.rs
+++ b/crates/discovery/src/lib.rs
@@ -3,6 +3,8 @@
 //! Peers periodically advertise signed presence beacons. The state machine
 //! validates identities, maintains a bounded TTL address book, and emits dial
 //! actions without owning sockets, clocks, streams, or an executor.
+//! Address-less beacons refresh presence and TTL state without triggering a
+//! dial request.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/discovery/src/lib.rs
+++ b/crates/discovery/src/lib.rs
@@ -1,0 +1,22 @@
+//! Sans-I/O pubsub peer discovery for minip2p.
+//!
+//! Peers periodically advertise signed presence beacons. The state machine
+//! validates identities, maintains a bounded TTL address book, and emits dial
+//! actions without owning sockets, clocks, streams, or an executor.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+mod agent;
+mod config;
+mod events;
+mod message;
+
+pub use agent::DiscoveryAgent;
+pub use config::{DiscoveryConfig, DiscoveryConfigError};
+pub use events::{DiscoveryAction, DiscoveryEvent, KnownPeer};
+pub use message::{
+    Beacon, DISCOVERY_TOPIC, DiscoveryWireError, MAX_ADDR_LEN, MAX_BEACON_ADDRS, MAX_BEACON_SIZE,
+    MAX_PUBLIC_KEY_LEN, MAX_TOPIC_LEN,
+};

--- a/crates/discovery/src/message.rs
+++ b/crates/discovery/src/message.rs
@@ -12,8 +12,10 @@ pub const MAX_BEACON_SIZE: usize = 8192;
 pub const MAX_BEACON_ADDRS: usize = 64;
 /// Maximum bytes in one encoded multiaddr.
 pub const MAX_ADDR_LEN: usize = 1024;
-/// Maximum bytes in the protobuf-encoded public key.
-pub const MAX_PUBLIC_KEY_LEN: usize = 128;
+/// Maximum bytes in a protobuf-encoded public key that can fill a beacon by itself.
+///
+/// The three remaining bytes encode the field tag and its two-byte length prefix.
+pub const MAX_PUBLIC_KEY_LEN: usize = MAX_BEACON_SIZE - 3;
 
 const WIRE_VARINT: u64 = 0;
 const WIRE_64: u64 = 1;
@@ -255,15 +257,6 @@ mod tests {
         }
         .encode();
         assert!(Beacon::decode(&key).is_ok());
-        let key = Beacon {
-            public_key: vec![0; MAX_PUBLIC_KEY_LEN + 1],
-            addrs: vec![],
-        }
-        .encode();
-        assert_eq!(
-            Beacon::decode(&key),
-            Err(DiscoveryWireError::PublicKeyTooLarge)
-        );
         let addr = Beacon {
             public_key: vec![],
             addrs: vec![vec![0; MAX_ADDR_LEN + 1]],
@@ -282,5 +275,17 @@ mod tests {
             Beacon::decode(&many),
             Err(DiscoveryWireError::TooManyAddresses)
         );
+    }
+
+    #[test]
+    fn accepts_variable_length_public_keys_within_the_beacon_budget() {
+        let key = Beacon {
+            // Large enough to cover ordinary RSA public-key protobufs and to
+            // regress the former 128-byte wire limit.
+            public_key: vec![7; 1_024],
+            addrs: vec![],
+        };
+
+        assert_eq!(Beacon::decode(&key.encode()).unwrap(), key);
     }
 }

--- a/crates/discovery/src/message.rs
+++ b/crates/discovery/src/message.rs
@@ -1,0 +1,258 @@
+//! Protobuf wire codec compatible with js-libp2p pubsub peer discovery.
+
+use alloc::vec::Vec;
+
+/// Default js-libp2p-compatible discovery topic.
+pub const DISCOVERY_TOPIC: &str = "_peer-discovery._p2p._pubsub";
+/// Maximum topic length, deliberately equal to minip2p-pubsub's bound.
+pub const MAX_TOPIC_LEN: usize = 1024;
+/// Maximum encoded beacon payload.
+pub const MAX_BEACON_SIZE: usize = 8192;
+/// Maximum address fields in a beacon.
+pub const MAX_BEACON_ADDRS: usize = 64;
+/// Maximum bytes in one encoded multiaddr.
+pub const MAX_ADDR_LEN: usize = 1024;
+/// Maximum bytes in the protobuf-encoded public key.
+pub const MAX_PUBLIC_KEY_LEN: usize = 128;
+
+const WIRE_VARINT: u64 = 0;
+const WIRE_64: u64 = 1;
+const WIRE_LEN: u64 = 2;
+const WIRE_32: u64 = 5;
+const MAX_FIELD_NUMBER: u64 = (1 << 29) - 1;
+
+/// Presence payload: protobuf `Peer { bytes publicKey = 1; repeated bytes addrs = 2; }`.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Beacon {
+    /// Deterministic libp2p public-key protobuf bytes.
+    pub public_key: Vec<u8>,
+    /// Binary multiaddrs, normally suffixed with `/p2p/<publisher>`.
+    pub addrs: Vec<Vec<u8>>,
+}
+
+impl Beacon {
+    /// Encodes the beacon using canonical proto3 field ordering.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        if !self.public_key.is_empty() {
+            write_len_field(1, &self.public_key, &mut out);
+        }
+        for addr in &self.addrs {
+            write_len_field(2, addr, &mut out);
+        }
+        out
+    }
+
+    /// Decodes a bounded beacon, skipping protobuf-compatible unknown fields.
+    pub fn decode(input: &[u8]) -> Result<Self, DiscoveryWireError> {
+        if input.len() > MAX_BEACON_SIZE {
+            return Err(DiscoveryWireError::BeaconTooLarge);
+        }
+        let mut beacon = Self::default();
+        let mut idx = 0;
+        while idx < input.len() {
+            let tag = read_varint(input, &mut idx)?;
+            let field = tag >> 3;
+            let wire = tag & 7;
+            if field == 0 {
+                return Err(DiscoveryWireError::FieldZero);
+            }
+            if field > MAX_FIELD_NUMBER {
+                return Err(DiscoveryWireError::InvalidFieldNumber);
+            }
+            match (field, wire) {
+                (1, WIRE_LEN) => {
+                    let value = read_len(input, &mut idx)?;
+                    if value.len() > MAX_PUBLIC_KEY_LEN {
+                        return Err(DiscoveryWireError::PublicKeyTooLarge);
+                    }
+                    beacon.public_key = value.to_vec();
+                }
+                (2, WIRE_LEN) => {
+                    if beacon.addrs.len() == MAX_BEACON_ADDRS {
+                        return Err(DiscoveryWireError::TooManyAddresses);
+                    }
+                    let value = read_len(input, &mut idx)?;
+                    if value.len() > MAX_ADDR_LEN {
+                        return Err(DiscoveryWireError::AddressTooLarge);
+                    }
+                    beacon.addrs.push(value.to_vec());
+                }
+                (_, wire) => skip_field(input, &mut idx, wire)?,
+            }
+        }
+        Ok(beacon)
+    }
+}
+
+/// Why a beacon payload could not be decoded safely.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum DiscoveryWireError {
+    /// The top-level payload exceeds [`MAX_BEACON_SIZE`].
+    #[error("discovery beacon exceeds the maximum size")]
+    BeaconTooLarge,
+    /// A protobuf varint is truncated, too long, or overflows.
+    #[error("invalid protobuf varint")]
+    InvalidVarint,
+    /// Protobuf field zero is forbidden.
+    #[error("protobuf field number zero is invalid")]
+    FieldZero,
+    /// The field number exceeds protobuf's 29-bit range.
+    #[error("protobuf field number exceeds the supported range")]
+    InvalidFieldNumber,
+    /// A length-delimited value extends beyond the input.
+    #[error("truncated length-delimited protobuf field")]
+    Truncated,
+    /// Groups and reserved wire types are unsupported.
+    #[error("unsupported protobuf wire type {0}")]
+    UnsupportedWireType(u64),
+    /// The public-key field exceeds its bound.
+    #[error("discovery public key exceeds the maximum length")]
+    PublicKeyTooLarge,
+    /// An address field exceeds its bound.
+    #[error("discovery address exceeds the maximum length")]
+    AddressTooLarge,
+    /// More than [`MAX_BEACON_ADDRS`] address fields were present.
+    #[error("discovery beacon contains too many addresses")]
+    TooManyAddresses,
+}
+
+fn write_len_field(field: u64, value: &[u8], out: &mut Vec<u8>) {
+    write_varint((field << 3) | WIRE_LEN, out);
+    write_varint(value.len() as u64, out);
+    out.extend_from_slice(value);
+}
+
+fn write_varint(mut value: u64, out: &mut Vec<u8>) {
+    while value >= 0x80 {
+        out.push((value as u8) | 0x80);
+        value >>= 7;
+    }
+    out.push(value as u8);
+}
+
+fn read_varint(input: &[u8], idx: &mut usize) -> Result<u64, DiscoveryWireError> {
+    let mut value = 0u64;
+    for shift in (0..70).step_by(7) {
+        let byte = *input.get(*idx).ok_or(DiscoveryWireError::InvalidVarint)?;
+        *idx += 1;
+        if shift == 63 && byte > 1 {
+            return Err(DiscoveryWireError::InvalidVarint);
+        }
+        value |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    Err(DiscoveryWireError::InvalidVarint)
+}
+
+fn read_len<'a>(input: &'a [u8], idx: &mut usize) -> Result<&'a [u8], DiscoveryWireError> {
+    let len: usize = read_varint(input, idx)?
+        .try_into()
+        .map_err(|_| DiscoveryWireError::Truncated)?;
+    let end = idx.checked_add(len).ok_or(DiscoveryWireError::Truncated)?;
+    let value = input.get(*idx..end).ok_or(DiscoveryWireError::Truncated)?;
+    *idx = end;
+    Ok(value)
+}
+
+fn skip_field(input: &[u8], idx: &mut usize, wire: u64) -> Result<(), DiscoveryWireError> {
+    match wire {
+        WIRE_VARINT => {
+            read_varint(input, idx)?;
+        }
+        WIRE_64 => {
+            *idx = idx.checked_add(8).ok_or(DiscoveryWireError::Truncated)?;
+            if *idx > input.len() {
+                return Err(DiscoveryWireError::Truncated);
+            }
+        }
+        WIRE_LEN => {
+            let _ = read_len(input, idx)?;
+        }
+        WIRE_32 => {
+            *idx = idx.checked_add(4).ok_or(DiscoveryWireError::Truncated)?;
+            if *idx > input.len() {
+                return Err(DiscoveryWireError::Truncated);
+            }
+        }
+        other => return Err(DiscoveryWireError::UnsupportedWireType(other)),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn golden_vector_and_empty_round_trip() {
+        let beacon = Beacon {
+            public_key: vec![1, 2, 3],
+            addrs: vec![vec![4, 5], vec![]],
+        };
+        assert_eq!(
+            beacon.encode(),
+            vec![0x0a, 3, 1, 2, 3, 0x12, 2, 4, 5, 0x12, 0]
+        );
+        assert_eq!(Beacon::decode(&beacon.encode()).unwrap(), beacon);
+        assert_eq!(Beacon::decode(&[]).unwrap(), Beacon::default());
+    }
+
+    #[test]
+    fn rejects_malformed_and_skips_unknown_fields() {
+        assert_eq!(Beacon::decode(&[0]), Err(DiscoveryWireError::FieldZero));
+        assert_eq!(
+            Beacon::decode(&[0x0b]),
+            Err(DiscoveryWireError::UnsupportedWireType(3))
+        );
+        assert_eq!(
+            Beacon::decode(&[0x0a, 2, 1]),
+            Err(DiscoveryWireError::Truncated)
+        );
+        let input = [0x18, 0x96, 1, 0x0a, 1, 7];
+        assert_eq!(Beacon::decode(&input).unwrap().public_key, vec![7]);
+    }
+
+    #[test]
+    fn enforces_each_cap() {
+        assert_eq!(
+            Beacon::decode(&vec![0; MAX_BEACON_SIZE + 1]),
+            Err(DiscoveryWireError::BeaconTooLarge)
+        );
+        let key = Beacon {
+            public_key: vec![0; MAX_PUBLIC_KEY_LEN],
+            addrs: vec![],
+        }
+        .encode();
+        assert!(Beacon::decode(&key).is_ok());
+        let key = Beacon {
+            public_key: vec![0; MAX_PUBLIC_KEY_LEN + 1],
+            addrs: vec![],
+        }
+        .encode();
+        assert_eq!(
+            Beacon::decode(&key),
+            Err(DiscoveryWireError::PublicKeyTooLarge)
+        );
+        let addr = Beacon {
+            public_key: vec![],
+            addrs: vec![vec![0; MAX_ADDR_LEN + 1]],
+        }
+        .encode();
+        assert_eq!(
+            Beacon::decode(&addr),
+            Err(DiscoveryWireError::AddressTooLarge)
+        );
+        let many = Beacon {
+            public_key: vec![],
+            addrs: vec![vec![]; MAX_BEACON_ADDRS + 1],
+        }
+        .encode();
+        assert_eq!(
+            Beacon::decode(&many),
+            Err(DiscoveryWireError::TooManyAddresses)
+        );
+    }
+}

--- a/crates/discovery/src/message.rs
+++ b/crates/discovery/src/message.rs
@@ -31,9 +31,21 @@ pub struct Beacon {
 }
 
 impl Beacon {
+    /// Returns the exact number of bytes produced by [`Self::encode`].
+    pub fn encoded_len(&self) -> usize {
+        let mut len = 0usize;
+        if !self.public_key.is_empty() {
+            len = len.saturating_add(len_field_size(self.public_key.len()));
+        }
+        for addr in &self.addrs {
+            len = len.saturating_add(len_field_size(addr.len()));
+        }
+        len
+    }
+
     /// Encodes the beacon using canonical proto3 field ordering.
     pub fn encode(&self) -> Vec<u8> {
-        let mut out = Vec::new();
+        let mut out = Vec::with_capacity(self.encoded_len());
         if !self.public_key.is_empty() {
             write_len_field(1, &self.public_key, &mut out);
         }
@@ -123,6 +135,21 @@ fn write_len_field(field: u64, value: &[u8], out: &mut Vec<u8>) {
     out.extend_from_slice(value);
 }
 
+fn len_field_size(value_len: usize) -> usize {
+    1usize
+        .saturating_add(varint_size(value_len))
+        .saturating_add(value_len)
+}
+
+fn varint_size(mut value: usize) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        len += 1;
+    }
+    len
+}
+
 fn write_varint(mut value: u64, out: &mut Vec<u8>) {
     while value >= 0x80 {
         out.push((value as u8) | 0x80);
@@ -197,6 +224,7 @@ mod tests {
             vec![0x0a, 3, 1, 2, 3, 0x12, 2, 4, 5, 0x12, 0]
         );
         assert_eq!(Beacon::decode(&beacon.encode()).unwrap(), beacon);
+        assert_eq!(beacon.encoded_len(), beacon.encode().len());
         assert_eq!(Beacon::decode(&[]).unwrap(), Beacon::default());
     }
 

--- a/crates/minip2p/Cargo.toml
+++ b/crates/minip2p/Cargo.toml
@@ -11,9 +11,11 @@ workspace = true
 [features]
 nat = ["dep:minip2p-nat", "dep:getrandom"]
 pubsub = ["dep:minip2p-pubsub", "dep:thiserror"]
+discovery = ["nat", "pubsub", "dep:minip2p-discovery"]
 
 [dependencies]
 minip2p-core = { path = "../core" }
+minip2p-discovery = { path = "../discovery", optional = true }
 minip2p-identify = { path = "../identify" }
 minip2p-identity = { path = "../identity" }
 minip2p-nat = { path = "../nat", optional = true }

--- a/crates/minip2p/README.md
+++ b/crates/minip2p/README.md
@@ -26,6 +26,13 @@ Event waits (`next_event`, `wait_peer_ready`, `wait_ping_rtt`) accept an
 `Instant` (absolute deadline), a `Duration` (relative timeout), or
 `minip2p::Deadline::NEVER` to block until the event arrives.
 
+With the `discovery` feature, `.discovery()` enables signed pubsub presence
+beacons, a bounded TTL address book, and caller-driven automatic NAT connects.
+It implies the `nat` and `pubsub` features. Applications can inspect
+`known_peers`, drain `DiscoveryEvent`s, or pass a validated `DiscoveryConfig`
+to select a room-scoped topic and policy. Unsigned discovery beacons are always
+rejected even if unsigned application pubsub messages are allowed.
+
 Built-in protocol ids (`/ipfs/id/1.0.0`, `/ipfs/ping/1.0.0` -- see
 `minip2p::RESERVED_PROTOCOL_IDS`) belong to the endpoint's own handlers;
 registering one via `EndpointBuilder::protocol` makes the `bind_quic*` step

--- a/crates/minip2p/README.md
+++ b/crates/minip2p/README.md
@@ -26,6 +26,10 @@ Event waits (`next_event`, `wait_peer_ready`, `wait_ping_rtt`) accept an
 `Instant` (absolute deadline), a `Duration` (relative timeout), or
 `minip2p::Deadline::NEVER` to block until the event arrives.
 
+When an application permanently relinquishes a stream, `Endpoint::abandon_stream`
+resets it, purges already-buffered events, and suppresses later stream events.
+Use `Endpoint::reset_stream` when those terminal events should remain visible.
+
 With the `discovery` feature, `.discovery()` enables signed pubsub presence
 beacons, a bounded TTL address book, and caller-driven automatic NAT connects.
 It implies the `nat` and `pubsub` features. Applications can inspect

--- a/crates/minip2p/src/discovery.rs
+++ b/crates/minip2p/src/discovery.rs
@@ -266,7 +266,10 @@ impl DiscoveryDriver {
                 self.agent.dial_failed(&peer, &error.to_string(), now);
             }
             NatEvent::HolePunchFailed { .. } => {}
-            _ => unreachable!("only connect-correlated NAT events are harvested"),
+            // `sweep` currently calls this only for variants selected by
+            // `nat_connect_id`. Ignore future correlated variants rather
+            // than turning a harmless facade-version skew into a panic.
+            _ => {}
         }
     }
 
@@ -342,6 +345,10 @@ fn nat_connect_id(event: &NatEvent) -> Option<ConnectId> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
+    use std::time::{Duration, Instant};
+
+    use crate::{Endpoint, Event};
     use minip2p_discovery::DiscoveryConfig;
     use minip2p_identity::Ed25519Keypair;
     use minip2p_nat::{NatAgent, NatConfig, Now};
@@ -350,6 +357,69 @@ mod tests {
         let keypair = Ed25519Keypair::generate();
         let agent = DiscoveryAgent::new(keypair.public_key(), DiscoveryConfig::default()).unwrap();
         DiscoveryDriver::new(agent)
+    }
+
+    fn endpoint_with_protocol(protocol: &str) -> Endpoint {
+        Endpoint::builder()
+            .protocol(protocol)
+            .discovery_config(DiscoveryConfig {
+                auto_dial: false,
+                beacon_interval_ms: 100,
+                peer_ttl_ms: 2_000,
+                ..DiscoveryConfig::default()
+            })
+            .expect("valid discovery config")
+            .bind_quic("127.0.0.1:0")
+            .expect("bind endpoint")
+    }
+
+    fn connected_user_stream(protocol: &str) -> (Endpoint, Endpoint, StreamId) {
+        let mut a = endpoint_with_protocol(protocol);
+        let mut b = endpoint_with_protocol(protocol);
+        a.listen().expect("a listens");
+        let b_addr = b.listen().expect("b listens");
+        let a_peer = a.peer_id().clone();
+        let b_peer = b.peer_id().clone();
+        a.dial(&b_addr).expect("a dials b");
+
+        let connection_deadline = Instant::now() + Duration::from_secs(10);
+        while !a.connected_peers().contains(&b_peer) || !b.connected_peers().contains(&a_peer) {
+            assert!(Instant::now() < connection_deadline, "connection timed out");
+            let _ = a.next_event(Duration::from_millis(20)).expect("a drives");
+            let _ = b.next_event(Duration::from_millis(20)).expect("b drives");
+        }
+
+        let stream_id = a.open_stream(&b_peer, protocol).expect("open user stream");
+        let ready_deadline = Instant::now() + Duration::from_secs(10);
+        let mut a_ready = false;
+        let mut b_ready = false;
+        while !a_ready || !b_ready {
+            assert!(Instant::now() < ready_deadline, "stream setup timed out");
+            if let Some(event) = a.next_event(Duration::from_millis(20)).expect("a drives") {
+                a_ready |= matches!(
+                    event,
+                    Event::StreamReady { stream_id: got, .. } if got == stream_id
+                );
+            }
+            if let Some(event) = b.next_event(Duration::from_millis(20)).expect("b drives") {
+                b_ready |= matches!(
+                    event,
+                    Event::StreamReady { stream_id: got, .. } if got == stream_id
+                );
+            }
+        }
+        (a, b, stream_id)
+    }
+
+    fn is_stream_event(event: &Event, peer: &PeerId, stream_id: StreamId) -> bool {
+        matches!(
+            event,
+            Event::StreamReady { peer_id, stream_id: got, .. }
+                | Event::StreamData { peer_id, stream_id: got, .. }
+                | Event::StreamRemoteWriteClosed { peer_id, stream_id: got }
+                | Event::StreamClosed { peer_id, stream_id: got }
+                if peer_id == peer && *got == stream_id
+        )
     }
 
     #[test]
@@ -449,6 +519,318 @@ mod tests {
 
         let selected = driver.live_bridge_keys_for_peer(&target);
         assert_eq!(selected, vec![(target_relay, StreamId::new(1))]);
+    }
+
+    #[test]
+    fn fallback_and_both_cancel_arms_update_bridge_ownership() {
+        let mut endpoint = endpoint_with_protocol("/test/discovery-driver/1");
+        let relay = Ed25519Keypair::generate().peer_id();
+        let target = Ed25519Keypair::generate().peer_id();
+        let fallback_id = endpoint.nat.as_mut().expect("NAT enabled").agent.connect(
+            target.clone(),
+            Vec::new(),
+            Now::from_mono(0),
+        );
+        {
+            let Endpoint {
+                swarm,
+                nat,
+                discovery,
+                ..
+            } = &mut endpoint;
+            let nat = nat.as_mut().expect("NAT enabled");
+            let discovery = discovery.as_mut().expect("discovery enabled");
+            discovery.inflight.insert(fallback_id, target.clone());
+            discovery.bridges.insert(
+                (relay.clone(), StreamId::new(10)),
+                BridgeState::Live {
+                    connect_id: fallback_id,
+                    target_peer: target.clone(),
+                },
+            );
+            discovery.handle_nat_event(
+                NatEvent::FellBackToRelay {
+                    connect_id: fallback_id,
+                    peer: target.clone(),
+                },
+                nat,
+                swarm,
+                1,
+            );
+            assert!(!discovery.inflight.contains_key(&fallback_id));
+            assert!(
+                !discovery
+                    .bridges
+                    .contains_key(&(relay.clone(), StreamId::new(10))),
+                "a synchronous reset failure must drop the bridge"
+            );
+        }
+
+        let active_target = Ed25519Keypair::generate().peer_id();
+        let active_id = endpoint.nat.as_mut().expect("NAT enabled").agent.connect(
+            active_target.clone(),
+            Vec::new(),
+            Now::from_mono(2),
+        );
+        {
+            let Endpoint {
+                swarm,
+                nat,
+                discovery,
+                ..
+            } = &mut endpoint;
+            let nat = nat.as_mut().expect("NAT enabled");
+            let discovery = discovery.as_mut().expect("discovery enabled");
+            discovery.inflight.insert(active_id, active_target.clone());
+            discovery.bridges.insert(
+                (relay.clone(), StreamId::new(11)),
+                BridgeState::Live {
+                    connect_id: active_id,
+                    target_peer: active_target.clone(),
+                },
+            );
+            discovery.cancel_peer(&active_target, nat, swarm);
+            assert!(!discovery.inflight.contains_key(&active_id));
+            assert_eq!(
+                discovery.bridges.get(&(relay.clone(), StreamId::new(11))),
+                Some(&BridgeState::Tombstone),
+                "the NAT attempt owns the active bridge reset"
+            );
+        }
+
+        let orphan_target = Ed25519Keypair::generate().peer_id();
+        let orphan_id = endpoint.nat.as_mut().expect("NAT enabled").agent.connect(
+            orphan_target.clone(),
+            Vec::new(),
+            Now::from_mono(3),
+        );
+        let Endpoint {
+            swarm,
+            nat,
+            discovery,
+            ..
+        } = &mut endpoint;
+        let nat = nat.as_mut().expect("NAT enabled");
+        let discovery = discovery.as_mut().expect("discovery enabled");
+        discovery.bridges.insert(
+            (relay.clone(), StreamId::new(12)),
+            BridgeState::Live {
+                connect_id: orphan_id,
+                target_peer: orphan_target.clone(),
+            },
+        );
+        discovery.cancel_peer(&orphan_target, nat, swarm);
+        assert!(
+            !discovery.bridges.contains_key(&(relay, StreamId::new(12))),
+            "an orphan bridge with a rejected reset must be dropped"
+        );
+    }
+
+    #[test]
+    fn relayed_path_upgrade_tombstones_the_released_bridge() {
+        let mut endpoint = endpoint_with_protocol("/test/discovery-upgrade/1");
+        let relay = Ed25519Keypair::generate().peer_id();
+        let target = Ed25519Keypair::generate().peer_id();
+        let stream_id = StreamId::new(20);
+        let connect_id = endpoint.nat.as_mut().expect("NAT enabled").agent.connect(
+            target.clone(),
+            Vec::new(),
+            Now::from_mono(0),
+        );
+        let relayed = Path::Relayed {
+            relay: relay.clone(),
+            stream_id,
+            pending_data: Vec::new(),
+            remote_write_closed: false,
+        };
+        let Endpoint {
+            swarm,
+            nat,
+            discovery,
+            ..
+        } = &mut endpoint;
+        let nat = nat.as_mut().expect("NAT enabled");
+        let discovery = discovery.as_mut().expect("discovery enabled");
+        discovery.inflight.insert(connect_id, target.clone());
+        discovery.handle_nat_event(
+            NatEvent::PathEstablished {
+                connect_id,
+                peer: target.clone(),
+                path: relayed.clone(),
+            },
+            nat,
+            swarm,
+            0,
+        );
+        assert!(matches!(
+            discovery.bridges.get(&(relay.clone(), stream_id)),
+            Some(BridgeState::Live { .. })
+        ));
+
+        discovery.handle_nat_event(
+            NatEvent::PathUpgraded {
+                connect_id,
+                peer: target,
+                from: relayed,
+                to: Path::DirectPunched,
+            },
+            nat,
+            swarm,
+            1,
+        );
+        assert!(!discovery.inflight.contains_key(&connect_id));
+        assert_eq!(
+            discovery.bridges.get(&(relay, stream_id)),
+            Some(&BridgeState::Tombstone)
+        );
+    }
+
+    #[test]
+    fn real_bridge_fallback_resets_and_claims_terminal_events() {
+        const PROTOCOL: &str = "/test/discovery-real-bridge/1";
+        let (mut owner, mut remote, stream_id) = connected_user_stream(PROTOCOL);
+        let relay = remote.peer_id().clone();
+        let target = Ed25519Keypair::generate().peer_id();
+        let connect_id = owner.nat.as_mut().expect("NAT enabled").agent.connect(
+            target.clone(),
+            Vec::new(),
+            Now::from_mono(0),
+        );
+
+        {
+            let Endpoint {
+                swarm,
+                nat,
+                discovery,
+                ..
+            } = &mut owner;
+            let nat = nat.as_mut().expect("NAT enabled");
+            let discovery = discovery.as_mut().expect("discovery enabled");
+            discovery.inflight.insert(connect_id, target.clone());
+            discovery.handle_nat_event(
+                NatEvent::PathEstablished {
+                    connect_id,
+                    peer: target.clone(),
+                    path: Path::Relayed {
+                        relay: relay.clone(),
+                        stream_id,
+                        pending_data: Vec::new(),
+                        remote_write_closed: false,
+                    },
+                },
+                nat,
+                swarm,
+                0,
+            );
+        }
+        remote
+            .send_stream(owner.peer_id(), stream_id, b"bridge payload".to_vec())
+            .expect("remote sends bridge data");
+        remote
+            .close_stream_write(owner.peer_id(), stream_id)
+            .expect("remote closes bridge write side");
+        {
+            let Endpoint {
+                swarm,
+                nat,
+                discovery,
+                ..
+            } = &mut owner;
+            let nat = nat.as_mut().expect("NAT enabled");
+            let discovery = discovery.as_mut().expect("discovery enabled");
+            discovery.handle_nat_event(
+                NatEvent::FellBackToRelay {
+                    connect_id,
+                    peer: target,
+                },
+                nat,
+                swarm,
+                1,
+            );
+            assert_eq!(
+                discovery.bridges.get(&(relay.clone(), stream_id)),
+                Some(&BridgeState::Tombstone),
+                "the real stream reset must succeed"
+            );
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            let _ = remote
+                .next_event(Duration::from_millis(10))
+                .expect("remote drives");
+            if let Some(event) = owner
+                .next_event(Duration::from_millis(10))
+                .expect("owner drives")
+            {
+                assert!(
+                    !is_stream_event(&event, &relay, stream_id),
+                    "bridge event leaked after designation: {event:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn into_swarm_suppresses_queued_and_future_bridge_events() {
+        const PROTOCOL: &str = "/test/discovery-into-swarm/1";
+        let (mut owner, mut remote, stream_id) = connected_user_stream(PROTOCOL);
+        let relay = remote.peer_id().clone();
+        let target = Ed25519Keypair::generate().peer_id();
+        let connect_id = owner.nat.as_mut().expect("NAT enabled").agent.connect(
+            target.clone(),
+            Vec::new(),
+            Now::from_mono(0),
+        );
+        owner
+            .discovery
+            .as_mut()
+            .expect("discovery enabled")
+            .bridges
+            .insert(
+                (relay.clone(), stream_id),
+                BridgeState::Live {
+                    connect_id,
+                    target_peer: target,
+                },
+            );
+
+        remote
+            .send_stream(owner.peer_id(), stream_id, b"queued bridge data".to_vec())
+            .expect("remote sends queued data");
+        let saw_queued_stream_event = Cell::new(false);
+        owner
+            .swarm_mut()
+            .run_until(Instant::now() + Duration::from_millis(500), |event| {
+                if is_stream_event(event, &relay, stream_id) {
+                    saw_queued_stream_event.set(true);
+                }
+                false
+            })
+            .expect("queue raw stream event");
+        assert!(
+            saw_queued_stream_event.get(),
+            "the handoff test must begin with a queued bridge event"
+        );
+
+        let owner_peer = owner.peer_id().clone();
+        let mut swarm = owner.into_swarm();
+        let _ = remote.close_stream_write(&owner_peer, stream_id);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            let _ = remote
+                .next_event(Duration::from_millis(10))
+                .expect("remote drives");
+            if let Some(event) = swarm
+                .poll_next(Duration::from_millis(10))
+                .expect("raw swarm drives")
+            {
+                assert!(
+                    !is_stream_event(&event, &relay, stream_id),
+                    "abandoned bridge event leaked after handoff: {event:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/minip2p/src/discovery.rs
+++ b/crates/minip2p/src/discovery.rs
@@ -834,6 +834,65 @@ mod tests {
     }
 
     #[test]
+    fn endpoint_abandon_stream_purges_focused_wait_buffer_and_future_events() {
+        const PROTOCOL: &str = "/test/endpoint-abandon/1";
+        let (mut owner, mut remote, stream_id) = connected_user_stream(PROTOCOL);
+        let remote_peer = remote.peer_id().clone();
+
+        remote
+            .send_stream(owner.peer_id(), stream_id, b"buffer me".to_vec())
+            .expect("remote sends stream data");
+        let buffer_deadline = Instant::now() + Duration::from_secs(2);
+        while !owner
+            .pending_events
+            .iter()
+            .any(|event| is_stream_event(event, &remote_peer, stream_id))
+        {
+            assert!(
+                Instant::now() < buffer_deadline,
+                "focused wait did not buffer the stream event"
+            );
+            let _ = remote
+                .next_event(Duration::from_millis(10))
+                .expect("remote drives");
+            let _ = owner
+                .next_discovery_event(Duration::from_millis(10))
+                .expect("focused wait drives owner");
+        }
+
+        owner
+            .abandon_stream(&remote_peer, stream_id)
+            .expect("owner abandons stream");
+        assert!(
+            !owner.pending_events.iter().any(|event| is_stream_event(
+                event,
+                &remote_peer,
+                stream_id
+            )),
+            "abandon must purge the endpoint-focused-wait buffer"
+        );
+
+        remote
+            .close_stream_write(owner.peer_id(), stream_id)
+            .expect("remote closes stream write side");
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while Instant::now() < deadline {
+            let _ = remote
+                .next_event(Duration::from_millis(10))
+                .expect("remote drives");
+            if let Some(event) = owner
+                .next_event(Duration::from_millis(10))
+                .expect("owner drives")
+            {
+                assert!(
+                    !is_stream_event(&event, &remote_peer, stream_id),
+                    "abandoned stream event leaked through Endpoint: {event:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn topic_bound_stays_in_lockstep_with_pubsub() {
         assert_eq!(
             minip2p_discovery::MAX_TOPIC_LEN,

--- a/crates/minip2p/src/discovery.rs
+++ b/crates/minip2p/src/discovery.rs
@@ -24,9 +24,12 @@ pub enum DiscoveryError {
     Driver(#[from] Error),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum BridgeState {
-    Live { connect_id: ConnectId },
+    Live {
+        connect_id: ConnectId,
+        target_peer: PeerId,
+    },
     Tombstone,
 }
 
@@ -209,8 +212,13 @@ impl DiscoveryDriver {
                 Path::Relayed {
                     relay, stream_id, ..
                 } => {
-                    self.bridges
-                        .insert((relay, stream_id), BridgeState::Live { connect_id });
+                    self.bridges.insert(
+                        (relay, stream_id),
+                        BridgeState::Live {
+                            connect_id,
+                            target_peer: peer,
+                        },
+                    );
                 }
             },
             NatEvent::PathUpgraded {
@@ -234,7 +242,7 @@ impl DiscoveryDriver {
                     .bridges
                     .iter()
                     .filter(|(_, state)| {
-                        matches!(state, BridgeState::Live { connect_id: id } if *id == connect_id)
+                        matches!(state, BridgeState::Live { connect_id: id, .. } if *id == connect_id)
                     })
                     .map(|(key, _)| key.clone())
                     .collect();
@@ -272,18 +280,13 @@ impl DiscoveryDriver {
             nat.pump(swarm);
             self.inflight.remove(&id);
             for state in self.bridges.values_mut() {
-                if matches!(state, BridgeState::Live { connect_id } if *connect_id == id) {
+                if matches!(state, BridgeState::Live { connect_id, .. } if *connect_id == id) {
                     *state = BridgeState::Tombstone;
                 }
             }
             return;
         }
-        let keys: Vec<_> = self
-            .bridges
-            .iter()
-            .filter(|(_, state)| matches!(state, BridgeState::Live { .. }))
-            .map(|(key, _)| key.clone())
-            .collect();
+        let keys = self.live_bridge_keys_for_peer(peer);
         for key in keys {
             if swarm.reset_stream(&key.0, key.1).is_ok() {
                 self.bridges.insert(key, BridgeState::Tombstone);
@@ -293,13 +296,23 @@ impl DiscoveryDriver {
         }
     }
 
+    fn live_bridge_keys_for_peer(&self, peer: &PeerId) -> Vec<(PeerId, StreamId)> {
+        self.bridges
+            .iter()
+            .filter(|(_, state)| {
+                matches!(state, BridgeState::Live { target_peer, .. } if target_peer == peer)
+            })
+            .map(|(key, _)| key.clone())
+            .collect()
+    }
+
     /// Cancels attempts and suppresses every bridge before raw-swarm handoff.
     pub(crate) fn shutdown(&mut self, nat: &mut NatDriver, swarm: &mut Swarm<QuicEndpoint>) {
         let attempts: Vec<ConnectId> = self.inflight.keys().copied().collect();
         for id in attempts {
             nat.agent.cancel(id, nat.now());
             for state in self.bridges.values_mut() {
-                if matches!(state, BridgeState::Live { connect_id } if *connect_id == id) {
+                if matches!(state, BridgeState::Live { connect_id, .. } if *connect_id == id) {
                     *state = BridgeState::Tombstone;
                 }
             }
@@ -346,7 +359,7 @@ mod tests {
         let target = Ed25519Keypair::generate().peer_id();
         let mut nat = NatAgent::new(driver.agent.local_peer_id().clone(), NatConfig::default());
         let connect_id = nat.connect(
-            target,
+            target.clone(),
             Vec::new(),
             Now {
                 mono_ms: 0,
@@ -354,9 +367,13 @@ mod tests {
             },
         );
         let stream_id = StreamId::new(7);
-        driver
-            .bridges
-            .insert((relay.clone(), stream_id), BridgeState::Live { connect_id });
+        driver.bridges.insert(
+            (relay.clone(), stream_id),
+            BridgeState::Live {
+                connect_id,
+                target_peer: target,
+            },
+        );
         assert!(driver.ingest(&SwarmEvent::StreamData {
             peer_id: relay.clone(),
             stream_id,
@@ -389,6 +406,49 @@ mod tests {
             .insert((relay.clone(), StreamId::new(2)), BridgeState::Tombstone);
         driver.observe(&SwarmEvent::ConnectionClosed { peer_id: relay });
         assert!(driver.bridges.is_empty());
+    }
+
+    #[test]
+    fn orphan_bridge_selection_is_scoped_to_target_peer() {
+        let mut driver = driver();
+        let target = Ed25519Keypair::generate().peer_id();
+        let unrelated = Ed25519Keypair::generate().peer_id();
+        let target_relay = Ed25519Keypair::generate().peer_id();
+        let unrelated_relay = Ed25519Keypair::generate().peer_id();
+        let mut nat = NatAgent::new(driver.agent.local_peer_id().clone(), NatConfig::default());
+        let target_id = nat.connect(
+            target.clone(),
+            Vec::new(),
+            Now {
+                mono_ms: 0,
+                unix_secs: None,
+            },
+        );
+        let unrelated_id = nat.connect(
+            unrelated.clone(),
+            Vec::new(),
+            Now {
+                mono_ms: 1,
+                unix_secs: None,
+            },
+        );
+        driver.bridges.insert(
+            (target_relay.clone(), StreamId::new(1)),
+            BridgeState::Live {
+                connect_id: target_id,
+                target_peer: target.clone(),
+            },
+        );
+        driver.bridges.insert(
+            (unrelated_relay, StreamId::new(2)),
+            BridgeState::Live {
+                connect_id: unrelated_id,
+                target_peer: unrelated,
+            },
+        );
+
+        let selected = driver.live_bridge_keys_for_peer(&target);
+        assert_eq!(selected, vec![(target_relay, StreamId::new(1))]);
     }
 
     #[test]

--- a/crates/minip2p/src/discovery.rs
+++ b/crates/minip2p/src/discovery.rs
@@ -1,0 +1,401 @@
+//! Facade wiring for pubsub discovery and NAT traversal.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::time::Instant;
+
+use minip2p_core::PeerId;
+use minip2p_discovery::{DiscoveryAction, DiscoveryAgent, DiscoveryEvent};
+use minip2p_nat::{ConnectId, NatEvent, Path};
+use minip2p_pubsub::PubsubEvent;
+use minip2p_quic::QuicEndpoint;
+use minip2p_swarm::{Swarm, SwarmEvent};
+use minip2p_transport::StreamId;
+
+use crate::{Error, nat::NatDriver, pubsub::PubsubDriver};
+
+/// Errors from discovery-focused endpoint waits.
+#[derive(Debug, thiserror::Error)]
+pub enum DiscoveryError {
+    /// Discovery was not enabled with the endpoint builder.
+    #[error("discovery is not enabled on this endpoint (EndpointBuilder::discovery)")]
+    NotEnabled,
+    /// The endpoint failed while driving the swarm.
+    #[error(transparent)]
+    Driver(#[from] Error),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BridgeState {
+    Live { connect_id: ConnectId },
+    Tombstone,
+}
+
+/// Coordinates beacon traffic, automatic NAT connects, and released bridges.
+pub(crate) struct DiscoveryDriver {
+    pub(crate) agent: DiscoveryAgent,
+    pub(crate) events: VecDeque<DiscoveryEvent>,
+    epoch: Instant,
+    pub(crate) inflight: BTreeMap<ConnectId, PeerId>,
+    pub(crate) bridges: BTreeMap<(PeerId, StreamId), BridgeState>,
+    last_local_addrs: Vec<minip2p_core::Multiaddr>,
+}
+
+impl DiscoveryDriver {
+    pub(crate) fn new(agent: DiscoveryAgent) -> Self {
+        Self {
+            agent,
+            events: VecDeque::new(),
+            epoch: Instant::now(),
+            inflight: BTreeMap::new(),
+            bridges: BTreeMap::new(),
+            last_local_addrs: Vec::new(),
+        }
+    }
+
+    pub(crate) fn now_ms(&self) -> u64 {
+        self.epoch.elapsed().as_millis() as u64
+    }
+
+    /// Observes lifecycle events regardless of which protocol driver claims them.
+    pub(crate) fn observe(&mut self, event: &SwarmEvent) {
+        let now = self.now_ms();
+        match event {
+            SwarmEvent::ConnectionEstablished { peer_id } => {
+                // A second establishment supersedes the relay connection that
+                // owned any tracked stream ids.
+                self.bridges.retain(|(relay, _), _| relay != peer_id);
+                self.agent.peer_connected(peer_id, now);
+            }
+            SwarmEvent::ConnectionClosed { peer_id } => {
+                self.bridges.retain(|(relay, _), _| relay != peer_id);
+                self.agent.peer_disconnected(peer_id, now);
+            }
+            _ => {}
+        }
+    }
+
+    /// Claims data and terminal events for released bridges discovery owns.
+    pub(crate) fn ingest(&mut self, event: &SwarmEvent) -> bool {
+        let key = match event {
+            SwarmEvent::StreamData {
+                peer_id, stream_id, ..
+            }
+            | SwarmEvent::StreamRemoteWriteClosed { peer_id, stream_id }
+            | SwarmEvent::StreamClosed { peer_id, stream_id } => {
+                Some((peer_id.clone(), *stream_id))
+            }
+            _ => None,
+        };
+        let Some(key) = key else {
+            return false;
+        };
+        if !self.bridges.contains_key(&key) {
+            return false;
+        }
+        if matches!(event, SwarmEvent::StreamClosed { .. }) {
+            self.bridges.remove(&key);
+        }
+        true
+    }
+
+    /// Runs all cross-driver work until no new work is produced.
+    pub(crate) fn sweep(
+        &mut self,
+        pubsub: &mut PubsubDriver,
+        nat: &mut NatDriver,
+        swarm: &mut Swarm<QuicEndpoint>,
+    ) {
+        loop {
+            let mut progressed = false;
+            let now = self.now_ms();
+
+            let local_addrs = swarm.core().local_addresses();
+            if self.last_local_addrs != local_addrs {
+                self.last_local_addrs = local_addrs.to_vec();
+                self.agent.set_local_addrs(local_addrs, now);
+                progressed = true;
+            }
+
+            let mut retained = VecDeque::new();
+            while let Some(event) = pubsub.events.pop_front() {
+                let consumed = match &event {
+                    PubsubEvent::Message {
+                        from,
+                        topics,
+                        data,
+                        signed,
+                        ..
+                    } if topics.iter().any(|topic| topic == self.agent.topic()) => {
+                        self.agent.handle_beacon(from, data, *signed, now);
+                        true
+                    }
+                    PubsubEvent::PeerSubscribed { topic, .. }
+                    | PubsubEvent::PeerUnsubscribed { topic, .. }
+                        if topic == self.agent.topic() =>
+                    {
+                        true
+                    }
+                    _ => false,
+                };
+                if consumed {
+                    progressed = true;
+                } else {
+                    retained.push_back(event);
+                }
+            }
+            pubsub.events = retained;
+
+            let mut retained = VecDeque::new();
+            while let Some(event) = nat.events.pop_front() {
+                let connect_id = nat_connect_id(&event);
+                if connect_id.is_some_and(|id| self.inflight.contains_key(&id)) {
+                    progressed = true;
+                    self.handle_nat_event(event, nat, swarm, now);
+                } else {
+                    retained.push_back(event);
+                }
+            }
+            nat.events = retained;
+
+            if self.agent.next_timeout(now) == Some(0) {
+                self.agent.handle_tick(now);
+                progressed = true;
+            }
+
+            while let Some(action) = self.agent.poll_action() {
+                progressed = true;
+                match action {
+                    DiscoveryAction::PublishBeacon { topic, payload } => {
+                        let _ = pubsub.agent.publish(&topic, payload, pubsub.now_ms());
+                        pubsub.pump(swarm);
+                    }
+                    DiscoveryAction::Dial { peer, addrs } => {
+                        let id = nat.agent.connect(peer.clone(), addrs, nat.now());
+                        nat.pump(swarm);
+                        self.inflight.insert(id, peer);
+                    }
+                    DiscoveryAction::CancelDial { peer } => {
+                        self.cancel_peer(&peer, nat, swarm);
+                    }
+                }
+            }
+            while let Some(event) = self.agent.poll_event() {
+                progressed = true;
+                self.events.push_back(event);
+            }
+            if !progressed {
+                break;
+            }
+        }
+    }
+
+    fn handle_nat_event(
+        &mut self,
+        event: NatEvent,
+        _nat: &mut NatDriver,
+        swarm: &mut Swarm<QuicEndpoint>,
+        now: u64,
+    ) {
+        match event {
+            NatEvent::PathEstablished {
+                connect_id,
+                peer,
+                path,
+            } => match path {
+                Path::DirectDialed | Path::DirectPunched => {
+                    self.inflight.remove(&connect_id);
+                    self.agent.dial_succeeded(&peer, now);
+                }
+                Path::Relayed {
+                    relay, stream_id, ..
+                } => {
+                    self.bridges
+                        .insert((relay, stream_id), BridgeState::Live { connect_id });
+                }
+            },
+            NatEvent::PathUpgraded {
+                connect_id,
+                peer,
+                from,
+                ..
+            } => {
+                if let Path::Relayed {
+                    relay, stream_id, ..
+                } = from
+                {
+                    self.bridges
+                        .insert((relay, stream_id), BridgeState::Tombstone);
+                }
+                self.inflight.remove(&connect_id);
+                self.agent.dial_succeeded(&peer, now);
+            }
+            NatEvent::FellBackToRelay { connect_id, peer } => {
+                let keys: Vec<_> = self
+                    .bridges
+                    .iter()
+                    .filter(|(_, state)| {
+                        matches!(state, BridgeState::Live { connect_id: id } if *id == connect_id)
+                    })
+                    .map(|(key, _)| key.clone())
+                    .collect();
+                for key in keys {
+                    if swarm.reset_stream(&key.0, key.1).is_ok() {
+                        self.bridges.insert(key, BridgeState::Tombstone);
+                    } else {
+                        self.bridges.remove(&key);
+                    }
+                }
+                self.inflight.remove(&connect_id);
+                self.agent
+                    .dial_failed(&peer, "relayed only; direct path required", now);
+            }
+            NatEvent::ConnectFailed {
+                connect_id,
+                peer,
+                error,
+            } => {
+                self.inflight.remove(&connect_id);
+                self.agent.dial_failed(&peer, &error.to_string(), now);
+            }
+            NatEvent::HolePunchFailed { .. } => {}
+            _ => unreachable!("only connect-correlated NAT events are harvested"),
+        }
+    }
+
+    fn cancel_peer(&mut self, peer: &PeerId, nat: &mut NatDriver, swarm: &mut Swarm<QuicEndpoint>) {
+        let active = self
+            .inflight
+            .iter()
+            .find_map(|(id, candidate)| (candidate == peer).then_some(*id));
+        if let Some(id) = active {
+            nat.agent.cancel(id, nat.now());
+            nat.pump(swarm);
+            self.inflight.remove(&id);
+            for state in self.bridges.values_mut() {
+                if matches!(state, BridgeState::Live { connect_id } if *connect_id == id) {
+                    *state = BridgeState::Tombstone;
+                }
+            }
+            return;
+        }
+        let keys: Vec<_> = self
+            .bridges
+            .iter()
+            .filter(|(_, state)| matches!(state, BridgeState::Live { .. }))
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in keys {
+            if swarm.reset_stream(&key.0, key.1).is_ok() {
+                self.bridges.insert(key, BridgeState::Tombstone);
+            } else {
+                self.bridges.remove(&key);
+            }
+        }
+    }
+
+    /// Cancels attempts and suppresses every bridge before raw-swarm handoff.
+    pub(crate) fn shutdown(&mut self, nat: &mut NatDriver, swarm: &mut Swarm<QuicEndpoint>) {
+        let attempts: Vec<ConnectId> = self.inflight.keys().copied().collect();
+        for id in attempts {
+            nat.agent.cancel(id, nat.now());
+            for state in self.bridges.values_mut() {
+                if matches!(state, BridgeState::Live { connect_id } if *connect_id == id) {
+                    *state = BridgeState::Tombstone;
+                }
+            }
+        }
+        self.inflight.clear();
+        nat.pump(swarm);
+        let bridges: Vec<_> = self.bridges.keys().cloned().collect();
+        for (relay, stream_id) in bridges {
+            let _ = swarm.abandon_stream(&relay, stream_id);
+        }
+        self.bridges.clear();
+        self.events.clear();
+    }
+}
+
+fn nat_connect_id(event: &NatEvent) -> Option<ConnectId> {
+    match event {
+        NatEvent::PathEstablished { connect_id, .. }
+        | NatEvent::PathUpgraded { connect_id, .. }
+        | NatEvent::HolePunchFailed { connect_id, .. }
+        | NatEvent::FellBackToRelay { connect_id, .. }
+        | NatEvent::ConnectFailed { connect_id, .. } => Some(*connect_id),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use minip2p_discovery::DiscoveryConfig;
+    use minip2p_identity::Ed25519Keypair;
+    use minip2p_nat::{NatAgent, NatConfig, Now};
+
+    fn driver() -> DiscoveryDriver {
+        let keypair = Ed25519Keypair::generate();
+        let agent = DiscoveryAgent::new(keypair.public_key(), DiscoveryConfig::default()).unwrap();
+        DiscoveryDriver::new(agent)
+    }
+
+    #[test]
+    fn bridge_events_are_claimed_through_terminal_close() {
+        let mut driver = driver();
+        let relay = Ed25519Keypair::generate().peer_id();
+        let target = Ed25519Keypair::generate().peer_id();
+        let mut nat = NatAgent::new(driver.agent.local_peer_id().clone(), NatConfig::default());
+        let connect_id = nat.connect(
+            target,
+            Vec::new(),
+            Now {
+                mono_ms: 0,
+                unix_secs: None,
+            },
+        );
+        let stream_id = StreamId::new(7);
+        driver
+            .bridges
+            .insert((relay.clone(), stream_id), BridgeState::Live { connect_id });
+        assert!(driver.ingest(&SwarmEvent::StreamData {
+            peer_id: relay.clone(),
+            stream_id,
+            data: vec![1],
+        }));
+        assert!(driver.ingest(&SwarmEvent::StreamRemoteWriteClosed {
+            peer_id: relay.clone(),
+            stream_id,
+        }));
+        assert!(driver.ingest(&SwarmEvent::StreamClosed {
+            peer_id: relay,
+            stream_id,
+        }));
+        assert!(driver.bridges.is_empty());
+    }
+
+    #[test]
+    fn relay_lifecycle_clears_live_and_tombstone_stream_ids() {
+        let mut driver = driver();
+        let relay = Ed25519Keypair::generate().peer_id();
+        driver
+            .bridges
+            .insert((relay.clone(), StreamId::new(1)), BridgeState::Tombstone);
+        driver.observe(&SwarmEvent::ConnectionEstablished {
+            peer_id: relay.clone(),
+        });
+        assert!(driver.bridges.is_empty());
+        driver
+            .bridges
+            .insert((relay.clone(), StreamId::new(2)), BridgeState::Tombstone);
+        driver.observe(&SwarmEvent::ConnectionClosed { peer_id: relay });
+        assert!(driver.bridges.is_empty());
+    }
+
+    #[test]
+    fn topic_bound_stays_in_lockstep_with_pubsub() {
+        assert_eq!(
+            minip2p_discovery::MAX_TOPIC_LEN,
+            minip2p_pubsub::MAX_TOPIC_LEN
+        );
+    }
+}

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -6,12 +6,20 @@
 //! small batteries-included API for identity, QUIC, listen/dial, ping, and
 //! event polling.
 
+#[cfg(feature = "discovery")]
+mod discovery;
 #[cfg(feature = "nat")]
 mod nat;
 #[cfg(feature = "pubsub")]
 mod pubsub;
 
+#[cfg(feature = "discovery")]
+pub use discovery::DiscoveryError;
 pub use minip2p_core::{Multiaddr, PeerAddr, PeerId, Protocol};
+#[cfg(feature = "discovery")]
+pub use minip2p_discovery::{
+    DISCOVERY_TOPIC, DiscoveryConfig, DiscoveryConfigError, DiscoveryEvent, KnownPeer,
+};
 pub use minip2p_identify::IdentifyMessage;
 pub use minip2p_identity::Ed25519Keypair;
 #[cfg(feature = "nat")]
@@ -53,6 +61,8 @@ pub struct Endpoint {
     nat: Option<nat::NatDriver>,
     #[cfg(feature = "pubsub")]
     pubsub: Option<pubsub::PubsubDriver>,
+    #[cfg(feature = "discovery")]
+    discovery: Option<discovery::DiscoveryDriver>,
     /// Application events set aside while a driver-focused wait was driving
     /// the endpoint; drained first by [`Endpoint::next_event`].
     #[cfg(any(feature = "nat", feature = "pubsub"))]
@@ -265,6 +275,10 @@ impl Endpoint {
     /// Whether any agent driver is active on this endpoint.
     #[cfg(any(feature = "nat", feature = "pubsub"))]
     fn has_drivers(&self) -> bool {
+        #[cfg(feature = "discovery")]
+        if self.discovery.is_some() {
+            return true;
+        }
         #[cfg(feature = "nat")]
         if self.nat.is_some() {
             return true;
@@ -284,19 +298,24 @@ impl Endpoint {
     /// Returns `true` when a driver claimed the event.
     #[cfg(any(feature = "nat", feature = "pubsub"))]
     fn ingest_into_drivers(&mut self, event: &Event) -> bool {
+        #[cfg(feature = "discovery")]
+        if let Some(discovery) = self.discovery.as_mut() {
+            discovery.observe(event);
+        }
+        let mut claimed = false;
         #[cfg(feature = "nat")]
-        if let Some(nat) = self.nat.as_mut()
-            && nat.ingest(event, &mut self.swarm)
-        {
-            return true;
+        if let Some(nat) = self.nat.as_mut() {
+            claimed = nat.ingest(event, &mut self.swarm);
         }
         #[cfg(feature = "pubsub")]
-        if let Some(pubsub) = self.pubsub.as_mut()
-            && pubsub.ingest(event, &mut self.swarm)
-        {
-            return true;
+        if !claimed && let Some(pubsub) = self.pubsub.as_mut() {
+            claimed = pubsub.ingest(event, &mut self.swarm);
         }
-        false
+        #[cfg(feature = "discovery")]
+        if let Some(discovery) = self.discovery.as_mut() {
+            claimed |= discovery.ingest(event);
+        }
+        claimed
     }
 
     /// Ticks every active driver.
@@ -309,6 +328,14 @@ impl Endpoint {
         #[cfg(feature = "pubsub")]
         if let Some(pubsub) = self.pubsub.as_mut() {
             pubsub.tick(&mut self.swarm);
+        }
+        #[cfg(feature = "discovery")]
+        if let (Some(discovery), Some(pubsub), Some(nat)) = (
+            self.discovery.as_mut(),
+            self.pubsub.as_mut(),
+            self.nat.as_mut(),
+        ) {
+            discovery.sweep(pubsub, nat, &mut self.swarm);
         }
     }
 
@@ -324,6 +351,10 @@ impl Endpoint {
         #[cfg(feature = "pubsub")]
         if let Some(pubsub) = self.pubsub.as_ref() {
             len += pubsub.events.len();
+        }
+        #[cfg(feature = "discovery")]
+        if let Some(discovery) = self.discovery.as_ref() {
+            len += discovery.events.len();
         }
         len
     }
@@ -342,6 +373,12 @@ impl Endpoint {
         #[cfg(feature = "pubsub")]
         if let Some(pubsub) = self.pubsub.as_ref()
             && let Some(ms) = pubsub.agent.next_timeout(pubsub.now_ms())
+        {
+            step = step.earliest(Deadline::from(std::time::Duration::from_millis(ms.max(1))));
+        }
+        #[cfg(feature = "discovery")]
+        if let Some(discovery) = self.discovery.as_ref()
+            && let Some(ms) = discovery.agent.next_timeout(discovery.now_ms())
         {
             step = step.earliest(Deadline::from(std::time::Duration::from_millis(ms.max(1))));
         }
@@ -761,6 +798,53 @@ impl Endpoint {
         }
     }
 
+    /// Returns the current discovery address-book snapshot.
+    #[cfg(feature = "discovery")]
+    pub fn known_peers(&self) -> Vec<KnownPeer> {
+        self.discovery
+            .as_ref()
+            .map(|driver| driver.agent.known_peers())
+            .unwrap_or_default()
+    }
+
+    /// Drains all queued discovery events.
+    #[cfg(feature = "discovery")]
+    pub fn take_discovery_events(&mut self) -> Vec<DiscoveryEvent> {
+        self.discovery
+            .as_mut()
+            .map(|driver| driver.events.drain(..).collect())
+            .unwrap_or_default()
+    }
+
+    /// Returns the next discovery event while preserving unrelated swarm events.
+    #[cfg(feature = "discovery")]
+    pub fn next_discovery_event(
+        &mut self,
+        deadline: impl Into<Deadline>,
+    ) -> Result<Option<DiscoveryEvent>, DiscoveryError> {
+        let deadline = deadline.into();
+        let mut expired_poll_used = false;
+        loop {
+            match self.discovery.as_mut() {
+                Some(discovery) => {
+                    if let Some(event) = discovery.events.pop_front() {
+                        return Ok(Some(event));
+                    }
+                }
+                None => return Err(DiscoveryError::NotEnabled),
+            }
+            self.ensure_pending_event_capacity()?;
+            let poll = self.poll_new_event_driven(deadline, &mut expired_poll_used)?;
+            match poll.kind {
+                DriverPollKind::Application => self
+                    .pending_events
+                    .push_back(poll.event.expect("application poll carries event")),
+                DriverPollKind::Progress => {}
+                DriverPollKind::Deadline => return Ok(None),
+            }
+        }
+    }
+
     /// Borrows the underlying swarm.
     pub fn swarm(&self) -> &Swarm<QuicEndpoint> {
         &self.swarm
@@ -773,7 +857,20 @@ impl Endpoint {
 
     /// Decomposes this endpoint into the underlying swarm.
     pub fn into_swarm(self) -> Swarm<QuicEndpoint> {
-        self.swarm
+        #[cfg(feature = "discovery")]
+        {
+            let mut endpoint = self;
+            if let (Some(discovery), Some(nat)) =
+                (endpoint.discovery.as_mut(), endpoint.nat.as_mut())
+            {
+                discovery.shutdown(nat, &mut endpoint.swarm);
+            }
+            endpoint.swarm
+        }
+        #[cfg(not(feature = "discovery"))]
+        {
+            self.swarm
+        }
     }
 }
 
@@ -793,6 +890,8 @@ pub struct EndpointBuilder {
     pubsub_enabled: bool,
     #[cfg(feature = "pubsub")]
     pubsub_config: Option<FloodsubConfig>,
+    #[cfg(feature = "discovery")]
+    discovery_config: Option<DiscoveryConfig>,
 }
 
 impl Default for EndpointBuilder {
@@ -812,6 +911,8 @@ impl Default for EndpointBuilder {
             pubsub_enabled: false,
             #[cfg(feature = "pubsub")]
             pubsub_config: None,
+            #[cfg(feature = "discovery")]
+            discovery_config: None,
         }
     }
 }
@@ -826,6 +927,8 @@ struct BuilderParts {
     nat_config: Option<NatConfig>,
     #[cfg(feature = "pubsub")]
     pubsub_config: Option<FloodsubConfig>,
+    #[cfg(feature = "discovery")]
+    discovery_config: Option<DiscoveryConfig>,
 }
 
 impl EndpointBuilder {
@@ -906,6 +1009,28 @@ impl EndpointBuilder {
         self
     }
 
+    /// Enables signed pubsub peer discovery with interoperable defaults.
+    #[cfg(feature = "discovery")]
+    pub fn discovery(mut self) -> Self {
+        self.pubsub_enabled = true;
+        self.discovery_config = Some(DiscoveryConfig::default());
+        self
+    }
+
+    /// Enables discovery with an explicitly validated configuration.
+    ///
+    /// Validation occurs before any transport bind can allocate a socket.
+    #[cfg(feature = "discovery")]
+    pub fn discovery_config(
+        mut self,
+        config: DiscoveryConfig,
+    ) -> Result<Self, DiscoveryConfigError> {
+        config.validate()?;
+        self.pubsub_enabled = true;
+        self.discovery_config = Some(config);
+        Ok(self)
+    }
+
     /// Builds an endpoint with a QUIC transport bound to `bind_addr`.
     pub fn bind_quic(self, bind_addr: impl AsRef<str>) -> Result<Endpoint, Error> {
         let parts = self.into_parts()?;
@@ -953,7 +1078,17 @@ impl EndpointBuilder {
         let nat_config = {
             let enabled = self.nat_config.is_some()
                 || !self.relays.is_empty()
-                || !self.autonat_servers.is_empty();
+                || !self.autonat_servers.is_empty()
+                || cfg!(feature = "discovery") && {
+                    #[cfg(feature = "discovery")]
+                    {
+                        self.discovery_config.is_some()
+                    }
+                    #[cfg(not(feature = "discovery"))]
+                    {
+                        false
+                    }
+                };
             enabled.then(|| {
                 let mut config = self.nat_config.unwrap_or_default();
                 config.relays.extend(self.relays);
@@ -972,6 +1107,8 @@ impl EndpointBuilder {
             pubsub_config: self
                 .pubsub_enabled
                 .then(|| self.pubsub_config.unwrap_or_default()),
+            #[cfg(feature = "discovery")]
+            discovery_config: self.discovery_config,
         })
     }
 }
@@ -1020,6 +1157,8 @@ fn build_endpoint(parts: BuilderParts, transport: QuicEndpoint) -> Result<Endpoi
         let agent = minip2p_nat::NatAgent::new(swarm.local_peer_id().clone(), config);
         nat::NatDriver::new(agent, relay_addrs)
     });
+    #[cfg(feature = "discovery")]
+    let discovery_config = parts.discovery_config;
     #[cfg(feature = "pubsub")]
     let pubsub = parts.pubsub_config.map(|config| {
         // Message ids are (from, seqno); a wall-clock seed keeps restarts
@@ -1032,12 +1171,36 @@ fn build_endpoint(parts: BuilderParts, transport: QuicEndpoint) -> Result<Endpoi
             minip2p_pubsub::FloodsubAgent::new(parts.keypair.clone(), config, initial_seqno);
         pubsub::PubsubDriver::new(agent)
     });
+    #[cfg(feature = "discovery")]
+    let mut pubsub = pubsub;
+    #[cfg(feature = "discovery")]
+    if let (Some(pubsub), Some(config)) = (pubsub.as_mut(), discovery_config.as_ref()) {
+        pubsub
+            .agent
+            .subscribe(&config.topic, 0)
+            .map_err(|_| Error::Invariant {
+                reason: "validated discovery topic was rejected by pubsub",
+            })?;
+    }
+    #[cfg(feature = "discovery")]
+    let discovery = match discovery_config {
+        Some(config) => {
+            let agent = minip2p_discovery::DiscoveryAgent::new(parts.keypair.public_key(), config)
+                .map_err(|_| Error::Invariant {
+                    reason: "validated discovery configuration was rejected",
+                })?;
+            Some(discovery::DiscoveryDriver::new(agent))
+        }
+        None => None,
+    };
     Ok(Endpoint {
         swarm,
         #[cfg(feature = "nat")]
         nat,
         #[cfg(feature = "pubsub")]
         pubsub,
+        #[cfg(feature = "discovery")]
+        discovery,
         #[cfg(any(feature = "nat", feature = "pubsub"))]
         pending_events: std::collections::VecDeque::new(),
     })
@@ -1046,6 +1209,19 @@ fn build_endpoint(parts: BuilderParts, transport: QuicEndpoint) -> Result<Endpoi
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "discovery")]
+    #[test]
+    fn discovery_config_is_rejected_before_binding() {
+        let config = DiscoveryConfig {
+            beacon_interval_ms: 0,
+            ..DiscoveryConfig::default()
+        };
+        assert!(matches!(
+            Endpoint::builder().discovery_config(config),
+            Err(DiscoveryConfigError::ZeroBeaconInterval)
+        ));
+    }
     #[cfg(feature = "nat")]
     use std::time::Duration;
 

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -1252,6 +1252,44 @@ mod tests {
             Err(PubsubError::DiscoveryTopicReserved)
         ));
     }
+
+    #[cfg(feature = "discovery")]
+    #[test]
+    fn discovery_focused_waits_preserve_events_and_enforce_the_spin_guard() {
+        let mut endpoint = Endpoint::builder()
+            .discovery()
+            .bind_quic("127.0.0.1:0")
+            .expect("bind discovery endpoint");
+        let unrelated = Ed25519Keypair::generate().peer_id();
+
+        endpoint.pending_events.push_back(Event::ConnectionClosed {
+            peer_id: unrelated.clone(),
+        });
+        assert!(
+            endpoint
+                .next_discovery_event(Duration::from_millis(5))
+                .expect("discovery wait")
+                .is_none(),
+            "a buffered application event must not make next_discovery_event spin"
+        );
+        assert!(matches!(
+            endpoint
+                .next_event(Duration::from_millis(1))
+                .expect("drain buffered event"),
+            Some(Event::ConnectionClosed { peer_id }) if peer_id == unrelated
+        ));
+
+        for _ in 0..RUN_UNTIL_SKIP_LIMIT {
+            endpoint.pending_events.push_back(Event::ConnectionClosed {
+                peer_id: unrelated.clone(),
+            });
+        }
+        assert!(matches!(
+            endpoint.next_discovery_event(Deadline::NEVER),
+            Err(DiscoveryError::Driver(Error::EventBacklogExceeded { limit }))
+                if limit == RUN_UNTIL_SKIP_LIMIT
+        ));
+    }
     #[cfg(feature = "nat")]
     use std::time::Duration;
 

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -726,9 +726,19 @@ impl Endpoint {
     }
 
     /// Withdraws a pubsub subscription. Returns `Ok(false)` when not
-    /// subscribed.
+    /// subscribed. The configured discovery topic is reserved while
+    /// discovery is enabled and returns
+    /// [`PubsubError::DiscoveryTopicReserved`].
     #[cfg(feature = "pubsub")]
     pub fn unsubscribe(&mut self, topic: &str) -> Result<bool, PubsubError> {
+        #[cfg(feature = "discovery")]
+        if self
+            .discovery
+            .as_ref()
+            .is_some_and(|discovery| discovery.agent.topic() == topic)
+        {
+            return Err(PubsubError::DiscoveryTopicReserved);
+        }
         let Some(pubsub) = self.pubsub.as_mut() else {
             return Err(PubsubError::NotEnabled);
         };
@@ -1220,6 +1230,26 @@ mod tests {
         assert!(matches!(
             Endpoint::builder().discovery_config(config),
             Err(DiscoveryConfigError::ZeroBeaconInterval)
+        ));
+    }
+
+    #[cfg(feature = "discovery")]
+    #[test]
+    fn discovery_topic_cannot_be_unsubscribed_independently() {
+        let topic = "/minip2p/test/discovery";
+        let config = DiscoveryConfig {
+            topic: topic.into(),
+            ..DiscoveryConfig::default()
+        };
+        let mut endpoint = Endpoint::builder()
+            .discovery_config(config)
+            .expect("valid discovery configuration")
+            .bind_quic("127.0.0.1:0")
+            .expect("bind discovery endpoint");
+
+        assert!(matches!(
+            endpoint.unsubscribe(topic),
+            Err(PubsubError::DiscoveryTopicReserved)
         ));
     }
     #[cfg(feature = "nat")]

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -1020,6 +1020,10 @@ impl EndpointBuilder {
     }
 
     /// Enables signed pubsub peer discovery with interoperable defaults.
+    ///
+    /// The discovery topic is driver-owned: subscribing to it again through
+    /// [`Endpoint::subscribe`] is redundant, and its pubsub messages and
+    /// subscription events are consumed before reaching the application.
     #[cfg(feature = "discovery")]
     pub fn discovery(mut self) -> Self {
         self.pubsub_enabled = true;
@@ -1030,6 +1034,9 @@ impl EndpointBuilder {
     /// Enables discovery with an explicitly validated configuration.
     ///
     /// Validation occurs before any transport bind can allocate a socket.
+    /// The configured topic is driver-owned: subscribing to it again through
+    /// [`Endpoint::subscribe`] is redundant, and its pubsub messages and
+    /// subscription events are consumed before reaching the application.
     #[cfg(feature = "discovery")]
     pub fn discovery_config(
         mut self,

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -235,6 +235,19 @@ impl Endpoint {
         self.swarm.reset_stream(peer_id, stream_id)
     }
 
+    /// Resets and forgets an application stream that will no longer be consumed.
+    ///
+    /// Unlike [`Endpoint::reset_stream`], this also discards matching events
+    /// already buffered by the endpoint and suppresses later data, EOF, and
+    /// close events for the stream. Repeated calls are idempotent.
+    pub fn abandon_stream(&mut self, peer_id: &PeerId, stream_id: StreamId) -> Result<(), Error> {
+        let result = self.swarm.abandon_stream(peer_id, stream_id);
+        #[cfg(any(feature = "nat", feature = "pubsub"))]
+        self.pending_events
+            .retain(|event| !event_matches_stream(event, peer_id, stream_id));
+        result
+    }
+
     /// Polls the endpoint once and returns all currently available events.
     ///
     /// With NAT configured, events belonging to the traversal agent are
@@ -882,6 +895,32 @@ impl Endpoint {
             self.swarm
         }
     }
+}
+
+#[cfg(any(feature = "nat", feature = "pubsub"))]
+fn event_matches_stream(event: &Event, peer_id: &PeerId, stream_id: StreamId) -> bool {
+    matches!(
+        event,
+        Event::StreamReady {
+            peer_id: event_peer,
+            stream_id: event_stream,
+            ..
+        }
+            | Event::StreamData {
+                peer_id: event_peer,
+                stream_id: event_stream,
+                ..
+            }
+            | Event::StreamRemoteWriteClosed {
+                peer_id: event_peer,
+                stream_id: event_stream,
+            }
+            | Event::StreamClosed {
+                peer_id: event_peer,
+                stream_id: event_stream,
+            }
+            if event_peer == peer_id && *event_stream == stream_id
+    )
 }
 
 /// Builder for [`Endpoint`].

--- a/crates/minip2p/src/pubsub.rs
+++ b/crates/minip2p/src/pubsub.rs
@@ -25,6 +25,10 @@ pub enum PubsubError {
     /// ([`EndpointBuilder::pubsub`](crate::EndpointBuilder::pubsub)).
     #[error("pubsub is not enabled on this endpoint (EndpointBuilder::pubsub)")]
     NotEnabled,
+    /// The topic is owned by the active discovery driver and cannot be
+    /// withdrawn independently.
+    #[error("cannot unsubscribe from the discovery topic while discovery is enabled")]
+    DiscoveryTopicReserved,
     /// The publish was refused (topic validation, size, backpressure).
     #[error(transparent)]
     Publish(#[from] minip2p_pubsub::PublishError),

--- a/crates/minip2p/tests/discovery.rs
+++ b/crates/minip2p/tests/discovery.rs
@@ -1,0 +1,116 @@
+//! Loopback facade coverage for pubsub peer discovery.
+
+#![cfg(feature = "discovery")]
+
+use std::time::{Duration, Instant};
+
+use minip2p::{DiscoveryConfig, DiscoveryEvent, Endpoint, Event, PubsubEvent};
+
+const DISCOVERY_TOPIC: &str = "/minip2p/test/loopback-discovery";
+
+fn discovery_endpoint() -> Endpoint {
+    Endpoint::builder()
+        .discovery_config(DiscoveryConfig {
+            topic: DISCOVERY_TOPIC.into(),
+            beacon_interval_ms: 100,
+            peer_ttl_ms: 2_000,
+            auto_dial: false,
+            ..DiscoveryConfig::default()
+        })
+        .expect("valid discovery config")
+        .bind_quic("127.0.0.1:0")
+        .expect("bind loopback endpoint")
+}
+
+fn assert_no_discovery_pubsub(events: Vec<PubsubEvent>) {
+    for event in events {
+        let leaked = match &event {
+            PubsubEvent::Message { topics, .. } => {
+                topics.iter().any(|topic| topic == DISCOVERY_TOPIC)
+            }
+            PubsubEvent::PeerSubscribed { topic, .. }
+            | PubsubEvent::PeerUnsubscribed { topic, .. } => topic == DISCOVERY_TOPIC,
+            _ => false,
+        };
+        assert!(!leaked, "discovery pubsub event leaked: {event:?}");
+    }
+}
+
+#[test]
+fn beacons_do_not_leak_to_the_application() {
+    let mut a = discovery_endpoint();
+    let mut b = discovery_endpoint();
+    let a_addr = a.listen().expect("a listens");
+    let b_addr = b.listen().expect("b listens");
+    let a_peer = a.peer_id().clone();
+    let b_peer = b.peer_id().clone();
+    a.dial(&b_addr).expect("a dials b");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while a.known_peers().iter().all(|known| known.peer != b_peer)
+        || b.known_peers().iter().all(|known| known.peer != a_peer)
+    {
+        assert!(Instant::now() < deadline, "discovery timed out");
+        let _ = a.next_event(Duration::from_millis(20)).expect("a drives");
+        let _ = b.next_event(Duration::from_millis(20)).expect("b drives");
+        assert_no_discovery_pubsub(a.take_pubsub_events());
+        assert_no_discovery_pubsub(b.take_pubsub_events());
+    }
+
+    let a_seen_by_b = b
+        .known_peers()
+        .into_iter()
+        .find(|known| known.peer == a_peer)
+        .expect("b knows a");
+    let b_seen_by_a = a
+        .known_peers()
+        .into_iter()
+        .find(|known| known.peer == b_peer)
+        .expect("a knows b");
+    assert!(a_seen_by_b.addrs.contains(a_addr.transport()));
+    assert!(b_seen_by_a.addrs.contains(b_addr.transport()));
+    assert_no_discovery_pubsub(a.take_pubsub_events());
+    assert_no_discovery_pubsub(b.take_pubsub_events());
+}
+
+#[test]
+fn next_discovery_event_buffers_application_events() {
+    let mut a = discovery_endpoint();
+    let mut b = discovery_endpoint();
+    a.listen().expect("a listens");
+    let b_addr = b.listen().expect("b listens");
+    let b_peer = b.peer_id().clone();
+    a.dial(&b_addr).expect("a dials b");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let discovered = loop {
+        assert!(Instant::now() < deadline, "discovery event timed out");
+        if let Some(event) = a
+            .next_discovery_event(Duration::from_millis(20))
+            .expect("focused discovery wait")
+        {
+            break event;
+        }
+        let _ = b.next_event(Duration::from_millis(20)).expect("b drives");
+    };
+    assert!(matches!(
+        discovered,
+        DiscoveryEvent::PeerDiscovered { peer, .. } if peer == b_peer
+    ));
+
+    let drain_deadline = Instant::now() + Duration::from_secs(5);
+    let mut saw_connection = false;
+    while !saw_connection && Instant::now() < drain_deadline {
+        if let Some(event) = a
+            .next_event(Duration::from_millis(20))
+            .expect("drain buffered application event")
+        {
+            saw_connection = matches!(event, Event::ConnectionEstablished { .. });
+        }
+        let _ = b.next_event(Duration::from_millis(20)).expect("b drives");
+    }
+    assert!(
+        saw_connection,
+        "focused wait must preserve connection events"
+    );
+}

--- a/crates/pubsub/README.md
+++ b/crates/pubsub/README.md
@@ -19,3 +19,7 @@ machine that routes published messages to subscribed peers by flooding.
 - minip2p emits exactly one topic per published message (current go-libp2p
   singular `topic` field); the repeated `topic_ids` form is decoded for
   legacy compatibility.
+Delivered message events include a `signed` flag. It is `true` only when a
+signature was present and verified; accepted unsigned interoperability messages
+carry `false`, allowing higher-level protocols such as peer discovery to require
+authentication independently of application-message policy.

--- a/crates/pubsub/src/agent.rs
+++ b/crates/pubsub/src/agent.rs
@@ -858,7 +858,7 @@ impl FloodsubAgent {
     }
 
     fn process_message(&mut self, arrival: &PeerId, message: RawMessage, now_ms: u64) {
-        let (from, seqno) = match message.verify(self.config.allow_unsigned) {
+        let (from, seqno, signed) = match message.verify(self.config.allow_unsigned) {
             Ok(v) => v,
             Err(e) => {
                 // A bad message is dropped; the stream survives (only
@@ -888,6 +888,7 @@ impl FloodsubAgent {
                 topics: message.topic_ids.clone(),
                 data: message.data.clone().unwrap_or_default(),
                 seqno,
+                signed,
             });
         }
 

--- a/crates/pubsub/src/events.rs
+++ b/crates/pubsub/src/events.rs
@@ -66,6 +66,8 @@ pub enum PubsubEvent {
         /// 8 big-endian bytes, rust-libp2p floodsub 20 random bytes.
         /// Together with `from` it identifies the message for dedup.
         seqno: Vec<u8>,
+        /// Whether the message carried a signature that passed verification.
+        signed: bool,
     },
     /// A peer announced a subscription.
     PeerSubscribed {

--- a/crates/pubsub/src/message.rs
+++ b/crates/pubsub/src/message.rs
@@ -131,7 +131,7 @@ pub enum MessageVerifyError {
     #[error("message from field is not a valid peer id")]
     InvalidFrom,
     /// The `seqno` field is missing, empty, or longer than
-    /// [`MAX_SEQNO_LEN`] bytes.
+    /// `MAX_SEQNO_LEN` bytes (currently 64).
     #[error("message seqno must be 1..=64 bytes")]
     InvalidSeqno,
     /// The message carries no signature and unsigned messages are refused.
@@ -304,8 +304,8 @@ impl RawMessage {
         Ok(message)
     }
 
-    /// Verifies this message per StrictSign and returns its publisher and
-    /// dedup seqno bytes.
+    /// Verifies this message per StrictSign and returns its publisher,
+    /// dedup seqno bytes, and whether it carried a verified signature.
     ///
     /// Rules (see the crate README for the interop rationale):
     /// - `from` must parse as a peer id; `seqno` must be 1..=64 bytes —
@@ -318,7 +318,10 @@ impl RawMessage {
     /// - The signing key must round-trip to `from`
     ///   (`PeerId::from_public_key(key) == from`) whether it came from the
     ///   `key` field or was recovered from an inline-Ed25519 `from`.
-    pub fn verify(&self, allow_unsigned: bool) -> Result<(PeerId, Vec<u8>), MessageVerifyError> {
+    pub fn verify(
+        &self,
+        allow_unsigned: bool,
+    ) -> Result<(PeerId, Vec<u8>, bool), MessageVerifyError> {
         let from_bytes = self
             .from
             .as_deref()
@@ -338,7 +341,7 @@ impl RawMessage {
                 return Err(MessageVerifyError::KeyWithoutSignature);
             }
             if allow_unsigned {
-                return Ok((from, seqno));
+                return Ok((from, seqno, false));
             }
             return Err(MessageVerifyError::MissingSignature);
         };
@@ -364,7 +367,7 @@ impl RawMessage {
         public_key
             .verify(&self.sign_bytes(), signature)
             .map_err(|_| MessageVerifyError::SignatureInvalid)?;
-        Ok((from, seqno))
+        Ok((from, seqno, true))
     }
 }
 
@@ -817,9 +820,10 @@ mod tests {
         let kp = keypair();
         let message = RawMessage::build_signed(&kp, "chat", b"hello".to_vec(), 42);
         assert!(message.key.is_none(), "key must be omitted on the wire");
-        let (from, seqno) = message.verify(false).expect("verify");
+        let (from, seqno, signed) = message.verify(false).expect("verify");
         assert_eq!(from, kp.peer_id());
         assert_eq!(seqno, 42u64.to_be_bytes().to_vec());
+        assert!(signed);
     }
 
     #[test]
@@ -896,9 +900,10 @@ mod tests {
             unsigned.verify(false),
             Err(MessageVerifyError::MissingSignature)
         );
-        let (from, seqno) = unsigned.verify(true).expect("allow_unsigned accepts");
+        let (from, seqno, signed) = unsigned.verify(true).expect("allow_unsigned accepts");
         assert_eq!(from, kp.peer_id());
         assert_eq!(seqno, 9u64.to_be_bytes().to_vec());
+        assert!(!signed);
 
         // Seqno length is implementation-defined: rust-libp2p floodsub
         // emits 20 random bytes. Anything 1..=64 is accepted.

--- a/crates/pubsub/tests/agent.rs
+++ b/crates/pubsub/tests/agent.rs
@@ -269,8 +269,9 @@ fn subscription_snapshot_flows_on_peer_ready_and_publish_reaches_subscribers() {
     let frame = complete_send(&mut a, &b, StreamId::new(8), 30).expect("publish frame");
     let rpc = decode_rpc(&frame);
     assert_eq!(rpc.publish.len(), 1);
-    let (from, _) = rpc.publish[0].verify(false).expect("we sign our messages");
+    let (from, _, signed) = rpc.publish[0].verify(false).expect("we sign our messages");
     assert_eq!(&from, a.local_peer_id());
+    assert!(signed);
     assert_eq!(rpc.publish[0].data.as_deref(), Some(&b"hello"[..]));
 }
 
@@ -671,7 +672,7 @@ fn bad_signature_drops_the_message_but_the_stream_survives() {
     assert!(
         drain_events(&mut a)
             .iter()
-            .any(|e| matches!(e, PubsubEvent::Message { .. }))
+            .any(|e| matches!(e, PubsubEvent::Message { signed: true, .. }))
     );
 }
 
@@ -720,7 +721,7 @@ fn unsigned_messages_require_the_allow_unsigned_config() {
     assert!(
         drain_events(&mut lax)
             .iter()
-            .any(|e| matches!(e, PubsubEvent::Message { .. }))
+            .any(|e| matches!(e, PubsubEvent::Message { signed: false, .. }))
     );
 
     // Live-interop regression: rust-libp2p floodsub seqnos are 20 random

--- a/crates/pubsub/tests/golden_go.rs
+++ b/crates/pubsub/tests/golden_go.rs
@@ -34,9 +34,10 @@ fn go_libp2p_signed_message_decodes_and_verifies() {
 
     // StrictSign verification against go's actual signature: this is the
     // canonical-re-encode rule proving out end to end.
-    let (from, _seqno) = message
+    let (from, _seqno, signed) = message
         .verify(false)
         .expect("go-signed message must pass strict verification");
+    assert!(signed);
     let expected = include_str!("testdata/go_peer_id.txt");
     assert_eq!(from.to_base58(), expected.trim());
 }

--- a/crates/swarm/README.md
+++ b/crates/swarm/README.md
@@ -78,7 +78,7 @@ The core is deterministic when callers use a simple mutate-then-drain loop:
 1. Feed exactly one external input into the core with `core.handle_input(...)`, or call one application intent such as `ping`, `open_stream`, or `send_stream`.
 2. Drain `core.poll_output()`.
 3. Execute each `SwarmOutput::Action` against your transport.
-4. Feed driver results back with `SwarmInput::StreamOpened`, `SwarmInput::OpenStreamFailed`, or `SwarmInput::RuntimeError`.
+4. Feed driver results back with `SwarmInput::StreamOpened`, `SwarmInput::OpenStreamFailed`, or `SwarmInput::RuntimeError`. If executing a `SwarmAction::ResetStream` fails, also call `core.reset_stream_failed(conn_id, stream_id)` so a later reset can be retried.
 5. Hand each `SwarmOutput::Event` to the application.
 6. Before waiting on I/O again, `core.is_idle()` should be true.
 

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -95,6 +95,17 @@ struct PendingOpen {
     target: ProtocolKind,
 }
 
+fn stream_event_matches(event: &SwarmEvent, peer_id: &PeerId, stream_id: StreamId) -> bool {
+    matches!(
+        event,
+        SwarmEvent::StreamReady { peer_id: peer, stream_id: stream, .. }
+            | SwarmEvent::StreamData { peer_id: peer, stream_id: stream, .. }
+            | SwarmEvent::StreamRemoteWriteClosed { peer_id: peer, stream_id: stream }
+            | SwarmEvent::StreamClosed { peer_id: peer, stream_id: stream }
+            if peer == peer_id && *stream == stream_id
+    )
+}
+
 // ---------------------------------------------------------------------------
 // SwarmCore
 // ---------------------------------------------------------------------------
@@ -127,6 +138,10 @@ pub struct SwarmCore {
     outbound_negotiators: BTreeMap<(ConnectionId, StreamId), PendingOutbound>,
     /// Streams that completed negotiation: maps to the owning protocol.
     stream_owner: BTreeMap<(ConnectionId, StreamId), ProtocolKind>,
+    /// User streams for which a reset has already been queued.
+    reset_pending: BTreeSet<(ConnectionId, StreamId)>,
+    /// Streams deliberately forgotten by their consumer until transport close.
+    abandoned_streams: BTreeSet<(ConnectionId, StreamId)>,
     /// Outstanding OpenStream requests keyed by token; populated when the
     /// core emits `SwarmAction::OpenStream` and drained when the driver
     /// reports the allocated stream id back via [`SwarmInput::StreamOpened`].
@@ -190,6 +205,8 @@ impl SwarmCore {
             inbound_negotiators: BTreeMap::new(),
             outbound_negotiators: BTreeMap::new(),
             stream_owner: BTreeMap::new(),
+            reset_pending: BTreeSet::new(),
+            abandoned_streams: BTreeSet::new(),
             pending_opens: BTreeMap::new(),
             next_open_token: 1,
             supported_protocols,
@@ -436,8 +453,41 @@ impl SwarmCore {
         stream_id: StreamId,
     ) -> Result<(), SwarmError> {
         let conn_id = self.require_stream_conn(peer_id, stream_id)?;
-        self.actions
-            .push_back(SwarmAction::ResetStream { conn_id, stream_id });
+        if self.reset_pending.insert((conn_id, stream_id)) {
+            self.actions
+                .push_back(SwarmAction::ResetStream { conn_id, stream_id });
+        }
+        Ok(())
+    }
+
+    /// Resets and forgets a stream whose consumer will never read it again.
+    ///
+    /// A reset is queued at most once. Already-buffered events and all later
+    /// data, EOF, and close events for the stream are suppressed.
+    pub fn abandon_stream(
+        &mut self,
+        peer_id: &PeerId,
+        stream_id: StreamId,
+    ) -> Result<(), SwarmError> {
+        if self.abandoned_streams.iter().any(|(conn_id, sid)| {
+            *sid == stream_id && self.conn_to_peer.get(conn_id) == Some(peer_id)
+        }) {
+            self.events
+                .retain(|event| !stream_event_matches(event, peer_id, stream_id));
+            return Ok(());
+        }
+        let conn_id = self.require_stream_conn(peer_id, stream_id)?;
+        let key = (conn_id, stream_id);
+        if self.reset_pending.insert(key) {
+            self.actions
+                .push_back(SwarmAction::ResetStream { conn_id, stream_id });
+        }
+        self.abandoned_streams.insert(key);
+        self.stream_owner.remove(&key);
+        self.inbound_negotiators.remove(&key);
+        self.outbound_negotiators.remove(&key);
+        self.events
+            .retain(|event| !stream_event_matches(event, peer_id, stream_id));
         Ok(())
     }
 
@@ -894,6 +944,8 @@ impl SwarmCore {
         }
         self.conn_to_remote_addr.remove(&old_id);
         self.stream_owner.retain(|(cid, _), _| *cid != old_id);
+        self.reset_pending.retain(|(cid, _)| *cid != old_id);
+        self.abandoned_streams.retain(|(cid, _)| *cid != old_id);
         self.inbound_negotiators
             .retain(|(cid, _), _| *cid != old_id);
         self.outbound_negotiators
@@ -1123,6 +1175,13 @@ impl SwarmCore {
     fn handle_stream_closed(&mut self, conn_id: ConnectionId, stream_id: StreamId) {
         let key = (conn_id, stream_id);
 
+        self.reset_pending.remove(&key);
+        if self.abandoned_streams.remove(&key) {
+            self.inbound_negotiators.remove(&key);
+            self.outbound_negotiators.remove(&key);
+            return;
+        }
+
         if let Some(protocol) = self.stream_owner.remove(&key)
             && let Some(peer_id) = self.conn_to_peer.get(&conn_id).cloned()
         {
@@ -1176,6 +1235,8 @@ impl SwarmCore {
         }
 
         self.stream_owner.retain(|(cid, _), _| *cid != conn_id);
+        self.reset_pending.retain(|(cid, _)| *cid != conn_id);
+        self.abandoned_streams.retain(|(cid, _)| *cid != conn_id);
         self.inbound_negotiators
             .retain(|(cid, _), _| *cid != conn_id);
         self.outbound_negotiators
@@ -1787,6 +1848,65 @@ mod tests {
 
         assert!(core.ping.is_idle());
         assert!(core.poll_output().is_none());
+    }
+
+    #[test]
+    fn abandon_stream_is_reset_idempotent_and_suppresses_queued_and_future_events() {
+        let mut core = test_core();
+        let peer = PeerId::from_public_key_protobuf(b"abandoned-peer");
+        let conn = ConnectionId::new(44);
+        let stream = StreamId::new(9);
+        core.conn_to_peer.insert(conn, peer.clone());
+        core.peer_to_conn.insert(peer.clone(), conn);
+        core.stream_owner
+            .insert((conn, stream), ProtocolKind::User("/test/1".into()));
+        core.events.push_back(SwarmEvent::StreamData {
+            peer_id: peer.clone(),
+            stream_id: stream,
+            data: vec![1],
+        });
+
+        core.reset_stream(&peer, stream).unwrap();
+        core.abandon_stream(&peer, stream).unwrap();
+        core.abandon_stream(&peer, stream).unwrap();
+        let outputs: Vec<_> = core::iter::from_fn(|| core.poll_output()).collect();
+        assert_eq!(
+            outputs
+                .iter()
+                .filter(|output| matches!(output, SwarmOutput::Action(SwarmAction::ResetStream { stream_id, .. }) if *stream_id == stream))
+                .count(),
+            1
+        );
+        assert!(
+            !outputs
+                .iter()
+                .any(|output| matches!(output, SwarmOutput::Event(_)))
+        );
+
+        feed(
+            &mut core,
+            TransportEvent::StreamData {
+                id: conn,
+                stream_id: stream,
+                data: vec![2],
+            },
+        );
+        feed(
+            &mut core,
+            TransportEvent::StreamRemoteWriteClosed {
+                id: conn,
+                stream_id: stream,
+            },
+        );
+        feed(
+            &mut core,
+            TransportEvent::StreamClosed {
+                id: conn,
+                stream_id: stream,
+            },
+        );
+        assert!(drain_events(&mut core).is_empty());
+        assert!(!core.abandoned_streams.contains(&(conn, stream)));
     }
 
     #[test]

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -18,7 +18,8 @@
 //! 1. perform one mutation (`handle_input` or an application-facing method
 //!    such as `ping`);
 //! 2. drain [`SwarmOutput`] values from [`SwarmCore::poll_output`], executing
-//!    each action and feeding driver results back through `handle_input`;
+//!    each action and feeding driver results back through `handle_input` (or
+//!    [`SwarmCore::reset_stream_failed`] when a reset action is rejected);
 //! 3. repeat output draining until no new outputs are produced.
 //!
 //! After a full drain, [`SwarmCore::is_idle`] returns `true`. Treating that as
@@ -464,9 +465,15 @@ impl SwarmCore {
         Ok(())
     }
 
-    /// Lets the std driver retry a reset that the transport rejected.
-    #[cfg(feature = "std")]
-    pub(crate) fn reset_stream_failed(&mut self, conn_id: ConnectionId, stream_id: StreamId) {
+    /// Reports that the transport rejected a queued stream reset.
+    ///
+    /// A driver must call this after executing a [`SwarmAction::ResetStream`]
+    /// action unsuccessfully. The acknowledgment clears the pending marker so
+    /// a later [`reset_stream`](Self::reset_stream) or
+    /// [`abandon_stream`](Self::abandon_stream) call can queue another reset.
+    /// Successful resets need no acknowledgment; their marker is cleared when
+    /// the transport reports that the stream or connection closed.
+    pub fn reset_stream_failed(&mut self, conn_id: ConnectionId, stream_id: StreamId) {
         self.reset_pending.remove(&(conn_id, stream_id));
     }
 
@@ -479,6 +486,11 @@ impl SwarmCore {
         peer_id: &PeerId,
         stream_id: StreamId,
     ) -> Result<(), SwarmError> {
+        // Ownership is relinquished even if the transport has already closed
+        // and forgotten the stream. In that case there is nothing left to
+        // reset, but a terminal event may still be queued for the consumer.
+        self.events
+            .retain(|event| !stream_event_matches(event, peer_id, stream_id));
         if let Some(key) = self
             .abandoned_streams
             .iter()
@@ -493,8 +505,6 @@ impl SwarmCore {
                     stream_id: key.1,
                 });
             }
-            self.events
-                .retain(|event| !stream_event_matches(event, peer_id, stream_id));
             return Ok(());
         }
         let conn_id = self.require_stream_conn(peer_id, stream_id)?;
@@ -507,8 +517,6 @@ impl SwarmCore {
         self.stream_owner.remove(&key);
         self.inbound_negotiators.remove(&key);
         self.outbound_negotiators.remove(&key);
-        self.events
-            .retain(|event| !stream_event_matches(event, peer_id, stream_id));
         Ok(())
     }
 
@@ -1964,6 +1972,28 @@ mod tests {
             core.poll_output(),
             Some(SwarmOutput::Action(SwarmAction::ResetStream { .. }))
         ));
+    }
+
+    #[test]
+    fn abandon_purges_a_terminal_event_after_the_stream_was_forgotten() {
+        let mut core = test_core();
+        let peer = PeerId::from_public_key_protobuf(b"closed-before-abandon-peer");
+        let conn = ConnectionId::new(46);
+        let stream = StreamId::new(11);
+        core.conn_to_peer.insert(conn, peer.clone());
+        core.peer_to_conn.insert(peer.clone(), conn);
+        core.stream_owner
+            .insert((conn, stream), ProtocolKind::User("/test/1".into()));
+
+        feed(
+            &mut core,
+            TransportEvent::StreamClosed {
+                id: conn,
+                stream_id: stream,
+            },
+        );
+        assert!(core.abandon_stream(&peer, stream).is_err());
+        assert!(core.poll_output().is_none());
     }
 
     #[test]

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -95,7 +95,11 @@ struct PendingOpen {
     target: ProtocolKind,
 }
 
-fn stream_event_matches(event: &SwarmEvent, peer_id: &PeerId, stream_id: StreamId) -> bool {
+pub(crate) fn stream_event_matches(
+    event: &SwarmEvent,
+    peer_id: &PeerId,
+    stream_id: StreamId,
+) -> bool {
     matches!(
         event,
         SwarmEvent::StreamReady { peer_id: peer, stream_id: stream, .. }
@@ -460,6 +464,12 @@ impl SwarmCore {
         Ok(())
     }
 
+    /// Lets the std driver retry a reset that the transport rejected.
+    #[cfg(feature = "std")]
+    pub(crate) fn reset_stream_failed(&mut self, conn_id: ConnectionId, stream_id: StreamId) {
+        self.reset_pending.remove(&(conn_id, stream_id));
+    }
+
     /// Resets and forgets a stream whose consumer will never read it again.
     ///
     /// A reset is queued at most once. Already-buffered events and all later
@@ -469,9 +479,20 @@ impl SwarmCore {
         peer_id: &PeerId,
         stream_id: StreamId,
     ) -> Result<(), SwarmError> {
-        if self.abandoned_streams.iter().any(|(conn_id, sid)| {
-            *sid == stream_id && self.conn_to_peer.get(conn_id) == Some(peer_id)
-        }) {
+        if let Some(key) = self
+            .abandoned_streams
+            .iter()
+            .find(|(conn_id, sid)| {
+                *sid == stream_id && self.conn_to_peer.get(conn_id) == Some(peer_id)
+            })
+            .copied()
+        {
+            if self.reset_pending.insert(key) {
+                self.actions.push_back(SwarmAction::ResetStream {
+                    conn_id: key.0,
+                    stream_id: key.1,
+                });
+            }
             self.events
                 .retain(|event| !stream_event_matches(event, peer_id, stream_id));
             return Ok(());
@@ -1907,6 +1928,42 @@ mod tests {
         );
         assert!(drain_events(&mut core).is_empty());
         assert!(!core.abandoned_streams.contains(&(conn, stream)));
+    }
+
+    #[test]
+    fn failed_reset_can_be_retried_before_and_after_abandonment() {
+        let mut core = test_core();
+        let peer = PeerId::from_public_key_protobuf(b"reset-retry-peer");
+        let conn = ConnectionId::new(45);
+        let stream = StreamId::new(10);
+        core.conn_to_peer.insert(conn, peer.clone());
+        core.peer_to_conn.insert(peer.clone(), conn);
+        core.stream_owner
+            .insert((conn, stream), ProtocolKind::User("/test/1".into()));
+
+        core.reset_stream(&peer, stream).unwrap();
+        assert!(matches!(
+            core.poll_output(),
+            Some(SwarmOutput::Action(SwarmAction::ResetStream { .. }))
+        ));
+        core.reset_stream_failed(conn, stream);
+        core.reset_stream(&peer, stream).unwrap();
+        assert!(matches!(
+            core.poll_output(),
+            Some(SwarmOutput::Action(SwarmAction::ResetStream { .. }))
+        ));
+        core.reset_stream_failed(conn, stream);
+        core.abandon_stream(&peer, stream).unwrap();
+        assert!(matches!(
+            core.poll_output(),
+            Some(SwarmOutput::Action(SwarmAction::ResetStream { .. }))
+        ));
+        core.reset_stream_failed(conn, stream);
+        core.abandon_stream(&peer, stream).unwrap();
+        assert!(matches!(
+            core.poll_output(),
+            Some(SwarmOutput::Action(SwarmAction::ResetStream { .. }))
+        ));
     }
 
     #[test]

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -13,7 +13,7 @@ use minip2p_identify::{IdentifyConfig, IdentifyMessage};
 use minip2p_ping::{PING_PAYLOAD_LEN, PingConfig};
 use minip2p_transport::{ConnectionId, StreamId, Transport, TransportError, WaitOutcome};
 
-use crate::core::SwarmCore;
+use crate::core::{SwarmCore, stream_event_matches};
 use crate::events::{
     SwarmAction, SwarmError, SwarmErrorKind, SwarmEvent, SwarmInput, SwarmOutput, SwarmRuntimeError,
 };
@@ -532,16 +532,8 @@ impl<T: Transport> Swarm<T> {
         stream_id: StreamId,
     ) -> Result<(), DriverError> {
         self.core.abandon_stream(peer_id, stream_id)?;
-        self.event_buffer.retain(|event| {
-            !matches!(
-                event,
-                SwarmEvent::StreamReady { peer_id: peer, stream_id: stream, .. }
-                    | SwarmEvent::StreamData { peer_id: peer, stream_id: stream, .. }
-                    | SwarmEvent::StreamRemoteWriteClosed { peer_id: peer, stream_id: stream }
-                    | SwarmEvent::StreamClosed { peer_id: peer, stream_id: stream }
-                    if peer == peer_id && *stream == stream_id
-            )
-        });
+        self.event_buffer
+            .retain(|event| !stream_event_matches(event, peer_id, stream_id));
         self.flush_actions();
         Ok(())
     }
@@ -846,6 +838,7 @@ impl<T: Transport> Swarm<T> {
             }
             SwarmAction::ResetStream { conn_id, stream_id } => {
                 if let Err(e) = self.transport.reset_stream(conn_id, stream_id) {
+                    self.core.reset_stream_failed(conn_id, stream_id);
                     self.core.handle_input(SwarmInput::RuntimeError(runtime_error(
                         SwarmErrorKind::Transport,
                         Some(conn_id),
@@ -1336,6 +1329,7 @@ mod tests {
         next_stream: u64,
         user_protocol: String,
         failing_stream: Option<StreamId>,
+        reset_calls: usize,
     }
 
     impl FailingSendTransport {
@@ -1350,6 +1344,7 @@ mod tests {
                 next_stream: 1,
                 user_protocol: user_protocol.to_string(),
                 failing_stream: None,
+                reset_calls: 0,
             }
         }
     }
@@ -1432,7 +1427,10 @@ mod tests {
         }
 
         fn reset_stream(&mut self, _: ConnectionId, _: StreamId) -> Result<(), TransportError> {
-            Ok(())
+            self.reset_calls += 1;
+            Err(TransportError::ResourceExhausted {
+                resource: "test reset capacity",
+            })
         }
 
         fn close(&mut self, _: ConnectionId) -> Result<(), TransportError> {
@@ -1444,18 +1442,16 @@ mod tests {
         }
     }
 
-    #[test]
-    fn send_stream_transport_failure_is_a_synchronous_error() {
-        const PROTOCOL: &str = "/test/1.0.0";
+    fn ready_user_swarm(protocol: &str) -> (Swarm<FailingSendTransport>, PeerId, StreamId) {
         let remote_peer = Ed25519Keypair::generate().peer_id();
         let keypair = Ed25519Keypair::generate();
         let identify = IdentifyConfig {
             protocol_version: "test/1".into(),
             agent_version: "test/1".into(),
-            protocols: vec![PROTOCOL.into()],
+            protocols: vec![protocol.into()],
             public_key: keypair.public_key().encode_protobuf(),
         };
-        let transport = FailingSendTransport::connected(remote_peer.clone(), PROTOCOL);
+        let transport = FailingSendTransport::connected(remote_peer.clone(), protocol);
         let mut swarm = Swarm::new(
             transport,
             identify,
@@ -1463,12 +1459,12 @@ mod tests {
             keypair.peer_id(),
         );
         swarm
-            .add_protocol(PROTOCOL)
+            .add_protocol(protocol)
             .expect("test protocol id is not reserved");
         swarm.poll().expect("process connected event");
 
         let stream_id = swarm
-            .open_stream(&remote_peer, PROTOCOL)
+            .open_stream(&remote_peer, protocol)
             .expect("open user stream");
         let mut ready = false;
         for _ in 0..5 {
@@ -1486,6 +1482,13 @@ mod tests {
             }
         }
         assert!(ready, "user stream must finish multistream negotiation");
+        (swarm, remote_peer, stream_id)
+    }
+
+    #[test]
+    fn send_stream_transport_failure_is_a_synchronous_error() {
+        const PROTOCOL: &str = "/test/1.0.0";
+        let (mut swarm, remote_peer, stream_id) = ready_user_swarm(PROTOCOL);
 
         // The transport rejects the payload write. Callers that commit
         // state once a stream closes (the pubsub one-shot sender) must see
@@ -1509,6 +1512,21 @@ mod tests {
             )),
             "synchronous Err must suppress the duplicate buffered event"
         );
+    }
+
+    #[test]
+    fn transport_reset_failure_remains_retryable() {
+        const PROTOCOL: &str = "/test/1.0.0";
+        let (mut swarm, remote_peer, stream_id) = ready_user_swarm(PROTOCOL);
+
+        swarm
+            .reset_stream(&remote_peer, stream_id)
+            .expect("reset dispatch is asynchronous");
+        swarm
+            .reset_stream(&remote_peer, stream_id)
+            .expect("failed reset must remain retryable");
+
+        assert_eq!(swarm.transport().reset_calls, 2);
     }
 
     /// A `StreamData` event whose stream id encodes its position, so tests

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -522,6 +522,30 @@ impl<T: Transport> Swarm<T> {
         Ok(())
     }
 
+    /// Resets and forgets a stream whose consumer will never read it again.
+    ///
+    /// This is idempotent with a previously queued reset and removes matching
+    /// events already buffered by both the Sans-I/O core and this driver.
+    pub fn abandon_stream(
+        &mut self,
+        peer_id: &PeerId,
+        stream_id: StreamId,
+    ) -> Result<(), DriverError> {
+        self.core.abandon_stream(peer_id, stream_id)?;
+        self.event_buffer.retain(|event| {
+            !matches!(
+                event,
+                SwarmEvent::StreamReady { peer_id: peer, stream_id: stream, .. }
+                    | SwarmEvent::StreamData { peer_id: peer, stream_id: stream, .. }
+                    | SwarmEvent::StreamRemoteWriteClosed { peer_id: peer, stream_id: stream }
+                    | SwarmEvent::StreamClosed { peer_id: peer, stream_id: stream }
+                    if peer == peer_id && *stream == stream_id
+            )
+        });
+        self.flush_actions();
+        Ok(())
+    }
+
     /// Drive the swarm: poll transport, feed events to core, dispatch
     /// actions, return application-visible events. Must be called repeatedly.
     ///

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -531,9 +531,10 @@ impl<T: Transport> Swarm<T> {
         peer_id: &PeerId,
         stream_id: StreamId,
     ) -> Result<(), DriverError> {
-        self.core.abandon_stream(peer_id, stream_id)?;
+        let result = self.core.abandon_stream(peer_id, stream_id);
         self.event_buffer
             .retain(|event| !stream_event_matches(event, peer_id, stream_id));
+        result?;
         self.flush_actions();
         Ok(())
     }

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -13,5 +13,5 @@ name = "minip2p-chat"
 path = "src/main.rs"
 
 [dependencies]
-minip2p = { path = "../../crates/minip2p", features = ["nat", "pubsub"] }
+minip2p = { path = "../../crates/minip2p", features = ["discovery"] }
 minip2p-example-common = { path = "../common" }

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -6,11 +6,13 @@ agent hole-punches direct paths where needed, and messages flood the room
 signed end-to-end (libp2p StrictSign).
 
 ```text
-minip2p-chat host        [--topic <t>] [--nick <n>] [--relay <relay-peer-addr>] [--key <path>] [--listen <quic-multiaddr>]
-minip2p-chat join <addr> [--topic <t>] [--nick <n>] [--relay <peer-addr>] [--key <path>] [--listen <quic-multiaddr>]
+minip2p-chat host        [--topic <t>] [--nick <n>] [--relay <relay-peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
+minip2p-chat join <addr> [--topic <t>] [--nick <n>] [--relay <peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
 ```
 
-Type lines on stdin to chat; Ctrl-D leaves.
+Type lines on stdin to chat; Ctrl-D leaves. By default peers advertise addresses
+on a room-scoped discovery topic and form direct leaf-to-leaf mesh edges. Pass
+`--no-mesh` in either mode to preserve the original host-forwarded star.
 
 ## Quickstart (one machine)
 
@@ -27,10 +29,17 @@ $ cargo run -p minip2p-chat -- join /ip4/127.0.0.1/udp/54321/quic-v1/p2p/12D3Koo
 $ cargo run -p minip2p-chat -- join /ip4/127.0.0.1/udp/54321/quic-v1/p2p/12D3KooW… --nick bob
 ```
 
-Lines typed by alice appear at the host and at bob — bob receives them
-*through* the host (floodsub star forwarding); alice sees her own line as a
+Lines typed by alice appear at the host and at bob. Once discovery settles,
+alice and bob have their own direct edge and keep chatting if the host exits;
+alice sees her own line as a
 local `[you]` echo only (no self-delivery). This is exactly what the CI
 e2e test (`tests/chat.rs`) runs.
+
+Discovery filters wildcard listen addresses. For a relay-free mesh, bind an
+explicitly dialable address such as `--listen /ip4/127.0.0.1/udp/0/quic-v1`
+for local testing (or a real interface address across machines). A node with
+only wildcard binds and no AutoNAT-confirmed or relay circuit address can be
+present in the room but cannot be automatically dialed.
 
 ## NAT'd host (relay + hole punch)
 

--- a/examples/chat/src/cli.rs
+++ b/examples/chat/src/cli.rs
@@ -3,8 +3,8 @@
 //! The grammar is:
 //!
 //! ```text
-//! minip2p-chat host        [--topic <t>] [--nick <n>] [--relay <relay-peer-addr>] [--key <path>] [--listen <quic-multiaddr>]
-//! minip2p-chat join <addr> [--topic <t>] [--nick <n>] [--relay <peer-addr>] [--key <path>] [--listen <quic-multiaddr>]
+//! minip2p-chat host        [--topic <t>] [--nick <n>] [--relay <relay-peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
+//! minip2p-chat join <addr> [--topic <t>] [--nick <n>] [--relay <peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
 //! ```
 //!
 //! `<addr>` is either the host's printed `bound=` peer-addr, or its
@@ -58,6 +58,8 @@ pub struct ChatOptions {
     /// Accept unsigned messages (rust-libp2p floodsub interop; its
     /// floodsub does not sign). Signed messages are still verified.
     pub allow_unsigned: bool,
+    /// Disable peer discovery and preserve the host-forwarded star topology.
+    pub no_mesh: bool,
 }
 
 /// Parse error surfaced back to `main` so the binary exits with a readable
@@ -103,7 +105,7 @@ fn parse_join(args: Vec<String>) -> Result<Mode, CliError> {
     let mut i = 0;
     while i < args.len() {
         let arg = &args[i];
-        if arg == "--allow-unsigned" {
+        if arg == "--allow-unsigned" || arg == "--no-mesh" {
             // Boolean flag: no value follows.
             rest.push(arg.clone());
             i += 1;
@@ -190,6 +192,14 @@ impl Flags {
             match key.as_str() {
                 "--allow-unsigned" => {
                     chat.allow_unsigned = true;
+                    i += 1;
+                    continue;
+                }
+                "--no-mesh" => {
+                    if chat.no_mesh {
+                        return Err(CliError("--no-mesh specified twice".into()));
+                    }
+                    chat.no_mesh = true;
                     i += 1;
                     continue;
                 }
@@ -285,8 +295,8 @@ pub fn usage() -> String {
     "minip2p-chat -- group chat over floodsub with NAT traversal.
 
 USAGE:
-    minip2p-chat host        [--topic <t>] [--nick <n>] [--relay <relay-peer-addr>] [--key <path>] [--listen <quic-multiaddr>]
-    minip2p-chat join <addr> [--topic <t>] [--nick <n>] [--relay <peer-addr>] [--key <path>] [--listen <quic-multiaddr>]
+    minip2p-chat host        [--topic <t>] [--nick <n>] [--relay <relay-peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
+    minip2p-chat join <addr> [--topic <t>] [--nick <n>] [--relay <peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
 
 NOTES:
     <addr>    the host's printed `bound=` peer-addr, or its `circuit=`
@@ -301,6 +311,7 @@ NOTES:
     --allow-unsigned
               accept unsigned messages (rust-libp2p floodsub interop;
               signed messages are still verified)
+    --no-mesh preserve the host-forwarded star by disabling peer discovery
 
     Type lines on stdin to chat; EOF (Ctrl-D) exits.
 
@@ -356,5 +367,26 @@ mod tests {
         for raw in cases {
             assert!(parse_join_target(raw).is_err(), "'{raw}' must be rejected");
         }
+    }
+
+    #[test]
+    fn no_mesh_is_boolean_in_every_join_position_and_rejects_duplicates() {
+        let target = format!("{RELAY}/p2p/{PEER_ID}");
+        for args in [
+            vec!["join", "--no-mesh", target.as_str()],
+            vec!["join", target.as_str(), "--no-mesh"],
+            vec!["join", "--allow-unsigned", target.as_str(), "--no-mesh"],
+        ] {
+            let parsed = parse(args.into_iter().map(str::to_string).collect()).unwrap();
+            let Mode::Join { chat, .. } = parsed else {
+                panic!()
+            };
+            assert!(chat.no_mesh);
+        }
+        let duplicate = vec!["host", "--no-mesh", "--no-mesh"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        assert!(parse(duplicate).is_err());
     }
 }

--- a/examples/chat/src/modes.rs
+++ b/examples/chat/src/modes.rs
@@ -341,7 +341,7 @@ fn run_chat(
             .map(|(key, _)| key.clone())
             .collect();
         for (relay_peer, stream_id) in expired {
-            let _ = endpoint.reset_stream(&relay_peer, stream_id);
+            let _ = endpoint.abandon_stream(&relay_peer, stream_id);
             responder_bridges.remove(&(relay_peer, stream_id));
         }
         if last_keepalive.elapsed() >= KEEPALIVE_INTERVAL {
@@ -381,7 +381,7 @@ fn run_chat(
             match &event {
                 Event::ConnectionEstablished { peer_id } => {
                     println!("[{role}] connected peer={peer_id}");
-                    reset_responder_bridges(endpoint, &mut responder_bridges, peer_id);
+                    abandon_responder_bridges(endpoint, &mut responder_bridges, peer_id);
                 }
                 Event::ConnectionClosed { peer_id } => {
                     println!("[{role}] disconnected peer={peer_id}");
@@ -436,7 +436,7 @@ fn run_chat(
                     );
                 }
                 NatEvent::InboundDirectUpgrade { peer } => {
-                    reset_responder_bridges(endpoint, &mut responder_bridges, peer);
+                    abandon_responder_bridges(endpoint, &mut responder_bridges, peer);
                 }
                 _ => {}
             }
@@ -490,7 +490,7 @@ fn run_chat(
     }
 }
 
-fn reset_responder_bridges(
+fn abandon_responder_bridges(
     endpoint: &mut Endpoint,
     bridges: &mut BTreeMap<(PeerId, StreamId), ResponderBridge>,
     target: &PeerId,
@@ -501,7 +501,7 @@ fn reset_responder_bridges(
         .map(|(key, _)| key.clone())
         .collect();
     for (relay, stream_id) in matches {
-        let _ = endpoint.reset_stream(&relay, stream_id);
+        let _ = endpoint.abandon_stream(&relay, stream_id);
         bridges.remove(&(relay, stream_id));
     }
 }

--- a/examples/chat/src/modes.rs
+++ b/examples/chat/src/modes.rs
@@ -35,15 +35,21 @@ struct ResponderBridge {
     cleanup_deadline: Instant,
 }
 
+struct ChatEndpoint {
+    endpoint: Endpoint,
+    responder_bridge_lifetime: Duration,
+}
+
 // --- endpoint construction --------------------------------------------------
 
 fn build_endpoint(
     role: &str,
     relays: &[PeerAddr],
     options: &ChatOptions,
-) -> Result<Endpoint, Box<dyn Error>> {
+) -> Result<ChatEndpoint, Box<dyn Error>> {
     let keypair = load_keypair(options.key_path.as_deref(), role)?;
     let nat_config = NatConfig::default();
+    let responder_bridge_lifetime = responder_bridge_lifetime(&nat_config);
     let mut builder = Endpoint::builder()
         .identity(keypair)
         .agent_version(AGENT)
@@ -67,14 +73,27 @@ fn build_endpoint(
     for relay in relays {
         builder = builder.relay(relay.clone());
     }
-    match &options.listen_addr {
+    let endpoint = match &options.listen_addr {
         Some(addr) => builder
             .bind_quic_multiaddr(addr)
-            .map_err(|e| format!("quic bind {addr}: {e}").into()),
+            .map_err(|e| format!("quic bind {addr}: {e}"))?,
         None => builder
             .bind_quic_dual_stack()
-            .map_err(|e| format!("quic dual-stack bind: {e}").into()),
-    }
+            .map_err(|e| format!("quic dual-stack bind: {e}"))?,
+    };
+    Ok(ChatEndpoint {
+        endpoint,
+        responder_bridge_lifetime,
+    })
+}
+
+fn responder_bridge_lifetime(config: &NatConfig) -> Duration {
+    Duration::from_millis(
+        config
+            .punch_deadline_ms
+            .saturating_mul(1 + u64::from(config.punch_max_retries))
+            .saturating_add(1_000),
+    )
 }
 
 fn topic_and_nick(options: &ChatOptions, endpoint: &Endpoint) -> (String, String) {
@@ -96,7 +115,10 @@ fn topic_and_nick(options: &ChatOptions, endpoint: &Endpoint) -> (String, String
 /// joiners use.
 pub fn run_host(relay: Option<PeerAddr>, options: ChatOptions) -> Result<(), Box<dyn Error>> {
     let relays: Vec<PeerAddr> = relay.into_iter().collect();
-    let mut endpoint = build_endpoint("host", &relays, &options)?;
+    let ChatEndpoint {
+        mut endpoint,
+        responder_bridge_lifetime,
+    } = build_endpoint("host", &relays, &options)?;
     let peer_addrs = endpoint
         .listen_all()
         .map_err(|e| format!("listen failed: {e}"))?;
@@ -123,7 +145,14 @@ pub fn run_host(relay: Option<PeerAddr>, options: ChatOptions) -> Result<(), Box
         .map_err(|e| format!("subscribe: {e}"))?;
     println!("[host] subscribed topic={topic} nick={nick}");
 
-    run_chat(&mut endpoint, &topic, &nick, "host", relays.first())
+    run_chat(
+        &mut endpoint,
+        &topic,
+        &nick,
+        "host",
+        relays.first(),
+        responder_bridge_lifetime,
+    )
 }
 
 /// Drives the endpoint until the relay reservation lands, printing the
@@ -170,7 +199,10 @@ pub fn run_join(
         relays.push(extra);
     }
 
-    let mut endpoint = build_endpoint("join", &relays, &options)?;
+    let ChatEndpoint {
+        mut endpoint,
+        responder_bridge_lifetime,
+    } = build_endpoint("join", &relays, &options)?;
     // Listening seeds the agent's bound addresses — the local half of the
     // DCUtR candidate set.
     endpoint
@@ -224,7 +256,14 @@ pub fn run_join(
         .map_err(|e| format!("subscribe: {e}"))?;
     println!("[join] subscribed topic={topic} nick={nick}");
 
-    run_chat(&mut endpoint, &topic, &nick, "join", None)
+    run_chat(
+        &mut endpoint,
+        &topic,
+        &nick,
+        "join",
+        None,
+        responder_bridge_lifetime,
+    )
 }
 
 fn wait_for_direct_upgrade(
@@ -278,6 +317,7 @@ fn run_chat(
     nick: &str,
     role: &str,
     relay: Option<&PeerAddr>,
+    responder_bridge_lifetime: Duration,
 ) -> Result<(), Box<dyn Error>> {
     let input = spawn_stdin_reader();
     eprintln!("[{role}] type to chat; Ctrl-D to leave");
@@ -292,11 +332,6 @@ fn run_chat(
     // every connected peer well inside that window.
     const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
     let mut last_keepalive = Instant::now();
-    let nat_defaults = NatConfig::default();
-    let bridge_lifetime_ms = nat_defaults
-        .punch_deadline_ms
-        .saturating_mul(1 + u64::from(nat_defaults.punch_max_retries))
-        .saturating_add(1_000);
     let mut responder_bridges: BTreeMap<(PeerId, StreamId), ResponderBridge> = BTreeMap::new();
 
     loop {
@@ -396,8 +431,7 @@ fn run_chat(
                         (relay.clone(), *stream_id),
                         ResponderBridge {
                             target_peer: peer.clone(),
-                            cleanup_deadline: Instant::now()
-                                + Duration::from_millis(bridge_lifetime_ms),
+                            cleanup_deadline: Instant::now() + responder_bridge_lifetime,
                         },
                     );
                 }
@@ -474,4 +508,23 @@ fn reset_responder_bridges(
 
 fn short(peer: &PeerId) -> String {
     peer.to_base58().chars().take(8).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn responder_bridge_lifetime_comes_from_the_endpoint_nat_config() {
+        let config = NatConfig {
+            punch_deadline_ms: 7,
+            punch_max_retries: 4,
+            ..NatConfig::default()
+        };
+
+        assert_eq!(
+            responder_bridge_lifetime(&config),
+            Duration::from_millis(1_035)
+        );
+    }
 }

--- a/examples/chat/src/modes.rs
+++ b/examples/chat/src/modes.rs
@@ -1,6 +1,7 @@
 //! The chat runner: endpoint construction, host/join startup flows, and
 //! the shared stdin-driven chat loop.
 
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::io::BufRead;
 use std::sync::mpsc;
@@ -8,8 +9,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use minip2p::{
-    Endpoint, Event, FloodsubConfig, NatConfig, NatEvent, Path, PeerAddr, PeerId, PublishError,
-    PubsubError, PubsubEvent,
+    DISCOVERY_TOPIC, DiscoveryConfig, DiscoveryEvent, Endpoint, Event, FloodsubConfig, NatConfig,
+    NatEvent, Path, PeerAddr, PeerId, PublishError, PubsubError, PubsubEvent, StreamId,
 };
 
 use minip2p_example_common::{
@@ -29,6 +30,11 @@ const PUNCH_WAIT: Duration = Duration::from_secs(30);
 /// Identify must complete before floodsub can open streams.
 const READY_DEADLINE: Duration = Duration::from_secs(15);
 
+struct ResponderBridge {
+    target_peer: PeerId,
+    cleanup_deadline: Instant,
+}
+
 // --- endpoint construction --------------------------------------------------
 
 fn build_endpoint(
@@ -37,6 +43,7 @@ fn build_endpoint(
     options: &ChatOptions,
 ) -> Result<Endpoint, Box<dyn Error>> {
     let keypair = load_keypair(options.key_path.as_deref(), role)?;
+    let nat_config = NatConfig::default();
     let mut builder = Endpoint::builder()
         .identity(keypair)
         .agent_version(AGENT)
@@ -44,7 +51,19 @@ fn build_endpoint(
             allow_unsigned: options.allow_unsigned,
             ..FloodsubConfig::default()
         })
-        .nat_config(NatConfig::default());
+        .nat_config(nat_config);
+    if !options.no_mesh {
+        let room = options
+            .topic
+            .clone()
+            .unwrap_or_else(|| DEFAULT_TOPIC.to_string());
+        builder = builder.discovery_config(DiscoveryConfig {
+            topic: format!("{room}/{DISCOVERY_TOPIC}"),
+            beacon_interval_ms: 2_000,
+            peer_ttl_ms: 10_000,
+            ..DiscoveryConfig::default()
+        })?;
+    }
     for relay in relays {
         builder = builder.relay(relay.clone());
     }
@@ -273,8 +292,23 @@ fn run_chat(
     // every connected peer well inside that window.
     const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
     let mut last_keepalive = Instant::now();
+    let nat_defaults = NatConfig::default();
+    let bridge_lifetime_ms = nat_defaults
+        .punch_deadline_ms
+        .saturating_mul(1 + u64::from(nat_defaults.punch_max_retries))
+        .saturating_add(1_000);
+    let mut responder_bridges: BTreeMap<(PeerId, StreamId), ResponderBridge> = BTreeMap::new();
 
     loop {
+        let expired: Vec<_> = responder_bridges
+            .iter()
+            .filter(|(_, bridge)| Instant::now() >= bridge.cleanup_deadline)
+            .map(|(key, _)| key.clone())
+            .collect();
+        for (relay_peer, stream_id) in expired {
+            let _ = endpoint.reset_stream(&relay_peer, stream_id);
+            responder_bridges.remove(&(relay_peer, stream_id));
+        }
         if last_keepalive.elapsed() >= KEEPALIVE_INTERVAL {
             last_keepalive = Instant::now();
             for peer in endpoint.connected_peers() {
@@ -312,9 +346,11 @@ fn run_chat(
             match &event {
                 Event::ConnectionEstablished { peer_id } => {
                     println!("[{role}] connected peer={peer_id}");
+                    reset_responder_bridges(endpoint, &mut responder_bridges, peer_id);
                 }
                 Event::ConnectionClosed { peer_id } => {
                     println!("[{role}] disconnected peer={peer_id}");
+                    responder_bridges.retain(|(relay_peer, _), _| relay_peer != peer_id);
                 }
                 Event::Error(error) => {
                     eprintln!("[{role}] error {:?}: {}", error.kind, error.detail);
@@ -349,6 +385,27 @@ fn run_chat(
 
         for event in endpoint.take_nat_events() {
             print_nat_event(role, &event);
+            match &event {
+                NatEvent::InboundRelayCircuit {
+                    peer,
+                    relay,
+                    stream_id,
+                    ..
+                } => {
+                    responder_bridges.insert(
+                        (relay.clone(), *stream_id),
+                        ResponderBridge {
+                            target_peer: peer.clone(),
+                            cleanup_deadline: Instant::now()
+                                + Duration::from_millis(bridge_lifetime_ms),
+                        },
+                    );
+                }
+                NatEvent::InboundDirectUpgrade { peer } => {
+                    reset_responder_bridges(endpoint, &mut responder_bridges, peer);
+                }
+                _ => {}
+            }
             // A reservation that lands late (after the startup wait warned)
             // or is re-acquired after a loss still needs its circuit
             // address printed -- joiners have nothing to paste otherwise.
@@ -362,6 +419,56 @@ fn run_chat(
                 );
             }
         }
+
+        for event in endpoint.take_discovery_events() {
+            match event {
+                DiscoveryEvent::PeerDiscovered { peer, addrs } => {
+                    println!(
+                        "[{role}] discovered peer={} addrs={}",
+                        short(&peer),
+                        addrs.len()
+                    );
+                }
+                DiscoveryEvent::PeerUpdated { peer, addrs } => {
+                    println!(
+                        "[{role}] mesh-updated peer={} addrs={}",
+                        short(&peer),
+                        addrs.len()
+                    );
+                }
+                DiscoveryEvent::PeerExpired { peer } => {
+                    println!("[{role}] peer-expired peer={}", short(&peer));
+                }
+                DiscoveryEvent::DialFailed { peer, reason } => {
+                    eprintln!(
+                        "[{role}] mesh-dial-failed peer={} reason={reason}",
+                        short(&peer)
+                    );
+                }
+                DiscoveryEvent::ProtocolViolation { peer, reason } => {
+                    eprintln!(
+                        "[{role}] discovery-violation peer={} reason={reason}",
+                        short(&peer)
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn reset_responder_bridges(
+    endpoint: &mut Endpoint,
+    bridges: &mut BTreeMap<(PeerId, StreamId), ResponderBridge>,
+    target: &PeerId,
+) {
+    let matches: Vec<_> = bridges
+        .iter()
+        .filter(|(_, bridge)| &bridge.target_peer == target)
+        .map(|(key, _)| key.clone())
+        .collect();
+    for (relay, stream_id) in matches {
+        let _ = endpoint.reset_stream(&relay, stream_id);
+        bridges.remove(&(relay, stream_id));
     }
 }
 

--- a/examples/chat/tests/chat.rs
+++ b/examples/chat/tests/chat.rs
@@ -136,6 +136,12 @@ impl Peer {
         writeln!(stdin, "{text}").expect("write to child stdin");
     }
 
+    fn kill(&mut self) {
+        drop(self.stdin.take());
+        self.child.0.kill().expect("kill child");
+        let _ = self.child.0.wait();
+    }
+
     /// Closes stdin (EOF) and waits for a clean exit.
     fn leave(mut self, deadline: Instant) {
         drop(self.stdin.take());
@@ -169,13 +175,13 @@ fn three_peer_star_chats_end_to_end() {
     let deadline = Instant::now() + TEST_DEADLINE;
 
     // --- 1. Host binds and prints its join address. ---
-    let host = Peer::spawn("host", &["host", "--nick", "hostess"]);
+    let host = Peer::spawn("host", &["host", "--nick", "hostess", "--no-mesh"]);
     let bound = host.wait_line(deadline, |line| line.starts_with("[host] bound="));
     let addr = bound.trim_start_matches("[host] bound=").to_string();
 
     // --- 2. Two joiners dial the host; nobody knows anybody else. ---
-    let mut alice = Peer::spawn("alice", &["join", &addr, "--nick", "alice"]);
-    let mut bob = Peer::spawn("bob", &["join", &addr, "--nick", "bob"]);
+    let mut alice = Peer::spawn("alice", &["join", &addr, "--nick", "alice", "--no-mesh"]);
+    let mut bob = Peer::spawn("bob", &["join", &addr, "--nick", "bob", "--no-mesh"]);
 
     // --- 3. Subscription handshakes settle (floodsub has no history:
     //        publishing earlier would vanish). ---
@@ -214,4 +220,57 @@ fn three_peer_star_chats_end_to_end() {
     alice.leave(deadline);
     bob.leave(deadline);
     host.leave(deadline);
+}
+
+#[test]
+fn three_peer_mesh_survives_host_death() {
+    let deadline = Instant::now() + Duration::from_secs(45);
+    let listen = "/ip4/127.0.0.1/udp/0/quic-v1";
+    let mut host = Peer::spawn("host", &["host", "--nick", "hostess", "--listen", listen]);
+    let addr = host
+        .wait_line(deadline, |line| line.starts_with("[host] bound="))
+        .trim_start_matches("[host] bound=")
+        .to_string();
+
+    let mut alice = Peer::spawn(
+        "alice",
+        &["join", &addr, "--nick", "alice", "--listen", listen],
+    );
+    let mut bob = Peer::spawn("bob", &["join", &addr, "--nick", "bob", "--listen", listen]);
+    let alice_id = alice
+        .wait_line(deadline, |line| line.starts_with("[join] us="))
+        .trim_start_matches("[join] us=")
+        .to_string();
+    let bob_id = bob
+        .wait_line(deadline, |line| line.starts_with("[join] us="))
+        .trim_start_matches("[join] us=")
+        .to_string();
+
+    alice.wait_line(deadline, |line| {
+        line.contains("connected peer=") && line.contains(&bob_id)
+    });
+    bob.wait_line(deadline, |line| {
+        line.contains("connected peer=") && line.contains(&alice_id)
+    });
+    alice.wait_line(deadline, |line| {
+        line.contains("peer-subscribed") && line.contains(&bob_id) && line.contains("minip2p-chat")
+    });
+    bob.wait_line(deadline, |line| {
+        line.contains("peer-subscribed")
+            && line.contains(&alice_id)
+            && line.contains("minip2p-chat")
+    });
+
+    host.kill();
+    alice.say("still here");
+    bob.wait_line(deadline, |line| line.contains("alice: still here"));
+    assert_eq!(
+        bob.count_lines(|line| line.contains("alice: still here")),
+        1
+    );
+    bob.say("mesh lives");
+    alice.wait_line(deadline, |line| line.contains("bob: mesh lives"));
+
+    alice.leave(deadline);
+    bob.leave(deadline);
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -141,6 +141,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minip2p-discovery"
+version = "0.1.0"
+dependencies = [
+ "minip2p-core",
+ "minip2p-identity",
+ "thiserror",
+]
+
+[[package]]
 name = "minip2p-fuzz"
 version = "0.0.0"
 dependencies = [
@@ -148,7 +157,9 @@ dependencies = [
  "minip2p-autonat",
  "minip2p-core",
  "minip2p-dcutr",
+ "minip2p-discovery",
  "minip2p-identify",
+ "minip2p-identity",
  "minip2p-multistream-select",
  "minip2p-relay",
  "minip2p-transport",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,6 +17,8 @@ libfuzzer-sys = "0.4.13"
 minip2p-autonat = { path = "../crates/autonat" }
 minip2p-core = { path = "../crates/core" }
 minip2p-dcutr = { path = "../crates/dcutr" }
+minip2p-discovery = { path = "../crates/discovery", default-features = false }
+minip2p-identity = { path = "../crates/identity", default-features = false }
 minip2p-identify = { path = "../crates/identify" }
 minip2p-multistream-select = { path = "../crates/multistream-select" }
 minip2p-relay = { path = "../crates/relay" }

--- a/fuzz/fuzz_targets/wire_inputs.rs
+++ b/fuzz/fuzz_targets/wire_inputs.rs
@@ -4,7 +4,9 @@ use libfuzzer_sys::fuzz_target;
 use minip2p_autonat::{AutoNatClient, AutoNatClientInput, AutoNatServer, AutoNatServerInput};
 use minip2p_core::{Multiaddr, PeerId, SansIoProtocol};
 use minip2p_dcutr::{FrameDecode as DcutrFrame, HolePunch};
+use minip2p_discovery::{Beacon, DiscoveryAgent, DiscoveryConfig};
 use minip2p_identify::{IdentifyConfig, IdentifyInput, IdentifyMessage, IdentifyProtocol};
+use minip2p_identity::{KeyType, PublicKey};
 use minip2p_multistream_select::{MultistreamInput, MultistreamSelect};
 use minip2p_relay::{FrameDecode as RelayFrame, HopMessage, StopMessage};
 use minip2p_transport::StreamId;
@@ -18,6 +20,7 @@ fuzz_target!(|data: &[u8]| {
     fuzz_multistream(data);
     fuzz_identify(data);
     fuzz_autonat(data);
+    fuzz_discovery(data);
 
     if let RelayFrame::Complete { payload, .. } = minip2p_relay::decode_frame(data) {
         let _ = HopMessage::decode(payload);
@@ -41,6 +44,21 @@ fn fuzz_multistream(data: &[u8]) {
         while machine.poll_output().is_some() {}
         let _ = machine.take_remaining_buffer();
     }
+}
+
+fn fuzz_discovery(data: &[u8]) {
+    let _ = Beacon::decode(data);
+    let local = PublicKey::new(KeyType::Ed25519, vec![1; 32]);
+    let remote = PublicKey::new(KeyType::Ed25519, vec![2; 32]);
+    let remote_peer = PeerId::from_public_key(&remote);
+    let config = DiscoveryConfig {
+        auto_dial: false,
+        ..DiscoveryConfig::default()
+    };
+    let mut agent = DiscoveryAgent::new(local, config).expect("default discovery config");
+    agent.handle_beacon(&remote_peer, data, true, 0);
+    while agent.poll_action().is_some() {}
+    while agent.poll_event().is_some() {}
 }
 
 /// Exercises both the raw message decoder and the state-machine path that

--- a/fuzz/fuzz_targets/wire_inputs.rs
+++ b/fuzz/fuzz_targets/wire_inputs.rs
@@ -57,6 +57,12 @@ fn fuzz_discovery(data: &[u8]) {
     };
     let mut agent = DiscoveryAgent::new(local, config).expect("default discovery config");
     agent.handle_beacon(&remote_peer, data, true, 0);
+    let authenticated = Beacon {
+        public_key: remote.encode_protobuf(),
+        addrs: vec![data.to_vec()],
+    }
+    .encode();
+    agent.handle_beacon(&remote_peer, &authenticated, true, 1);
     while agent.poll_action().is_some() {}
     while agent.poll_event().is_some() {}
 }

--- a/justfile
+++ b/justfile
@@ -11,6 +11,7 @@ check:
     cargo check -p minip2p --features nat
     cargo check -p minip2p --features pubsub
     cargo check -p minip2p --features nat,pubsub
+    cargo check -p minip2p --features discovery
 
 clippy:
     cargo clippy --workspace --all-targets -- -D warnings
@@ -21,16 +22,18 @@ test:
     cargo test -p minip2p --features nat
     cargo test -p minip2p --features pubsub
     cargo test -p minip2p --features nat,pubsub
+    cargo test -p minip2p --features discovery
 
 check-nostd:
     rustup target add thumbv7em-none-eabi
-    cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-pubsub -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm -p minip2p-nat
+    cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-pubsub -p minip2p-discovery -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm -p minip2p-nat
 
 peer-ping:
     cargo test -p minip2p-peer --test ping
 
 docs:
     cargo doc --workspace --no-deps
+    cargo doc -p minip2p --features nat,pubsub,discovery --no-deps
 
 bench:
     cargo bench -p minip2p-core --bench multiaddr


### PR DESCRIPTION
## Summary
- add a no-std pubsub peer-discovery codec and deterministic TTL address-book agent
- integrate authenticated beacons, automatic NAT dialing, bridge ownership, and clean stream abandonment into the Endpoint facade
- upgrade chat to form room-scoped meshes, support --no-mesh, and survive host loss
- extend CI, feature matrices, documentation, no-std validation, and fuzz coverage

## Verification
- cargo test --workspace
- cargo test -p minip2p across nat, pubsub, nat+pubsub, and discovery feature combinations
- cargo clippy for the workspace, fuzz workspace, and facade feature combinations with warnings denied
- thumbv7em-none-eabi no-std checks including minip2p-discovery
- workspace and feature-complete facade documentation builds
- three-peer mesh host-death integration test
- 30-second wire_inputs fuzz run: 1,060,959 executions, no crashes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `minip2p-discovery` for signed pubsub peer discovery with a TTL address book and automatic NAT-aware dialing, with stricter beacon address filtering. Integrates into the endpoint; chat forms room meshes with `--no-mesh` fallback, and CI/fuzz/no-std include discovery.

- **New Features**
  - `minip2p-discovery`: sans-I/O agent, js-libp2p-compatible beacon codec, bounded TTL address book, address-less presence refresh, normalized address filtering, and auto-dial with peer-id tie-break/backoff.
  - `minip2p` `discovery` feature: enable via `.discovery_config(...)`/`.discovery()`; authenticated beacons, NAT dialing/bridge ownership, `DiscoveryEvent`/`KnownPeer`; pubsub events expose a `signed` flag; discovery topic is reserved and unsubscribe returns `PubsubError::DiscoveryTopicReserved`.
  - Swarm: `abandon_stream` to reset, purge buffered stream events, and suppress later events.
  - Chat: discovery-driven room meshes that survive host loss; `--no-mesh` preserves the original star.

- **Migration**
  - Build `minip2p` with the `discovery` feature (implies `nat` and `pubsub`).
  - Use `.discovery_config(DiscoveryConfig)` or `.discovery()` to set topic/policy; default topic is `DISCOVERY_TOPIC`.
  - Discovery beacons must be signed; unsigned application pubsub messages can still be allowed but are rejected by discovery.
  - Unsubscribing the discovery topic while discovery is enabled returns `PubsubError::DiscoveryTopicReserved`.

<sup>Written for commit 4b849210354b9f60ad4c1a3cf74d92f3d5068086. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

