### PR TITLE
feat(circuit): add relayed transport wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - run: cargo clippy -p minip2p --features nat,pubsub --all-targets -- -D warnings
       - run: cargo clippy -p minip2p --features discovery --all-targets -- -D warnings
       - run: cargo clippy --manifest-path fuzz/Cargo.toml --all-targets -- -D warnings
-      - run: cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-noise -p minip2p-yamux -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-pubsub -p minip2p-discovery -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm -p minip2p-nat
+      - run: cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-noise -p minip2p-yamux -p minip2p-circuit -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-pubsub -p minip2p-discovery -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm -p minip2p-nat
       - run: cargo test --workspace
       - run: cargo test -p minip2p --features nat
       - run: cargo test -p minip2p --features pubsub

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "minip2p-circuit"
+version = "0.1.0"
+dependencies = [
+ "getrandom",
+ "minip2p-core",
+ "minip2p-identity",
+ "minip2p-multistream-select",
+ "minip2p-noise",
+ "minip2p-test-support",
+ "minip2p-transport",
+ "minip2p-yamux",
+ "thiserror",
+]
+
+[[package]]
 name = "minip2p-core"
 version = "0.1.0"
 dependencies = [
@@ -990,6 +1005,7 @@ version = "0.1.0"
 dependencies = [
  "minip2p-core",
  "minip2p-relay",
+ "minip2p-transport",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 exclude = ["fuzz"]
 members = [
     "crates/autonat",
+    "crates/circuit",
     "crates/core",
     "crates/dcutr",
     "crates/discovery",

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Sans-I/O protocol crates (`no_std + alloc`):
 - `crates/tls` (`minip2p-tls`): libp2p TLS certificate generation and peer verification.
 - `crates/noise` (`minip2p-noise`): Sans-I/O libp2p Noise XX security handshake and transport cipher.
 - `crates/yamux` (`minip2p-yamux`): bounded Sans-I/O libp2p Yamux stream multiplexer.
+- `crates/circuit` (`minip2p-circuit`): Sans-I/O transport wrapper that promotes relay bridge streams through Noise + Yamux into ordinary transport connections.
 - `crates/multistream-select` (`minip2p-multistream-select`): `/multistream/1.0.0` negotiation state machine.
 - `crates/ping` (`minip2p-ping`): `/ipfs/ping/1.0.0` state machine with RTT measurement.
 - `crates/identify` (`minip2p-identify`): `/ipfs/id/1.0.0` state machine for protocol and address exchange.

--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "minip2p-circuit"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[features]
+default = ["std"]
+std = [
+    "dep:getrandom",
+    "minip2p-core/std",
+    "minip2p-identity/std",
+    "minip2p-multistream-select/std",
+    "minip2p-noise/std",
+    "minip2p-transport/std",
+    "minip2p-yamux/std",
+    "thiserror/std",
+]
+
+[dependencies]
+getrandom = { version = "0.4.3", default-features = false, optional = true }
+minip2p-core = { path = "../core", default-features = false }
+minip2p-identity = { path = "../identity", default-features = false, features = ["ed25519"] }
+minip2p-multistream-select = { path = "../multistream-select", default-features = false }
+minip2p-noise = { path = "../noise", default-features = false }
+minip2p-transport = { path = "../transport", default-features = false }
+minip2p-yamux = { path = "../yamux", default-features = false }
+thiserror = { version = "2.0.18", default-features = false }
+
+[dev-dependencies]
+minip2p-test-support = { path = "../test-support" }

--- a/crates/circuit/README.md
+++ b/crates/circuit/README.md
@@ -1,0 +1,13 @@
+# minip2p-circuit
+
+`minip2p-circuit` turns an already-negotiated relay bridge stream into a
+regular minip2p `Transport` connection. It is fully Sans-I/O: multistream
+selection, Noise, and Yamux are driven over the bridge while the wrapped
+transport remains responsible for actual I/O.
+
+The wrapper assigns circuit connections IDs with the high bit set, leaving
+wrapped transport IDs unchanged. Callers adopt HOP/STOP bridge streams with
+`CircuitTransport::adopt_bridge` and then use the ordinary `Transport` API.
+
+Default features enable OS entropy. Disable default features for
+`no_std + alloc` and provide an `EntropySource` explicitly.

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -34,6 +34,11 @@ use thiserror::Error;
 /// Marker bit reserved for circuit connection identifiers.
 pub const CIRCUIT_ID_BIT: u64 = 1 << 63;
 
+// A retired bridge suppresses late inner-transport events after the circuit's
+// public `Closed`. Keep this finite because a peer may never finish closing
+// its half of a gracefully closed bridge.
+const MAX_RETIRED_BRIDGES: usize = 1024;
+
 fn is_circuit_id(id: ConnectionId) -> bool {
     id.as_u64() & CIRCUIT_ID_BIT != 0
 }
@@ -179,6 +184,7 @@ pub struct CircuitTransport<T, E> {
     circuits: BTreeMap<ConnectionId, Circuit>,
     bridge_index: BTreeMap<(ConnectionId, StreamId), ConnectionId>,
     retired_bridges: BTreeSet<(ConnectionId, StreamId)>,
+    retired_bridge_order: VecDeque<(ConnectionId, StreamId)>,
     active_inner: BTreeSet<ConnectionId>,
     direct_by_peer: BTreeMap<PeerId, BTreeSet<ConnectionId>>,
     direct_by_conn: BTreeMap<ConnectionId, PeerId>,
@@ -197,6 +203,7 @@ impl<T, E> CircuitTransport<T, E> {
             circuits: BTreeMap::new(),
             bridge_index: BTreeMap::new(),
             retired_bridges: BTreeSet::new(),
+            retired_bridge_order: VecDeque::new(),
             active_inner: BTreeSet::new(),
             direct_by_peer: BTreeMap::new(),
             direct_by_conn: BTreeMap::new(),
@@ -390,7 +397,7 @@ impl<T: Transport, E: EntropySource> CircuitTransport<T, E> {
     /// Reports that a bridge stream fully closed or reset.
     pub fn inject_bridge_closed(&mut self, inner_conn: ConnectionId, bridge_stream: StreamId) {
         let key = (inner_conn, bridge_stream);
-        self.retired_bridges.remove(&key);
+        self.release_retired_bridge(key);
         if let Some(id) = self.bridge_index.get(&key).copied() {
             let pre_ready = self.circuits.get(&id).is_some_and(|c| !c.is_ready());
             self.fail_circuit(id, "relay bridge closed".to_string(), pre_ready);
@@ -409,6 +416,30 @@ impl<T: Transport, E: EntropySource> CircuitTransport<T, E> {
         let result = operation(self, &mut circuit);
         self.circuits.insert(id, circuit);
         result
+    }
+
+    fn retire_bridge(&mut self, key: (ConnectionId, StreamId)) {
+        if !self.retired_bridges.insert(key) {
+            return;
+        }
+        self.retired_bridge_order.push_back(key);
+        if self.retired_bridge_order.len() > MAX_RETIRED_BRIDGES
+            && let Some(expired) = self.retired_bridge_order.pop_front()
+        {
+            self.retired_bridges.remove(&expired);
+        }
+    }
+
+    fn release_retired_bridge(&mut self, key: (ConnectionId, StreamId)) {
+        if self.retired_bridges.remove(&key) {
+            self.retired_bridge_order
+                .retain(|candidate| *candidate != key);
+        }
+    }
+
+    fn release_retired_bridges_for_connection(&mut self, id: ConnectionId) {
+        self.retired_bridges.retain(|(conn, _)| *conn != id);
+        self.retired_bridge_order.retain(|(conn, _)| *conn != id);
     }
 
     fn start_phase(&mut self, circuit: &Circuit, phase: Phase) -> Result<Phase, String> {
@@ -742,7 +773,7 @@ impl<T: Transport, E: EntropySource> CircuitTransport<T, E> {
         };
         let key = circuit.bridge_key();
         self.bridge_index.remove(&key);
-        self.retired_bridges.insert(key);
+        self.retire_bridge(key);
         let _ = self
             .inner
             .reset_stream(circuit.inner_conn, circuit.bridge_stream);
@@ -904,14 +935,17 @@ impl<T: Transport, E: EntropySource> CircuitTransport<T, E> {
                         .is_some_and(|circuit| !circuit.is_ready());
                     self.fail_circuit(circuit_id, "relay connection closed".to_string(), pre_ready);
                 }
-                self.retired_bridges.retain(|(conn, _)| *conn != id);
+                self.release_retired_bridges_for_connection(id);
                 self.pending.push_back(TransportEvent::Closed { id });
             }
             other => self.pending.push_back(other),
         }
     }
 
-    fn circuit_stream(id: ConnectionId, stream_id: StreamId) -> Result<u32, TransportError> {
+    fn circuit_stream(&self, id: ConnectionId, stream_id: StreamId) -> Result<u32, TransportError> {
+        if !self.circuits.contains_key(&id) {
+            return Err(TransportError::ConnectionNotFound { id });
+        }
         u32::try_from(stream_id.as_u64())
             .map_err(|_| TransportError::StreamNotFound { id, stream_id })
     }
@@ -957,7 +991,7 @@ impl<T: Transport, E: EntropySource> CircuitTransport<T, E> {
         stream_id: StreamId,
         data: Vec<u8>,
     ) -> Result<(), TransportError> {
-        let stream = Self::circuit_stream(id, stream_id)?;
+        let stream = self.circuit_stream(id, stream_id)?;
         let mut circuit = self
             .circuits
             .remove(&id)
@@ -1055,7 +1089,7 @@ impl<T: Transport, E: EntropySource> Transport for CircuitTransport<T, E> {
         if !is_circuit_id(id) {
             return self.inner.close_stream_write(id, stream_id);
         }
-        let stream = Self::circuit_stream(id, stream_id)?;
+        let stream = self.circuit_stream(id, stream_id)?;
         match self.operate_ready(id, |yamux| yamux.close_write(stream)) {
             Ok(()) => Ok(()),
             Err(error @ TransportError::ConnectionNotFound { .. })
@@ -1076,7 +1110,7 @@ impl<T: Transport, E: EntropySource> Transport for CircuitTransport<T, E> {
         if !is_circuit_id(id) {
             return self.inner.reset_stream(id, stream_id);
         }
-        let stream = Self::circuit_stream(id, stream_id)?;
+        let stream = self.circuit_stream(id, stream_id)?;
         match self.operate_ready(id, |yamux| yamux.reset(stream)) {
             Ok(()) => Ok(()),
             Err(error @ TransportError::ConnectionNotFound { .. })
@@ -1099,7 +1133,7 @@ impl<T: Transport, E: EntropySource> Transport for CircuitTransport<T, E> {
             .ok_or(TransportError::ConnectionNotFound { id })?;
         let key = circuit.bridge_key();
         self.bridge_index.remove(&key);
-        self.retired_bridges.insert(key);
+        self.retire_bridge(key);
         let ready = circuit.is_ready();
         let mut graceful = false;
         if let Some(Phase::Ready {
@@ -1653,6 +1687,26 @@ mod tests {
             })
         );
 
+        let oversized_stream = StreamId::new(u64::from(u32::MAX) + 1);
+        assert_eq!(
+            a.send_stream(unknown_connection, oversized_stream, vec![1]),
+            Err(TransportError::ConnectionNotFound {
+                id: unknown_connection,
+            })
+        );
+        assert_eq!(
+            a.close_stream_write(unknown_connection, oversized_stream),
+            Err(TransportError::ConnectionNotFound {
+                id: unknown_connection,
+            })
+        );
+        assert_eq!(
+            a.reset_stream(unknown_connection, oversized_stream),
+            Err(TransportError::ConnectionNotFound {
+                id: unknown_connection,
+            })
+        );
+
         assert!(matches!(
             a.send_stream(circuit_id, stream, vec![1]),
             Err(TransportError::StreamSendFailed { id, stream_id, .. })
@@ -2015,6 +2069,28 @@ mod tests {
             "unexpected peer close events: {peer_events:?}"
         );
         assert!(b.poll().expect("terminal peer state").is_empty());
+    }
+
+    #[test]
+    fn gracefully_closed_bridge_tombstones_are_bounded() {
+        let (mut a, mut b, circuit_id, bridge, a_peer, b_peer) = setup_close_observed_pair();
+        complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
+        let inner_conn = ConnectionId::new(1);
+
+        a.close(circuit_id).expect("graceful circuit close");
+        let _ = a.poll().expect("local close event");
+        assert!(a.retired_bridges.contains(&(inner_conn, bridge)));
+
+        for index in 0..MAX_RETIRED_BRIDGES {
+            a.retire_bridge((
+                inner_conn,
+                StreamId::new(10_000 + u64::try_from(index).expect("usize fits u64")),
+            ));
+        }
+
+        assert_eq!(a.retired_bridges.len(), MAX_RETIRED_BRIDGES);
+        assert_eq!(a.retired_bridge_order.len(), MAX_RETIRED_BRIDGES);
+        assert!(!a.retired_bridges.contains(&(inner_conn, bridge)));
     }
 
     #[test]

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -1,0 +1,2290 @@
+//! Relay-circuit transport built from an existing ordered bridge stream.
+//!
+//! The wrapper performs multistream-select, Noise XX, and Yamux without
+//! owning sockets, clocks, or an executor. Wrapped transport connection IDs
+//! pass through unchanged; circuit IDs have [`CIRCUIT_ID_BIT`] set.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![warn(missing_docs)]
+
+extern crate alloc;
+
+use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::time::Duration;
+
+use minip2p_core::{Multiaddr, Protocol, SansIoProtocol};
+use minip2p_identity::{Ed25519Keypair, PeerId};
+use minip2p_multistream_select::{MultistreamInput, MultistreamOutput, MultistreamSelect};
+use minip2p_noise::{
+    NOISE_PROTOCOL_ID, NoiseConfig, NoiseInput, NoiseOutput, NoiseRole, NoiseSession,
+};
+use minip2p_transport::{
+    ConnectionEndpoint, ConnectionId, StreamId, Transport, TransportError, TransportEvent,
+    WaitOutcome,
+};
+use minip2p_yamux::{
+    YAMUX_PROTOCOL_ID, YamuxConfig, YamuxError, YamuxInput, YamuxOutput, YamuxRole, YamuxSession,
+};
+use thiserror::Error;
+
+/// Marker bit reserved for circuit connection identifiers.
+pub const CIRCUIT_ID_BIT: u64 = 1 << 63;
+
+fn is_circuit_id(id: ConnectionId) -> bool {
+    id.as_u64() & CIRCUIT_ID_BIT != 0
+}
+
+/// Supplies fresh cryptographic entropy for one circuit adoption.
+pub trait EntropySource {
+    /// Fills `destination` with unpredictable bytes.
+    fn fill(&mut self, destination: &mut [u8]) -> Result<(), EntropyError>;
+}
+
+/// Failure to obtain cryptographic entropy.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+#[error("entropy source failed: {0}")]
+pub struct EntropyError(&'static str);
+
+impl EntropyError {
+    /// Creates an entropy failure with source-specific diagnostic context.
+    pub const fn new(message: &'static str) -> Self {
+        Self(message)
+    }
+}
+
+/// Entropy source backed by the operating system.
+#[cfg(feature = "std")]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OsEntropy;
+
+#[cfg(feature = "std")]
+impl EntropySource for OsEntropy {
+    fn fill(&mut self, destination: &mut [u8]) -> Result<(), EntropyError> {
+        getrandom::fill(destination).map_err(|_| EntropyError("OS randomness unavailable"))
+    }
+}
+
+/// Which endpoint initiated the relayed connection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CircuitRole {
+    /// Sent the relay HOP CONNECT request.
+    Initiator,
+    /// Accepted the relay STOP CONNECT request.
+    Responder,
+}
+
+/// Description of a relay stream that has become a transparent byte bridge.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BridgeAdoption {
+    /// Wrapped transport connection to the relay.
+    pub inner_conn: ConnectionId,
+    /// Stream carrying the relayed byte bridge.
+    pub bridge_stream: StreamId,
+    /// Relay peer used to form the circuit endpoint address.
+    pub relay: PeerId,
+    /// Expected peer at the other end of the bridge.
+    pub remote_peer: PeerId,
+    /// Local role in the end-to-end circuit handshake.
+    pub role: CircuitRole,
+    /// Bytes already read beyond the relay CONNECT response.
+    pub pending_data: Vec<u8>,
+    /// Whether the bridge's remote write side was already closed.
+    pub remote_write_closed: bool,
+}
+
+/// Synchronous errors from adopting a relay bridge.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum AdoptError {
+    /// The bridge is already adopted with different immutable metadata.
+    #[error("bridge is already adopted with conflicting parameters")]
+    ConflictingAdoption,
+    /// A verified direct connection to the peer already exists.
+    #[error("peer already has a direct connection")]
+    PeerAlreadyDirect,
+    /// The bridge cannot carry a handshake because its remote write side closed.
+    #[error("bridge remote write side is closed")]
+    RemoteWriteClosed,
+    /// The wrapped relay connection is not active.
+    #[error("wrapped relay connection is unknown")]
+    UnknownConnection,
+    /// Fresh Noise key material could not be generated.
+    #[error(transparent)]
+    Entropy(#[from] EntropyError),
+    /// All circuit connection identifiers have been allocated.
+    #[error("circuit connection IDs exhausted")]
+    IdsExhausted,
+}
+
+enum Phase {
+    SelectNoise {
+        select: MultistreamSelect,
+        noise: Option<NoiseSession>,
+    },
+    Noise {
+        noise: NoiseSession,
+    },
+    SelectYamux {
+        noise: NoiseSession,
+        select: MultistreamSelect,
+        peer: PeerId,
+    },
+    Ready {
+        noise: NoiseSession,
+        yamux: YamuxSession,
+        peer: PeerId,
+    },
+}
+
+struct Circuit {
+    id: ConnectionId,
+    inner_conn: ConnectionId,
+    bridge_stream: StreamId,
+    relay: PeerId,
+    remote_peer: PeerId,
+    role: CircuitRole,
+    phase: Option<Phase>,
+}
+
+impl Circuit {
+    fn bridge_key(&self) -> (ConnectionId, StreamId) {
+        (self.inner_conn, self.bridge_stream)
+    }
+
+    fn endpoint(&self, peer: Option<PeerId>) -> ConnectionEndpoint {
+        let address = Multiaddr::from_protocols(vec![
+            Protocol::P2p(self.relay.clone()),
+            Protocol::P2pCircuit,
+        ]);
+        match peer {
+            Some(peer) => ConnectionEndpoint::with_peer_id(address, peer),
+            None => ConnectionEndpoint::new(address),
+        }
+    }
+
+    fn is_ready(&self) -> bool {
+        matches!(self.phase, Some(Phase::Ready { .. }))
+    }
+}
+
+/// A transport wrapper that promotes relay bridge streams into connections.
+pub struct CircuitTransport<T, E> {
+    inner: T,
+    entropy: E,
+    identity: Ed25519Keypair,
+    yamux_config: YamuxConfig,
+    circuits: BTreeMap<ConnectionId, Circuit>,
+    bridge_index: BTreeMap<(ConnectionId, StreamId), ConnectionId>,
+    retired_bridges: BTreeSet<(ConnectionId, StreamId)>,
+    active_inner: BTreeSet<ConnectionId>,
+    direct_by_peer: BTreeMap<PeerId, BTreeSet<ConnectionId>>,
+    direct_by_conn: BTreeMap<ConnectionId, PeerId>,
+    pending: VecDeque<TransportEvent>,
+    next_circuit_id: Option<u64>,
+}
+
+impl<T, E> CircuitTransport<T, E> {
+    /// Wraps a transport with an explicit entropy source and local identity.
+    pub fn new(inner: T, identity: Ed25519Keypair, entropy: E) -> Self {
+        Self {
+            inner,
+            entropy,
+            identity,
+            yamux_config: YamuxConfig::default(),
+            circuits: BTreeMap::new(),
+            bridge_index: BTreeMap::new(),
+            retired_bridges: BTreeSet::new(),
+            active_inner: BTreeSet::new(),
+            direct_by_peer: BTreeMap::new(),
+            direct_by_conn: BTreeMap::new(),
+            pending: VecDeque::new(),
+            next_circuit_id: Some(1),
+        }
+    }
+
+    /// Replaces the Yamux limits used by subsequently adopted circuits.
+    pub fn set_yamux_config(&mut self, config: YamuxConfig) {
+        self.yamux_config = config;
+    }
+
+    /// Returns whether an identifier belongs to a circuit connection.
+    pub fn is_circuit(id: ConnectionId) -> bool {
+        is_circuit_id(id)
+    }
+
+    /// Returns the active circuit connection identifiers.
+    pub fn circuit_ids(&self) -> Vec<ConnectionId> {
+        self.circuits.keys().copied().collect()
+    }
+
+    /// Borrows the wrapped transport.
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Mutably borrows the wrapped transport.
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T: Transport, E: EntropySource> CircuitTransport<T, E> {
+    /// Promotes an already-negotiated relay bridge into a circuit connection.
+    ///
+    /// Repeating the same `(inner_conn, bridge_stream)` adoption is
+    /// idempotent and returns the existing circuit identifier when its relay,
+    /// remote peer, role, and remote-write state agree. Conflicting immutable
+    /// metadata returns [`AdoptError::ConflictingAdoption`].
+    pub fn adopt_bridge(&mut self, adoption: BridgeAdoption) -> Result<ConnectionId, AdoptError> {
+        let key = (adoption.inner_conn, adoption.bridge_stream);
+        if let Some(id) = self.bridge_index.get(&key).copied() {
+            let circuit = self
+                .circuits
+                .get(&id)
+                .expect("bridge index must reference an active circuit");
+            if adoption.remote_write_closed
+                || adoption.relay != circuit.relay
+                || adoption.remote_peer != circuit.remote_peer
+                || adoption.role != circuit.role
+            {
+                return Err(AdoptError::ConflictingAdoption);
+            }
+            return Ok(id);
+        }
+        if adoption.remote_write_closed {
+            return Err(AdoptError::RemoteWriteClosed);
+        }
+        if !self.active_inner.contains(&adoption.inner_conn) {
+            return Err(AdoptError::UnknownConnection);
+        }
+        if self
+            .direct_by_peer
+            .get(&adoption.remote_peer)
+            .is_some_and(|connections| !connections.is_empty())
+        {
+            return Err(AdoptError::PeerAlreadyDirect);
+        }
+
+        let sequence = self.next_circuit_id.ok_or(AdoptError::IdsExhausted)?;
+        let next = sequence
+            .checked_add(1)
+            .filter(|value| *value < CIRCUIT_ID_BIT);
+
+        let mut static_secret = [0u8; 32];
+        let mut ephemeral_secret = [0u8; 32];
+        self.entropy.fill(&mut static_secret)?;
+        self.entropy.fill(&mut ephemeral_secret)?;
+
+        let id = ConnectionId::new(CIRCUIT_ID_BIT | sequence);
+        let noise = NoiseSession::new(NoiseConfig {
+            role: match adoption.role {
+                CircuitRole::Initiator => NoiseRole::Initiator,
+                CircuitRole::Responder => NoiseRole::Responder,
+            },
+            identity: self.identity.clone(),
+            static_secret,
+            ephemeral_secret,
+            expected_peer: Some(adoption.remote_peer.clone()),
+        });
+        let select = match adoption.role {
+            CircuitRole::Initiator => MultistreamSelect::dialer(NOISE_PROTOCOL_ID),
+            CircuitRole::Responder => MultistreamSelect::listener([NOISE_PROTOCOL_ID.to_string()]),
+        };
+        let circuit = Circuit {
+            id,
+            inner_conn: adoption.inner_conn,
+            bridge_stream: adoption.bridge_stream,
+            relay: adoption.relay,
+            remote_peer: adoption.remote_peer,
+            role: adoption.role,
+            phase: Some(Phase::SelectNoise {
+                select,
+                noise: Some(noise),
+            }),
+        };
+
+        self.next_circuit_id = next;
+        self.bridge_index.insert(key, id);
+        if adoption.role == CircuitRole::Responder {
+            self.pending.push_back(TransportEvent::IncomingConnection {
+                id,
+                endpoint: circuit.endpoint(None),
+            });
+        }
+        self.circuits.insert(id, circuit);
+
+        let start_result = self.with_circuit(id, |this, circuit| {
+            let phase = circuit
+                .phase
+                .take()
+                .ok_or_else(|| "circuit phase unavailable".to_string())?;
+            let phase = this.start_phase(circuit, phase)?;
+            circuit.phase = Some(phase);
+            Ok(())
+        });
+        if let Err(message) = start_result {
+            self.fail_circuit(id, message, true);
+            return Ok(id);
+        }
+        if !adoption.pending_data.is_empty() {
+            self.inject_bridge_data(
+                adoption.inner_conn,
+                adoption.bridge_stream,
+                adoption.pending_data,
+            );
+        }
+        Ok(id)
+    }
+
+    /// Injects bytes read from a bridge outside the wrapped transport poll.
+    pub fn inject_bridge_data(
+        &mut self,
+        inner_conn: ConnectionId,
+        bridge_stream: StreamId,
+        data: Vec<u8>,
+    ) {
+        let key = (inner_conn, bridge_stream);
+        let Some(id) = self.bridge_index.get(&key).copied() else {
+            return;
+        };
+        // `feed_phase` temporarily takes the phase and leaves it absent on
+        // error, so capture readiness before entering it. In particular, a
+        // normal Yamux GoAway from a Ready circuit must close without being
+        // misclassified as a pre-handshake protocol failure.
+        let pre_ready = self.circuits.get(&id).is_some_and(|c| !c.is_ready());
+        let result = self.with_circuit(id, |this, circuit| {
+            let phase = circuit
+                .phase
+                .take()
+                .ok_or_else(|| "circuit phase unavailable".to_string())?;
+            let phase = this.feed_phase(circuit, phase, data)?;
+            circuit.phase = Some(phase);
+            Ok(())
+        });
+        if let Err(message) = &result {
+            let normal_go_away = message == "remote closed the Yamux session";
+            self.fail_circuit(id, message.clone(), pre_ready || !normal_go_away);
+        }
+    }
+
+    /// Reports that a bridge received its remote FIN.
+    pub fn inject_bridge_remote_write_closed(
+        &mut self,
+        inner_conn: ConnectionId,
+        bridge_stream: StreamId,
+    ) {
+        let key = (inner_conn, bridge_stream);
+        if let Some(id) = self.bridge_index.get(&key).copied() {
+            let pre_ready = self.circuits.get(&id).is_some_and(|c| !c.is_ready());
+            self.fail_circuit(
+                id,
+                "relay bridge remote write side closed".to_string(),
+                pre_ready,
+            );
+        }
+    }
+
+    /// Reports that a bridge stream fully closed or reset.
+    pub fn inject_bridge_closed(&mut self, inner_conn: ConnectionId, bridge_stream: StreamId) {
+        let key = (inner_conn, bridge_stream);
+        self.retired_bridges.remove(&key);
+        if let Some(id) = self.bridge_index.get(&key).copied() {
+            let pre_ready = self.circuits.get(&id).is_some_and(|c| !c.is_ready());
+            self.fail_circuit(id, "relay bridge closed".to_string(), pre_ready);
+        }
+    }
+
+    fn with_circuit<R>(
+        &mut self,
+        id: ConnectionId,
+        operation: impl FnOnce(&mut Self, &mut Circuit) -> Result<R, String>,
+    ) -> Result<R, String> {
+        let mut circuit = self
+            .circuits
+            .remove(&id)
+            .ok_or_else(|| format!("circuit {id} is unknown"))?;
+        let result = operation(self, &mut circuit);
+        self.circuits.insert(id, circuit);
+        result
+    }
+
+    fn start_phase(&mut self, circuit: &Circuit, phase: Phase) -> Result<Phase, String> {
+        match phase {
+            Phase::SelectNoise { mut select, noise } => {
+                select
+                    .handle_input(MultistreamInput::Start)
+                    .map_err(|error| format!("Noise multistream start failed: {error}"))?;
+                self.drain_raw_select(circuit, &mut select)?;
+                Ok(Phase::SelectNoise { select, noise })
+            }
+            other => Ok(other),
+        }
+    }
+
+    fn feed_phase(
+        &mut self,
+        circuit: &Circuit,
+        phase: Phase,
+        data: Vec<u8>,
+    ) -> Result<Phase, String> {
+        match phase {
+            Phase::SelectNoise {
+                mut select,
+                mut noise,
+            } => {
+                select
+                    .handle_input(MultistreamInput::Data(data))
+                    .map_err(|error| format!("Noise multistream failed: {error}"))?;
+                let mut negotiated = false;
+                while let Some(output) = select.poll_output() {
+                    match output {
+                        MultistreamOutput::OutboundData(bytes) => {
+                            self.send_bridge(circuit, bytes)?;
+                        }
+                        MultistreamOutput::Negotiated { protocol }
+                            if protocol == NOISE_PROTOCOL_ID =>
+                        {
+                            negotiated = true;
+                        }
+                        MultistreamOutput::Negotiated { .. } | MultistreamOutput::NotAvailable => {
+                            return Err("remote did not negotiate Noise".to_string());
+                        }
+                        MultistreamOutput::ProtocolError { reason } => {
+                            return Err(format!("Noise multistream protocol error: {reason}"));
+                        }
+                    }
+                }
+                if !negotiated {
+                    return Ok(Phase::SelectNoise { select, noise });
+                }
+                let remaining = select.take_remaining_buffer();
+                let mut noise = noise
+                    .take()
+                    .ok_or_else(|| "Noise session unavailable".to_string())?;
+                noise
+                    .handle_input(NoiseInput::Start)
+                    .map_err(|error| format!("Noise start failed: {error}"))?;
+                let (peer, decrypted) = self.drain_noise(circuit, &mut noise)?;
+                if peer.is_some() || !decrypted.is_empty() {
+                    return Err("Noise produced transport data before input".to_string());
+                }
+                if remaining.is_empty() {
+                    Ok(Phase::Noise { noise })
+                } else {
+                    self.feed_phase(circuit, Phase::Noise { noise }, remaining)
+                }
+            }
+            Phase::Noise { mut noise } => {
+                noise
+                    .handle_input(NoiseInput::Data(data))
+                    .map_err(|error| format!("Noise handshake failed: {error}"))?;
+                let (peer, decrypted) = self.drain_noise(circuit, &mut noise)?;
+                let Some(peer) = peer else {
+                    if !decrypted.is_empty() {
+                        return Err("Noise decrypted data before authentication".to_string());
+                    }
+                    return Ok(Phase::Noise { noise });
+                };
+                let mut select = match circuit.role {
+                    CircuitRole::Initiator => MultistreamSelect::dialer(YAMUX_PROTOCOL_ID),
+                    CircuitRole::Responder => {
+                        MultistreamSelect::listener([YAMUX_PROTOCOL_ID.to_string()])
+                    }
+                };
+                select
+                    .handle_input(MultistreamInput::Start)
+                    .map_err(|error| format!("Yamux multistream start failed: {error}"))?;
+                self.drain_encrypted_select(circuit, &mut noise, &mut select)?;
+                let mut phase = Phase::SelectYamux {
+                    noise,
+                    select,
+                    peer,
+                };
+                for plaintext in decrypted {
+                    phase = self.feed_decrypted_yamux_select(circuit, phase, plaintext)?;
+                }
+                Ok(phase)
+            }
+            Phase::SelectYamux {
+                mut noise,
+                select,
+                peer,
+            } => {
+                noise
+                    .handle_input(NoiseInput::Data(data))
+                    .map_err(|error| format!("Noise transport failed: {error}"))?;
+                let (unexpected_peer, decrypted) = self.drain_noise(circuit, &mut noise)?;
+                if unexpected_peer.is_some() {
+                    return Err("Noise authenticated twice".to_string());
+                }
+                let mut phase = Phase::SelectYamux {
+                    noise,
+                    select,
+                    peer,
+                };
+                for plaintext in decrypted {
+                    phase = self.feed_decrypted_yamux_select(circuit, phase, plaintext)?;
+                }
+                Ok(phase)
+            }
+            Phase::Ready {
+                mut noise,
+                mut yamux,
+                peer,
+            } => {
+                noise
+                    .handle_input(NoiseInput::Data(data))
+                    .map_err(|error| format!("Noise transport failed: {error}"))?;
+                let (unexpected_peer, decrypted) = self.drain_noise(circuit, &mut noise)?;
+                if unexpected_peer.is_some() {
+                    return Err("Noise authenticated twice".to_string());
+                }
+                for plaintext in decrypted {
+                    let result = yamux.handle_input(YamuxInput::Data(plaintext));
+                    self.drain_yamux(circuit, &mut noise, &mut yamux)?;
+                    result.map_err(|error| format!("Yamux protocol failed: {error}"))?;
+                }
+                Ok(Phase::Ready { noise, yamux, peer })
+            }
+        }
+    }
+
+    fn feed_decrypted_yamux_select(
+        &mut self,
+        circuit: &Circuit,
+        phase: Phase,
+        plaintext: Vec<u8>,
+    ) -> Result<Phase, String> {
+        let Phase::SelectYamux {
+            mut noise,
+            mut select,
+            peer,
+        } = phase
+        else {
+            return Err("Yamux selection completed before pipelined data".to_string());
+        };
+        select
+            .handle_input(MultistreamInput::Data(plaintext))
+            .map_err(|error| format!("Yamux multistream failed: {error}"))?;
+        let mut negotiated = false;
+        while let Some(output) = select.poll_output() {
+            match output {
+                MultistreamOutput::OutboundData(bytes) => {
+                    self.encrypt_bridge(circuit, &mut noise, bytes)?;
+                }
+                MultistreamOutput::Negotiated { protocol } if protocol == YAMUX_PROTOCOL_ID => {
+                    negotiated = true;
+                }
+                MultistreamOutput::Negotiated { .. } | MultistreamOutput::NotAvailable => {
+                    return Err("remote did not negotiate Yamux".to_string());
+                }
+                MultistreamOutput::ProtocolError { reason } => {
+                    return Err(format!("Yamux multistream protocol error: {reason}"));
+                }
+            }
+        }
+        if !negotiated {
+            return Ok(Phase::SelectYamux {
+                noise,
+                select,
+                peer,
+            });
+        }
+        if self
+            .direct_by_peer
+            .get(&peer)
+            .is_some_and(|connections| !connections.is_empty())
+        {
+            return Err("direct connection won circuit arbitration".to_string());
+        }
+        let remaining = select.take_remaining_buffer();
+        let mut yamux = YamuxSession::with_config(
+            match circuit.role {
+                CircuitRole::Initiator => YamuxRole::Client,
+                CircuitRole::Responder => YamuxRole::Server,
+            },
+            self.yamux_config.clone(),
+        )
+        .map_err(|error| format!("invalid Yamux configuration: {error}"))?;
+        self.pending.push_back(TransportEvent::Connected {
+            id: circuit.id,
+            endpoint: circuit.endpoint(Some(peer.clone())),
+        });
+        if !remaining.is_empty() {
+            let result = yamux.handle_input(YamuxInput::Data(remaining));
+            self.drain_yamux(circuit, &mut noise, &mut yamux)?;
+            result.map_err(|error| format!("Yamux protocol failed: {error}"))?;
+        }
+        Ok(Phase::Ready { noise, yamux, peer })
+    }
+
+    fn drain_raw_select(
+        &mut self,
+        circuit: &Circuit,
+        select: &mut MultistreamSelect,
+    ) -> Result<(), String> {
+        while let Some(output) = select.poll_output() {
+            if let MultistreamOutput::OutboundData(bytes) = output {
+                self.send_bridge(circuit, bytes)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn drain_encrypted_select(
+        &mut self,
+        circuit: &Circuit,
+        noise: &mut NoiseSession,
+        select: &mut MultistreamSelect,
+    ) -> Result<(), String> {
+        while let Some(output) = select.poll_output() {
+            if let MultistreamOutput::OutboundData(bytes) = output {
+                self.encrypt_bridge(circuit, noise, bytes)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn drain_noise(
+        &mut self,
+        circuit: &Circuit,
+        noise: &mut NoiseSession,
+    ) -> Result<(Option<PeerId>, Vec<Vec<u8>>), String> {
+        let mut peer = None;
+        let mut decrypted = Vec::new();
+        while let Some(output) = noise.poll_output() {
+            match output {
+                NoiseOutput::Outbound(bytes) => self.send_bridge(circuit, bytes)?,
+                NoiseOutput::HandshakeComplete {
+                    peer: authenticated,
+                    ..
+                } => peer = Some(authenticated),
+                NoiseOutput::Decrypted(bytes) => decrypted.push(bytes),
+            }
+        }
+        Ok((peer, decrypted))
+    }
+
+    fn drain_yamux(
+        &mut self,
+        circuit: &Circuit,
+        noise: &mut NoiseSession,
+        yamux: &mut YamuxSession,
+    ) -> Result<(), String> {
+        while let Some(output) = yamux.poll_output() {
+            match output {
+                YamuxOutput::Outbound(bytes) => self.encrypt_bridge(circuit, noise, bytes)?,
+                YamuxOutput::IncomingStream { stream } => {
+                    self.pending.push_back(TransportEvent::IncomingStream {
+                        id: circuit.id,
+                        stream_id: StreamId::new(u64::from(stream)),
+                    });
+                }
+                YamuxOutput::Data { stream, data } => {
+                    self.pending.push_back(TransportEvent::StreamData {
+                        id: circuit.id,
+                        stream_id: StreamId::new(u64::from(stream)),
+                        data,
+                    });
+                }
+                YamuxOutput::RemoteWriteClosed { stream } => {
+                    self.pending
+                        .push_back(TransportEvent::StreamRemoteWriteClosed {
+                            id: circuit.id,
+                            stream_id: StreamId::new(u64::from(stream)),
+                        });
+                }
+                YamuxOutput::StreamClosed { stream } => {
+                    self.pending.push_back(TransportEvent::StreamClosed {
+                        id: circuit.id,
+                        stream_id: StreamId::new(u64::from(stream)),
+                    });
+                }
+                YamuxOutput::GoAwayReceived { code: 0 } => {
+                    return Err("remote closed the Yamux session".to_string());
+                }
+                YamuxOutput::GoAwayReceived { code } => {
+                    return Err(format!("remote closed Yamux with error code {code}"));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn send_bridge(&mut self, circuit: &Circuit, bytes: Vec<u8>) -> Result<(), String> {
+        self.inner
+            .send_stream(circuit.inner_conn, circuit.bridge_stream, bytes)
+            .map_err(|error| format!("relay bridge send failed: {error}"))
+    }
+
+    fn encrypt_bridge(
+        &mut self,
+        circuit: &Circuit,
+        noise: &mut NoiseSession,
+        plaintext: Vec<u8>,
+    ) -> Result<(), String> {
+        noise
+            .handle_input(NoiseInput::Encrypt(plaintext))
+            .map_err(|error| format!("Noise encryption failed: {error}"))?;
+        let (peer, decrypted) = self.drain_noise(circuit, noise)?;
+        if peer.is_some() || !decrypted.is_empty() {
+            return Err("unexpected Noise output while encrypting".to_string());
+        }
+        Ok(())
+    }
+
+    fn fail_circuit(&mut self, id: ConnectionId, message: String, emit_error: bool) {
+        let Some(circuit) = self.circuits.remove(&id) else {
+            return;
+        };
+        let key = circuit.bridge_key();
+        self.bridge_index.remove(&key);
+        self.retired_bridges.insert(key);
+        let _ = self
+            .inner
+            .reset_stream(circuit.inner_conn, circuit.bridge_stream);
+        if emit_error {
+            self.pending
+                .push_back(TransportEvent::Error { id, message });
+        }
+        self.pending.push_back(TransportEvent::Closed { id });
+    }
+
+    fn record_direct(&mut self, id: ConnectionId, peer: PeerId) {
+        if let Some(previous) = self.direct_by_conn.insert(id, peer.clone())
+            && previous != peer
+            && let Some(ids) = self.direct_by_peer.get_mut(&previous)
+        {
+            ids.remove(&id);
+            if ids.is_empty() {
+                self.direct_by_peer.remove(&previous);
+            }
+        }
+        self.direct_by_peer
+            .entry(peer.clone())
+            .or_default()
+            .insert(id);
+        let losers: Vec<_> = self
+            .circuits
+            .iter()
+            .filter_map(|(circuit_id, circuit)| {
+                (!circuit.is_ready() && circuit.remote_peer == peer).then_some(*circuit_id)
+            })
+            .collect();
+        for circuit_id in losers {
+            self.fail_circuit(
+                circuit_id,
+                "direct connection won circuit arbitration".to_string(),
+                true,
+            );
+        }
+    }
+
+    fn remove_direct(&mut self, id: ConnectionId) {
+        let Some(peer) = self.direct_by_conn.remove(&id) else {
+            return;
+        };
+        if let Some(ids) = self.direct_by_peer.get_mut(&peer) {
+            ids.remove(&id);
+            if ids.is_empty() {
+                self.direct_by_peer.remove(&peer);
+            }
+        }
+    }
+
+    fn reject_inner_collision(&mut self, id: ConnectionId) {
+        self.active_inner.remove(&id);
+        self.remove_direct(id);
+        let _ = self.inner.close(id);
+        self.pending.push_back(TransportEvent::Error {
+            id,
+            message: "wrapped transport used the circuit connection-ID bit".to_string(),
+        });
+    }
+
+    fn handle_inner_event(&mut self, event: TransportEvent) {
+        let event_id = match &event {
+            TransportEvent::Connected { id, .. }
+            | TransportEvent::StreamOpened { id, .. }
+            | TransportEvent::IncomingStream { id, .. }
+            | TransportEvent::StreamData { id, .. }
+            | TransportEvent::StreamRemoteWriteClosed { id, .. }
+            | TransportEvent::StreamClosed { id, .. }
+            | TransportEvent::Closed { id }
+            | TransportEvent::Error { id, .. }
+            | TransportEvent::IncomingConnection { id, .. }
+            | TransportEvent::PeerIdentityVerified { id, .. } => Some(*id),
+            TransportEvent::Listening { .. } => None,
+        };
+        if event_id.is_some_and(is_circuit_id) {
+            self.reject_inner_collision(event_id.expect("checked above"));
+            return;
+        }
+
+        match event {
+            TransportEvent::IncomingConnection { id, endpoint } => {
+                self.active_inner.insert(id);
+                self.pending
+                    .push_back(TransportEvent::IncomingConnection { id, endpoint });
+            }
+            TransportEvent::Connected { id, endpoint } => {
+                self.active_inner.insert(id);
+                if let Some(peer) = endpoint.peer_id().cloned() {
+                    self.record_direct(id, peer);
+                }
+                self.pending
+                    .push_back(TransportEvent::Connected { id, endpoint });
+            }
+            TransportEvent::PeerIdentityVerified {
+                id,
+                endpoint,
+                previous_peer_id,
+            } => {
+                if let Some(peer) = endpoint.peer_id().cloned() {
+                    self.record_direct(id, peer);
+                }
+                self.pending
+                    .push_back(TransportEvent::PeerIdentityVerified {
+                        id,
+                        endpoint,
+                        previous_peer_id,
+                    });
+            }
+            TransportEvent::StreamData {
+                id,
+                stream_id,
+                data,
+            } => {
+                let key = (id, stream_id);
+                if self.bridge_index.contains_key(&key) {
+                    self.inject_bridge_data(id, stream_id, data);
+                } else if !self.retired_bridges.contains(&key) {
+                    self.pending.push_back(TransportEvent::StreamData {
+                        id,
+                        stream_id,
+                        data,
+                    });
+                }
+            }
+            TransportEvent::StreamRemoteWriteClosed { id, stream_id } => {
+                let key = (id, stream_id);
+                if self.bridge_index.contains_key(&key) {
+                    self.inject_bridge_remote_write_closed(id, stream_id);
+                } else if !self.retired_bridges.contains(&key) {
+                    self.pending
+                        .push_back(TransportEvent::StreamRemoteWriteClosed { id, stream_id });
+                }
+            }
+            TransportEvent::StreamClosed { id, stream_id } => {
+                let key = (id, stream_id);
+                if self.bridge_index.contains_key(&key) || self.retired_bridges.contains(&key) {
+                    self.inject_bridge_closed(id, stream_id);
+                } else {
+                    self.pending
+                        .push_back(TransportEvent::StreamClosed { id, stream_id });
+                }
+            }
+            TransportEvent::Closed { id } => {
+                self.active_inner.remove(&id);
+                self.remove_direct(id);
+                let riding: Vec<_> = self
+                    .circuits
+                    .iter()
+                    .filter_map(|(circuit_id, circuit)| {
+                        (circuit.inner_conn == id).then_some(*circuit_id)
+                    })
+                    .collect();
+                for circuit_id in riding {
+                    let pre_ready = self
+                        .circuits
+                        .get(&circuit_id)
+                        .is_some_and(|circuit| !circuit.is_ready());
+                    self.fail_circuit(circuit_id, "relay connection closed".to_string(), pre_ready);
+                }
+                self.retired_bridges.retain(|(conn, _)| *conn != id);
+                self.pending.push_back(TransportEvent::Closed { id });
+            }
+            other => self.pending.push_back(other),
+        }
+    }
+
+    fn circuit_stream(id: ConnectionId, stream_id: StreamId) -> Result<u32, TransportError> {
+        u32::try_from(stream_id.as_u64())
+            .map_err(|_| TransportError::StreamNotFound { id, stream_id })
+    }
+
+    fn operate_ready<R>(
+        &mut self,
+        id: ConnectionId,
+        operation: impl FnOnce(&mut YamuxSession) -> Result<R, YamuxError>,
+    ) -> Result<R, TransportError> {
+        let mut circuit = self
+            .circuits
+            .remove(&id)
+            .ok_or(TransportError::ConnectionNotFound { id })?;
+        let Some(Phase::Ready {
+            mut noise,
+            mut yamux,
+            peer,
+        }) = circuit.phase.take()
+        else {
+            self.circuits.insert(id, circuit);
+            return Err(TransportError::InvalidState {
+                id,
+                state: minip2p_transport::ConnectionState::Connecting,
+                expected: minip2p_transport::ConnectionState::Connected,
+            });
+        };
+        let result = operation(&mut yamux);
+        let drain = self.drain_yamux(&circuit, &mut noise, &mut yamux);
+        circuit.phase = Some(Phase::Ready { noise, yamux, peer });
+        self.circuits.insert(id, circuit);
+        if let Err(message) = drain {
+            self.fail_circuit(id, message.clone(), false);
+            return Err(TransportError::PollError { reason: message });
+        }
+        result.map_err(|error| TransportError::PollError {
+            reason: error.to_string(),
+        })
+    }
+
+    fn send_circuit(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+        data: Vec<u8>,
+    ) -> Result<(), TransportError> {
+        let stream = Self::circuit_stream(id, stream_id)?;
+        let mut circuit = self
+            .circuits
+            .remove(&id)
+            .ok_or(TransportError::ConnectionNotFound { id })?;
+        let Some(Phase::Ready {
+            mut noise,
+            mut yamux,
+            peer,
+        }) = circuit.phase.take()
+        else {
+            self.circuits.insert(id, circuit);
+            return Err(TransportError::InvalidState {
+                id,
+                state: minip2p_transport::ConnectionState::Connecting,
+                expected: minip2p_transport::ConnectionState::Connected,
+            });
+        };
+        let result = yamux.send(stream, data);
+        let drain = self.drain_yamux(&circuit, &mut noise, &mut yamux);
+        circuit.phase = Some(Phase::Ready { noise, yamux, peer });
+        self.circuits.insert(id, circuit);
+        if let Err(message) = drain {
+            self.fail_circuit(id, message.clone(), false);
+            return Err(TransportError::StreamSendFailed {
+                id,
+                stream_id,
+                reason: message,
+            });
+        }
+        match result {
+            Ok(()) => Ok(()),
+            Err(YamuxError::SendBufferFull { .. }) => Err(TransportError::StreamSendFailed {
+                id,
+                stream_id,
+                reason: "Yamux send buffer is full".to_string(),
+            }),
+            Err(error) => Err(TransportError::StreamSendFailed {
+                id,
+                stream_id,
+                reason: error.to_string(),
+            }),
+        }
+    }
+
+    fn drain_pending_events(&mut self) -> Vec<TransportEvent> {
+        self.pending.drain(..).collect()
+    }
+}
+
+impl<T: Transport, E: EntropySource> Transport for CircuitTransport<T, E> {
+    fn dial(&mut self, address: &minip2p_core::PeerAddr) -> Result<ConnectionId, TransportError> {
+        let id = self.inner.dial(address)?;
+        if is_circuit_id(id) {
+            let _ = self.inner.close(id);
+            return Err(TransportError::DialFailed {
+                id,
+                reason: "wrapped transport used the circuit connection-ID bit".to_string(),
+            });
+        }
+        Ok(id)
+    }
+
+    fn listen(&mut self, address: &Multiaddr) -> Result<Multiaddr, TransportError> {
+        self.inner.listen(address)
+    }
+
+    fn open_stream(&mut self, id: ConnectionId) -> Result<StreamId, TransportError> {
+        if !is_circuit_id(id) {
+            return self.inner.open_stream(id);
+        }
+        let stream = self.operate_ready(id, YamuxSession::open_stream)?;
+        let stream_id = StreamId::new(u64::from(stream));
+        self.pending
+            .push_back(TransportEvent::StreamOpened { id, stream_id });
+        Ok(stream_id)
+    }
+
+    fn send_stream(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+        data: Vec<u8>,
+    ) -> Result<(), TransportError> {
+        if !is_circuit_id(id) {
+            return self.inner.send_stream(id, stream_id, data);
+        }
+        self.send_circuit(id, stream_id, data)
+    }
+
+    fn close_stream_write(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+    ) -> Result<(), TransportError> {
+        if !is_circuit_id(id) {
+            return self.inner.close_stream_write(id, stream_id);
+        }
+        let stream = Self::circuit_stream(id, stream_id)?;
+        match self.operate_ready(id, |yamux| yamux.close_write(stream)) {
+            Ok(()) => Ok(()),
+            Err(error @ TransportError::ConnectionNotFound { .. })
+            | Err(error @ TransportError::InvalidState { .. }) => Err(error),
+            Err(error) => Err(TransportError::StreamCloseWriteFailed {
+                id,
+                stream_id,
+                reason: error.to_string(),
+            }),
+        }
+    }
+
+    fn reset_stream(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+    ) -> Result<(), TransportError> {
+        if !is_circuit_id(id) {
+            return self.inner.reset_stream(id, stream_id);
+        }
+        let stream = Self::circuit_stream(id, stream_id)?;
+        match self.operate_ready(id, |yamux| yamux.reset(stream)) {
+            Ok(()) => Ok(()),
+            Err(error @ TransportError::ConnectionNotFound { .. })
+            | Err(error @ TransportError::InvalidState { .. }) => Err(error),
+            Err(error) => Err(TransportError::StreamResetFailed {
+                id,
+                stream_id,
+                reason: error.to_string(),
+            }),
+        }
+    }
+
+    fn close(&mut self, id: ConnectionId) -> Result<(), TransportError> {
+        if !is_circuit_id(id) {
+            return self.inner.close(id);
+        }
+        let mut circuit = self
+            .circuits
+            .remove(&id)
+            .ok_or(TransportError::ConnectionNotFound { id })?;
+        let key = circuit.bridge_key();
+        self.bridge_index.remove(&key);
+        self.retired_bridges.insert(key);
+        let ready = circuit.is_ready();
+        let mut graceful = false;
+        if let Some(Phase::Ready {
+            mut noise,
+            mut yamux,
+            ..
+        }) = circuit.phase.take()
+        {
+            yamux.go_away(0);
+            graceful = self.drain_yamux(&circuit, &mut noise, &mut yamux).is_ok()
+                && self
+                    .inner
+                    .close_stream_write(circuit.inner_conn, circuit.bridge_stream)
+                    .is_ok();
+        }
+        if !ready || !graceful {
+            let _ = self
+                .inner
+                .reset_stream(circuit.inner_conn, circuit.bridge_stream);
+        }
+        self.pending.push_back(TransportEvent::Closed { id });
+        Ok(())
+    }
+
+    fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError> {
+        if !self.pending.is_empty() {
+            return Ok(self.drain_pending_events());
+        }
+        for event in self.inner.poll()? {
+            self.handle_inner_event(event);
+        }
+        Ok(self.drain_pending_events())
+    }
+
+    fn next_timeout(&self) -> Option<Duration> {
+        if self.pending.is_empty() {
+            self.inner.next_timeout()
+        } else {
+            Some(Duration::ZERO)
+        }
+    }
+
+    fn wait_for_input(&mut self, timeout: Duration) -> WaitOutcome {
+        if self.pending.is_empty() {
+            self.inner.wait_for_input(timeout)
+        } else {
+            WaitOutcome::Ready
+        }
+    }
+
+    fn local_addresses(&self) -> Vec<Multiaddr> {
+        self.inner.local_addresses()
+    }
+
+    fn active_inbound_connection_sources(&self) -> Vec<Multiaddr> {
+        self.inner.active_inbound_connection_sources()
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> CircuitTransport<T, OsEntropy> {
+    /// Wraps a transport using operating-system entropy.
+    pub fn new_os(inner: T, identity: Ed25519Keypair) -> Self {
+        Self::new(inner, identity, OsEntropy)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use minip2p_test_support::InMemoryTransport;
+
+    #[derive(Clone, Debug)]
+    struct CounterEntropy(u8);
+
+    impl EntropySource for CounterEntropy {
+        fn fill(&mut self, destination: &mut [u8]) -> Result<(), EntropyError> {
+            self.0 = self.0.wrapping_add(1);
+            destination.fill(self.0);
+            Ok(())
+        }
+    }
+
+    struct FailingEntropy;
+
+    impl EntropySource for FailingEntropy {
+        fn fill(&mut self, _destination: &mut [u8]) -> Result<(), EntropyError> {
+            Err(EntropyError("injected failure"))
+        }
+    }
+
+    struct CloseObservingTransport<T> {
+        inner: T,
+        fail_close_write: bool,
+        close_write_calls: usize,
+        reset_calls: usize,
+    }
+
+    impl<T> CloseObservingTransport<T> {
+        fn new(inner: T) -> Self {
+            Self {
+                inner,
+                fail_close_write: false,
+                close_write_calls: 0,
+                reset_calls: 0,
+            }
+        }
+    }
+
+    impl<T: Transport> Transport for CloseObservingTransport<T> {
+        fn dial(
+            &mut self,
+            address: &minip2p_core::PeerAddr,
+        ) -> Result<ConnectionId, TransportError> {
+            self.inner.dial(address)
+        }
+
+        fn listen(&mut self, address: &Multiaddr) -> Result<Multiaddr, TransportError> {
+            self.inner.listen(address)
+        }
+
+        fn open_stream(&mut self, id: ConnectionId) -> Result<StreamId, TransportError> {
+            self.inner.open_stream(id)
+        }
+
+        fn send_stream(
+            &mut self,
+            id: ConnectionId,
+            stream_id: StreamId,
+            data: Vec<u8>,
+        ) -> Result<(), TransportError> {
+            self.inner.send_stream(id, stream_id, data)
+        }
+
+        fn close_stream_write(
+            &mut self,
+            id: ConnectionId,
+            stream_id: StreamId,
+        ) -> Result<(), TransportError> {
+            self.close_write_calls += 1;
+            if self.fail_close_write {
+                return Err(TransportError::StreamCloseWriteFailed {
+                    id,
+                    stream_id,
+                    reason: "injected FIN failure".to_string(),
+                });
+            }
+            self.inner.close_stream_write(id, stream_id)
+        }
+
+        fn reset_stream(
+            &mut self,
+            id: ConnectionId,
+            stream_id: StreamId,
+        ) -> Result<(), TransportError> {
+            self.reset_calls += 1;
+            self.inner.reset_stream(id, stream_id)
+        }
+
+        fn close(&mut self, id: ConnectionId) -> Result<(), TransportError> {
+            self.inner.close(id)
+        }
+
+        fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError> {
+            self.inner.poll()
+        }
+
+        fn next_timeout(&self) -> Option<Duration> {
+            self.inner.next_timeout()
+        }
+
+        fn wait_for_input(&mut self, timeout: Duration) -> WaitOutcome {
+            self.inner.wait_for_input(timeout)
+        }
+
+        fn local_addresses(&self) -> Vec<Multiaddr> {
+            self.inner.local_addresses()
+        }
+
+        fn active_inbound_connection_sources(&self) -> Vec<Multiaddr> {
+            self.inner.active_inbound_connection_sources()
+        }
+    }
+
+    type CloseObservedCircuit =
+        CircuitTransport<CloseObservingTransport<InMemoryTransport>, CounterEntropy>;
+    type TestCircuit = CircuitTransport<InMemoryTransport, CounterEntropy>;
+    type CloseObservedPair = (
+        CloseObservedCircuit,
+        TestCircuit,
+        ConnectionId,
+        StreamId,
+        PeerId,
+        PeerId,
+    );
+
+    fn identity(seed: u8) -> Ed25519Keypair {
+        Ed25519Keypair::from_secret_key_bytes([seed; 32])
+    }
+
+    fn setup_pair_with_yamux_config(
+        yamux_config: Option<YamuxConfig>,
+    ) -> (
+        CircuitTransport<InMemoryTransport, CounterEntropy>,
+        CircuitTransport<InMemoryTransport, CounterEntropy>,
+        ConnectionId,
+        StreamId,
+        PeerId,
+        PeerId,
+    ) {
+        let relay = identity(9).peer_id();
+        let a_identity = identity(1);
+        let b_identity = identity(2);
+        let a_peer = a_identity.peer_id();
+        let b_peer = b_identity.peer_id();
+        let (inner_a, inner_b) = InMemoryTransport::pair(relay.clone(), relay.clone());
+        let inner_conn = inner_a.connection_id();
+        let mut a = CircuitTransport::new(inner_a, a_identity, CounterEntropy(10));
+        let mut b = CircuitTransport::new(inner_b, b_identity, CounterEntropy(20));
+        if let Some(config) = yamux_config {
+            a.set_yamux_config(config.clone());
+            b.set_yamux_config(config);
+        }
+
+        let _ = a.poll().expect("initial A events");
+        let _ = b.poll().expect("initial B events");
+        let bridge = a.inner_mut().open_stream(inner_conn).expect("bridge open");
+        let _ = a.poll().expect("local bridge event");
+        let _ = b.poll().expect("remote bridge event");
+
+        let a_id = a
+            .adopt_bridge(BridgeAdoption {
+                inner_conn,
+                bridge_stream: bridge,
+                relay: relay.clone(),
+                remote_peer: b_peer.clone(),
+                role: CircuitRole::Initiator,
+                pending_data: Vec::new(),
+                remote_write_closed: false,
+            })
+            .expect("initiator adoption");
+        let b_id = b
+            .adopt_bridge(BridgeAdoption {
+                inner_conn,
+                bridge_stream: bridge,
+                relay,
+                remote_peer: a_peer.clone(),
+                role: CircuitRole::Responder,
+                pending_data: Vec::new(),
+                remote_write_closed: false,
+            })
+            .expect("responder adoption");
+        // Circuit IDs are endpoint-local; synchronized test counters let the
+        // pair helpers refer to both deterministic IDs with one value.
+        assert_eq!(a_id, b_id);
+        assert!(CircuitTransport::<InMemoryTransport, CounterEntropy>::is_circuit(a_id));
+        let incoming = b.poll().expect("responder incoming");
+        assert!(matches!(
+            incoming.as_slice(),
+            [TransportEvent::IncomingConnection { id, endpoint }]
+                if *id == b_id && endpoint.peer_id().is_none()
+        ));
+        (a, b, a_id, bridge, a_peer, b_peer)
+    }
+
+    fn setup_pair() -> (
+        CircuitTransport<InMemoryTransport, CounterEntropy>,
+        CircuitTransport<InMemoryTransport, CounterEntropy>,
+        ConnectionId,
+        StreamId,
+        PeerId,
+        PeerId,
+    ) {
+        setup_pair_with_yamux_config(None)
+    }
+
+    fn setup_close_observed_pair() -> CloseObservedPair {
+        let relay = identity(9).peer_id();
+        let a_identity = identity(1);
+        let b_identity = identity(2);
+        let a_peer = a_identity.peer_id();
+        let b_peer = b_identity.peer_id();
+        let (inner_a, inner_b) = InMemoryTransport::pair(relay.clone(), relay.clone());
+        let inner_conn = inner_a.connection_id();
+        let mut a = CircuitTransport::new(
+            CloseObservingTransport::new(inner_a),
+            a_identity,
+            CounterEntropy(10),
+        );
+        let mut b = CircuitTransport::new(inner_b, b_identity, CounterEntropy(20));
+        let _ = a.poll().expect("initial A events");
+        let _ = b.poll().expect("initial B events");
+        let bridge = a.inner_mut().open_stream(inner_conn).expect("bridge open");
+        let _ = a.poll().expect("local bridge event");
+        let _ = b.poll().expect("remote bridge event");
+        let a_id = a
+            .adopt_bridge(BridgeAdoption {
+                inner_conn,
+                bridge_stream: bridge,
+                relay: relay.clone(),
+                remote_peer: b_peer.clone(),
+                role: CircuitRole::Initiator,
+                pending_data: Vec::new(),
+                remote_write_closed: false,
+            })
+            .expect("initiator adoption");
+        let b_id = b
+            .adopt_bridge(BridgeAdoption {
+                inner_conn,
+                bridge_stream: bridge,
+                relay,
+                remote_peer: a_peer.clone(),
+                role: CircuitRole::Responder,
+                pending_data: Vec::new(),
+                remote_write_closed: false,
+            })
+            .expect("responder adoption");
+        // Circuit IDs are endpoint-local; synchronized test counters let the
+        // pair helpers refer to both deterministic IDs with one value.
+        assert_eq!(a_id, b_id);
+        assert!(matches!(
+            b.poll().expect("responder incoming").as_slice(),
+            [TransportEvent::IncomingConnection { id, .. }] if *id == b_id
+        ));
+        (a, b, a_id, bridge, a_peer, b_peer)
+    }
+
+    fn complete_handshake<TA, EA, TB, EB>(
+        a: &mut CircuitTransport<TA, EA>,
+        b: &mut CircuitTransport<TB, EB>,
+        circuit_id: ConnectionId,
+        a_peer: &PeerId,
+        b_peer: &PeerId,
+    ) where
+        TA: Transport,
+        EA: EntropySource,
+        TB: Transport,
+        EB: EntropySource,
+    {
+        let mut a_connected = false;
+        let mut b_connected = false;
+        for _ in 0..32 {
+            for event in a.poll().expect("drive initiator") {
+                if let TransportEvent::Connected { id, endpoint } = event
+                    && id == circuit_id
+                {
+                    assert_eq!(endpoint.peer_id(), Some(b_peer));
+                    a_connected = true;
+                }
+            }
+            for event in b.poll().expect("drive responder") {
+                if let TransportEvent::Connected { id, endpoint } = event
+                    && id == circuit_id
+                {
+                    assert_eq!(endpoint.peer_id(), Some(a_peer));
+                    b_connected = true;
+                }
+            }
+            if a_connected && b_connected {
+                return;
+            }
+        }
+        panic!("circuit handshake did not complete");
+    }
+
+    #[test]
+    fn circuit_runs_noise_yamux_and_stream_contract() {
+        let (mut a, mut b, circuit_id, _bridge, a_peer, b_peer) = setup_pair();
+        complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
+
+        let stream = a.open_stream(circuit_id).expect("open circuit stream");
+        assert_eq!(stream.as_u64() % 2, 1, "initiator streams are odd");
+        assert!(a
+            .poll()
+            .expect("opened")
+            .iter()
+            .any(|event| matches!(event, TransportEvent::StreamOpened { id, stream_id } if *id == circuit_id && *stream_id == stream)));
+        let incoming = b.poll().expect("incoming stream");
+        assert!(incoming.iter().any(|event| matches!(event,
+            TransportEvent::IncomingStream { id, stream_id }
+                if *id == circuit_id && *stream_id == stream
+        )));
+
+        a.send_stream(circuit_id, stream, b"hello".to_vec())
+            .expect("send");
+        let data = b.poll().expect("data");
+        assert!(data.iter().any(|event| matches!(event,
+            TransportEvent::StreamData { id, stream_id, data }
+                if *id == circuit_id && *stream_id == stream && data == b"hello"
+        )));
+
+        a.close_stream_write(circuit_id, stream).expect("FIN");
+        let eof = b.poll().expect("remote FIN");
+        assert!(eof.iter().any(|event| matches!(event,
+            TransportEvent::StreamRemoteWriteClosed { id, stream_id }
+                if *id == circuit_id && *stream_id == stream
+        )));
+        b.send_stream(circuit_id, stream, b"reply".to_vec())
+            .expect("reverse send remains open");
+        let reply = a.poll().expect("reply");
+        assert!(reply.iter().any(|event| matches!(event,
+            TransportEvent::StreamData { data, .. } if data == b"reply"
+        )));
+
+        b.reset_stream(circuit_id, stream).expect("reset");
+        let local_closed = b.poll().expect("local reset close");
+        assert_eq!(
+            local_closed
+                .iter()
+                .filter(|event| matches!(event, TransportEvent::StreamClosed { id, stream_id } if *id == circuit_id && *stream_id == stream))
+                .count(),
+            1
+        );
+        let remote_closed = a.poll().expect("remote reset close");
+        assert!(remote_closed.iter().any(|event| matches!(event,
+            TransportEvent::StreamClosed { id, stream_id }
+                if *id == circuit_id && *stream_id == stream
+        )));
+    }
+
+    #[test]
+    fn wrapper_transport_contract_orders_connection_and_stream_events() {
+        let (mut a, mut b, circuit_id, _bridge, a_peer, b_peer) = setup_pair();
+        let mut a_events = Vec::new();
+        let mut b_events = Vec::new();
+        for _ in 0..32 {
+            a_events.extend(a.poll().expect("drive initiator"));
+            b_events.extend(b.poll().expect("drive responder"));
+            let a_connected = a_events.iter().any(
+                |event| matches!(event, TransportEvent::Connected { id, .. } if *id == circuit_id),
+            );
+            let b_connected = b_events.iter().any(
+                |event| matches!(event, TransportEvent::Connected { id, .. } if *id == circuit_id),
+            );
+            if a_connected && b_connected {
+                break;
+            }
+        }
+        for (events, expected_peer) in [(&a_events, &b_peer), (&b_events, &a_peer)] {
+            assert_eq!(
+                events
+                    .iter()
+                    .filter(|event| matches!(event, TransportEvent::Connected { id, .. } if *id == circuit_id))
+                    .count(),
+                1,
+                "Connected must be emitted exactly once"
+            );
+            let connected = events
+                .iter()
+                .position(|event| {
+                    matches!(event,
+                        TransportEvent::Connected { id, endpoint }
+                            if *id == circuit_id && endpoint.peer_id() == Some(expected_peer)
+                    )
+                })
+                .expect("authenticated Connected event");
+            assert!(!events[..connected].iter().any(|event| matches!(
+                event,
+                TransportEvent::StreamOpened { id, .. }
+                    | TransportEvent::IncomingStream { id, .. }
+                    | TransportEvent::StreamData { id, .. }
+                    | TransportEvent::StreamRemoteWriteClosed { id, .. }
+                    | TransportEvent::StreamClosed { id, .. }
+                    if *id == circuit_id
+            )));
+        }
+        assert!(a.poll().expect("idle initiator").is_empty());
+        assert!(b.poll().expect("idle responder").is_empty());
+
+        let stream = a.open_stream(circuit_id).expect("open stream");
+        a.send_stream(circuit_id, stream, b"ordered".to_vec())
+            .expect("send immediately after open");
+        assert_eq!(
+            a.poll().expect("local stream event"),
+            [TransportEvent::StreamOpened {
+                id: circuit_id,
+                stream_id: stream,
+            }]
+        );
+        let inbound = b.poll().expect("coalesced stream open and data");
+        let incoming = inbound
+            .iter()
+            .position(|event| {
+                matches!(event,
+                    TransportEvent::IncomingStream { id, stream_id }
+                        if *id == circuit_id && *stream_id == stream
+                )
+            })
+            .expect("IncomingStream event");
+        let data = inbound
+            .iter()
+            .position(|event| {
+                matches!(event,
+                    TransportEvent::StreamData { id, stream_id, data }
+                        if *id == circuit_id && *stream_id == stream && data == b"ordered"
+                )
+            })
+            .expect("StreamData event");
+        assert!(incoming < data, "IncomingStream must precede StreamData");
+
+        a.reset_stream(circuit_id, stream).expect("reset stream");
+        assert_eq!(
+            a.poll().expect("immediate local terminal event"),
+            [TransportEvent::StreamClosed {
+                id: circuit_id,
+                stream_id: stream,
+            }]
+        );
+        assert_eq!(
+            b.poll().expect("remote terminal event"),
+            [TransportEvent::StreamClosed {
+                id: circuit_id,
+                stream_id: stream,
+            }]
+        );
+        assert!(a.poll().expect("no events after local terminal").is_empty());
+        assert!(
+            b.poll()
+                .expect("no events after remote terminal")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn wrapper_transport_contract_rejects_unknown_connection_and_stream_ids() {
+        let (mut a, mut b, circuit_id, _bridge, a_peer, b_peer) = setup_pair();
+        complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
+        let unknown_connection = ConnectionId::new(CIRCUIT_ID_BIT | 999);
+        let stream = StreamId::new(99);
+
+        assert!(matches!(
+            a.open_stream(unknown_connection),
+            Err(TransportError::ConnectionNotFound { id }) if id == unknown_connection
+        ));
+        assert!(matches!(
+            a.send_stream(unknown_connection, stream, vec![1]),
+            Err(TransportError::ConnectionNotFound { id }) if id == unknown_connection
+        ));
+        assert!(matches!(
+            a.close_stream_write(unknown_connection, stream),
+            Err(TransportError::ConnectionNotFound { id }) if id == unknown_connection
+        ));
+        assert!(matches!(
+            a.reset_stream(unknown_connection, stream),
+            Err(TransportError::ConnectionNotFound { id }) if id == unknown_connection
+        ));
+        assert_eq!(
+            a.close(unknown_connection),
+            Err(TransportError::ConnectionNotFound {
+                id: unknown_connection,
+            })
+        );
+
+        assert!(matches!(
+            a.send_stream(circuit_id, stream, vec![1]),
+            Err(TransportError::StreamSendFailed { id, stream_id, .. })
+                if id == circuit_id && stream_id == stream
+        ));
+        assert!(matches!(
+            a.close_stream_write(circuit_id, stream),
+            Err(TransportError::StreamCloseWriteFailed { id, stream_id, .. })
+                if id == circuit_id && stream_id == stream
+        ));
+        assert!(matches!(
+            a.reset_stream(circuit_id, stream),
+            Err(TransportError::StreamResetFailed { id, stream_id, .. })
+                if id == circuit_id && stream_id == stream
+        ));
+    }
+
+    #[test]
+    fn adoption_processes_pending_bridge_bytes_before_live_input() {
+        let relay = identity(9).peer_id();
+        let a_identity = identity(1);
+        let b_identity = identity(2);
+        let a_peer = a_identity.peer_id();
+        let b_peer = b_identity.peer_id();
+        let (inner_a, inner_b) = InMemoryTransport::pair(relay.clone(), relay.clone());
+        let inner_conn = inner_a.connection_id();
+        let mut a = CircuitTransport::new(inner_a, a_identity, CounterEntropy(10));
+        let mut b = CircuitTransport::new(inner_b, b_identity, CounterEntropy(20));
+        let _ = a.poll().expect("initial A events");
+        let _ = b.poll().expect("initial B events");
+        let bridge = a.inner_mut().open_stream(inner_conn).expect("bridge open");
+        let _ = a.poll().expect("local bridge event");
+        let _ = b.poll().expect("remote bridge event");
+        let circuit_id = a
+            .adopt_bridge(BridgeAdoption {
+                inner_conn,
+                bridge_stream: bridge,
+                relay: relay.clone(),
+                remote_peer: b_peer.clone(),
+                role: CircuitRole::Initiator,
+                pending_data: Vec::new(),
+                remote_write_closed: false,
+            })
+            .expect("initiator adoption");
+        let header = b
+            .inner_mut()
+            .poll()
+            .expect("read pipelined header")
+            .into_iter()
+            .find_map(|event| match event {
+                TransportEvent::StreamData { data, .. } => Some(data),
+                _ => None,
+            })
+            .expect("initiator multistream header");
+        let split = header.len() / 2;
+        b.adopt_bridge(BridgeAdoption {
+            inner_conn,
+            bridge_stream: bridge,
+            relay,
+            remote_peer: a_peer.clone(),
+            role: CircuitRole::Responder,
+            pending_data: header[..split].to_vec(),
+            remote_write_closed: false,
+        })
+        .expect("responder adoption with partial pending data");
+        assert!(matches!(
+            b.poll().expect("incoming event").as_slice(),
+            [TransportEvent::IncomingConnection { .. }]
+        ));
+        b.inject_bridge_data(inner_conn, bridge, header[split..].to_vec());
+        complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
+    }
+
+    #[test]
+    fn adoption_processes_pipelined_selection_and_noise_message() {
+        let relay = identity(9).peer_id();
+        let a_identity = identity(1);
+        let b_identity = identity(2);
+        let a_peer = a_identity.peer_id();
+        let b_peer = b_identity.peer_id();
+        let (inner_a, inner_b) = InMemoryTransport::pair(relay.clone(), relay.clone());
+        let inner_conn = inner_a.connection_id();
+        let mut a = CircuitTransport::new(inner_a, a_identity.clone(), CounterEntropy(10));
+        let mut b = CircuitTransport::new(inner_b, b_identity, CounterEntropy(20));
+        let _ = a.poll().expect("initial A events");
+        let _ = b.poll().expect("initial B events");
+        let bridge = a.inner_mut().open_stream(inner_conn).expect("bridge open");
+        let _ = a.poll().expect("local bridge event");
+        let _ = b.poll().expect("remote bridge event");
+
+        let mut select = MultistreamSelect::dialer(NOISE_PROTOCOL_ID);
+        select
+            .handle_input(MultistreamInput::Start)
+            .expect("scripted multistream start");
+        let mut pending_data = Vec::new();
+        while let Some(output) = select.poll_output() {
+            if let MultistreamOutput::OutboundData(bytes) = output {
+                pending_data.extend(bytes);
+            }
+        }
+        let mut scripted_listener = MultistreamSelect::listener([NOISE_PROTOCOL_ID.to_string()]);
+        scripted_listener
+            .handle_input(MultistreamInput::Start)
+            .expect("scripted listener start");
+        let listener_header = match scripted_listener.poll_output() {
+            Some(MultistreamOutput::OutboundData(bytes)) => bytes,
+            other => panic!("expected listener header, got {other:?}"),
+        };
+        select
+            .handle_input(MultistreamInput::Data(listener_header))
+            .expect("scripted dialer receives listener header");
+        while let Some(output) = select.poll_output() {
+            if let MultistreamOutput::OutboundData(bytes) = output {
+                pending_data.extend(bytes);
+            }
+        }
+        let selection_len = pending_data.len();
+        let mut scripted_noise = NoiseSession::new(NoiseConfig {
+            role: NoiseRole::Initiator,
+            identity: a_identity,
+            static_secret: [11; 32],
+            ephemeral_secret: [12; 32],
+            expected_peer: Some(b_peer.clone()),
+        });
+        scripted_noise
+            .handle_input(NoiseInput::Start)
+            .expect("scripted Noise start");
+        while let Some(output) = scripted_noise.poll_output() {
+            if let NoiseOutput::Outbound(bytes) = output {
+                pending_data.extend(bytes);
+            }
+        }
+        assert!(selection_len > 0 && pending_data.len() > selection_len);
+
+        let circuit_id = b
+            .adopt_bridge(BridgeAdoption {
+                inner_conn,
+                bridge_stream: bridge,
+                relay: relay.clone(),
+                remote_peer: a_peer.clone(),
+                role: CircuitRole::Responder,
+                pending_data,
+                remote_write_closed: false,
+            })
+            .expect("responder adopts pipelined selection and Noise msg1");
+        let responder_events = b.poll().expect("responder incoming event");
+        assert!(
+            matches!(
+                responder_events.as_slice(),
+                [TransportEvent::IncomingConnection { id, .. }] if *id == circuit_id
+            ),
+            "unexpected pipelined adoption events: {responder_events:?}"
+        );
+
+        let a_id = a
+            .adopt_bridge(BridgeAdoption {
+                inner_conn,
+                bridge_stream: bridge,
+                relay,
+                remote_peer: b_peer.clone(),
+                role: CircuitRole::Initiator,
+                pending_data: Vec::new(),
+                remote_write_closed: false,
+            })
+            .expect("real initiator adoption");
+        assert_eq!(a_id, circuit_id);
+
+        // The responder already consumed the scripted copy of the dialer's
+        // selection and msg1, so discard the identical selection emitted by
+        // the real initiator before letting it consume the responder reply.
+        let duplicate_selection = b.inner_mut().poll().expect("duplicate selection");
+        assert!(
+            duplicate_selection
+                .iter()
+                .any(|event| matches!(event, TransportEvent::StreamData { .. }))
+        );
+        let _ = a.poll().expect("initiator consumes pipelined response");
+
+        // Receiving the real selection reply emits the duplicate protocol
+        // proposal and Noise msg1 before msg3 and the encrypted Yamux
+        // selection. Drop those first two data events, then route the
+        // remaining bridge events through the wrapper.
+        let mut real_followup = b.inner_mut().poll().expect("real Noise follow-up");
+        for expected in ["protocol proposal", "Noise msg1"] {
+            let duplicate = real_followup
+                .iter()
+                .position(|event| matches!(event, TransportEvent::StreamData { .. }))
+                .unwrap_or_else(|| panic!("duplicate {expected}"));
+            real_followup.remove(duplicate);
+        }
+        for event in real_followup {
+            b.handle_inner_event(event);
+        }
+
+        complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
+    }
+
+    fn assert_pre_ready_bridge_failure(events: &[TransportEvent], circuit_id: ConnectionId) {
+        assert!(matches!(
+            events,
+            [
+                TransportEvent::Error { id: error_id, .. },
+                TransportEvent::Closed { id: closed_id },
+            ] if *error_id == circuit_id && *closed_id == circuit_id
+        ));
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            TransportEvent::Connected { id, .. } if *id == circuit_id
+        )));
+    }
+
+    #[test]
+    fn bridge_reset_mid_handshake_is_terminal() {
+        let (mut a, _b, circuit_id, bridge, _a_peer, _b_peer) = setup_pair();
+        let inner_conn = ConnectionId::new(1);
+
+        a.inject_bridge_closed(inner_conn, bridge);
+        let events = a.poll().expect("pre-ready bridge reset");
+        assert_pre_ready_bridge_failure(&events, circuit_id);
+        assert!(a.poll().expect("consume reset acknowledgement").is_empty());
+
+        a.inject_bridge_data(inner_conn, bridge, b"late".to_vec());
+        a.inject_bridge_remote_write_closed(inner_conn, bridge);
+        a.inject_bridge_closed(inner_conn, bridge);
+        assert!(a.poll().expect("nothing follows terminal close").is_empty());
+    }
+
+    #[test]
+    fn bridge_remote_fin_mid_handshake_is_terminal() {
+        let (mut a, _b, circuit_id, bridge, _a_peer, _b_peer) = setup_pair();
+        let inner_conn = ConnectionId::new(1);
+
+        a.inject_bridge_remote_write_closed(inner_conn, bridge);
+        let events = a.poll().expect("pre-ready bridge FIN");
+        assert_pre_ready_bridge_failure(&events, circuit_id);
+        assert!(a.poll().expect("consume reset acknowledgement").is_empty());
+
+        a.inject_bridge_data(inner_conn, bridge, b"late".to_vec());
+        assert!(a.poll().expect("post-close data is ignored").is_empty());
+    }
+
+    #[test]
+    fn adoption_is_idempotent_and_close_is_terminal() {
+        let (mut a, mut b, circuit_id, bridge, a_peer, b_peer) = setup_pair();
+        let relay = identity(9).peer_id();
+        let duplicate = a
+            .adopt_bridge(BridgeAdoption {
+                inner_conn: ConnectionId::new(1),
+                bridge_stream: bridge,
+                relay: relay.clone(),
+                remote_peer: b_peer.clone(),
+                role: CircuitRole::Initiator,
+                pending_data: Vec::new(),
+                remote_write_closed: false,
+            })
+            .expect("identical duplicate is idempotent");
+        assert_eq!(duplicate, circuit_id);
+        assert_eq!(
+            a.adopt_bridge(BridgeAdoption {
+                inner_conn: ConnectionId::new(1),
+                bridge_stream: bridge,
+                relay: identity(8).peer_id(),
+                remote_peer: b_peer.clone(),
+                role: CircuitRole::Initiator,
+                pending_data: Vec::new(),
+                remote_write_closed: false,
+            }),
+            Err(AdoptError::ConflictingAdoption)
+        );
+        assert_eq!(
+            a.adopt_bridge(BridgeAdoption {
+                inner_conn: ConnectionId::new(1),
+                bridge_stream: bridge,
+                relay,
+                remote_peer: b_peer.clone(),
+                role: CircuitRole::Initiator,
+                pending_data: Vec::new(),
+                remote_write_closed: true,
+            }),
+            Err(AdoptError::ConflictingAdoption)
+        );
+        complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
+        a.close(circuit_id).expect("graceful close");
+        let events = a.poll().expect("closed event");
+        assert_eq!(events, vec![TransportEvent::Closed { id: circuit_id }]);
+        assert!(matches!(
+            a.open_stream(circuit_id),
+            Err(TransportError::ConnectionNotFound { .. })
+        ));
+        a.inject_bridge_data(ConnectionId::new(1), bridge, b"late".to_vec());
+        a.inject_bridge_remote_write_closed(ConnectionId::new(1), bridge);
+        a.inject_bridge_closed(ConnectionId::new(1), bridge);
+        assert!(a.poll().expect("late bridge events are dropped").is_empty());
+    }
+
+    #[test]
+    fn ready_close_sends_go_away_then_bridge_fin_without_reset() {
+        let (mut a, mut b, circuit_id, _bridge, a_peer, b_peer) = setup_close_observed_pair();
+        complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
+        let stream = a.open_stream(circuit_id).expect("open stream before close");
+        let _ = a.poll().expect("local stream open");
+        let _ = b.poll().expect("remote stream open");
+        let _ = a.poll().expect("stream acknowledgement");
+        a.send_stream(circuit_id, stream, b"queued-before-close".to_vec())
+            .expect("queue application data before close");
+
+        a.close(circuit_id).expect("graceful circuit close");
+        assert_eq!(a.inner().close_write_calls, 1);
+        assert_eq!(a.inner().reset_calls, 0);
+        assert_eq!(
+            a.poll().expect("local close event"),
+            [
+                TransportEvent::StreamClosed {
+                    id: circuit_id,
+                    stream_id: stream,
+                },
+                TransportEvent::Closed { id: circuit_id },
+            ]
+        );
+
+        let peer_wire = b.inner_mut().poll().expect("peer bridge events");
+        let data_positions: Vec<_> = peer_wire
+            .iter()
+            .enumerate()
+            .filter_map(|(index, event)| {
+                matches!(event, TransportEvent::StreamData { .. }).then_some(index)
+            })
+            .collect();
+        assert_eq!(
+            data_positions.len(),
+            2,
+            "application data and encrypted GoAway must both reach the peer"
+        );
+        let go_away = data_positions[1];
+        let fin = peer_wire
+            .iter()
+            .position(|event| matches!(event, TransportEvent::StreamRemoteWriteClosed { .. }))
+            .expect("bridge FIN reaches the peer");
+        assert!(go_away < fin, "GoAway must be queued before bridge FIN");
+        assert!(
+            !peer_wire
+                .iter()
+                .any(|event| matches!(event, TransportEvent::StreamClosed { .. }))
+        );
+        for event in peer_wire {
+            b.handle_inner_event(event);
+        }
+        let peer_events = b.poll().expect("peer observes data then GoAway");
+        assert!(
+            matches!(
+                peer_events.as_slice(),
+                [
+                    TransportEvent::StreamData { id, stream_id, data },
+                    TransportEvent::Closed { id: closed_id },
+                ] if *id == circuit_id
+                    && *stream_id == stream
+                    && data == b"queued-before-close"
+                    && *closed_id == circuit_id
+            ),
+            "unexpected peer close events: {peer_events:?}"
+        );
+        assert!(b.poll().expect("terminal peer state").is_empty());
+    }
+
+    #[test]
+    fn ready_close_resets_bridge_when_fin_fails() {
+        let (mut a, mut b, circuit_id, _bridge, a_peer, b_peer) = setup_close_observed_pair();
+        complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
+        a.inner_mut().fail_close_write = true;
+
+        a.close(circuit_id).expect("fallback circuit close");
+        assert_eq!(a.inner().close_write_calls, 1);
+        assert_eq!(a.inner().reset_calls, 1);
+        assert_eq!(
+            a.poll().expect("local close event"),
+            [TransportEvent::Closed { id: circuit_id }]
+        );
+
+        let peer_wire = b.inner_mut().poll().expect("peer bridge events");
+        assert!(
+            peer_wire
+                .iter()
+                .any(|event| matches!(event, TransportEvent::StreamData { .. }))
+        );
+        assert!(
+            peer_wire
+                .iter()
+                .any(|event| matches!(event, TransportEvent::StreamClosed { .. }))
+        );
+        assert!(
+            !peer_wire
+                .iter()
+                .any(|event| matches!(event, TransportEvent::StreamRemoteWriteClosed { .. }))
+        );
+        for event in peer_wire {
+            b.handle_inner_event(event);
+        }
+        assert_eq!(
+            b.poll().expect("peer observes terminal close"),
+            [TransportEvent::Closed { id: circuit_id }]
+        );
+    }
+
+    #[test]
+    fn close_before_ready_resets_bridge_and_is_terminal() {
+        let (mut a, _b, circuit_id, bridge, _a_peer, _b_peer) = setup_close_observed_pair();
+        let inner_conn = ConnectionId::new(1);
+
+        a.close(circuit_id).expect("pre-ready close");
+        assert_eq!(a.inner().close_write_calls, 0);
+        assert_eq!(a.inner().reset_calls, 1);
+        assert_eq!(
+            a.poll().expect("pre-ready close event"),
+            [TransportEvent::Closed { id: circuit_id }]
+        );
+        assert_eq!(
+            a.close(circuit_id),
+            Err(TransportError::ConnectionNotFound { id: circuit_id })
+        );
+        assert!(a.poll().expect("consume reset acknowledgement").is_empty());
+        a.inject_bridge_data(inner_conn, bridge, b"late".to_vec());
+        assert!(a.poll().expect("post-close data is ignored").is_empty());
+    }
+
+    #[test]
+    fn relay_connection_close_closes_each_ready_circuit_once() {
+        let (mut a, mut b, circuit_id, _bridge, a_peer, b_peer) = setup_pair();
+        complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
+        let stream = a
+            .open_stream(circuit_id)
+            .expect("open stream before relay loss");
+        let _ = a.poll().expect("local stream open");
+        let _ = b.poll().expect("remote stream open");
+
+        a.inner_mut()
+            .close(ConnectionId::new(1))
+            .expect("relay connection closes");
+        let events = a.poll().expect("relay close mapping");
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, TransportEvent::Closed { id } if *id == circuit_id))
+                .count(),
+            1
+        );
+        assert!(events.iter().any(|event| matches!(
+            event,
+            TransportEvent::Closed { id } if *id == ConnectionId::new(1)
+        )));
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            TransportEvent::StreamClosed { id, stream_id }
+                if *id == circuit_id && *stream_id == stream
+        )));
+        assert!(a.poll().expect("relay close is terminal").is_empty());
+    }
+
+    #[test]
+    fn yamux_backpressure_is_stream_scoped_and_session_survives() {
+        let receive_window = 256 * 1024;
+        let max_buffered_send = 64;
+        let config = YamuxConfig {
+            receive_window,
+            max_frame_len: 64 * 1024,
+            max_streams: 8,
+            max_buffered_send,
+            max_total_buffered_send: 128,
+        };
+        let (mut a, mut b, circuit_id, _bridge, a_peer, b_peer) =
+            setup_pair_with_yamux_config(Some(config));
+        complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
+
+        let initiator_stream = a.open_stream(circuit_id).expect("initiator stream");
+        assert_eq!(initiator_stream.as_u64() % 2, 1);
+        let _ = a.poll().expect("local open");
+        let _ = b.poll().expect("remote open");
+
+        let error = a
+            .send_stream(
+                circuit_id,
+                initiator_stream,
+                vec![0; receive_window as usize + max_buffered_send + 1],
+            )
+            .expect_err("send beyond the Yamux queue cap");
+        assert!(matches!(error, TransportError::StreamSendFailed { .. }));
+        a.send_stream(circuit_id, initiator_stream, b"still-alive".to_vec())
+            .expect("backpressure must not poison the stream");
+        assert!(b.poll().expect("small data").iter().any(|event| matches!(
+            event,
+            TransportEvent::StreamData { data, .. } if data == b"still-alive"
+        )));
+
+        let responder_stream = b.open_stream(circuit_id).expect("responder stream");
+        assert_eq!(responder_stream.as_u64() % 2, 0);
+    }
+
+    #[test]
+    fn adoption_rejects_invalid_preconditions_without_consuming_ids() {
+        let relay = identity(9).peer_id();
+        let local = identity(1);
+        let remote = identity(2).peer_id();
+        let (inner, _) = InMemoryTransport::pair(local.peer_id(), relay.clone());
+        let mut transport = CircuitTransport::new(inner, local, CounterEntropy(1));
+        assert_eq!(
+            transport.adopt_bridge(BridgeAdoption {
+                inner_conn: ConnectionId::new(99),
+                bridge_stream: StreamId::new(1),
+                relay,
+                remote_peer: remote,
+                role: CircuitRole::Initiator,
+                pending_data: Vec::new(),
+                remote_write_closed: false,
+            }),
+            Err(AdoptError::UnknownConnection)
+        );
+        assert!(transport.circuit_ids().is_empty());
+    }
+
+    #[test]
+    fn direct_connection_wins_before_and_during_circuit_handshake() {
+        let local = identity(1);
+        let remote = identity(2).peer_id();
+        let relay = identity(9).peer_id();
+        let (inner, _) = InMemoryTransport::pair(local.peer_id(), remote.clone());
+        let mut direct_first = CircuitTransport::new(inner, local, CounterEntropy(1));
+        let _ = direct_first.poll().expect("record direct connection");
+        assert_eq!(
+            direct_first.adopt_bridge(BridgeAdoption {
+                inner_conn: ConnectionId::new(1),
+                bridge_stream: StreamId::new(1),
+                relay: relay.clone(),
+                remote_peer: remote.clone(),
+                role: CircuitRole::Initiator,
+                pending_data: Vec::new(),
+                remote_write_closed: false,
+            }),
+            Err(AdoptError::PeerAlreadyDirect)
+        );
+
+        let (mut a, _b, circuit_id, _bridge, _a_peer, b_peer) = setup_pair();
+        a.inner_mut().push_event(TransportEvent::Connected {
+            id: ConnectionId::new(2),
+            endpoint: ConnectionEndpoint::with_peer_id(
+                "/ip4/198.51.100.1/udp/5001/quic-v1"
+                    .parse()
+                    .expect("direct endpoint"),
+                b_peer,
+            ),
+        });
+        let events = a.poll().expect("direct connection arrives");
+        assert!(events.iter().any(|event| matches!(
+            event,
+            TransportEvent::Error { id, .. } if *id == circuit_id
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            TransportEvent::Closed { id } if *id == circuit_id
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            TransportEvent::Connected { id, .. } if *id == ConnectionId::new(2)
+        )));
+    }
+
+    #[test]
+    fn adoption_failures_leave_bridge_and_identifier_ownership_with_caller() {
+        let local = identity(1);
+        let remote = identity(2).peer_id();
+        let relay = identity(9).peer_id();
+        let (inner, _) = InMemoryTransport::pair(local.peer_id(), relay.clone());
+        let mut transport = CircuitTransport::new(inner, local, FailingEntropy);
+        let _ = transport.poll().expect("activate wrapped connection");
+        let adoption = BridgeAdoption {
+            inner_conn: ConnectionId::new(1),
+            bridge_stream: StreamId::new(7),
+            relay,
+            remote_peer: remote,
+            role: CircuitRole::Initiator,
+            pending_data: Vec::new(),
+            remote_write_closed: false,
+        };
+        assert!(matches!(
+            transport.adopt_bridge(adoption.clone()),
+            Err(AdoptError::Entropy(_))
+        ));
+        assert!(transport.circuit_ids().is_empty());
+        assert_eq!(
+            transport.adopt_bridge(BridgeAdoption {
+                remote_write_closed: true,
+                ..adoption.clone()
+            }),
+            Err(AdoptError::RemoteWriteClosed)
+        );
+        assert!(transport.circuit_ids().is_empty());
+        transport.next_circuit_id = None;
+        assert_eq!(
+            transport.adopt_bridge(BridgeAdoption {
+                remote_write_closed: false,
+                ..adoption
+            }),
+            Err(AdoptError::IdsExhausted)
+        );
+    }
+
+    #[test]
+    fn wrapped_high_bit_ids_are_rejected_without_becoming_circuits() {
+        let local = identity(1);
+        let relay = identity(9).peer_id();
+        let (inner, _) = InMemoryTransport::pair(local.peer_id(), relay);
+        let mut transport = CircuitTransport::new(inner, local, CounterEntropy(1));
+        let _ = transport.poll().expect("initial direct event");
+        // InMemoryTransport::dial is intentionally stubbed, so this fixture
+        // covers polled collisions; dial-return collisions need a dial fake.
+        let collision = ConnectionId::new(CIRCUIT_ID_BIT | 77);
+        transport
+            .inner_mut()
+            .push_event(TransportEvent::IncomingConnection {
+                id: collision,
+                endpoint: ConnectionEndpoint::new(
+                    "/ip4/203.0.113.7/udp/7007/quic-v1"
+                        .parse()
+                        .expect("collision endpoint"),
+                ),
+            });
+        let events = transport.poll().expect("collision event");
+        assert_eq!(
+            events,
+            vec![TransportEvent::Error {
+                id: collision,
+                message: "wrapped transport used the circuit connection-ID bit".to_string(),
+            }]
+        );
+        assert!(transport.circuit_ids().is_empty());
+    }
+}

--- a/crates/minip2p/src/discovery.rs
+++ b/crates/minip2p/src/discovery.rs
@@ -63,13 +63,13 @@ impl DiscoveryDriver {
     pub(crate) fn observe(&mut self, event: &SwarmEvent) {
         let now = self.now_ms();
         match event {
-            SwarmEvent::ConnectionEstablished { peer_id } => {
+            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 // A second establishment supersedes the relay connection that
                 // owned any tracked stream ids.
                 self.bridges.retain(|(relay, _), _| relay != peer_id);
                 self.agent.peer_connected(peer_id, now);
             }
-            SwarmEvent::ConnectionClosed { peer_id } => {
+            SwarmEvent::ConnectionClosed { peer_id, .. } => {
                 self.bridges.retain(|(relay, _), _| relay != peer_id);
                 self.agent.peer_disconnected(peer_id, now);
             }
@@ -83,10 +83,12 @@ impl DiscoveryDriver {
             SwarmEvent::StreamData {
                 peer_id, stream_id, ..
             }
-            | SwarmEvent::StreamRemoteWriteClosed { peer_id, stream_id }
-            | SwarmEvent::StreamClosed { peer_id, stream_id } => {
-                Some((peer_id.clone(), *stream_id))
+            | SwarmEvent::StreamRemoteWriteClosed {
+                peer_id, stream_id, ..
             }
+            | SwarmEvent::StreamClosed {
+                peer_id, stream_id, ..
+            } => Some((peer_id.clone(), *stream_id)),
             _ => None,
         };
         let Some(key) = key else {
@@ -416,8 +418,8 @@ mod tests {
             event,
             Event::StreamReady { peer_id, stream_id: got, .. }
                 | Event::StreamData { peer_id, stream_id: got, .. }
-                | Event::StreamRemoteWriteClosed { peer_id, stream_id: got }
-                | Event::StreamClosed { peer_id, stream_id: got }
+                | Event::StreamRemoteWriteClosed { peer_id, stream_id: got, .. }
+                | Event::StreamClosed { peer_id, stream_id: got, .. }
                 if peer_id == peer && *got == stream_id
         )
     }
@@ -446,15 +448,18 @@ mod tests {
         );
         assert!(driver.ingest(&SwarmEvent::StreamData {
             peer_id: relay.clone(),
+            conn_id: minip2p_transport::ConnectionId::new(1),
             stream_id,
             data: vec![1],
         }));
         assert!(driver.ingest(&SwarmEvent::StreamRemoteWriteClosed {
             peer_id: relay.clone(),
+            conn_id: minip2p_transport::ConnectionId::new(1),
             stream_id,
         }));
         assert!(driver.ingest(&SwarmEvent::StreamClosed {
             peer_id: relay,
+            conn_id: minip2p_transport::ConnectionId::new(1),
             stream_id,
         }));
         assert!(driver.bridges.is_empty());
@@ -469,12 +474,16 @@ mod tests {
             .insert((relay.clone(), StreamId::new(1)), BridgeState::Tombstone);
         driver.observe(&SwarmEvent::ConnectionEstablished {
             peer_id: relay.clone(),
+            conn_id: minip2p_transport::ConnectionId::new(1),
         });
         assert!(driver.bridges.is_empty());
         driver
             .bridges
             .insert((relay.clone(), StreamId::new(2)), BridgeState::Tombstone);
-        driver.observe(&SwarmEvent::ConnectionClosed { peer_id: relay });
+        driver.observe(&SwarmEvent::ConnectionClosed {
+            peer_id: relay,
+            conn_id: minip2p_transport::ConnectionId::new(1),
+        });
         assert!(driver.bridges.is_empty());
     }
 

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -914,10 +914,12 @@ fn event_matches_stream(event: &Event, peer_id: &PeerId, stream_id: StreamId) ->
             | Event::StreamRemoteWriteClosed {
                 peer_id: event_peer,
                 stream_id: event_stream,
+                ..
             }
             | Event::StreamClosed {
                 peer_id: event_peer,
                 stream_id: event_stream,
+                ..
             }
             if event_peer == peer_id && *event_stream == stream_id
     )
@@ -1310,6 +1312,7 @@ mod tests {
 
         endpoint.pending_events.push_back(Event::ConnectionClosed {
             peer_id: unrelated.clone(),
+            conn_id: ConnectionId::new(1),
         });
         assert!(
             endpoint
@@ -1322,12 +1325,13 @@ mod tests {
             endpoint
                 .next_event(Duration::from_millis(1))
                 .expect("drain buffered event"),
-            Some(Event::ConnectionClosed { peer_id }) if peer_id == unrelated
+            Some(Event::ConnectionClosed { peer_id, .. }) if peer_id == unrelated
         ));
 
         for _ in 0..RUN_UNTIL_SKIP_LIMIT {
             endpoint.pending_events.push_back(Event::ConnectionClosed {
                 peer_id: unrelated.clone(),
+                conn_id: ConnectionId::new(1),
             });
         }
         assert!(matches!(
@@ -1420,6 +1424,7 @@ mod tests {
 
         endpoint.pending_events.push_back(Event::ConnectionClosed {
             peer_id: unrelated.clone(),
+            conn_id: ConnectionId::new(1),
         });
         assert!(
             endpoint
@@ -1432,7 +1437,7 @@ mod tests {
             endpoint
                 .next_event(Duration::from_millis(1))
                 .expect("drain buffered event"),
-            Some(Event::ConnectionClosed { peer_id }) if peer_id == unrelated
+            Some(Event::ConnectionClosed { peer_id, .. }) if peer_id == unrelated
         ));
 
         let id = endpoint
@@ -1448,6 +1453,7 @@ mod tests {
             .clear();
         endpoint.pending_events.push_back(Event::ConnectionClosed {
             peer_id: unrelated.clone(),
+            conn_id: ConnectionId::new(1),
         });
         assert!(
             endpoint
@@ -1460,12 +1466,13 @@ mod tests {
             endpoint
                 .next_event(Duration::from_millis(1))
                 .expect("drain buffered event"),
-            Some(Event::ConnectionClosed { peer_id }) if peer_id == unrelated
+            Some(Event::ConnectionClosed { peer_id, .. }) if peer_id == unrelated
         ));
 
         for _ in 0..RUN_UNTIL_SKIP_LIMIT {
             endpoint.pending_events.push_back(Event::ConnectionClosed {
                 peer_id: unrelated.clone(),
+                conn_id: ConnectionId::new(1),
             });
         }
         assert!(matches!(

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -369,7 +369,7 @@ impl NatAgent {
         let mut handled = false;
         let mut touched_state = false;
         match event {
-            SwarmEvent::ConnectionEstablished { peer_id } => {
+            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 touched_state = true;
                 // Any session dial toward this peer has done its job (ours
                 // landed, or another machine's did — either way the peer is
@@ -411,7 +411,7 @@ impl NatAgent {
                     circuit.on_peer_connected(peer_id, &mut self.shared, now);
                 }
             }
-            SwarmEvent::ConnectionClosed { peer_id } => {
+            SwarmEvent::ConnectionClosed { peer_id, .. } => {
                 touched_state = true;
                 self.shared.connected.remove(peer_id);
                 self.shared.ready.remove(peer_id);
@@ -456,6 +456,7 @@ impl NatAgent {
                 stream_id,
                 protocol_id,
                 initiated_locally,
+                ..
             } => {
                 if !initiated_locally && protocol_id == STOP_PROTOCOL_ID {
                     // STOP is a relay control protocol, but registration of
@@ -504,16 +505,21 @@ impl NatAgent {
                 peer_id,
                 stream_id,
                 data,
+                ..
             } => {
                 handled = self.route_stream(peer_id, *stream_id, StreamInput::Data(data), now);
                 touched_state = handled;
             }
-            SwarmEvent::StreamRemoteWriteClosed { peer_id, stream_id } => {
+            SwarmEvent::StreamRemoteWriteClosed {
+                peer_id, stream_id, ..
+            } => {
                 handled =
                     self.route_stream(peer_id, *stream_id, StreamInput::RemoteWriteClosed, now);
                 touched_state = handled;
             }
-            SwarmEvent::StreamClosed { peer_id, stream_id } => {
+            SwarmEvent::StreamClosed {
+                peer_id, stream_id, ..
+            } => {
                 if let Some(id) = self.shared.take_released_bridge(peer_id, *stream_id) {
                     handled = true;
                     if let Some(attempt) = self.attempts.get_mut(&id) {

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -211,6 +211,7 @@ fn unconfigured_peer_cannot_claim_an_inbound_stop_stream() {
     let stream = StreamId::new(88);
     let handled = h.agent.handle_event_with_disposition(
         &SwarmEvent::StreamReady {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: attacker.clone(),
             stream_id: stream,
             protocol_id: minip2p_relay::STOP_PROTOCOL_ID.to_string(),
@@ -228,6 +229,7 @@ fn unconfigured_peer_cannot_claim_an_inbound_stop_stream() {
 
     assert!(h.agent.handle_event_with_disposition(
         &SwarmEvent::StreamData {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: attacker.clone(),
             stream_id: stream,
             data: stop_connect(&h.target),
@@ -236,6 +238,7 @@ fn unconfigured_peer_cannot_claim_an_inbound_stop_stream() {
     ));
     assert!(h.agent.handle_event_with_disposition(
         &SwarmEvent::StreamRemoteWriteClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: attacker.clone(),
             stream_id: stream,
         },
@@ -243,6 +246,7 @@ fn unconfigured_peer_cannot_claim_an_inbound_stop_stream() {
     ));
     assert!(h.agent.handle_event_with_disposition(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: attacker.clone(),
             stream_id: stream,
         },
@@ -261,6 +265,7 @@ fn remote_write_close_during_dcutr_releases_relay_and_keeps_direct_dials_live() 
 
     h.agent.handle_event(
         &SwarmEvent::StreamRemoteWriteClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: h.relay.clone(),
             stream_id: stream,
         },
@@ -308,6 +313,7 @@ fn relay_supersede_scrubs_old_stream_ids_without_resetting_the_new_connection() 
 
     h.agent.handle_event(
         &SwarmEvent::ConnectionEstablished {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: h.relay.clone(),
         },
         at(310),
@@ -323,6 +329,7 @@ fn relay_supersede_scrubs_old_stream_ids_without_resetting_the_new_connection() 
     // must not be routed into the retired attempt.
     h.agent.handle_event(
         &SwarmEvent::StreamData {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: h.relay.clone(),
             stream_id: stream,
             data: b"new connection data".to_vec(),
@@ -341,6 +348,7 @@ fn bridge_close_before_dcutr_finishes_waits_for_live_direct_dials() {
 
     h.agent.handle_event(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: h.relay.clone(),
             stream_id: stream,
         },
@@ -370,6 +378,7 @@ fn released_bridge_close_cannot_be_reported_as_a_relay_fallback() {
     // terminal event to keep the direct-upgrade race honest.
     h.agent.handle_event(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: h.relay.clone(),
             stream_id: stream,
         },
@@ -633,6 +642,7 @@ fn foreign_stream_events_are_ignored_without_state_changes() {
     assert!(!h.agent.owns_stream(&h.target, stream));
     h.agent.handle_event(
         &SwarmEvent::StreamData {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: h.target.clone(),
             stream_id: stream,
             data: b"app data".to_vec(),
@@ -814,8 +824,13 @@ fn reporter_disconnect_drops_its_observation() {
     // reconnects the relay, but the stale observation must not come back.
     let relay = h.relay.clone();
     identify_observed(&mut h.agent, &relay, &maddr(departed), at(0));
-    h.agent
-        .handle_event(&SwarmEvent::ConnectionClosed { peer_id: relay }, at(1));
+    h.agent.handle_event(
+        &SwarmEvent::ConnectionClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
+            peer_id: relay,
+        },
+        at(1),
+    );
 
     let (_id, stream) = drive_to_bridged(&mut h, 10);
     let actions = drain_actions(&mut h.agent);

--- a/crates/nat/tests/common/mod.rs
+++ b/crates/nat/tests/common/mod.rs
@@ -317,6 +317,7 @@ impl Harness {
     pub fn relay_session_ready(&mut self, now: Now) {
         self.agent.handle_event(
             &SwarmEvent::ConnectionEstablished {
+                conn_id: minip2p_transport::ConnectionId::new(1),
                 peer_id: self.relay.clone(),
             },
             now,
@@ -333,6 +334,7 @@ impl Harness {
     pub fn stream_ready(&mut self, stream: StreamId, now: Now) {
         self.agent.handle_event(
             &SwarmEvent::StreamReady {
+                conn_id: minip2p_transport::ConnectionId::new(1),
                 peer_id: self.relay.clone(),
                 stream_id: stream,
                 protocol_id: HOP_PROTOCOL_ID.to_string(),
@@ -345,6 +347,7 @@ impl Harness {
     pub fn stream_data(&mut self, stream: StreamId, data: Vec<u8>, now: Now) {
         self.agent.handle_event(
             &SwarmEvent::StreamData {
+                conn_id: minip2p_transport::ConnectionId::new(1),
                 peer_id: self.relay.clone(),
                 stream_id: stream,
                 data,
@@ -356,6 +359,7 @@ impl Harness {
     pub fn target_connected(&mut self, now: Now) {
         self.agent.handle_event(
             &SwarmEvent::ConnectionEstablished {
+                conn_id: minip2p_transport::ConnectionId::new(1),
                 peer_id: self.target.clone(),
             },
             now,

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -86,6 +86,7 @@ impl Hk {
     fn session_ready(&mut self, peer: &PeerId, protocols: &[&str], now: Now) {
         self.agent.handle_event(
             &SwarmEvent::ConnectionEstablished {
+                conn_id: minip2p_transport::ConnectionId::new(1),
                 peer_id: peer.clone(),
             },
             now,
@@ -102,6 +103,7 @@ impl Hk {
     fn stream_ready(&mut self, peer: &PeerId, stream: StreamId, protocol: &str, now: Now) {
         self.agent.handle_event(
             &SwarmEvent::StreamReady {
+                conn_id: minip2p_transport::ConnectionId::new(1),
                 peer_id: peer.clone(),
                 stream_id: stream,
                 protocol_id: protocol.to_string(),
@@ -114,6 +116,7 @@ impl Hk {
     fn stream_data(&mut self, peer: &PeerId, stream: StreamId, data: Vec<u8>, now: Now) {
         self.agent.handle_event(
             &SwarmEvent::StreamData {
+                conn_id: minip2p_transport::ConnectionId::new(1),
                 peer_id: peer.clone(),
                 stream_id: stream,
                 data,
@@ -527,6 +530,7 @@ fn lost_relay_connection_emits_lost_and_reacquires() {
     let relay = hk.relay.clone();
     hk.agent.handle_event(
         &SwarmEvent::ConnectionClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: relay.clone(),
         },
         at(5_000),
@@ -562,6 +566,7 @@ fn relay_supersede_during_renewal_emits_reservation_lost() {
     let relay = hk.relay.clone();
     hk.agent.handle_event(
         &SwarmEvent::ConnectionEstablished {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: relay.clone(),
         },
         at_unix(renew_at + 1, 1_790),

--- a/crates/nat/tests/inbound.rs
+++ b/crates/nat/tests/inbound.rs
@@ -28,6 +28,7 @@ fn inbound_harness(mut config: NatConfig) -> Harness {
 fn inbound_stop_stream(h: &mut Harness, stream: StreamId, t: u64) {
     h.agent.handle_event(
         &SwarmEvent::StreamReady {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: h.relay.clone(),
             stream_id: stream,
             protocol_id: STOP_PROTOCOL_ID.to_string(),
@@ -226,6 +227,7 @@ fn remote_write_close_keeps_an_accepted_bridge_alive_until_handoff() {
 
     h.agent.handle_event(
         &SwarmEvent::StreamRemoteWriteClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: h.relay.clone(),
             stream_id: stream,
         },
@@ -286,6 +288,7 @@ fn inbound_application_streams_are_never_claimed() {
     let stream = StreamId::new(STOP_STREAM);
     h.agent.handle_event(
         &SwarmEvent::StreamReady {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: h.relay.clone(),
             stream_id: stream,
             protocol_id: "/my-app/1.0.0".to_string(),
@@ -309,6 +312,7 @@ fn relay_disconnect_before_release_drops_the_circuit() {
 
     h.agent.handle_event(
         &SwarmEvent::ConnectionClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: h.relay.clone(),
         },
         at(20),

--- a/crates/nat/tests/two_agents.rs
+++ b/crates/nat/tests/two_agents.rs
@@ -171,6 +171,7 @@ impl World {
                         let agent = self.agent(side);
                         agent.handle_event(
                             &SwarmEvent::ConnectionEstablished {
+                                conn_id: minip2p_transport::ConnectionId::new(1),
                                 peer_id: relay.clone(),
                             },
                             now,
@@ -229,6 +230,7 @@ impl World {
                 agent.stream_open_result(token, Ok(stream), now);
                 agent.handle_event(
                     &SwarmEvent::StreamReady {
+                        conn_id: minip2p_transport::ConnectionId::new(1),
                         peer_id: relay,
                         stream_id: stream,
                         protocol_id,
@@ -300,6 +302,7 @@ impl World {
                     let relay = self.relay_id.clone();
                     self.b.handle_event(
                         &SwarmEvent::StreamReady {
+                            conn_id: minip2p_transport::ConnectionId::new(1),
                             peer_id: relay,
                             stream_id: stop_stream,
                             protocol_id: STOP_PROTOCOL_ID.to_string(),
@@ -356,6 +359,7 @@ impl World {
         let now = at(self.now);
         self.agent(side).handle_event(
             &SwarmEvent::StreamData {
+                conn_id: minip2p_transport::ConnectionId::new(1),
                 peer_id: relay,
                 stream_id: stream,
                 data,
@@ -368,10 +372,20 @@ impl World {
     fn establish_direct(&mut self) {
         let (a_id, b_id) = (self.a_id.clone(), self.b_id.clone());
         let now = at(self.now);
-        self.a
-            .handle_event(&SwarmEvent::ConnectionEstablished { peer_id: b_id }, now);
-        self.b
-            .handle_event(&SwarmEvent::ConnectionEstablished { peer_id: a_id }, now);
+        self.a.handle_event(
+            &SwarmEvent::ConnectionEstablished {
+                conn_id: minip2p_transport::ConnectionId::new(1),
+                peer_id: b_id,
+            },
+            now,
+        );
+        self.b.handle_event(
+            &SwarmEvent::ConnectionEstablished {
+                conn_id: minip2p_transport::ConnectionId::new(1),
+                peer_id: a_id,
+            },
+            now,
+        );
     }
 
     /// B acquires its reservation through the emulated relay.

--- a/crates/pubsub/src/agent.rs
+++ b/crates/pubsub/src/agent.rs
@@ -290,11 +290,11 @@ impl FloodsubAgent {
     /// floodsub control plane and must not reach the application.
     pub fn handle_event(&mut self, event: &SwarmEvent, now_ms: u64) -> bool {
         match event {
-            SwarmEvent::ConnectionEstablished { peer_id } => {
+            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 self.on_connection_established(peer_id, now_ms);
                 false
             }
-            SwarmEvent::ConnectionClosed { peer_id } => {
+            SwarmEvent::ConnectionClosed { peer_id, .. } => {
                 self.on_connection_closed(peer_id);
                 false
             }
@@ -312,18 +312,20 @@ impl FloodsubAgent {
                 stream_id,
                 protocol_id,
                 initiated_locally,
+                ..
             } => self.on_stream_ready(peer_id, *stream_id, protocol_id, *initiated_locally, now_ms),
             SwarmEvent::StreamData {
                 peer_id,
                 stream_id,
                 data,
+                ..
             } => self.on_stream_data(peer_id, *stream_id, data, now_ms),
-            SwarmEvent::StreamRemoteWriteClosed { peer_id, stream_id } => {
-                self.on_stream_remote_write_closed(peer_id, *stream_id)
-            }
-            SwarmEvent::StreamClosed { peer_id, stream_id } => {
-                self.on_stream_closed(peer_id, *stream_id, now_ms)
-            }
+            SwarmEvent::StreamRemoteWriteClosed {
+                peer_id, stream_id, ..
+            } => self.on_stream_remote_write_closed(peer_id, *stream_id),
+            SwarmEvent::StreamClosed {
+                peer_id, stream_id, ..
+            } => self.on_stream_closed(peer_id, *stream_id, now_ms),
             _ => false,
         }
     }

--- a/crates/pubsub/tests/agent.rs
+++ b/crates/pubsub/tests/agent.rs
@@ -47,6 +47,7 @@ fn drain_events(a: &mut FloodsubAgent) -> Vec<PubsubEvent> {
 fn connect(a: &mut FloodsubAgent, peer: &PeerId, now: u64) {
     a.handle_event(
         &SwarmEvent::ConnectionEstablished {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: peer.clone(),
         },
         now,
@@ -89,6 +90,7 @@ fn negotiate_send(
     a.stream_open_result(peer, token, Ok(stream_id), now);
     let claimed = a.handle_event(
         &SwarmEvent::StreamReady {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: peer.clone(),
             stream_id,
             protocol_id: FLOODSUB_PROTOCOL_ID.to_string(),
@@ -121,6 +123,7 @@ fn complete_send(
     let frame = negotiate_send(a, peer, stream_id, now)?;
     a.handle_event(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: peer.clone(),
             stream_id,
         },
@@ -133,6 +136,7 @@ fn complete_send(
 fn inbound_open(a: &mut FloodsubAgent, peer: &PeerId, stream_id: StreamId, now: u64) -> bool {
     a.handle_event(
         &SwarmEvent::StreamReady {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: peer.clone(),
             stream_id,
             protocol_id: FLOODSUB_PROTOCOL_ID.to_string(),
@@ -145,6 +149,7 @@ fn inbound_open(a: &mut FloodsubAgent, peer: &PeerId, stream_id: StreamId, now: 
 fn inbound_data(a: &mut FloodsubAgent, peer: &PeerId, stream_id: StreamId, data: &[u8], now: u64) {
     let claimed = a.handle_event(
         &SwarmEvent::StreamData {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: peer.clone(),
             stream_id,
             data: data.to_vec(),
@@ -208,6 +213,7 @@ fn connect_subscribed(
         a.stream_open_result(peer, token, Ok(snapshot_stream), now);
         a.handle_event(
             &SwarmEvent::StreamReady {
+                conn_id: minip2p_transport::ConnectionId::new(1),
                 peer_id: peer.clone(),
                 stream_id: snapshot_stream,
                 protocol_id: FLOODSUB_PROTOCOL_ID.to_string(),
@@ -217,6 +223,7 @@ fn connect_subscribed(
         );
         a.handle_event(
             &SwarmEvent::StreamClosed {
+                conn_id: minip2p_transport::ConnectionId::new(1),
                 peer_id: peer.clone(),
                 stream_id: snapshot_stream,
             },
@@ -313,6 +320,7 @@ fn mid_flight_subscription_change_commits_the_sent_snapshot_only() {
     // Close commits the {a} snapshot, then the next RPC diffs {a} -> {b}.
     a.handle_event(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: stream,
         },
@@ -347,6 +355,7 @@ fn second_publish_waits_for_stream_closed_not_remote_write_closed() {
     // Remote half-close alone must not advance the queue.
     a.handle_event(
         &SwarmEvent::StreamRemoteWriteClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: stream,
         },
@@ -357,6 +366,7 @@ fn second_publish_waits_for_stream_closed_not_remote_write_closed() {
     // The terminal close does.
     a.handle_event(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: stream,
         },
@@ -381,6 +391,7 @@ fn stream_closed_in_negotiating_discards_without_committing() {
     // Closed before StreamReady: the frame was never sent.
     a.handle_event(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: stream,
         },
@@ -586,6 +597,7 @@ fn malformed_rpc_resets_the_stream_and_keeps_owning_it() {
     // Late events on the rejected stream stay claimed and quiet.
     assert!(a.handle_event(
         &SwarmEvent::StreamData {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: stream,
             data: vec![1, 2, 3],
@@ -594,6 +606,7 @@ fn malformed_rpc_resets_the_stream_and_keeps_owning_it() {
     ));
     assert!(a.handle_event(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: stream,
         },
@@ -878,6 +891,7 @@ fn inbound_eof_half_closes_locally_and_keeps_the_role_until_the_close() {
     // Clean EOF: we close our write half so the transport can finish.
     assert!(a.handle_event(
         &SwarmEvent::StreamRemoteWriteClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: stream,
         },
@@ -892,6 +906,7 @@ fn inbound_eof_half_closes_locally_and_keeps_the_role_until_the_close() {
     assert!(a.owns_stream(&b, stream));
     assert!(a.handle_event(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: stream,
         },
@@ -912,6 +927,7 @@ fn eof_inside_a_frame_is_a_violation() {
     inbound_data(&mut a, &b, stream, &frame[..frame.len() - 1], 2);
     assert!(a.handle_event(
         &SwarmEvent::StreamRemoteWriteClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: stream,
         },
@@ -1027,7 +1043,13 @@ fn disconnect_and_supersede_emit_one_aggregated_failure() {
     drain_actions(&mut a);
 
     // Supersede: repeat ConnectionEstablished.
-    a.handle_event(&SwarmEvent::ConnectionEstablished { peer_id: b.clone() }, 2);
+    a.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            conn_id: minip2p_transport::ConnectionId::new(1),
+            peer_id: b.clone(),
+        },
+        2,
+    );
     let events = drain_events(&mut a);
     let failures: Vec<&PubsubEvent> = events
         .iter()
@@ -1047,7 +1069,13 @@ fn disconnect_and_supersede_emit_one_aggregated_failure() {
     connect_subscribed(&mut a, &b, "t", StreamId::new(3), 0);
     a.publish("t", b"one".to_vec(), 1).unwrap();
     drain_actions(&mut a);
-    a.handle_event(&SwarmEvent::ConnectionClosed { peer_id: b.clone() }, 2);
+    a.handle_event(
+        &SwarmEvent::ConnectionClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
+            peer_id: b.clone(),
+        },
+        2,
+    );
     assert_eq!(
         drain_events(&mut a)
             .iter()
@@ -1062,7 +1090,13 @@ fn peer_ready_after_inbound_traffic_preserves_state() {
     let mut a = agent();
     let b = peer(2);
     // Inbound traffic creates the peer state before PeerReady runs.
-    a.handle_event(&SwarmEvent::ConnectionEstablished { peer_id: b.clone() }, 0);
+    a.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            conn_id: minip2p_transport::ConnectionId::new(1),
+            peer_id: b.clone(),
+        },
+        0,
+    );
     let stream = StreamId::new(3);
     assert!(inbound_open(&mut a, &b, stream, 1));
     inbound_data(&mut a, &b, stream, &remote_subscribe_frame("t"), 2);
@@ -1182,6 +1216,7 @@ fn foreign_streams_and_events_are_not_claimed() {
     connect(&mut a, &b, 0);
     assert!(!a.handle_event(
         &SwarmEvent::StreamReady {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: StreamId::new(40),
             protocol_id: "/some/app/1".to_string(),
@@ -1191,6 +1226,7 @@ fn foreign_streams_and_events_are_not_claimed() {
     ));
     assert!(!a.handle_event(
         &SwarmEvent::StreamData {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: StreamId::new(40),
             data: vec![1],
@@ -1199,6 +1235,7 @@ fn foreign_streams_and_events_are_not_claimed() {
     ));
     assert!(!a.handle_event(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: StreamId::new(40),
         },
@@ -1371,6 +1408,7 @@ fn send_failure_prevents_the_commit() {
     let (token, _) = open_stream_action(&actions).expect("re-drive re-opens");
     a.handle_event(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: stream,
         },
@@ -1382,6 +1420,7 @@ fn send_failure_prevents_the_commit() {
     a.stream_open_result(&b, token, Ok(retry_stream), 4);
     a.handle_event(
         &SwarmEvent::StreamReady {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: retry_stream,
             protocol_id: FLOODSUB_PROTOCOL_ID.to_string(),
@@ -1403,6 +1442,7 @@ fn send_failure_prevents_the_commit() {
     );
     a.handle_event(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: retry_stream,
         },
@@ -1474,6 +1514,7 @@ fn unrelated_local_stream_ready_leaves_the_sender_intact() {
     // the disposition must stay false and no actions may fire.
     let claimed = a.handle_event(
         &SwarmEvent::StreamReady {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: StreamId::new(77),
             protocol_id: "/other/1.0.0".to_string(),
@@ -1487,6 +1528,7 @@ fn unrelated_local_stream_ready_leaves_the_sender_intact() {
     // The in-flight send still commits normally on its own StreamClosed.
     a.handle_event(
         &SwarmEvent::StreamClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: b.clone(),
             stream_id: sent,
         },
@@ -1518,7 +1560,13 @@ fn late_open_result_after_disconnect_resets_the_stream() {
     let actions = drain_actions(&mut a);
     let (token, _) = open_stream_action(&actions).expect("snapshot open queued");
 
-    a.handle_event(&SwarmEvent::ConnectionClosed { peer_id: b.clone() }, 1);
+    a.handle_event(
+        &SwarmEvent::ConnectionClosed {
+            conn_id: minip2p_transport::ConnectionId::new(1),
+            peer_id: b.clone(),
+        },
+        1,
+    );
     drain_events(&mut a);
 
     let late = StreamId::new(9);
@@ -1544,7 +1592,13 @@ fn late_open_result_after_supersede_resets_the_stream() {
     let actions = drain_actions(&mut a);
     let (token, _) = open_stream_action(&actions).expect("snapshot open queued");
 
-    a.handle_event(&SwarmEvent::ConnectionEstablished { peer_id: b.clone() }, 1);
+    a.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            conn_id: minip2p_transport::ConnectionId::new(1),
+            peer_id: b.clone(),
+        },
+        1,
+    );
     drain_events(&mut a);
     drain_actions(&mut a);
 
@@ -1578,7 +1632,10 @@ fn late_open_result_still_resets_after_heavy_connection_churn() {
     // first token's record many times over.
     for i in 0..100u64 {
         a.handle_event(
-            &SwarmEvent::ConnectionEstablished { peer_id: b.clone() },
+            &SwarmEvent::ConnectionEstablished {
+                conn_id: minip2p_transport::ConnectionId::new(1),
+                peer_id: b.clone(),
+            },
             i + 1,
         );
         drain_events(&mut a);

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -105,9 +105,29 @@ pub(crate) fn stream_event_matches(
         event,
         SwarmEvent::StreamReady { peer_id: peer, stream_id: stream, .. }
             | SwarmEvent::StreamData { peer_id: peer, stream_id: stream, .. }
-            | SwarmEvent::StreamRemoteWriteClosed { peer_id: peer, stream_id: stream }
-            | SwarmEvent::StreamClosed { peer_id: peer, stream_id: stream }
+            | SwarmEvent::StreamRemoteWriteClosed { peer_id: peer, stream_id: stream, .. }
+            | SwarmEvent::StreamClosed { peer_id: peer, stream_id: stream, .. }
             if peer == peer_id && *stream == stream_id
+    )
+}
+
+fn stream_action_matches(action: &SwarmAction, conn_id: ConnectionId, stream_id: StreamId) -> bool {
+    matches!(
+        action,
+        SwarmAction::SendStream {
+            conn_id: action_conn,
+            stream_id: action_stream,
+            ..
+        }
+            | SwarmAction::CloseStreamWrite {
+                conn_id: action_conn,
+                stream_id: action_stream,
+            }
+            | SwarmAction::ResetStream {
+                conn_id: action_conn,
+                stream_id: action_stream,
+            }
+            if *action_conn == conn_id && *action_stream == stream_id
     )
 }
 
@@ -190,6 +210,10 @@ pub struct SwarmCore {
     // --- Output queues ---
     events: VecDeque<SwarmEvent>,
     actions: VecDeque<SwarmAction>,
+    /// Actions that must not execute until already-queued application events
+    /// have been surfaced. Supersession uses this to expose the old
+    /// connection's eager close before asking the transport to close it.
+    after_event_actions: VecDeque<SwarmAction>,
 }
 
 impl SwarmCore {
@@ -225,6 +249,7 @@ impl SwarmCore {
             established_peers: BTreeSet::new(),
             events: VecDeque::new(),
             actions: VecDeque::new(),
+            after_event_actions: VecDeque::new(),
         }
     }
 
@@ -272,14 +297,20 @@ impl SwarmCore {
 
     /// Returns the next core output, if any.
     ///
-    /// Actions are prioritized over application events because executing an
-    /// action can feed more input back into the core. Once no actions remain,
-    /// events are yielded in FIFO order.
+    /// Actions are normally prioritized over application events because
+    /// executing an action can feed more input back into the core. Connection
+    /// supersession is the one exception: its transport close is deferred
+    /// until the eager old-connection event has been yielded.
     pub fn poll_output(&mut self) -> Option<SwarmOutput> {
         if let Some(action) = self.actions.pop_front() {
             return Some(SwarmOutput::Action(action));
         }
-        self.events.pop_front().map(SwarmOutput::Event)
+        if let Some(event) = self.events.pop_front() {
+            return Some(SwarmOutput::Event(event));
+        }
+        self.after_event_actions
+            .pop_front()
+            .map(SwarmOutput::Action)
     }
 
     /// Returns true when the core has no pending driver actions or
@@ -289,7 +320,7 @@ impl SwarmCore {
     /// have fully drained the core before waiting on sockets, timers, or
     /// application input again.
     pub fn is_idle(&self) -> bool {
-        self.actions.is_empty() && self.events.is_empty()
+        self.actions.is_empty() && self.events.is_empty() && self.after_event_actions.is_empty()
     }
 
     /// Returns the milliseconds from `now_ms` until the earliest internal
@@ -475,6 +506,27 @@ impl SwarmCore {
     /// the transport reports that the stream or connection closed.
     pub fn reset_stream_failed(&mut self, conn_id: ConnectionId, stream_id: StreamId) {
         self.reset_pending.remove(&(conn_id, stream_id));
+    }
+
+    /// Forgets all swarm bookkeeping for a transport stream.
+    ///
+    /// Unlike [`abandon_stream`](Self::abandon_stream), this does not reset
+    /// the stream and does not remove application events that are already
+    /// queued. Pending send, half-close, and reset actions for the stream are
+    /// discarded so ownership transfers without a later swarm-side mutation.
+    /// It is intended for callers that transfer ownership of a raw stream to
+    /// another Sans-I/O protocol layer.
+    pub fn forget_stream(&mut self, conn_id: ConnectionId, stream_id: StreamId) {
+        let key = (conn_id, stream_id);
+        self.stream_owner.remove(&key);
+        self.inbound_negotiators.remove(&key);
+        self.outbound_negotiators.remove(&key);
+        self.reset_pending.remove(&key);
+        self.abandoned_streams.remove(&key);
+        self.actions
+            .retain(|action| !stream_action_matches(action, conn_id, stream_id));
+        self.after_event_actions
+            .retain(|action| !stream_action_matches(action, conn_id, stream_id));
     }
 
     /// Resets and forgets a stream whose consumer will never read it again.
@@ -920,6 +972,7 @@ impl SwarmCore {
             self.established_peers.insert(peer_id.clone());
             self.events.push_back(SwarmEvent::ConnectionEstablished {
                 peer_id: peer_id.clone(),
+                conn_id: id,
             });
 
             // Auto-open identify.
@@ -954,6 +1007,10 @@ impl SwarmCore {
 
     fn supersede_connection(&mut self, old_id: ConnectionId) {
         if let Some(peer_id) = self.conn_to_peer.remove(&old_id) {
+            self.events.push_back(SwarmEvent::ConnectionClosed {
+                peer_id: peer_id.clone(),
+                conn_id: old_id,
+            });
             let pending_ping = self.pending_pings.remove(&peer_id);
             let _ = self.ping.handle_input(PingInput::RemovePeer {
                 peer_id: peer_id.clone(),
@@ -980,7 +1037,7 @@ impl SwarmCore {
         self.outbound_negotiators
             .retain(|(cid, _), _| *cid != old_id);
         self.pending_opens.retain(|_, p| p.conn_id != old_id);
-        self.actions
+        self.after_event_actions
             .push_back(SwarmAction::CloseConnection { conn_id: old_id });
     }
 
@@ -1027,6 +1084,7 @@ impl SwarmCore {
 
         self.events.push_back(SwarmEvent::ConnectionEstablished {
             peer_id: new_peer_id.clone(),
+            conn_id,
         });
 
         self.try_emit_peer_ready(&new_peer_id);
@@ -1050,8 +1108,8 @@ impl SwarmCore {
     fn migrate_buffered_events(&mut self, old: &PeerId, new: &PeerId) {
         for event in &mut self.events {
             match event {
-                SwarmEvent::ConnectionEstablished { peer_id }
-                | SwarmEvent::ConnectionClosed { peer_id }
+                SwarmEvent::ConnectionEstablished { peer_id, .. }
+                | SwarmEvent::ConnectionClosed { peer_id, .. }
                 | SwarmEvent::PingTimeout { peer_id } => {
                     if peer_id == old {
                         *peer_id = new.clone();
@@ -1166,6 +1224,7 @@ impl SwarmCore {
             ProtocolKind::User(_) => {
                 self.events.push_back(SwarmEvent::StreamData {
                     peer_id,
+                    conn_id,
                     stream_id,
                     data,
                 });
@@ -1195,8 +1254,11 @@ impl SwarmCore {
             }
             ProtocolKind::IdentifyResponder => {}
             ProtocolKind::User(_) => {
-                self.events
-                    .push_back(SwarmEvent::StreamRemoteWriteClosed { peer_id, stream_id });
+                self.events.push_back(SwarmEvent::StreamRemoteWriteClosed {
+                    peer_id,
+                    conn_id,
+                    stream_id,
+                });
             }
         }
     }
@@ -1228,8 +1290,11 @@ impl SwarmCore {
                     self.drain_identify_outputs();
                 }
                 ProtocolKind::User(_) => {
-                    self.events
-                        .push_back(SwarmEvent::StreamClosed { peer_id, stream_id });
+                    self.events.push_back(SwarmEvent::StreamClosed {
+                        peer_id,
+                        conn_id,
+                        stream_id,
+                    });
                 }
             }
         }
@@ -1259,7 +1324,7 @@ impl SwarmCore {
                 self.ready_peers.remove(&peer_id);
                 self.established_peers.remove(&peer_id);
                 self.events
-                    .push_back(SwarmEvent::ConnectionClosed { peer_id });
+                    .push_back(SwarmEvent::ConnectionClosed { peer_id, conn_id });
             }
         }
 
@@ -1516,6 +1581,7 @@ impl SwarmCore {
             );
             self.events.push_back(SwarmEvent::StreamReady {
                 peer_id,
+                conn_id,
                 stream_id,
                 protocol_id: protocol.to_string(),
                 initiated_locally: false,
@@ -1582,6 +1648,7 @@ impl SwarmCore {
             ProtocolKind::User(protocol_id) => {
                 self.events.push_back(SwarmEvent::StreamReady {
                     peer_id,
+                    conn_id,
                     stream_id,
                     protocol_id,
                     initiated_locally: true,
@@ -1891,6 +1958,7 @@ mod tests {
             .insert((conn, stream), ProtocolKind::User("/test/1".into()));
         core.events.push_back(SwarmEvent::StreamData {
             peer_id: peer.clone(),
+            conn_id: conn,
             stream_id: stream,
             data: vec![1],
         });
@@ -2123,6 +2191,118 @@ mod tests {
             err,
             SwarmError::StreamNotFound { peer_id: p, stream_id: s }
                 if p == peer_id && s == stream_id
+        ));
+    }
+
+    #[test]
+    fn superseding_connection_reports_old_close_before_new_establishment() {
+        let mut core = test_core();
+        let peer_id = PeerId::from_public_key_protobuf(b"superseded-peer");
+        let original = ConnectionId::new(20);
+        let replacement = ConnectionId::new(21);
+        feed(
+            &mut core,
+            TransportEvent::Connected {
+                id: original,
+                endpoint: ConnectionEndpoint::with_peer_id(loopback_transport(), peer_id.clone()),
+            },
+        );
+        let _ = drain_events(&mut core);
+        feed(
+            &mut core,
+            TransportEvent::Connected {
+                id: replacement,
+                endpoint: ConnectionEndpoint::with_peer_id(loopback_transport(), peer_id),
+            },
+        );
+        let outputs: Vec<_> = core::iter::from_fn(|| core.poll_output()).collect();
+        let lifecycle: Vec<_> = outputs
+            .iter()
+            .filter_map(|output| match output {
+                SwarmOutput::Event(event @ SwarmEvent::ConnectionEstablished { .. })
+                | SwarmOutput::Event(event @ SwarmEvent::ConnectionClosed { .. }) => Some(event),
+                _ => None,
+            })
+            .collect();
+        assert!(matches!(
+            lifecycle.as_slice(),
+            [
+                SwarmEvent::ConnectionClosed { conn_id: closed, .. },
+                SwarmEvent::ConnectionEstablished { conn_id: second, .. },
+            ] if *closed == original && *second == replacement
+        ));
+        let closed_position = outputs
+            .iter()
+            .position(|output| matches!(output, SwarmOutput::Event(SwarmEvent::ConnectionClosed { conn_id, .. }) if *conn_id == original))
+            .expect("eager close event");
+        let close_action_position = outputs
+            .iter()
+            .position(|output| matches!(output, SwarmOutput::Action(SwarmAction::CloseConnection { conn_id }) if *conn_id == original))
+            .expect("transport close action");
+        assert!(closed_position < close_action_position);
+    }
+
+    #[test]
+    fn forget_stream_drops_bookkeeping_without_reset_or_event_purge() {
+        let mut core = test_core();
+        let peer = PeerId::from_public_key_protobuf(b"transferred-stream-peer");
+        let conn = ConnectionId::new(30);
+        let stream = StreamId::new(7);
+        let key = (conn, stream);
+        core.conn_to_peer.insert(conn, peer.clone());
+        core.peer_to_conn.insert(peer.clone(), conn);
+        core.stream_owner
+            .insert(key, ProtocolKind::User("/test/1".into()));
+        core.inbound_negotiators
+            .insert(key, MultistreamSelect::listener(["/test/1".to_string()]));
+        core.outbound_negotiators.insert(
+            key,
+            PendingOutbound {
+                negotiator: MultistreamSelect::dialer("/test/1"),
+                target: ProtocolKind::User("/test/1".into()),
+            },
+        );
+        core.reset_stream(&peer, stream)
+            .expect("active user stream can be reset");
+        core.abandoned_streams.insert(key);
+        core.actions.push_back(SwarmAction::SendStream {
+            conn_id: conn,
+            stream_id: stream,
+            data: vec![2],
+        });
+        core.actions.push_back(SwarmAction::CloseStreamWrite {
+            conn_id: conn,
+            stream_id: stream,
+        });
+        let other_stream = StreamId::new(8);
+        core.actions.push_back(SwarmAction::ResetStream {
+            conn_id: conn,
+            stream_id: other_stream,
+        });
+        core.events.push_back(SwarmEvent::StreamData {
+            peer_id: peer.clone(),
+            conn_id: conn,
+            stream_id: stream,
+            data: vec![1],
+        });
+
+        core.forget_stream(conn, stream);
+
+        assert!(!core.stream_owner.contains_key(&key));
+        assert!(!core.inbound_negotiators.contains_key(&key));
+        assert!(!core.outbound_negotiators.contains_key(&key));
+        assert!(!core.reset_pending.contains(&key));
+        assert!(!core.abandoned_streams.contains(&key));
+        assert_eq!(core.actions.len(), 1);
+        assert!(matches!(
+            core.actions.front(),
+            Some(SwarmAction::ResetStream { conn_id, stream_id })
+                if *conn_id == conn && *stream_id == other_stream
+        ));
+        assert!(matches!(
+            core.events.front(),
+            Some(SwarmEvent::StreamData { conn_id, stream_id, .. })
+                if *conn_id == conn && *stream_id == stream
         ));
     }
 

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -131,6 +131,30 @@ fn stream_action_matches(action: &SwarmAction, conn_id: ConnectionId, stream_id:
     )
 }
 
+fn connection_action_matches(action: &SwarmAction, conn_id: ConnectionId) -> bool {
+    match action {
+        SwarmAction::OpenStream {
+            conn_id: action_conn,
+            ..
+        }
+        | SwarmAction::SendStream {
+            conn_id: action_conn,
+            ..
+        }
+        | SwarmAction::CloseStreamWrite {
+            conn_id: action_conn,
+            ..
+        }
+        | SwarmAction::ResetStream {
+            conn_id: action_conn,
+            ..
+        }
+        | SwarmAction::CloseConnection {
+            conn_id: action_conn,
+        } => *action_conn == conn_id,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // SwarmCore
 // ---------------------------------------------------------------------------
@@ -1037,6 +1061,10 @@ impl SwarmCore {
         self.outbound_negotiators
             .retain(|(cid, _), _| *cid != old_id);
         self.pending_opens.retain(|_, p| p.conn_id != old_id);
+        self.actions
+            .retain(|action| !connection_action_matches(action, old_id));
+        self.after_event_actions
+            .retain(|action| !connection_action_matches(action, old_id));
         self.after_event_actions
             .push_back(SwarmAction::CloseConnection { conn_id: old_id });
     }
@@ -2191,6 +2219,59 @@ mod tests {
             err,
             SwarmError::StreamNotFound { peer_id: p, stream_id: s }
                 if p == peer_id && s == stream_id
+        ));
+    }
+
+    #[test]
+    fn superseding_connection_discards_undrained_old_actions() {
+        let mut core = test_core();
+        let peer_id = PeerId::from_public_key_protobuf(b"undrained-superseded-peer");
+        let original = ConnectionId::new(12);
+        let replacement = ConnectionId::new(13);
+        let stream = StreamId::new(8);
+
+        feed(
+            &mut core,
+            TransportEvent::Connected {
+                id: original,
+                endpoint: ConnectionEndpoint::with_peer_id(loopback_transport(), peer_id.clone()),
+            },
+        );
+        core.stream_owner.insert(
+            (original, stream),
+            ProtocolKind::User("/minip2p/test/1.0.0".into()),
+        );
+        core.send_stream(&peer_id, stream, b"stale".to_vec())
+            .expect("old connection stream should initially be active");
+        core.close_stream_write(&peer_id, stream)
+            .expect("old connection stream should initially be active");
+        core.reset_stream(&peer_id, stream)
+            .expect("old connection stream should initially be active");
+
+        // Supersede before draining the original connection's automatic
+        // Identify open or the application-requested stream actions.
+        feed(
+            &mut core,
+            TransportEvent::Connected {
+                id: replacement,
+                endpoint: ConnectionEndpoint::with_peer_id(loopback_transport(), peer_id),
+            },
+        );
+
+        assert!(
+            core.actions
+                .iter()
+                .all(|action| !connection_action_matches(action, original)),
+            "no ordinary action for the superseded connection may reach the driver"
+        );
+        assert!(
+            core.pending_opens
+                .values()
+                .all(|pending| pending.conn_id != original)
+        );
+        assert!(matches!(
+            core.after_event_actions.as_slices(),
+            ([SwarmAction::CloseConnection { conn_id }], []) if *conn_id == original
         ));
     }
 

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -186,6 +186,12 @@ pub struct Swarm<T: Transport> {
     /// when the buffer drains.
     event_buffer: VecDeque<SwarmEvent>,
 
+    /// Transport actions ordered after application events by the Sans-I/O
+    /// core. They are dispatched only after the buffered events have been
+    /// returned to the application. In particular, supersession must expose
+    /// `ConnectionClosed` before closing the old transport connection.
+    after_event_actions: VecDeque<SwarmAction>,
+
     /// Externally validated addresses advertised through Identify in
     /// addition to the transport's bound set. See
     /// [`Swarm::set_external_addresses`].
@@ -233,6 +239,7 @@ impl<T: Transport> Swarm<T> {
             core: SwarmCore::new(identify_config, ping_config),
             local_peer_id,
             event_buffer: VecDeque::new(),
+            after_event_actions: VecDeque::new(),
             external_addresses: Vec::new(),
             clock,
         }
@@ -522,6 +529,14 @@ impl<T: Transport> Swarm<T> {
         Ok(())
     }
 
+    /// Forgets swarm bookkeeping for a stream without touching the transport.
+    ///
+    /// This is used when ownership of a negotiated stream moves to another
+    /// protocol layer. Already-buffered events are intentionally preserved.
+    pub fn forget_stream(&mut self, conn_id: ConnectionId, stream_id: StreamId) {
+        self.core.forget_stream(conn_id, stream_id);
+    }
+
     /// Resets and forgets a stream whose consumer will never read it again.
     ///
     /// This is idempotent with a previously queued reset and removes matching
@@ -548,6 +563,12 @@ impl<T: Transport> Swarm<T> {
     pub fn poll(&mut self) -> Result<Vec<SwarmEvent>, DriverError> {
         let now_ms = self.now_ms();
 
+        // Actions deferred by the previous poll are now safe to dispatch if
+        // every event that preceded them has been returned to the caller.
+        // Do this before reading more transport input so superseded
+        // connections cannot produce another batch ahead of their close.
+        self.flush_actions();
+
         // 0. Refresh the core's snapshot of our listening addresses so
         //    Identify advertises the current bound set plus any validated
         //    external addresses. Cheap -- a handful of multiaddrs at most.
@@ -572,17 +593,10 @@ impl<T: Transport> Swarm<T> {
         // 3. Execute all queued actions (may cascade -- see flush_actions).
         self.flush_actions();
 
-        // 4. Return the application's events.
-        let mut events: Vec<SwarmEvent> = self.event_buffer.drain(..).collect();
-        while let Some(output) = self.core.poll_output() {
-            match output {
-                SwarmOutput::Action(action) => {
-                    self.dispatch_action(action, &mut None, &mut None, &mut None)
-                }
-                SwarmOutput::Event(event) => events.push(event),
-            }
-        }
-        Ok(events)
+        // 4. Return the application's events. `flush_actions` fully drained
+        //    the core; any action ordered after these events is held in the
+        //    driver's `after_event_actions` queue until a later call.
+        Ok(self.event_buffer.drain(..).collect())
     }
 
     /// Returns the next swarm event, sleeping internally until one arrives
@@ -761,12 +775,33 @@ impl<T: Transport> Swarm<T> {
     /// reported back).
     fn flush_actions(&mut self) {
         let mut allocated: Option<StreamId> = None;
+
+        // A buffered event has not yet been delivered by `poll_next`, so its
+        // dependent actions must remain deferred. `poll()` drains this buffer
+        // into its return value; the next driver call may then dispatch them.
+        if self.event_buffer.is_empty() {
+            while let Some(action) = self.after_event_actions.pop_front() {
+                self.dispatch_action(action, &mut allocated, &mut None, &mut None);
+            }
+        }
+
+        // Only events drained in this pass gate the actions that follow them.
+        // Pre-existing buffered events may be unrelated (for example, a
+        // failed reset's error before a synchronous retry), so they must not
+        // defer new caller-initiated work.
+        let mut saw_event = false;
         while let Some(output) = self.core.poll_output() {
             match output {
+                SwarmOutput::Action(action) if saw_event => {
+                    self.after_event_actions.push_back(action);
+                }
                 SwarmOutput::Action(action) => {
                     self.dispatch_action(action, &mut allocated, &mut None, &mut None)
                 }
-                SwarmOutput::Event(event) => self.event_buffer.push_back(event),
+                SwarmOutput::Event(event) => {
+                    saw_event = true;
+                    self.event_buffer.push_back(event);
+                }
             }
         }
     }
@@ -961,6 +996,101 @@ mod tests {
         }
     }
 
+    /// Deterministic transport that surfaces two connections to the same
+    /// peer on consecutive polls and records when the driver closes one.
+    struct SupersessionTransport {
+        event_batches: VecDeque<Vec<TransportEvent>>,
+        next_stream: u64,
+        close_calls: Vec<ConnectionId>,
+    }
+
+    impl SupersessionTransport {
+        fn new(peer_id: PeerId, original: ConnectionId, replacement: ConnectionId) -> Self {
+            let endpoint = || ConnectionEndpoint::with_peer_id(Multiaddr::new(), peer_id.clone());
+            Self {
+                event_batches: VecDeque::from([
+                    vec![TransportEvent::Connected {
+                        id: original,
+                        endpoint: endpoint(),
+                    }],
+                    vec![TransportEvent::Connected {
+                        id: replacement,
+                        endpoint: endpoint(),
+                    }],
+                ]),
+                next_stream: 1,
+                close_calls: Vec::new(),
+            }
+        }
+    }
+
+    impl Transport for SupersessionTransport {
+        fn dial(&mut self, _: &PeerAddr) -> Result<ConnectionId, TransportError> {
+            unreachable!()
+        }
+
+        fn listen(&mut self, _: &Multiaddr) -> Result<Multiaddr, TransportError> {
+            unreachable!()
+        }
+
+        fn open_stream(&mut self, _: ConnectionId) -> Result<StreamId, TransportError> {
+            let stream_id = StreamId::new(self.next_stream);
+            self.next_stream += 1;
+            Ok(stream_id)
+        }
+
+        fn send_stream(
+            &mut self,
+            _: ConnectionId,
+            _: StreamId,
+            _: Vec<u8>,
+        ) -> Result<(), TransportError> {
+            Ok(())
+        }
+
+        fn close_stream_write(
+            &mut self,
+            _: ConnectionId,
+            _: StreamId,
+        ) -> Result<(), TransportError> {
+            Ok(())
+        }
+
+        fn reset_stream(&mut self, _: ConnectionId, _: StreamId) -> Result<(), TransportError> {
+            Ok(())
+        }
+
+        fn close(&mut self, conn_id: ConnectionId) -> Result<(), TransportError> {
+            self.close_calls.push(conn_id);
+            Ok(())
+        }
+
+        fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError> {
+            Ok(self.event_batches.pop_front().unwrap_or_default())
+        }
+    }
+
+    fn supersession_swarm(
+        remote_peer: PeerId,
+        original: ConnectionId,
+        replacement: ConnectionId,
+    ) -> Swarm<SupersessionTransport> {
+        let keypair = Ed25519Keypair::generate();
+        let transport = SupersessionTransport::new(remote_peer, original, replacement);
+        let identify = IdentifyConfig {
+            protocol_version: "test/1".into(),
+            agent_version: "test/1".into(),
+            protocols: Vec::new(),
+            public_key: keypair.public_key().encode_protobuf(),
+        };
+        Swarm::new(
+            transport,
+            identify,
+            PingConfig::default(),
+            keypair.peer_id(),
+        )
+    }
+
     /// Transport whose `open_stream` fails on exactly one (1-based) call and
     /// succeeds otherwise, returning the call index as the stream id.
     struct FailingUserOpenTransport {
@@ -1071,6 +1201,74 @@ mod tests {
     }
 
     #[test]
+    fn superseded_connection_closes_after_public_event_is_returned() {
+        let remote_peer = Ed25519Keypair::generate().peer_id();
+        let original = ConnectionId::new(41);
+        let replacement = ConnectionId::new(42);
+        let mut swarm = supersession_swarm(remote_peer.clone(), original, replacement);
+
+        let first = swarm.poll().expect("original connection poll");
+        assert!(matches!(
+            first.as_slice(),
+            [SwarmEvent::ConnectionEstablished { conn_id, .. }] if *conn_id == original
+        ));
+
+        let superseded = swarm.poll().expect("replacement connection poll");
+        assert!(matches!(
+            superseded.as_slice(),
+            [
+                SwarmEvent::ConnectionClosed { conn_id: closed, .. },
+                SwarmEvent::ConnectionEstablished { conn_id: established, .. },
+            ] if *closed == original && *established == replacement
+        ));
+        assert!(
+            swarm.transport().close_calls.is_empty(),
+            "the old transport must remain open until the close event is returned"
+        );
+
+        let later = swarm.poll().expect("post-delivery poll");
+        assert!(later.is_empty());
+        assert_eq!(swarm.transport().close_calls, vec![original]);
+        assert_eq!(swarm.connected_peers(), vec![remote_peer]);
+    }
+
+    #[test]
+    fn superseded_connection_close_waits_for_buffered_poll_next_events() {
+        let remote_peer = Ed25519Keypair::generate().peer_id();
+        let original = ConnectionId::new(51);
+        let replacement = ConnectionId::new(52);
+        let mut swarm = supersession_swarm(remote_peer, original, replacement);
+
+        let _ = swarm.poll().expect("original connection poll");
+        let closed = swarm
+            .poll_next(Duration::ZERO)
+            .expect("replacement connection poll")
+            .expect("eager close event");
+        assert!(matches!(
+            closed,
+            SwarmEvent::ConnectionClosed { conn_id, .. } if conn_id == original
+        ));
+        assert!(swarm.transport().close_calls.is_empty());
+
+        // `poll_next` still owns the establishment event buffered from the
+        // same core turn, so it must return that event before dispatching the
+        // dependent close action.
+        let established = swarm
+            .poll_next(Duration::ZERO)
+            .expect("buffered replacement event")
+            .expect("replacement established event");
+        assert!(matches!(
+            established,
+            SwarmEvent::ConnectionEstablished { conn_id, .. } if conn_id == replacement
+        ));
+        assert!(swarm.transport().close_calls.is_empty());
+
+        let later = swarm.poll().expect("post-delivery poll");
+        assert!(later.is_empty());
+        assert_eq!(swarm.transport().close_calls, vec![original]);
+    }
+
+    #[test]
     fn deadline_earliest_picks_the_sooner_deadline() {
         let soon = Deadline::from(Duration::from_millis(10));
         let later = Deadline::from(Duration::from_secs(60));
@@ -1109,6 +1307,7 @@ mod tests {
             .event_buffer
             .push_back(SwarmEvent::ConnectionEstablished {
                 peer_id: peer_id.clone(),
+                conn_id: ConnectionId::new(1),
             });
 
         let event = swarm
@@ -1117,7 +1316,7 @@ mod tests {
             .expect("buffered event");
         assert!(matches!(
             event,
-            SwarmEvent::ConnectionEstablished { peer_id: p } if p == peer_id
+            SwarmEvent::ConnectionEstablished { peer_id: p, .. } if p == peer_id
         ));
     }
 
@@ -1129,6 +1328,7 @@ mod tests {
             .event_buffer
             .push_back(SwarmEvent::ConnectionEstablished {
                 peer_id: target_peer_id.clone(),
+                conn_id: ConnectionId::new(1),
             });
         swarm.event_buffer.push_back(SwarmEvent::PeerReady {
             peer_id: target_peer_id.clone(),
@@ -1149,7 +1349,7 @@ mod tests {
             .expect("restored event");
         assert!(matches!(
             restored,
-            SwarmEvent::ConnectionEstablished { peer_id } if peer_id == target_peer_id
+            SwarmEvent::ConnectionEstablished { peer_id, .. } if peer_id == target_peer_id
         ));
     }
 
@@ -1161,6 +1361,7 @@ mod tests {
             .event_buffer
             .push_back(SwarmEvent::ConnectionEstablished {
                 peer_id: peer_id.clone(),
+                conn_id: ConnectionId::new(1),
             });
         swarm.event_buffer.push_back(SwarmEvent::PeerReady {
             peer_id,
@@ -1197,6 +1398,7 @@ mod tests {
             .event_buffer
             .push_back(SwarmEvent::ConnectionEstablished {
                 peer_id: peer_id.clone(),
+                conn_id: ConnectionId::new(1),
             });
         swarm.event_buffer.push_back(SwarmEvent::PeerReady {
             peer_id: peer_id.clone(),
@@ -1218,7 +1420,7 @@ mod tests {
         assert_eq!(swarm.event_buffer.len(), 1);
         assert!(matches!(
             swarm.event_buffer.front(),
-            Some(SwarmEvent::ConnectionEstablished { peer_id: restored }) if *restored == peer_id
+            Some(SwarmEvent::ConnectionEstablished { peer_id: restored, .. }) if *restored == peer_id
         ));
     }
 
@@ -1535,6 +1737,7 @@ mod tests {
     fn indexed_stream_data(peer_id: &PeerId, index: u64) -> SwarmEvent {
         SwarmEvent::StreamData {
             peer_id: peer_id.clone(),
+            conn_id: ConnectionId::new(1),
             stream_id: StreamId::new(index),
             data: vec![0u8; 8],
         }

--- a/crates/swarm/src/events.rs
+++ b/crates/swarm/src/events.rs
@@ -16,9 +16,15 @@ use minip2p_transport::{ConnectionId, StreamId, TransportEvent};
 #[derive(Clone, Debug)]
 pub enum SwarmEvent {
     /// A new connection was established and identity verified.
-    ConnectionEstablished { peer_id: PeerId },
+    ConnectionEstablished {
+        peer_id: PeerId,
+        conn_id: ConnectionId,
+    },
     /// A connection was closed.
-    ConnectionClosed { peer_id: PeerId },
+    ConnectionClosed {
+        peer_id: PeerId,
+        conn_id: ConnectionId,
+    },
     /// Identify information received from a remote peer.
     IdentifyReceived {
         peer_id: PeerId,
@@ -43,6 +49,7 @@ pub enum SwarmEvent {
     /// when the remote peer did.
     StreamReady {
         peer_id: PeerId,
+        conn_id: ConnectionId,
         stream_id: StreamId,
         protocol_id: String,
         initiated_locally: bool,
@@ -50,17 +57,20 @@ pub enum SwarmEvent {
     /// Raw data arrived on a negotiated user stream.
     StreamData {
         peer_id: PeerId,
+        conn_id: ConnectionId,
         stream_id: StreamId,
         data: Vec<u8>,
     },
     /// The remote closed its write side on a user stream.
     StreamRemoteWriteClosed {
         peer_id: PeerId,
+        conn_id: ConnectionId,
         stream_id: StreamId,
     },
     /// A user stream was fully closed.
     StreamClosed {
         peer_id: PeerId,
+        conn_id: ConnectionId,
         stream_id: StreamId,
     },
     /// A non-fatal runtime error occurred.

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -11,3 +11,4 @@ workspace = true
 [dependencies]
 minip2p-core = { path = "../core" }
 minip2p-relay = { path = "../relay" }
+minip2p-transport = { path = "../transport" }

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -2,13 +2,288 @@
 //!
 //! This crate is `publish = false` and is used only through dev-dependencies.
 
-use std::collections::HashMap;
+use std::cell::RefCell;
+use std::collections::{HashMap, VecDeque};
+use std::rc::Rc;
+use std::time::Duration;
 
-use minip2p_core::PeerId;
+use minip2p_core::{Multiaddr, PeerAddr, PeerId};
 use minip2p_relay::{
     FrameDecode, HopMessage, HopMessageType, Peer, Reservation, Status, StopMessage,
     StopMessageType, decode_frame, encode_frame,
 };
+use minip2p_transport::{
+    ConnectionEndpoint, ConnectionId, StreamId, Transport, TransportError, TransportEvent,
+    WaitOutcome,
+};
+
+/// Deterministic, connected, in-memory implementation of the transport contract.
+///
+/// A pair transfers stream events directly into its partner's poll queue. It
+/// is intentionally single-threaded and is meant for protocol wrapper tests.
+pub struct InMemoryTransport {
+    shared: Rc<RefCell<InMemoryLink>>,
+    side: usize,
+    connection: ConnectionId,
+    local_addr: Multiaddr,
+    remote_addr: Multiaddr,
+}
+
+struct InMemoryLink {
+    queues: [VecDeque<TransportEvent>; 2],
+    next_stream: [u64; 2],
+    active: bool,
+    streams: HashMap<StreamId, InMemoryStream>,
+}
+
+#[derive(Default)]
+struct InMemoryStream {
+    write_closed: [bool; 2],
+    closed: bool,
+}
+
+impl InMemoryTransport {
+    /// Creates a connected pair and queues the normal inbound/connected events.
+    pub fn pair(local_peer: PeerId, remote_peer: PeerId) -> (Self, Self) {
+        let a_addr: Multiaddr = "/ip4/192.0.2.1/udp/4001/quic-v1"
+            .parse()
+            .expect("test multiaddr");
+        let b_addr: Multiaddr = "/ip4/192.0.2.2/udp/4002/quic-v1"
+            .parse()
+            .expect("test multiaddr");
+        let connection = ConnectionId::new(1);
+        let mut queues = [VecDeque::new(), VecDeque::new()];
+        queues[0].push_back(TransportEvent::Connected {
+            id: connection,
+            endpoint: ConnectionEndpoint::with_peer_id(b_addr.clone(), remote_peer),
+        });
+        queues[1].push_back(TransportEvent::IncomingConnection {
+            id: connection,
+            endpoint: ConnectionEndpoint::new(a_addr.clone()),
+        });
+        queues[1].push_back(TransportEvent::Connected {
+            id: connection,
+            endpoint: ConnectionEndpoint::with_peer_id(a_addr.clone(), local_peer),
+        });
+        let shared = Rc::new(RefCell::new(InMemoryLink {
+            queues,
+            next_stream: [1, 2],
+            active: true,
+            streams: HashMap::new(),
+        }));
+        (
+            Self {
+                shared: shared.clone(),
+                side: 0,
+                connection,
+                local_addr: a_addr.clone(),
+                remote_addr: b_addr.clone(),
+            },
+            Self {
+                shared,
+                side: 1,
+                connection,
+                local_addr: b_addr,
+                remote_addr: a_addr,
+            },
+        )
+    }
+
+    /// Returns the sole local connection identifier.
+    pub fn connection_id(&self) -> ConnectionId {
+        self.connection
+    }
+
+    /// Queues a synthetic local event for deterministic wrapper edge cases.
+    pub fn push_event(&mut self, event: TransportEvent) {
+        self.shared.borrow_mut().queues[self.side].push_back(event);
+    }
+
+    fn ensure_connection(&self, id: ConnectionId) -> Result<(), TransportError> {
+        if self.shared.borrow().active && id == self.connection {
+            Ok(())
+        } else {
+            Err(TransportError::ConnectionNotFound { id })
+        }
+    }
+
+    fn stream_not_found(&self, stream_id: StreamId) -> TransportError {
+        TransportError::StreamNotFound {
+            id: self.connection,
+            stream_id,
+        }
+    }
+}
+
+impl Transport for InMemoryTransport {
+    fn dial(&mut self, _addr: &PeerAddr) -> Result<ConnectionId, TransportError> {
+        Err(TransportError::InvalidConfig {
+            reason: "in-memory pair is already connected".into(),
+        })
+    }
+
+    fn listen(&mut self, _addr: &Multiaddr) -> Result<Multiaddr, TransportError> {
+        let addr = self.local_addr.clone();
+        self.shared.borrow_mut().queues[self.side]
+            .push_back(TransportEvent::Listening { addr: addr.clone() });
+        Ok(addr)
+    }
+
+    fn open_stream(&mut self, id: ConnectionId) -> Result<StreamId, TransportError> {
+        self.ensure_connection(id)?;
+        let other = 1 - self.side;
+        let mut shared = self.shared.borrow_mut();
+        let stream_id = StreamId::new(shared.next_stream[self.side]);
+        shared.next_stream[self.side] += 2;
+        let previous = shared.streams.insert(stream_id, InMemoryStream::default());
+        debug_assert!(previous.is_none(), "stream ids are unique within a pair");
+        shared.queues[self.side].push_back(TransportEvent::StreamOpened { id, stream_id });
+        shared.queues[other].push_back(TransportEvent::IncomingStream {
+            id: self.connection,
+            stream_id,
+        });
+        Ok(stream_id)
+    }
+
+    fn send_stream(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+        data: Vec<u8>,
+    ) -> Result<(), TransportError> {
+        self.ensure_connection(id)?;
+        let mut shared = self.shared.borrow_mut();
+        let Some(stream) = shared.streams.get(&stream_id) else {
+            return Err(self.stream_not_found(stream_id));
+        };
+        if stream.closed {
+            return Err(self.stream_not_found(stream_id));
+        }
+        if stream.write_closed[self.side] {
+            return Err(TransportError::StreamSendFailed {
+                id,
+                stream_id,
+                reason: "write side is closed".into(),
+            });
+        }
+        if data.is_empty() {
+            return Ok(());
+        }
+        shared.queues[1 - self.side].push_back(TransportEvent::StreamData {
+            id: self.connection,
+            stream_id,
+            data,
+        });
+        Ok(())
+    }
+
+    fn close_stream_write(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+    ) -> Result<(), TransportError> {
+        self.ensure_connection(id)?;
+        let other = 1 - self.side;
+        let mut shared = self.shared.borrow_mut();
+        let both_write_closed = {
+            let Some(stream) = shared.streams.get_mut(&stream_id) else {
+                return Err(self.stream_not_found(stream_id));
+            };
+            if stream.closed {
+                return Err(self.stream_not_found(stream_id));
+            }
+            if stream.write_closed[self.side] {
+                return Ok(());
+            }
+            stream.write_closed[self.side] = true;
+            let both_write_closed = stream.write_closed[other];
+            if both_write_closed {
+                stream.closed = true;
+            }
+            both_write_closed
+        };
+        shared.queues[other].push_back(TransportEvent::StreamRemoteWriteClosed {
+            id: self.connection,
+            stream_id,
+        });
+        if both_write_closed {
+            shared.queues[self.side].push_back(TransportEvent::StreamClosed { id, stream_id });
+            shared.queues[other].push_back(TransportEvent::StreamClosed {
+                id: self.connection,
+                stream_id,
+            });
+        }
+        Ok(())
+    }
+
+    fn reset_stream(
+        &mut self,
+        id: ConnectionId,
+        stream_id: StreamId,
+    ) -> Result<(), TransportError> {
+        self.ensure_connection(id)?;
+        let other = 1 - self.side;
+        let mut shared = self.shared.borrow_mut();
+        let Some(stream) = shared.streams.get_mut(&stream_id) else {
+            return Err(self.stream_not_found(stream_id));
+        };
+        if stream.closed {
+            return Ok(());
+        }
+        stream.closed = true;
+        shared.queues[self.side].push_back(TransportEvent::StreamClosed { id, stream_id });
+        shared.queues[other].push_back(TransportEvent::StreamClosed {
+            id: self.connection,
+            stream_id,
+        });
+        Ok(())
+    }
+
+    fn close(&mut self, id: ConnectionId) -> Result<(), TransportError> {
+        self.ensure_connection(id)?;
+        let other = 1 - self.side;
+        let mut shared = self.shared.borrow_mut();
+        shared.active = false;
+        for stream in shared.streams.values_mut() {
+            stream.closed = true;
+        }
+        shared.queues[self.side].push_back(TransportEvent::Closed { id });
+        shared.queues[other].push_back(TransportEvent::Closed {
+            id: self.connection,
+        });
+        Ok(())
+    }
+
+    fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError> {
+        Ok(self.shared.borrow_mut().queues[self.side]
+            .drain(..)
+            .collect())
+    }
+
+    fn next_timeout(&self) -> Option<Duration> {
+        (!self.shared.borrow().queues[self.side].is_empty()).then_some(Duration::ZERO)
+    }
+
+    fn wait_for_input(&mut self, _timeout: Duration) -> WaitOutcome {
+        if self.shared.borrow().queues[self.side].is_empty() {
+            WaitOutcome::Unsupported
+        } else {
+            WaitOutcome::Ready
+        }
+    }
+
+    fn local_addresses(&self) -> Vec<Multiaddr> {
+        vec![self.local_addr.clone()]
+    }
+
+    fn active_inbound_connection_sources(&self) -> Vec<Multiaddr> {
+        if self.side == 1 && self.shared.borrow().active {
+            vec![self.remote_addr.clone()]
+        } else {
+            Vec::new()
+        }
+    }
+}
 
 /// Result of handling one HOP CONNECT request.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -265,6 +540,150 @@ mod tests {
 
     fn peer(tag: &[u8]) -> PeerId {
         PeerId::from_public_key_protobuf(tag)
+    }
+
+    fn transport_pair() -> (InMemoryTransport, InMemoryTransport) {
+        InMemoryTransport::pair(peer(b"transport-a"), peer(b"transport-b"))
+    }
+
+    fn drain_startup(a: &mut InMemoryTransport, b: &mut InMemoryTransport) {
+        assert!(matches!(
+            a.poll().unwrap().as_slice(),
+            [TransportEvent::Connected { .. }]
+        ));
+        assert!(matches!(
+            b.poll().unwrap().as_slice(),
+            [
+                TransportEvent::IncomingConnection { .. },
+                TransportEvent::Connected { .. }
+            ]
+        ));
+    }
+
+    #[test]
+    fn in_memory_listen_emits_the_resolved_address() {
+        let (mut transport, mut peer) = transport_pair();
+        drain_startup(&mut transport, &mut peer);
+        let requested: Multiaddr = "/ip4/0.0.0.0/udp/0/quic-v1".parse().unwrap();
+
+        let resolved = transport.listen(&requested).unwrap();
+
+        assert_eq!(
+            transport.poll().unwrap(),
+            [TransportEvent::Listening {
+                addr: resolved.clone()
+            }]
+        );
+        assert_eq!(resolved, transport.local_addr);
+    }
+
+    #[test]
+    fn in_memory_rejects_unknown_stream_writes() {
+        let (mut a, mut b) = transport_pair();
+        drain_startup(&mut a, &mut b);
+        let id = a.connection_id();
+        let stream_id = StreamId::new(99);
+
+        assert_eq!(
+            a.send_stream(id, stream_id, vec![1, 2, 3]),
+            Err(TransportError::StreamNotFound { id, stream_id })
+        );
+        assert!(b.poll().unwrap().is_empty());
+    }
+
+    #[test]
+    fn in_memory_half_close_is_idempotent_and_closes_after_both_fins() {
+        let (mut a, mut b) = transport_pair();
+        drain_startup(&mut a, &mut b);
+        let id = a.connection_id();
+        let stream_id = a.open_stream(id).unwrap();
+        a.poll().unwrap();
+        b.poll().unwrap();
+
+        a.close_stream_write(id, stream_id).unwrap();
+        a.close_stream_write(id, stream_id).unwrap();
+        assert_eq!(
+            b.poll().unwrap(),
+            [TransportEvent::StreamRemoteWriteClosed { id, stream_id }]
+        );
+        assert!(matches!(
+            a.send_stream(id, stream_id, vec![1]),
+            Err(TransportError::StreamSendFailed { .. })
+        ));
+
+        b.close_stream_write(id, stream_id).unwrap();
+        assert_eq!(
+            a.poll().unwrap(),
+            [
+                TransportEvent::StreamRemoteWriteClosed { id, stream_id },
+                TransportEvent::StreamClosed { id, stream_id }
+            ]
+        );
+        assert_eq!(
+            b.poll().unwrap(),
+            [TransportEvent::StreamClosed { id, stream_id }]
+        );
+        assert_eq!(
+            b.send_stream(id, stream_id, vec![1]),
+            Err(TransportError::StreamNotFound { id, stream_id })
+        );
+    }
+
+    #[test]
+    fn in_memory_reset_is_idempotent_and_tombstones_the_stream() {
+        let (mut a, mut b) = transport_pair();
+        drain_startup(&mut a, &mut b);
+        let id = a.connection_id();
+        let stream_id = a.open_stream(id).unwrap();
+        a.poll().unwrap();
+        b.poll().unwrap();
+
+        a.reset_stream(id, stream_id).unwrap();
+        a.reset_stream(id, stream_id).unwrap();
+
+        assert_eq!(
+            a.poll().unwrap(),
+            [TransportEvent::StreamClosed { id, stream_id }]
+        );
+        assert_eq!(
+            b.poll().unwrap(),
+            [TransportEvent::StreamClosed { id, stream_id }]
+        );
+        assert_eq!(
+            a.send_stream(id, stream_id, vec![1]),
+            Err(TransportError::StreamNotFound { id, stream_id })
+        );
+        assert_eq!(
+            b.close_stream_write(id, stream_id),
+            Err(TransportError::StreamNotFound { id, stream_id })
+        );
+    }
+
+    #[test]
+    fn in_memory_close_disables_both_endpoints_before_closed_is_polled() {
+        let (mut a, mut b) = transport_pair();
+        drain_startup(&mut a, &mut b);
+        let id = a.connection_id();
+        let stream_id = a.open_stream(id).unwrap();
+        a.poll().unwrap();
+        b.poll().unwrap();
+
+        a.close(id).unwrap();
+
+        assert_eq!(
+            b.open_stream(id),
+            Err(TransportError::ConnectionNotFound { id })
+        );
+        assert_eq!(
+            b.send_stream(id, stream_id, vec![1]),
+            Err(TransportError::ConnectionNotFound { id })
+        );
+        assert_eq!(b.close(id), Err(TransportError::ConnectionNotFound { id }));
+        assert!(b.active_inbound_connection_sources().is_empty());
+        assert_eq!(a.poll().unwrap(), [TransportEvent::Closed { id }]);
+        assert_eq!(b.poll().unwrap(), [TransportEvent::Closed { id }]);
+        assert!(a.poll().unwrap().is_empty());
+        assert!(b.poll().unwrap().is_empty());
     }
 
     fn reserve(relay: &mut RelayEmulator, target: &PeerId) {

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -40,6 +40,7 @@ struct InMemoryLink {
 struct InMemoryStream {
     write_closed: [bool; 2],
     closed: bool,
+    close_delivered: [bool; 2],
 }
 
 impl InMemoryTransport {
@@ -244,9 +245,7 @@ impl Transport for InMemoryTransport {
         let other = 1 - self.side;
         let mut shared = self.shared.borrow_mut();
         shared.active = false;
-        for stream in shared.streams.values_mut() {
-            stream.closed = true;
-        }
+        shared.streams.clear();
         shared.queues[self.side].push_back(TransportEvent::Closed { id });
         shared.queues[other].push_back(TransportEvent::Closed {
             id: self.connection,
@@ -255,9 +254,31 @@ impl Transport for InMemoryTransport {
     }
 
     fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError> {
-        Ok(self.shared.borrow_mut().queues[self.side]
-            .drain(..)
-            .collect())
+        let mut shared = self.shared.borrow_mut();
+        let events = shared.queues[self.side].drain(..).collect::<Vec<_>>();
+        let mut fully_delivered = Vec::new();
+        for event in &events {
+            let stream_id = match event {
+                TransportEvent::StreamClosed { id, stream_id } if *id == self.connection => {
+                    *stream_id
+                }
+                _ => continue,
+            };
+            let Some(stream) = shared.streams.get_mut(&stream_id) else {
+                continue;
+            };
+            if !stream.closed {
+                continue;
+            }
+            stream.close_delivered[self.side] = true;
+            if stream.close_delivered == [true, true] {
+                fully_delivered.push(stream_id);
+            }
+        }
+        for stream_id in fully_delivered {
+            shared.streams.remove(&stream_id);
+        }
+        Ok(events)
     }
 
     fn next_timeout(&self) -> Option<Duration> {
@@ -623,6 +644,7 @@ mod tests {
             b.poll().unwrap(),
             [TransportEvent::StreamClosed { id, stream_id }]
         );
+        assert!(a.shared.borrow().streams.is_empty());
         assert_eq!(
             b.send_stream(id, stream_id, vec![1]),
             Err(TransportError::StreamNotFound { id, stream_id })
@@ -660,6 +682,34 @@ mod tests {
     }
 
     #[test]
+    fn in_memory_reclaims_terminal_streams_after_both_close_events_are_delivered() {
+        let (mut a, mut b) = transport_pair();
+        drain_startup(&mut a, &mut b);
+        let id = a.connection_id();
+
+        for _ in 0..128 {
+            let stream_id = a.open_stream(id).unwrap();
+            a.poll().unwrap();
+            b.poll().unwrap();
+
+            a.reset_stream(id, stream_id).unwrap();
+            a.reset_stream(id, stream_id).unwrap();
+            assert_eq!(a.shared.borrow().streams.len(), 1);
+
+            assert_eq!(
+                a.poll().unwrap(),
+                [TransportEvent::StreamClosed { id, stream_id }]
+            );
+            assert_eq!(a.shared.borrow().streams.len(), 1);
+            assert_eq!(
+                b.poll().unwrap(),
+                [TransportEvent::StreamClosed { id, stream_id }]
+            );
+            assert!(a.shared.borrow().streams.is_empty());
+        }
+    }
+
+    #[test]
     fn in_memory_close_disables_both_endpoints_before_closed_is_polled() {
         let (mut a, mut b) = transport_pair();
         drain_startup(&mut a, &mut b);
@@ -669,6 +719,8 @@ mod tests {
         b.poll().unwrap();
 
         a.close(id).unwrap();
+
+        assert!(a.shared.borrow().streams.is_empty());
 
         assert_eq!(
             b.open_stream(id),

--- a/examples/chat/src/modes.rs
+++ b/examples/chat/src/modes.rs
@@ -379,11 +379,11 @@ fn run_chat(
 
         if let Some(event) = endpoint.next_event(Duration::from_millis(100))? {
             match &event {
-                Event::ConnectionEstablished { peer_id } => {
+                Event::ConnectionEstablished { peer_id, .. } => {
                     println!("[{role}] connected peer={peer_id}");
                     abandon_responder_bridges(endpoint, &mut responder_bridges, peer_id);
                 }
-                Event::ConnectionClosed { peer_id } => {
+                Event::ConnectionClosed { peer_id, .. } => {
                     println!("[{role}] disconnected peer={peer_id}");
                     responder_bridges.retain(|(relay_peer, _), _| relay_peer != peer_id);
                 }

--- a/examples/peer/src/cli.rs
+++ b/examples/peer/src/cli.rs
@@ -298,10 +298,10 @@ fn parse_quic_multiaddr(flag: &str, value: &str) -> Result<Multiaddr, CliError> 
 /// (`listen` or `dial`).
 pub fn print_event(role: &str, event: &Event) {
     match event {
-        Event::ConnectionEstablished { peer_id } => {
+        Event::ConnectionEstablished { peer_id, .. } => {
             println!("[{role}] connected peer={peer_id}");
         }
-        Event::ConnectionClosed { peer_id } => {
+        Event::ConnectionClosed { peer_id, .. } => {
             println!("[{role}] disconnected peer={peer_id}");
         }
         Event::IdentifyReceived { peer_id, info } => {
@@ -337,6 +337,7 @@ pub fn print_event(role: &str, event: &Event) {
             stream_id,
             protocol_id,
             initiated_locally,
+            ..
         } => {
             let dir = if *initiated_locally {
                 "outbound"
@@ -352,16 +353,21 @@ pub fn print_event(role: &str, event: &Event) {
             peer_id,
             stream_id,
             data,
+            ..
         } => {
             println!(
                 "[{role}] user-stream-data peer={peer_id} stream={stream_id} bytes={}",
                 data.len()
             );
         }
-        Event::StreamRemoteWriteClosed { peer_id, stream_id } => {
+        Event::StreamRemoteWriteClosed {
+            peer_id, stream_id, ..
+        } => {
             println!("[{role}] user-stream-remote-write-closed peer={peer_id} stream={stream_id}");
         }
-        Event::StreamClosed { peer_id, stream_id } => {
+        Event::StreamClosed {
+            peer_id, stream_id, ..
+        } => {
             println!("[{role}] user-stream-closed peer={peer_id} stream={stream_id}");
         }
         Event::Error(error) => {

--- a/examples/peer/src/modes.rs
+++ b/examples/peer/src/modes.rs
@@ -253,6 +253,7 @@ fn handle_listen_event(
             stream_id,
             protocol_id,
             initiated_locally: false,
+            ..
         } if protocol_id == ECHO_PROTOCOL => {
             echo_streams.insert((peer_id.clone(), *stream_id));
         }
@@ -260,16 +261,19 @@ fn handle_listen_event(
             peer_id,
             stream_id,
             data,
+            ..
         } if echo_streams.contains(&(peer_id.clone(), *stream_id)) => {
             echo_bytes(endpoint, peer_id, *stream_id, data, echo_streams);
         }
-        Event::StreamRemoteWriteClosed { peer_id, stream_id }
-            if echo_streams.contains(&(peer_id.clone(), *stream_id)) =>
-        {
+        Event::StreamRemoteWriteClosed {
+            peer_id, stream_id, ..
+        } if echo_streams.contains(&(peer_id.clone(), *stream_id)) => {
             let _ = endpoint.close_stream_write(peer_id, *stream_id);
             echo_streams.remove(&(peer_id.clone(), *stream_id));
         }
-        Event::StreamClosed { peer_id, stream_id } => {
+        Event::StreamClosed {
+            peer_id, stream_id, ..
+        } => {
             echo_streams.remove(&(peer_id.clone(), *stream_id));
         }
         _ => {}
@@ -470,7 +474,7 @@ fn open_echo_stream(
             Event::StreamReady {
                 peer_id, stream_id, ..
             } if peer_id == peer && *stream_id == stream => return Ok(stream),
-            Event::ConnectionEstablished { peer_id } if peer_id == peer => {
+            Event::ConnectionEstablished { peer_id, .. } if peer_id == peer => {
                 print_event("dial", &event);
                 // A second punch connection just replaced the one this
                 // stream was opened on — the swarm keeps the newcomer and
@@ -684,6 +688,7 @@ fn ping_loop(
                 peer_id,
                 stream_id,
                 data,
+                ..
             } if *peer_id == channel.send_peer && *stream_id == channel.stream => {
                 frames.push(data);
                 while let Some(frame) = frames.pop() {
@@ -709,10 +714,12 @@ fn ping_loop(
                     return Ok(());
                 }
             }
-            Event::StreamRemoteWriteClosed { peer_id, stream_id }
-            | Event::StreamClosed { peer_id, stream_id }
-                if *peer_id == channel.send_peer && *stream_id == channel.stream =>
-            {
+            Event::StreamRemoteWriteClosed {
+                peer_id, stream_id, ..
+            }
+            | Event::StreamClosed {
+                peer_id, stream_id, ..
+            } if *peer_id == channel.send_peer && *stream_id == channel.stream => {
                 print_event("dial", &event);
                 if drain_deadline.is_some() {
                     stats.print_summary();
@@ -745,7 +752,7 @@ fn ping_loop(
                 stats.print_summary();
                 return Err("ping channel closed".into());
             }
-            Event::ConnectionClosed { peer_id } if *peer_id == channel.send_peer => {
+            Event::ConnectionClosed { peer_id, .. } if *peer_id == channel.send_peer => {
                 print_event("dial", &event);
                 stats.print_summary();
                 if drain_deadline.is_some() {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -260,6 +260,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "minip2p-circuit"
+version = "0.1.0"
+dependencies = [
+ "getrandom",
+ "minip2p-core",
+ "minip2p-identity",
+ "minip2p-multistream-select",
+ "minip2p-noise",
+ "minip2p-transport",
+ "minip2p-yamux",
+ "thiserror",
+]
+
+[[package]]
 name = "minip2p-core"
 version = "0.1.0"
 dependencies = [
@@ -290,6 +304,7 @@ version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
  "minip2p-autonat",
+ "minip2p-circuit",
  "minip2p-core",
  "minip2p-dcutr",
  "minip2p-discovery",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,6 +15,7 @@ unsafe_code = "forbid"
 [dependencies]
 libfuzzer-sys = "0.4.13"
 minip2p-autonat = { path = "../crates/autonat" }
+minip2p-circuit = { path = "../crates/circuit" }
 minip2p-core = { path = "../crates/core" }
 minip2p-dcutr = { path = "../crates/dcutr" }
 minip2p-discovery = { path = "../crates/discovery", default-features = false }

--- a/fuzz/fuzz_targets/wire_inputs.rs
+++ b/fuzz/fuzz_targets/wire_inputs.rs
@@ -2,7 +2,8 @@
 
 use libfuzzer_sys::fuzz_target;
 use minip2p_autonat::{AutoNatClient, AutoNatClientInput, AutoNatServer, AutoNatServerInput};
-use minip2p_core::{Multiaddr, PeerId, SansIoProtocol};
+use minip2p_circuit::{BridgeAdoption, CircuitRole, CircuitTransport, EntropyError, EntropySource};
+use minip2p_core::{Multiaddr, PeerAddr, PeerId, SansIoProtocol};
 use minip2p_dcutr::{FrameDecode as DcutrFrame, HolePunch};
 use minip2p_discovery::{Beacon, DiscoveryAgent, DiscoveryConfig};
 use minip2p_identify::{IdentifyConfig, IdentifyInput, IdentifyMessage, IdentifyProtocol};
@@ -10,7 +11,9 @@ use minip2p_identity::{KeyType, PublicKey};
 use minip2p_multistream_select::{MultistreamInput, MultistreamSelect};
 use minip2p_noise::{NoiseConfig, NoiseHandshakePayload, NoiseInput, NoiseRole, NoiseSession};
 use minip2p_relay::{FrameDecode as RelayFrame, HopMessage, StopMessage};
-use minip2p_transport::StreamId;
+use minip2p_transport::{
+    ConnectionEndpoint, ConnectionId, StreamId, Transport, TransportError, TransportEvent,
+};
 use minip2p_yamux::{FrameDecoder as YamuxFrameDecoder, YamuxRole, YamuxSession};
 
 fuzz_target!(|data: &[u8]| {
@@ -25,6 +28,7 @@ fuzz_target!(|data: &[u8]| {
     fuzz_discovery(data);
     fuzz_noise(data);
     fuzz_yamux(data);
+    fuzz_circuit(data);
 
     if let RelayFrame::Complete { payload, .. } = minip2p_relay::decode_frame(data) {
         let _ = HopMessage::decode(payload);
@@ -47,6 +51,119 @@ fn fuzz_multistream(data: &[u8]) {
         let _ = machine.handle_input(MultistreamInput::Data(data.to_vec()));
         while machine.poll_output().is_some() {}
         let _ = machine.take_remaining_buffer();
+    }
+}
+
+struct FixedEntropy;
+
+impl EntropySource for FixedEntropy {
+    fn fill(&mut self, destination: &mut [u8]) -> Result<(), EntropyError> {
+        destination.fill(7);
+        Ok(())
+    }
+}
+
+struct FuzzTransport {
+    initial: Option<TransportEvent>,
+}
+
+impl FuzzTransport {
+    fn new(relay: PeerId) -> Self {
+        Self {
+            initial: Some(TransportEvent::Connected {
+                id: ConnectionId::new(1),
+                endpoint: ConnectionEndpoint::with_peer_id(
+                    "/ip4/192.0.2.1/udp/4001/quic-v1"
+                        .parse()
+                        .expect("static fuzz address"),
+                    relay,
+                ),
+            }),
+        }
+    }
+}
+
+impl Transport for FuzzTransport {
+    fn dial(&mut self, _addr: &PeerAddr) -> Result<ConnectionId, TransportError> {
+        Err(TransportError::InvalidConfig {
+            reason: "fuzz transport does not dial".into(),
+        })
+    }
+
+    fn listen(&mut self, addr: &Multiaddr) -> Result<Multiaddr, TransportError> {
+        Ok(addr.clone())
+    }
+
+    fn open_stream(&mut self, _id: ConnectionId) -> Result<StreamId, TransportError> {
+        Ok(StreamId::new(1))
+    }
+
+    fn send_stream(
+        &mut self,
+        _id: ConnectionId,
+        _stream_id: StreamId,
+        _data: Vec<u8>,
+    ) -> Result<(), TransportError> {
+        Ok(())
+    }
+
+    fn close_stream_write(
+        &mut self,
+        _id: ConnectionId,
+        _stream_id: StreamId,
+    ) -> Result<(), TransportError> {
+        Ok(())
+    }
+
+    fn reset_stream(
+        &mut self,
+        _id: ConnectionId,
+        _stream_id: StreamId,
+    ) -> Result<(), TransportError> {
+        Ok(())
+    }
+
+    fn close(&mut self, _id: ConnectionId) -> Result<(), TransportError> {
+        Ok(())
+    }
+
+    fn poll(&mut self) -> Result<Vec<TransportEvent>, TransportError> {
+        Ok(self.initial.take().into_iter().collect())
+    }
+}
+
+/// Drives attacker-controlled bridge bytes through circuit negotiation.
+fn fuzz_circuit(data: &[u8]) {
+    // A valid fragmented multistream-select exchange advances both roles into
+    // the Noise decoder before attacker-controlled bytes begin.
+    const NOISE_SELECTION: &[u8] = b"\x13/multistream/1.0.0\n\x07/noise\n";
+    let relay = fuzz_peer_id();
+    let remote = PeerId::from_public_key_protobuf(b"minip2p-fuzz-circuit-remote");
+    let chunk_len = data.first().map_or(1, |byte| usize::from(byte % 16) + 1);
+    for role in [CircuitRole::Initiator, CircuitRole::Responder] {
+        let identity = minip2p_identity::Ed25519Keypair::from_secret_key_bytes([5; 32]);
+        let mut transport =
+            CircuitTransport::new(FuzzTransport::new(relay.clone()), identity, FixedEntropy);
+        let _ = transport.poll();
+        let _ = transport.adopt_bridge(BridgeAdoption {
+            inner_conn: ConnectionId::new(1),
+            bridge_stream: StreamId::new(1),
+            relay: relay.clone(),
+            remote_peer: remote.clone(),
+            role,
+            pending_data: NOISE_SELECTION[..1].to_vec(),
+            remote_write_closed: false,
+        });
+        for chunk in NOISE_SELECTION[1..].chunks(chunk_len) {
+            transport.inject_bridge_data(ConnectionId::new(1), StreamId::new(1), chunk.to_vec());
+        }
+        for chunk in data.chunks(chunk_len) {
+            transport.inject_bridge_data(ConnectionId::new(1), StreamId::new(1), chunk.to_vec());
+        }
+        transport.inject_bridge_remote_write_closed(ConnectionId::new(1), StreamId::new(1));
+        transport.inject_bridge_closed(ConnectionId::new(1), StreamId::new(1));
+        transport.inject_bridge_data(ConnectionId::new(1), StreamId::new(1), data.to_vec());
+        let _ = transport.poll();
     }
 }
 

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ test:
 
 check-nostd:
     rustup target add thumbv7em-none-eabi
-    cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-noise -p minip2p-yamux -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-pubsub -p minip2p-discovery -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm -p minip2p-nat
+    cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-core -p minip2p-identity -p minip2p-transport -p minip2p-tls -p minip2p-noise -p minip2p-yamux -p minip2p-circuit -p minip2p-identify -p minip2p-multistream-select -p minip2p-ping -p minip2p-pubsub -p minip2p-discovery -p minip2p-relay -p minip2p-autonat -p minip2p-dcutr -p minip2p-swarm -p minip2p-nat
 
 peer-ping:
     cargo test -p minip2p-peer --test ping

--- a/transports/quic/tests/swarm_e2e.rs
+++ b/transports/quic/tests/swarm_e2e.rs
@@ -111,7 +111,7 @@ fn swarm_ping_roundtrip_with_auto_identify() {
 
         for event in client_events {
             match event {
-                SwarmEvent::ConnectionEstablished { ref peer_id } => {
+                SwarmEvent::ConnectionEstablished { ref peer_id, .. } => {
                     assert_eq!(peer_id, &server_peer_id);
                     client_connected = true;
                 }
@@ -196,7 +196,7 @@ fn inbound_connection_does_not_collide_with_later_outbound_dial() {
             drive_three(&mut inbound_peer, &mut middle, &mut outbound_peer);
 
         let inbound_connected = inbound_events.iter().any(
-            |event| matches!(event, SwarmEvent::ConnectionEstablished { peer_id } if peer_id == &middle_peer_id),
+            |event| matches!(event, SwarmEvent::ConnectionEstablished { peer_id, .. } if peer_id == &middle_peer_id),
         );
         middle_saw_inbound |= middle_events
             .iter()
@@ -221,7 +221,7 @@ fn inbound_connection_does_not_collide_with_later_outbound_dial() {
             drive_three(&mut inbound_peer, &mut middle, &mut outbound_peer);
 
         if middle_events.iter().any(
-            |event| matches!(event, SwarmEvent::ConnectionEstablished { peer_id } if peer_id == &outbound_peer_id),
+            |event| matches!(event, SwarmEvent::ConnectionEstablished { peer_id, .. } if peer_id == &outbound_peer_id),
         ) {
             return;
         }
@@ -261,6 +261,7 @@ fn swarm_user_protocol_round_trip() {
                     ref peer_id,
                     stream_id,
                     ref data,
+                    ..
                 } if !server_echo_sent => {
                     // Echo the data back on the same stream.
                     server
@@ -290,6 +291,7 @@ fn swarm_user_protocol_round_trip() {
                     stream_id,
                     ref protocol_id,
                     initiated_locally,
+                    ..
                 } => {
                     assert_eq!(peer_id, &server_peer_id);
                     assert_eq!(protocol_id, USER_PROTOCOL_ID);


### PR DESCRIPTION
## Summary
- add a no_std Sans-I/O circuit transport that upgrades relay bridge streams through multistream-select, Noise, and Yamux
- add connection provenance and reset-free stream handoff groundwork to the swarm
- add reusable in-memory transport coverage, circuit edge-case tests, fuzz routing, docs, and CI no_std coverage

## Verification
- cargo test
- cargo test -p minip2p --features nat
- cargo test -p minip2p --features pubsub
- cargo test -p minip2p --features nat,pubsub
- cargo test -p minip2p --features discovery
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --manifest-path fuzz/Cargo.toml --all-targets -- -D warnings
- cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-circuit -p minip2p-swarm
- cargo doc --workspace --no-deps

PR-3 checkpoint only; NAT/facade integration remains for the next branch after review and merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `minip2p-circuit`, a Sans-I/O transport wrapper that upgrades relay bridge streams into normal connections via multistream-select, Noise, and Yamux. Swarm now tags events with `conn_id`, enforces supersession ordering, and defers transport teardown to guarantee reset-free stream handoff for circuit adoption (codex/issue-27).

- **New Features**
  - `minip2p-circuit` with `CircuitTransport::adopt_bridge` to turn HOP/STOP bridge streams into `Transport` connections (no_std + alloc); circuit connection IDs use the high bit.
  - Swarm: `conn_id` on all connection/stream events, ordered supersession with after-event teardown, and `Swarm::forget_stream` for reset-free bridge handoff.
  - Infra: in-memory `Transport` in `minip2p-test-support`, circuit tests and fuzzing, CI `no_std` checks.

- **Migration**
  - Update `SwarmEvent` pattern matches to include `conn_id` (or use `..`).
  - Use `Swarm::forget_stream(conn_id, stream_id)` when handing off a negotiated bridge stream to `CircuitTransport`.
  - For `no_std`, disable default features on `minip2p-circuit` and provide an `EntropySource`.

<sup>Written for commit 5498c6dfba9033b7e8734ad7a9d21ebe85f5a40c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

