### PR TITLE
feat(nat): integrate promoted circuit connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,7 @@ name = "minip2p"
 version = "0.1.0"
 dependencies = [
  "getrandom",
+ "minip2p-circuit",
  "minip2p-core",
  "minip2p-discovery",
  "minip2p-identify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,9 @@ dependencies = [
  "minip2p-nat",
  "minip2p-pubsub",
  "minip2p-quic",
+ "minip2p-relay",
  "minip2p-swarm",
+ "minip2p-test-support",
  "minip2p-transport",
  "thiserror",
 ]
@@ -822,6 +824,8 @@ version = "0.1.0"
 dependencies = [
  "minip2p",
  "minip2p-example-common",
+ "minip2p-relay",
+ "minip2p-test-support",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ cargo doc --workspace --no-deps --open
 - [x] Floodsub pubsub (`pubsub` feature) with libp2p wire interop, plus the chat example.
 - [x] Signed pubsub peer discovery (`discovery` feature), including automatic mesh dialing and host-death survival.
 - [ ] Gossipsub, on the same pubsub API surface.
-- [ ] A circuit transport, so relayed paths look like normal connections (today the relay bridge is a raw stream: chat requires a successful hole punch).
+- [x] A circuit transport, so relayed paths are end-to-end encrypted, multiplexed normal connections.

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -1932,6 +1932,73 @@ mod tests {
         complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
     }
 
+    #[test]
+    fn decrypt_batch_crosses_yamux_selection_into_ready_frames() {
+        let (mut a, mut b, circuit_id, bridge, _a_peer, _b_peer) = setup_pair();
+
+        // Stop immediately after B reaches Ready. Its encrypted Yamux
+        // selection confirmation is now queued for A, which is still in
+        // SelectYamux and has not consumed that ciphertext yet.
+        for _ in 0..32 {
+            let _ = a.poll().expect("drive initiator toward Yamux selection");
+            let _ = b.poll().expect("drive responder toward Yamux selection");
+            let a_selecting = matches!(
+                a.circuits.get(&circuit_id).and_then(|c| c.phase.as_ref()),
+                Some(Phase::SelectYamux { .. })
+            );
+            let b_ready = matches!(
+                b.circuits.get(&circuit_id).and_then(|c| c.phase.as_ref()),
+                Some(Phase::Ready { .. })
+            );
+            if a_selecting && b_ready {
+                break;
+            }
+        }
+        assert!(matches!(
+            a.circuits.get(&circuit_id).and_then(|c| c.phase.as_ref()),
+            Some(Phase::SelectYamux { .. })
+        ));
+        assert!(matches!(
+            b.circuits.get(&circuit_id).and_then(|c| c.phase.as_ref()),
+            Some(Phase::Ready { .. })
+        ));
+
+        // Queue a Yamux SYN behind the already-encrypted selection reply,
+        // then combine both Noise transport frames into one bridge read.
+        // Noise decrypts them as two plaintexts in one output batch: the
+        // first transitions A to Ready and the second must be routed through
+        // that newly-created Ready state.
+        let opened = b.open_stream(circuit_id).expect("open responder stream");
+        let raw = a.inner_mut().poll().expect("read encrypted bridge batch");
+        let chunks: Vec<_> = raw
+            .into_iter()
+            .filter_map(|event| match event {
+                TransportEvent::StreamData {
+                    stream_id, data, ..
+                } if stream_id == bridge => Some(data),
+                _ => None,
+            })
+            .collect();
+        assert!(chunks.len() >= 2, "expected selection and Yamux frames");
+        let coalesced = chunks.into_iter().flatten().collect();
+        let inner_conn = a
+            .circuits
+            .get(&circuit_id)
+            .expect("initiator circuit")
+            .inner_conn;
+        a.inject_bridge_data(inner_conn, bridge, coalesced);
+
+        let events = a.poll().expect("drain cross-boundary outputs");
+        assert!(events.iter().any(
+            |event| matches!(event, TransportEvent::Connected { id, .. } if *id == circuit_id)
+        ));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            TransportEvent::IncomingStream { id, stream_id }
+                if *id == circuit_id && *stream_id == opened
+        )));
+    }
+
     fn assert_pre_ready_bridge_failure(events: &[TransportEvent], circuit_id: ConnectionId) {
         assert!(matches!(
             events,

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -535,7 +535,7 @@ impl<T: Transport, E: EntropySource> CircuitTransport<T, E> {
                     peer,
                 };
                 for plaintext in decrypted {
-                    phase = self.feed_decrypted_yamux_select(circuit, phase, plaintext)?;
+                    phase = self.feed_decrypted_transport(circuit, phase, plaintext)?;
                 }
                 Ok(phase)
             }
@@ -557,7 +557,7 @@ impl<T: Transport, E: EntropySource> CircuitTransport<T, E> {
                     peer,
                 };
                 for plaintext in decrypted {
-                    phase = self.feed_decrypted_yamux_select(circuit, phase, plaintext)?;
+                    phase = self.feed_decrypted_transport(circuit, phase, plaintext)?;
                 }
                 Ok(phase)
             }
@@ -580,6 +580,34 @@ impl<T: Transport, E: EntropySource> CircuitTransport<T, E> {
                 }
                 Ok(Phase::Ready { noise, yamux, peer })
             }
+        }
+    }
+
+    /// Routes plaintext Noise transport messages across the exact Yamux
+    /// phase boundary. One bridge read may decrypt both the selection reply
+    /// and immediately-pipelined Yamux frames, so later plaintexts must use
+    /// the `Ready` state produced by an earlier one in the same batch.
+    fn feed_decrypted_transport(
+        &mut self,
+        circuit: &Circuit,
+        phase: Phase,
+        plaintext: Vec<u8>,
+    ) -> Result<Phase, String> {
+        match phase {
+            phase @ Phase::SelectYamux { .. } => {
+                self.feed_decrypted_yamux_select(circuit, phase, plaintext)
+            }
+            Phase::Ready {
+                mut noise,
+                mut yamux,
+                peer,
+            } => {
+                let result = yamux.handle_input(YamuxInput::Data(plaintext));
+                self.drain_yamux(circuit, &mut noise, &mut yamux)?;
+                result.map_err(|error| format!("Yamux protocol failed: {error}"))?;
+                Ok(Phase::Ready { noise, yamux, peer })
+            }
+            _ => Err("decrypted transport data arrived before Yamux selection".to_string()),
         }
     }
 

--- a/crates/minip2p/Cargo.toml
+++ b/crates/minip2p/Cargo.toml
@@ -9,12 +9,13 @@ readme = "README.md"
 workspace = true
 
 [features]
-nat = ["dep:minip2p-nat", "dep:getrandom"]
+nat = ["dep:minip2p-circuit", "dep:minip2p-nat", "dep:getrandom"]
 pubsub = ["dep:minip2p-pubsub", "dep:thiserror"]
 discovery = ["nat", "pubsub", "dep:minip2p-discovery"]
 
 [dependencies]
 minip2p-core = { path = "../core" }
+minip2p-circuit = { path = "../circuit", optional = true }
 minip2p-discovery = { path = "../discovery", optional = true }
 minip2p-identify = { path = "../identify" }
 minip2p-identity = { path = "../identity" }

--- a/crates/minip2p/Cargo.toml
+++ b/crates/minip2p/Cargo.toml
@@ -26,3 +26,7 @@ minip2p-swarm = { path = "../swarm" }
 minip2p-transport = { path = "../transport" }
 getrandom = { version = "0.4.3", optional = true }
 thiserror = { version = "2.0.18", optional = true }
+
+[dev-dependencies]
+minip2p-relay = { path = "../relay" }
+minip2p-test-support = { path = "../test-support" }

--- a/crates/minip2p/README.md
+++ b/crates/minip2p/README.md
@@ -30,6 +30,12 @@ When an application permanently relinquishes a stream, `Endpoint::abandon_stream
 resets it, purges already-buffered events, and suppresses later stream events.
 Use `Endpoint::reset_stream` when those terminal events should remain visible.
 
+With the `nat` feature, `EndpointTransport` is a
+`CircuitTransport<QuicEndpoint, OsEntropy>` and `EndpointSwarm` names the
+resulting concrete swarm type. Relay bridges are promoted through end-to-end
+Noise and Yamux before `wait_path` returns `Path::Relayed`, so application
+protocols use ordinary streams on direct and relayed paths alike.
+
 With the `discovery` feature, `.discovery()` enables signed pubsub presence
 beacons, a bounded TTL address book, and caller-driven automatic NAT connects.
 It implies the `nat` and `pubsub` features. Applications can inspect

--- a/crates/minip2p/src/discovery.rs
+++ b/crates/minip2p/src/discovery.rs
@@ -66,10 +66,6 @@ impl DiscoveryDriver {
         }
     }
 
-    pub(crate) fn ingest(&mut self, _event: &SwarmEvent) -> bool {
-        false
-    }
-
     /// Runs all cross-driver work until no new work is produced.
     pub(crate) fn sweep(
         &mut self,
@@ -228,11 +224,73 @@ fn nat_connect_id(event: &NatEvent) -> Option<ConnectId> {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use minip2p_discovery::DiscoveryConfig;
+    use minip2p_discovery::{DiscoveryAction, DiscoveryConfig};
+    use minip2p_identity::{Ed25519Keypair, PeerId as IdentityPeerId, PublicKey};
+    use minip2p_nat::{NatAgent, NatConfig, Now, Path};
     use minip2p_transport::StreamId;
 
     use super::*;
     use crate::{Endpoint, Event};
+
+    fn discovery_beacon(keypair: &Ed25519Keypair) -> (PeerId, Vec<u8>) {
+        let mut agent = DiscoveryAgent::new(
+            PublicKey::from(keypair),
+            DiscoveryConfig {
+                auto_dial: false,
+                ..DiscoveryConfig::default()
+            },
+        )
+        .expect("valid remote discovery agent");
+        agent.set_local_addrs(
+            &["/ip4/127.0.0.1/udp/4001/quic-v1"
+                .parse()
+                .expect("valid beacon address")],
+            0,
+        );
+        agent.handle_tick(0);
+        let payload = loop {
+            match agent.poll_action() {
+                Some(DiscoveryAction::PublishBeacon { payload, .. }) => break payload,
+                Some(_) => continue,
+                None => panic!("beacon was not published"),
+            }
+        };
+        (IdentityPeerId::from(keypair), payload)
+    }
+
+    fn discovery_with_inflight() -> (DiscoveryDriver, ConnectId, PeerId, PeerId) {
+        let local_key = Ed25519Keypair::from_secret_key_bytes([91; 32]);
+        let remote_key = Ed25519Keypair::from_secret_key_bytes([92; 32]);
+        let local = IdentityPeerId::from(&local_key);
+        let (remote, payload) = discovery_beacon(&remote_key);
+        let mut driver = DiscoveryDriver::new(
+            DiscoveryAgent::new(
+                PublicKey::from(&local_key),
+                DiscoveryConfig {
+                    dial_tie_break: false,
+                    ..DiscoveryConfig::default()
+                },
+            )
+            .expect("valid discovery agent"),
+        );
+        driver.agent.handle_beacon(&remote, &payload, true, 1);
+        assert!(matches!(
+            driver.agent.poll_event(),
+            Some(DiscoveryEvent::PeerDiscovered { peer, .. }) if peer == remote
+        ));
+        assert!(matches!(
+            driver.agent.poll_action(),
+            Some(DiscoveryAction::Dial { peer, .. }) if peer == remote
+        ));
+
+        let mut nat = NatAgent::new(local, NatConfig::default());
+        let connect_id = nat.connect(remote.clone(), Vec::new(), Now::from_mono(0));
+        driver.inflight.insert(connect_id, remote.clone());
+        let relay = PeerId::from_public_key_protobuf(
+            &PublicKey::from(&Ed25519Keypair::from_secret_key_bytes([93; 32])).encode_protobuf(),
+        );
+        (driver, connect_id, remote, relay)
+    }
 
     fn endpoint_with_protocol(protocol: &str) -> Endpoint {
         Endpoint::builder()
@@ -361,6 +419,92 @@ mod tests {
         assert_eq!(
             minip2p_discovery::MAX_TOPIC_LEN,
             minip2p_pubsub::MAX_TOPIC_LEN
+        );
+    }
+
+    #[test]
+    fn relayed_success_variants_complete_discovery_owned_dials() {
+        for fell_back in [false, true] {
+            let (mut driver, connect_id, remote, relay) = discovery_with_inflight();
+            let event = if fell_back {
+                NatEvent::FellBackToRelay {
+                    connect_id,
+                    peer: remote.clone(),
+                }
+            } else {
+                NatEvent::PathEstablished {
+                    connect_id,
+                    peer: remote.clone(),
+                    path: Path::Relayed { relay },
+                }
+            };
+            driver.handle_nat_event(event, 2);
+
+            assert!(!driver.inflight.contains_key(&connect_id));
+            driver.agent.dial_failed(&remote, "must already be idle", 3);
+            assert!(
+                driver.agent.poll_event().is_none(),
+                "successful relayed completion must collapse the discovery dial state"
+            );
+        }
+    }
+
+    #[test]
+    fn eager_supersede_close_preserves_discovery_connectivity() {
+        let a_key = Ed25519Keypair::from_secret_key_bytes([94; 32]);
+        let b_key = Ed25519Keypair::from_secret_key_bytes([95; 32]);
+        let (b_peer, beacon) = discovery_beacon(&b_key);
+        let config = DiscoveryConfig {
+            dial_tie_break: false,
+            beacon_interval_ms: 100,
+            peer_ttl_ms: 2_000,
+            ..DiscoveryConfig::default()
+        };
+        let mut a = Endpoint::builder()
+            .identity(a_key)
+            .discovery_config(config.clone())
+            .expect("valid discovery config")
+            .bind_quic("127.0.0.1:0")
+            .expect("bind a");
+        let mut b = Endpoint::builder()
+            .identity(b_key)
+            .discovery_config(config)
+            .expect("valid discovery config")
+            .bind_quic("127.0.0.1:0")
+            .expect("bind b");
+        a.listen().expect("a listens");
+        let b_addr = b.listen().expect("b listens");
+        a.dial(&b_addr).expect("first dial");
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !a.connected_peers().contains(&b_peer) {
+            assert!(Instant::now() < deadline, "first connection timed out");
+            let _ = a.next_event(Duration::from_millis(20)).expect("drive a");
+            let _ = b.next_event(Duration::from_millis(20)).expect("drive b");
+        }
+        let discovery = a.discovery.as_mut().expect("discovery enabled");
+        discovery.agent.handle_beacon(&b_peer, &beacon, true, 1);
+        while discovery.agent.poll_event().is_some() {}
+        assert!(discovery.agent.poll_action().is_none());
+
+        a.dial(&b_addr).expect("replacement dial");
+        let mut saw_old_close = false;
+        while !saw_old_close {
+            assert!(Instant::now() < deadline, "replacement timed out");
+            if let Some(Event::ConnectionClosed { peer_id, .. }) =
+                a.next_event(Duration::from_millis(20)).expect("drive a")
+            {
+                saw_old_close = peer_id == b_peer;
+            }
+            let _ = b.next_event(Duration::from_millis(20)).expect("drive b");
+        }
+        assert!(a.swarm.core().conn_for(&b_peer).is_some());
+
+        let discovery = a.discovery.as_mut().expect("discovery enabled");
+        discovery.agent.handle_beacon(&b_peer, &beacon, true, 2);
+        assert!(
+            discovery.agent.poll_action().is_none(),
+            "Closed(old) must not make discovery redial while new is installed"
         );
     }
 }

--- a/crates/minip2p/src/discovery.rs
+++ b/crates/minip2p/src/discovery.rs
@@ -5,12 +5,11 @@ use std::time::Instant;
 
 use minip2p_core::PeerId;
 use minip2p_discovery::{DiscoveryAction, DiscoveryAgent, DiscoveryEvent};
-use minip2p_nat::{ConnectId, NatEvent, Path};
+use minip2p_nat::{ConnectId, NatEvent};
 use minip2p_pubsub::PubsubEvent;
-use minip2p_quic::QuicEndpoint;
-use minip2p_swarm::{Swarm, SwarmEvent};
-use minip2p_transport::StreamId;
+use minip2p_swarm::SwarmEvent;
 
+use crate::EndpointSwarm;
 use crate::{Error, nat::NatDriver, pubsub::PubsubDriver};
 
 /// Errors from discovery-focused endpoint waits.
@@ -24,22 +23,12 @@ pub enum DiscoveryError {
     Driver(#[from] Error),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum BridgeState {
-    Live {
-        connect_id: ConnectId,
-        target_peer: PeerId,
-    },
-    Tombstone,
-}
-
-/// Coordinates beacon traffic, automatic NAT connects, and released bridges.
+/// Coordinates beacon traffic and automatic NAT connects.
 pub(crate) struct DiscoveryDriver {
     pub(crate) agent: DiscoveryAgent,
     pub(crate) events: VecDeque<DiscoveryEvent>,
     epoch: Instant,
     pub(crate) inflight: BTreeMap<ConnectId, PeerId>,
-    pub(crate) bridges: BTreeMap<(PeerId, StreamId), BridgeState>,
     last_local_addrs: Vec<minip2p_core::Multiaddr>,
 }
 
@@ -50,7 +39,6 @@ impl DiscoveryDriver {
             events: VecDeque::new(),
             epoch: Instant::now(),
             inflight: BTreeMap::new(),
-            bridges: BTreeMap::new(),
             last_local_addrs: Vec::new(),
         }
     }
@@ -60,47 +48,26 @@ impl DiscoveryDriver {
     }
 
     /// Observes lifecycle events regardless of which protocol driver claims them.
-    pub(crate) fn observe(&mut self, event: &SwarmEvent) {
+    pub(crate) fn observe(&mut self, event: &SwarmEvent, swarm: &EndpointSwarm) {
         let now = self.now_ms();
         match event {
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
-                // A second establishment supersedes the relay connection that
-                // owned any tracked stream ids.
-                self.bridges.retain(|(relay, _), _| relay != peer_id);
                 self.agent.peer_connected(peer_id, now);
             }
-            SwarmEvent::ConnectionClosed { peer_id, .. } => {
-                self.bridges.retain(|(relay, _), _| relay != peer_id);
+            SwarmEvent::ConnectionClosed { peer_id, .. }
+                if swarm.core().conn_for(peer_id).is_none() =>
+            {
+                // Eager supersession surfaces Closed(old) before
+                // Established(new), but the core has already installed the
+                // replacement. Preserve discovery continuity in that case.
                 self.agent.peer_disconnected(peer_id, now);
             }
             _ => {}
         }
     }
 
-    /// Claims data and terminal events for released bridges discovery owns.
-    pub(crate) fn ingest(&mut self, event: &SwarmEvent) -> bool {
-        let key = match event {
-            SwarmEvent::StreamData {
-                peer_id, stream_id, ..
-            }
-            | SwarmEvent::StreamRemoteWriteClosed {
-                peer_id, stream_id, ..
-            }
-            | SwarmEvent::StreamClosed {
-                peer_id, stream_id, ..
-            } => Some((peer_id.clone(), *stream_id)),
-            _ => None,
-        };
-        let Some(key) = key else {
-            return false;
-        };
-        if !self.bridges.contains_key(&key) {
-            return false;
-        }
-        if matches!(event, SwarmEvent::StreamClosed { .. }) {
-            self.bridges.remove(&key);
-        }
-        true
+    pub(crate) fn ingest(&mut self, _event: &SwarmEvent) -> bool {
+        false
     }
 
     /// Runs all cross-driver work until no new work is produced.
@@ -108,7 +75,7 @@ impl DiscoveryDriver {
         &mut self,
         pubsub: &mut PubsubDriver,
         nat: &mut NatDriver,
-        swarm: &mut Swarm<QuicEndpoint>,
+        swarm: &mut EndpointSwarm,
     ) {
         loop {
             let mut progressed = false;
@@ -155,7 +122,7 @@ impl DiscoveryDriver {
                 let connect_id = nat_connect_id(&event);
                 if connect_id.is_some_and(|id| self.inflight.contains_key(&id)) {
                     progressed = true;
-                    self.handle_nat_event(event, nat, swarm, now);
+                    self.handle_nat_event(event, now);
                 } else {
                     retained.push_back(event);
                 }
@@ -194,70 +161,17 @@ impl DiscoveryDriver {
         }
     }
 
-    fn handle_nat_event(
-        &mut self,
-        event: NatEvent,
-        _nat: &mut NatDriver,
-        swarm: &mut Swarm<QuicEndpoint>,
-        now: u64,
-    ) {
+    fn handle_nat_event(&mut self, event: NatEvent, now: u64) {
         match event {
             NatEvent::PathEstablished {
-                connect_id,
-                peer,
-                path,
-            } => match path {
-                Path::DirectDialed | Path::DirectPunched => {
-                    self.inflight.remove(&connect_id);
-                    self.agent.dial_succeeded(&peer, now);
-                }
-                Path::Relayed {
-                    relay, stream_id, ..
-                } => {
-                    self.bridges.insert(
-                        (relay, stream_id),
-                        BridgeState::Live {
-                            connect_id,
-                            target_peer: peer,
-                        },
-                    );
-                }
-            },
-            NatEvent::PathUpgraded {
-                connect_id,
-                peer,
-                from,
-                ..
-            } => {
-                if let Path::Relayed {
-                    relay, stream_id, ..
-                } = from
-                {
-                    self.bridges
-                        .insert((relay, stream_id), BridgeState::Tombstone);
-                }
+                connect_id, peer, ..
+            }
+            | NatEvent::PathUpgraded {
+                connect_id, peer, ..
+            }
+            | NatEvent::FellBackToRelay { connect_id, peer } => {
                 self.inflight.remove(&connect_id);
                 self.agent.dial_succeeded(&peer, now);
-            }
-            NatEvent::FellBackToRelay { connect_id, peer } => {
-                let keys: Vec<_> = self
-                    .bridges
-                    .iter()
-                    .filter(|(_, state)| {
-                        matches!(state, BridgeState::Live { connect_id: id, .. } if *id == connect_id)
-                    })
-                    .map(|(key, _)| key.clone())
-                    .collect();
-                for key in keys {
-                    if swarm.reset_stream(&key.0, key.1).is_ok() {
-                        self.bridges.insert(key, BridgeState::Tombstone);
-                    } else {
-                        self.bridges.remove(&key);
-                    }
-                }
-                self.inflight.remove(&connect_id);
-                self.agent
-                    .dial_failed(&peer, "relayed only; direct path required", now);
             }
             NatEvent::ConnectFailed {
                 connect_id,
@@ -268,14 +182,14 @@ impl DiscoveryDriver {
                 self.agent.dial_failed(&peer, &error.to_string(), now);
             }
             NatEvent::HolePunchFailed { .. } => {}
-            // `sweep` currently calls this only for variants selected by
+            // `sweep` calls this only for variants selected by
             // `nat_connect_id`. Ignore future correlated variants rather
-            // than turning a harmless facade-version skew into a panic.
+            // than turning harmless facade-version skew into a panic.
             _ => {}
         }
     }
 
-    fn cancel_peer(&mut self, peer: &PeerId, nat: &mut NatDriver, swarm: &mut Swarm<QuicEndpoint>) {
+    fn cancel_peer(&mut self, peer: &PeerId, nat: &mut NatDriver, swarm: &mut EndpointSwarm) {
         let active = self
             .inflight
             .iter()
@@ -284,51 +198,17 @@ impl DiscoveryDriver {
             nat.agent.cancel(id, nat.now());
             nat.pump(swarm);
             self.inflight.remove(&id);
-            for state in self.bridges.values_mut() {
-                if matches!(state, BridgeState::Live { connect_id, .. } if *connect_id == id) {
-                    *state = BridgeState::Tombstone;
-                }
-            }
-            return;
-        }
-        let keys = self.live_bridge_keys_for_peer(peer);
-        for key in keys {
-            if swarm.reset_stream(&key.0, key.1).is_ok() {
-                self.bridges.insert(key, BridgeState::Tombstone);
-            } else {
-                self.bridges.remove(&key);
-            }
         }
     }
 
-    fn live_bridge_keys_for_peer(&self, peer: &PeerId) -> Vec<(PeerId, StreamId)> {
-        self.bridges
-            .iter()
-            .filter(|(_, state)| {
-                matches!(state, BridgeState::Live { target_peer, .. } if target_peer == peer)
-            })
-            .map(|(key, _)| key.clone())
-            .collect()
-    }
-
-    /// Cancels attempts and suppresses every bridge before raw-swarm handoff.
-    pub(crate) fn shutdown(&mut self, nat: &mut NatDriver, swarm: &mut Swarm<QuicEndpoint>) {
+    /// Cancels all discovery-owned attempts before raw-swarm handoff.
+    pub(crate) fn shutdown(&mut self, nat: &mut NatDriver, swarm: &mut EndpointSwarm) {
         let attempts: Vec<ConnectId> = self.inflight.keys().copied().collect();
         for id in attempts {
             nat.agent.cancel(id, nat.now());
-            for state in self.bridges.values_mut() {
-                if matches!(state, BridgeState::Live { connect_id, .. } if *connect_id == id) {
-                    *state = BridgeState::Tombstone;
-                }
-            }
         }
         self.inflight.clear();
         nat.pump(swarm);
-        let bridges: Vec<_> = self.bridges.keys().cloned().collect();
-        for (relay, stream_id) in bridges {
-            let _ = swarm.abandon_stream(&relay, stream_id);
-        }
-        self.bridges.clear();
         self.events.clear();
     }
 }
@@ -346,20 +226,13 @@ fn nat_connect_id(event: &NatEvent) -> Option<ConnectId> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::cell::Cell;
     use std::time::{Duration, Instant};
 
-    use crate::{Endpoint, Event};
     use minip2p_discovery::DiscoveryConfig;
-    use minip2p_identity::Ed25519Keypair;
-    use minip2p_nat::{NatAgent, NatConfig, Now};
+    use minip2p_transport::StreamId;
 
-    fn driver() -> DiscoveryDriver {
-        let keypair = Ed25519Keypair::generate();
-        let agent = DiscoveryAgent::new(keypair.public_key(), DiscoveryConfig::default()).unwrap();
-        DiscoveryDriver::new(agent)
-    }
+    use super::*;
+    use crate::{Endpoint, Event};
 
     fn endpoint_with_protocol(protocol: &str) -> Endpoint {
         Endpoint::builder()
@@ -422,424 +295,6 @@ mod tests {
                 | Event::StreamClosed { peer_id, stream_id: got, .. }
                 if peer_id == peer && *got == stream_id
         )
-    }
-
-    #[test]
-    fn bridge_events_are_claimed_through_terminal_close() {
-        let mut driver = driver();
-        let relay = Ed25519Keypair::generate().peer_id();
-        let target = Ed25519Keypair::generate().peer_id();
-        let mut nat = NatAgent::new(driver.agent.local_peer_id().clone(), NatConfig::default());
-        let connect_id = nat.connect(
-            target.clone(),
-            Vec::new(),
-            Now {
-                mono_ms: 0,
-                unix_secs: None,
-            },
-        );
-        let stream_id = StreamId::new(7);
-        driver.bridges.insert(
-            (relay.clone(), stream_id),
-            BridgeState::Live {
-                connect_id,
-                target_peer: target,
-            },
-        );
-        assert!(driver.ingest(&SwarmEvent::StreamData {
-            peer_id: relay.clone(),
-            conn_id: minip2p_transport::ConnectionId::new(1),
-            stream_id,
-            data: vec![1],
-        }));
-        assert!(driver.ingest(&SwarmEvent::StreamRemoteWriteClosed {
-            peer_id: relay.clone(),
-            conn_id: minip2p_transport::ConnectionId::new(1),
-            stream_id,
-        }));
-        assert!(driver.ingest(&SwarmEvent::StreamClosed {
-            peer_id: relay,
-            conn_id: minip2p_transport::ConnectionId::new(1),
-            stream_id,
-        }));
-        assert!(driver.bridges.is_empty());
-    }
-
-    #[test]
-    fn relay_lifecycle_clears_live_and_tombstone_stream_ids() {
-        let mut driver = driver();
-        let relay = Ed25519Keypair::generate().peer_id();
-        driver
-            .bridges
-            .insert((relay.clone(), StreamId::new(1)), BridgeState::Tombstone);
-        driver.observe(&SwarmEvent::ConnectionEstablished {
-            peer_id: relay.clone(),
-            conn_id: minip2p_transport::ConnectionId::new(1),
-        });
-        assert!(driver.bridges.is_empty());
-        driver
-            .bridges
-            .insert((relay.clone(), StreamId::new(2)), BridgeState::Tombstone);
-        driver.observe(&SwarmEvent::ConnectionClosed {
-            peer_id: relay,
-            conn_id: minip2p_transport::ConnectionId::new(1),
-        });
-        assert!(driver.bridges.is_empty());
-    }
-
-    #[test]
-    fn orphan_bridge_selection_is_scoped_to_target_peer() {
-        let mut driver = driver();
-        let target = Ed25519Keypair::generate().peer_id();
-        let unrelated = Ed25519Keypair::generate().peer_id();
-        let target_relay = Ed25519Keypair::generate().peer_id();
-        let unrelated_relay = Ed25519Keypair::generate().peer_id();
-        let mut nat = NatAgent::new(driver.agent.local_peer_id().clone(), NatConfig::default());
-        let target_id = nat.connect(
-            target.clone(),
-            Vec::new(),
-            Now {
-                mono_ms: 0,
-                unix_secs: None,
-            },
-        );
-        let unrelated_id = nat.connect(
-            unrelated.clone(),
-            Vec::new(),
-            Now {
-                mono_ms: 1,
-                unix_secs: None,
-            },
-        );
-        driver.bridges.insert(
-            (target_relay.clone(), StreamId::new(1)),
-            BridgeState::Live {
-                connect_id: target_id,
-                target_peer: target.clone(),
-            },
-        );
-        driver.bridges.insert(
-            (unrelated_relay, StreamId::new(2)),
-            BridgeState::Live {
-                connect_id: unrelated_id,
-                target_peer: unrelated,
-            },
-        );
-
-        let selected = driver.live_bridge_keys_for_peer(&target);
-        assert_eq!(selected, vec![(target_relay, StreamId::new(1))]);
-    }
-
-    #[test]
-    fn fallback_and_both_cancel_arms_update_bridge_ownership() {
-        let mut endpoint = endpoint_with_protocol("/test/discovery-driver/1");
-        let relay = Ed25519Keypair::generate().peer_id();
-        let target = Ed25519Keypair::generate().peer_id();
-        let fallback_id = endpoint.nat.as_mut().expect("NAT enabled").agent.connect(
-            target.clone(),
-            Vec::new(),
-            Now::from_mono(0),
-        );
-        {
-            let Endpoint {
-                swarm,
-                nat,
-                discovery,
-                ..
-            } = &mut endpoint;
-            let nat = nat.as_mut().expect("NAT enabled");
-            let discovery = discovery.as_mut().expect("discovery enabled");
-            discovery.inflight.insert(fallback_id, target.clone());
-            discovery.bridges.insert(
-                (relay.clone(), StreamId::new(10)),
-                BridgeState::Live {
-                    connect_id: fallback_id,
-                    target_peer: target.clone(),
-                },
-            );
-            discovery.handle_nat_event(
-                NatEvent::FellBackToRelay {
-                    connect_id: fallback_id,
-                    peer: target.clone(),
-                },
-                nat,
-                swarm,
-                1,
-            );
-            assert!(!discovery.inflight.contains_key(&fallback_id));
-            assert!(
-                !discovery
-                    .bridges
-                    .contains_key(&(relay.clone(), StreamId::new(10))),
-                "a synchronous reset failure must drop the bridge"
-            );
-        }
-
-        let active_target = Ed25519Keypair::generate().peer_id();
-        let active_id = endpoint.nat.as_mut().expect("NAT enabled").agent.connect(
-            active_target.clone(),
-            Vec::new(),
-            Now::from_mono(2),
-        );
-        {
-            let Endpoint {
-                swarm,
-                nat,
-                discovery,
-                ..
-            } = &mut endpoint;
-            let nat = nat.as_mut().expect("NAT enabled");
-            let discovery = discovery.as_mut().expect("discovery enabled");
-            discovery.inflight.insert(active_id, active_target.clone());
-            discovery.bridges.insert(
-                (relay.clone(), StreamId::new(11)),
-                BridgeState::Live {
-                    connect_id: active_id,
-                    target_peer: active_target.clone(),
-                },
-            );
-            discovery.cancel_peer(&active_target, nat, swarm);
-            assert!(!discovery.inflight.contains_key(&active_id));
-            assert_eq!(
-                discovery.bridges.get(&(relay.clone(), StreamId::new(11))),
-                Some(&BridgeState::Tombstone),
-                "the NAT attempt owns the active bridge reset"
-            );
-        }
-
-        let orphan_target = Ed25519Keypair::generate().peer_id();
-        let orphan_id = endpoint.nat.as_mut().expect("NAT enabled").agent.connect(
-            orphan_target.clone(),
-            Vec::new(),
-            Now::from_mono(3),
-        );
-        let Endpoint {
-            swarm,
-            nat,
-            discovery,
-            ..
-        } = &mut endpoint;
-        let nat = nat.as_mut().expect("NAT enabled");
-        let discovery = discovery.as_mut().expect("discovery enabled");
-        discovery.bridges.insert(
-            (relay.clone(), StreamId::new(12)),
-            BridgeState::Live {
-                connect_id: orphan_id,
-                target_peer: orphan_target.clone(),
-            },
-        );
-        discovery.cancel_peer(&orphan_target, nat, swarm);
-        assert!(
-            !discovery.bridges.contains_key(&(relay, StreamId::new(12))),
-            "an orphan bridge with a rejected reset must be dropped"
-        );
-    }
-
-    #[test]
-    fn relayed_path_upgrade_tombstones_the_released_bridge() {
-        let mut endpoint = endpoint_with_protocol("/test/discovery-upgrade/1");
-        let relay = Ed25519Keypair::generate().peer_id();
-        let target = Ed25519Keypair::generate().peer_id();
-        let stream_id = StreamId::new(20);
-        let connect_id = endpoint.nat.as_mut().expect("NAT enabled").agent.connect(
-            target.clone(),
-            Vec::new(),
-            Now::from_mono(0),
-        );
-        let relayed = Path::Relayed {
-            relay: relay.clone(),
-            stream_id,
-            pending_data: Vec::new(),
-            remote_write_closed: false,
-        };
-        let Endpoint {
-            swarm,
-            nat,
-            discovery,
-            ..
-        } = &mut endpoint;
-        let nat = nat.as_mut().expect("NAT enabled");
-        let discovery = discovery.as_mut().expect("discovery enabled");
-        discovery.inflight.insert(connect_id, target.clone());
-        discovery.handle_nat_event(
-            NatEvent::PathEstablished {
-                connect_id,
-                peer: target.clone(),
-                path: relayed.clone(),
-            },
-            nat,
-            swarm,
-            0,
-        );
-        assert!(matches!(
-            discovery.bridges.get(&(relay.clone(), stream_id)),
-            Some(BridgeState::Live { .. })
-        ));
-
-        discovery.handle_nat_event(
-            NatEvent::PathUpgraded {
-                connect_id,
-                peer: target,
-                from: relayed,
-                to: Path::DirectPunched,
-            },
-            nat,
-            swarm,
-            1,
-        );
-        assert!(!discovery.inflight.contains_key(&connect_id));
-        assert_eq!(
-            discovery.bridges.get(&(relay, stream_id)),
-            Some(&BridgeState::Tombstone)
-        );
-    }
-
-    #[test]
-    fn real_bridge_fallback_resets_and_claims_terminal_events() {
-        const PROTOCOL: &str = "/test/discovery-real-bridge/1";
-        let (mut owner, mut remote, stream_id) = connected_user_stream(PROTOCOL);
-        let relay = remote.peer_id().clone();
-        let target = Ed25519Keypair::generate().peer_id();
-        let connect_id = owner.nat.as_mut().expect("NAT enabled").agent.connect(
-            target.clone(),
-            Vec::new(),
-            Now::from_mono(0),
-        );
-
-        {
-            let Endpoint {
-                swarm,
-                nat,
-                discovery,
-                ..
-            } = &mut owner;
-            let nat = nat.as_mut().expect("NAT enabled");
-            let discovery = discovery.as_mut().expect("discovery enabled");
-            discovery.inflight.insert(connect_id, target.clone());
-            discovery.handle_nat_event(
-                NatEvent::PathEstablished {
-                    connect_id,
-                    peer: target.clone(),
-                    path: Path::Relayed {
-                        relay: relay.clone(),
-                        stream_id,
-                        pending_data: Vec::new(),
-                        remote_write_closed: false,
-                    },
-                },
-                nat,
-                swarm,
-                0,
-            );
-        }
-        remote
-            .send_stream(owner.peer_id(), stream_id, b"bridge payload".to_vec())
-            .expect("remote sends bridge data");
-        remote
-            .close_stream_write(owner.peer_id(), stream_id)
-            .expect("remote closes bridge write side");
-        {
-            let Endpoint {
-                swarm,
-                nat,
-                discovery,
-                ..
-            } = &mut owner;
-            let nat = nat.as_mut().expect("NAT enabled");
-            let discovery = discovery.as_mut().expect("discovery enabled");
-            discovery.handle_nat_event(
-                NatEvent::FellBackToRelay {
-                    connect_id,
-                    peer: target,
-                },
-                nat,
-                swarm,
-                1,
-            );
-            assert_eq!(
-                discovery.bridges.get(&(relay.clone(), stream_id)),
-                Some(&BridgeState::Tombstone),
-                "the real stream reset must succeed"
-            );
-        }
-
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while Instant::now() < deadline {
-            let _ = remote
-                .next_event(Duration::from_millis(10))
-                .expect("remote drives");
-            if let Some(event) = owner
-                .next_event(Duration::from_millis(10))
-                .expect("owner drives")
-            {
-                assert!(
-                    !is_stream_event(&event, &relay, stream_id),
-                    "bridge event leaked after designation: {event:?}"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn into_swarm_suppresses_queued_and_future_bridge_events() {
-        const PROTOCOL: &str = "/test/discovery-into-swarm/1";
-        let (mut owner, mut remote, stream_id) = connected_user_stream(PROTOCOL);
-        let relay = remote.peer_id().clone();
-        let target = Ed25519Keypair::generate().peer_id();
-        let connect_id = owner.nat.as_mut().expect("NAT enabled").agent.connect(
-            target.clone(),
-            Vec::new(),
-            Now::from_mono(0),
-        );
-        owner
-            .discovery
-            .as_mut()
-            .expect("discovery enabled")
-            .bridges
-            .insert(
-                (relay.clone(), stream_id),
-                BridgeState::Live {
-                    connect_id,
-                    target_peer: target,
-                },
-            );
-
-        remote
-            .send_stream(owner.peer_id(), stream_id, b"queued bridge data".to_vec())
-            .expect("remote sends queued data");
-        let saw_queued_stream_event = Cell::new(false);
-        owner
-            .swarm_mut()
-            .run_until(Instant::now() + Duration::from_millis(500), |event| {
-                if is_stream_event(event, &relay, stream_id) {
-                    saw_queued_stream_event.set(true);
-                }
-                false
-            })
-            .expect("queue raw stream event");
-        assert!(
-            saw_queued_stream_event.get(),
-            "the handoff test must begin with a queued bridge event"
-        );
-
-        let owner_peer = owner.peer_id().clone();
-        let mut swarm = owner.into_swarm();
-        let _ = remote.close_stream_write(&owner_peer, stream_id);
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while Instant::now() < deadline {
-            let _ = remote
-                .next_event(Duration::from_millis(10))
-                .expect("remote drives");
-            if let Some(event) = swarm
-                .poll_next(Duration::from_millis(10))
-                .expect("raw swarm drives")
-            {
-                assert!(
-                    !is_stream_event(&event, &relay, stream_id),
-                    "abandoned bridge event leaked after handoff: {event:?}"
-                );
-            }
-        }
     }
 
     #[test]

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -33,16 +33,29 @@ pub use minip2p_pubsub::{
 };
 pub use minip2p_quic::QuicLimits;
 use minip2p_quic::{QuicEndpoint, QuicNodeConfig};
+use minip2p_swarm::SwarmBuilder;
 pub use minip2p_swarm::{
-    Deadline, DriverError as Error, RESERVED_PROTOCOL_IDS, RUN_UNTIL_SKIP_LIMIT, SwarmError,
+    Deadline, DriverError as Error, RESERVED_PROTOCOL_IDS, RUN_UNTIL_SKIP_LIMIT, Swarm, SwarmError,
     SwarmEvent as Event,
 };
-use minip2p_swarm::{Swarm, SwarmBuilder};
 pub use minip2p_transport::{ConnectionId, StreamId, TransportError};
 #[cfg(feature = "pubsub")]
 pub use pubsub::PubsubError;
 
 const DEFAULT_AGENT_VERSION: &str = "minip2p/0.1.0";
+
+/// Transport used by [`Endpoint`]. With NAT enabled, relay bridges are
+/// promoted into ordinary Noise/Yamux connections by `CircuitTransport`.
+#[cfg(feature = "nat")]
+pub type EndpointTransport =
+    minip2p_circuit::CircuitTransport<QuicEndpoint, minip2p_circuit::OsEntropy>;
+
+/// Transport used by [`Endpoint`] when NAT traversal is not compiled in.
+#[cfg(not(feature = "nat"))]
+pub type EndpointTransport = QuicEndpoint;
+
+/// Concrete swarm type owned by [`Endpoint`].
+pub type EndpointSwarm = Swarm<EndpointTransport>;
 
 /// App-facing minip2p endpoint over the default QUIC transport.
 ///
@@ -56,7 +69,7 @@ const DEFAULT_AGENT_VERSION: &str = "minip2p/0.1.0";
 /// see `Endpoint::connect`, `Endpoint::wait_path`, and
 /// `Endpoint::take_nat_events`.
 pub struct Endpoint {
-    swarm: Swarm<QuicEndpoint>,
+    swarm: EndpointSwarm,
     #[cfg(feature = "nat")]
     nat: Option<nat::NatDriver>,
     #[cfg(feature = "pubsub")]
@@ -157,17 +170,17 @@ impl Endpoint {
     /// IPv6 dials are started when both families are available. Use
     /// [`Endpoint::dial_ip4`] or [`Endpoint::dial_ip6`] to force one family.
     pub fn dial(&mut self, addr: &PeerAddr) -> Result<Vec<ConnectionId>, Error> {
-        Ok(self.swarm.transport_mut().dial_all(addr)?)
+        Ok(self.quic_mut().dial_all(addr)?)
     }
 
     /// Dials a remote peer using IPv4.
     pub fn dial_ip4(&mut self, addr: &PeerAddr) -> Result<ConnectionId, Error> {
-        Ok(self.swarm.transport_mut().dial_ip4(addr)?)
+        Ok(self.quic_mut().dial_ip4(addr)?)
     }
 
     /// Dials a remote peer using IPv6.
     pub fn dial_ip6(&mut self, addr: &PeerAddr) -> Result<ConnectionId, Error> {
-        Ok(self.swarm.transport_mut().dial_ip6(addr)?)
+        Ok(self.quic_mut().dial_ip6(addr)?)
     }
 
     /// Sends a ping to `peer_id`.
@@ -313,7 +326,7 @@ impl Endpoint {
     fn ingest_into_drivers(&mut self, event: &Event) -> bool {
         #[cfg(feature = "discovery")]
         if let Some(discovery) = self.discovery.as_mut() {
-            discovery.observe(event);
+            discovery.observe(event, &self.swarm);
         }
         let mut claimed = false;
         #[cfg(feature = "nat")]
@@ -869,17 +882,17 @@ impl Endpoint {
     }
 
     /// Borrows the underlying swarm.
-    pub fn swarm(&self) -> &Swarm<QuicEndpoint> {
+    pub fn swarm(&self) -> &EndpointSwarm {
         &self.swarm
     }
 
     /// Mutably borrows the underlying swarm.
-    pub fn swarm_mut(&mut self) -> &mut Swarm<QuicEndpoint> {
+    pub fn swarm_mut(&mut self) -> &mut EndpointSwarm {
         &mut self.swarm
     }
 
     /// Decomposes this endpoint into the underlying swarm.
-    pub fn into_swarm(self) -> Swarm<QuicEndpoint> {
+    pub fn into_swarm(self) -> EndpointSwarm {
         #[cfg(feature = "discovery")]
         {
             let mut endpoint = self;
@@ -894,6 +907,18 @@ impl Endpoint {
         {
             self.swarm
         }
+    }
+}
+
+impl Endpoint {
+    #[cfg(feature = "nat")]
+    fn quic_mut(&mut self) -> &mut QuicEndpoint {
+        self.swarm.transport_mut().inner_mut()
+    }
+
+    #[cfg(not(feature = "nat"))]
+    fn quic_mut(&mut self) -> &mut QuicEndpoint {
+        self.swarm.transport_mut()
     }
 }
 
@@ -1204,6 +1229,8 @@ fn build_endpoint(parts: BuilderParts, transport: QuicEndpoint) -> Result<Endpoi
     for protocol in protocols {
         builder = builder.protocol(protocol);
     }
+    #[cfg(feature = "nat")]
+    let transport = minip2p_circuit::CircuitTransport::new_os(transport, parts.keypair.clone());
     let swarm = builder.build(transport)?;
     #[cfg(feature = "nat")]
     let nat = parts.nat_config.map(|config| {

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -337,10 +337,6 @@ impl Endpoint {
         if !claimed && let Some(pubsub) = self.pubsub.as_mut() {
             claimed = pubsub.ingest(event, &mut self.swarm);
         }
-        #[cfg(feature = "discovery")]
-        if let Some(discovery) = self.discovery.as_mut() {
-            claimed |= discovery.ingest(event);
-        }
         claimed
     }
 

--- a/crates/minip2p/src/nat.rs
+++ b/crates/minip2p/src/nat.rs
@@ -5,13 +5,16 @@
 //! Available behind the `nat` cargo feature; see the `nat` methods on
 //! [`Endpoint`](crate::Endpoint) and [`EndpointBuilder`](crate::EndpointBuilder).
 
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
+use minip2p_circuit::{AdoptError, BridgeAdoption, CircuitRole, CircuitTransport};
 use minip2p_core::{Multiaddr, PeerId, Protocol};
-use minip2p_nat::{NatAction, NatAgent, NatEvent, Now};
-use minip2p_quic::QuicEndpoint;
-use minip2p_swarm::{Swarm, SwarmEvent};
+use minip2p_nat::{BridgeRole, NatAction, NatAgent, NatEvent, Now, PromoteError};
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::{ConnectionId, StreamId, Transport};
+
+use crate::EndpointSwarm;
 
 /// Drives a [`NatAgent`] against the endpoint's swarm.
 pub(crate) struct NatDriver {
@@ -27,6 +30,8 @@ pub(crate) struct NatDriver {
     relay_addrs: Vec<(PeerId, Multiaddr)>,
     /// Direct public addresses confirmed by AutoNAT.
     public_addrs: Vec<Multiaddr>,
+    /// Exact adopted bridge keys mapped to their promoted circuit ids.
+    promoted: BTreeMap<(ConnectionId, StreamId), ConnectionId>,
 }
 
 impl NatDriver {
@@ -38,6 +43,7 @@ impl NatDriver {
             reserved_relays: Vec::new(),
             relay_addrs,
             public_addrs: Vec::new(),
+            promoted: BTreeMap::new(),
         }
     }
 
@@ -57,16 +63,34 @@ impl NatDriver {
     /// Returns `true` when the event belongs to the NAT control plane and
     /// must not be forwarded to the application. The agent's disposition is
     /// authoritative even when handling claims or releases the stream.
-    pub(crate) fn ingest(&mut self, event: &SwarmEvent, swarm: &mut Swarm<QuicEndpoint>) -> bool {
+    pub(crate) fn ingest(&mut self, event: &SwarmEvent, swarm: &mut EndpointSwarm) -> bool {
         let now = self.now();
-        let handled = self.agent.handle_event_with_disposition(event, now);
+        if self.inject_straggler(event, swarm) {
+            self.pump(swarm);
+            return true;
+        }
+        let is_circuit = match event {
+            SwarmEvent::ConnectionEstablished { conn_id, .. }
+            | SwarmEvent::ConnectionClosed { conn_id, .. } => CircuitTransport::<
+                minip2p_quic::QuicEndpoint,
+                minip2p_circuit::OsEntropy,
+            >::is_circuit(*conn_id),
+            _ => false,
+        };
+        let handled = self
+            .agent
+            .handle_event_with_disposition_classified(event, is_circuit, now);
+        if let SwarmEvent::ConnectionClosed { conn_id, .. } = event {
+            self.promoted
+                .retain(|(inner_conn, _), circuit| inner_conn != conn_id && circuit != conn_id);
+        }
         self.pump(swarm);
         handled
     }
 
     /// Advances timers only when the agent reports a due deadline, then
     /// executes any resulting work.
-    pub(crate) fn tick(&mut self, swarm: &mut Swarm<QuicEndpoint>) {
+    pub(crate) fn tick(&mut self, swarm: &mut EndpointSwarm) {
         let now = self.now();
         if self.agent.next_timeout(now.mono_ms) != Some(0) {
             return;
@@ -77,7 +101,7 @@ impl NatDriver {
 
     /// Drains agent actions into swarm calls (echoing synchronous results
     /// back) and collects application-visible NAT events.
-    pub(crate) fn pump(&mut self, swarm: &mut Swarm<QuicEndpoint>) {
+    pub(crate) fn pump(&mut self, swarm: &mut EndpointSwarm) {
         loop {
             let mut progressed = false;
             while let Some(action) = self.agent.poll_action() {
@@ -93,9 +117,11 @@ impl NatDriver {
                 break;
             }
         }
+        let active: BTreeSet<_> = swarm.transport().circuit_ids().into_iter().collect();
+        self.promoted.retain(|_, id| active.contains(id));
     }
 
-    fn execute(&mut self, action: NatAction, swarm: &mut Swarm<QuicEndpoint>) {
+    fn execute(&mut self, action: NatAction, swarm: &mut EndpointSwarm) {
         let now = self.now();
         match action {
             NatAction::Dial { token, addr } => {
@@ -136,15 +162,109 @@ impl NatDriver {
             } => {
                 let mut payload = vec![0u8; payload_len];
                 if getrandom::fill(&mut payload).is_ok() {
-                    let _ = swarm.transport().send_raw_udp(&target, &payload);
+                    let _ = swarm.transport().inner().send_raw_udp(&target, &payload);
+                }
+            }
+            NatAction::PromoteBridge {
+                token,
+                inner_conn,
+                relay,
+                stream_id,
+                remote_peer,
+                role,
+                pending_data,
+                remote_write_closed,
+            } => {
+                let key = (inner_conn, stream_id);
+                if let Some(existing) = self.promoted.get(&key).copied() {
+                    self.agent.promote_result(token, Ok(existing), now);
+                    return;
+                }
+                swarm.forget_stream(inner_conn, stream_id);
+                let adoption = BridgeAdoption {
+                    inner_conn,
+                    bridge_stream: stream_id,
+                    relay,
+                    remote_peer,
+                    role: match role {
+                        BridgeRole::Initiator => CircuitRole::Initiator,
+                        BridgeRole::Responder => CircuitRole::Responder,
+                    },
+                    pending_data,
+                    remote_write_closed,
+                };
+                match swarm.transport_mut().adopt_bridge(adoption) {
+                    Ok(conn_id) => {
+                        self.promoted.insert(key, conn_id);
+                        self.agent.promote_result(token, Ok(conn_id), now);
+                    }
+                    Err(error) => {
+                        let promote_error = match &error {
+                            AdoptError::PeerAlreadyDirect => PromoteError::PeerAlreadyDirect,
+                            AdoptError::UnknownConnection => PromoteError::UnknownConnection,
+                            _ => PromoteError::Failed(error.to_string()),
+                        };
+                        self.agent.promote_result(token, Err(promote_error), now);
+                        if !matches!(error, AdoptError::UnknownConnection) {
+                            let _ = swarm
+                                .transport_mut()
+                                .inner_mut()
+                                .reset_stream(inner_conn, stream_id);
+                        }
+                    }
+                }
+            }
+            NatAction::CloseCircuit { conn_id } => {
+                let result = swarm.transport_mut().close(conn_id);
+                if result.is_ok()
+                    || matches!(
+                        result,
+                        Err(minip2p_transport::TransportError::ConnectionNotFound { .. })
+                    )
+                {
+                    self.promoted.retain(|_, id| *id != conn_id);
                 }
             }
         }
     }
 
+    fn inject_straggler(&mut self, event: &SwarmEvent, swarm: &mut EndpointSwarm) -> bool {
+        let key = match event {
+            SwarmEvent::StreamData {
+                conn_id, stream_id, ..
+            }
+            | SwarmEvent::StreamRemoteWriteClosed {
+                conn_id, stream_id, ..
+            }
+            | SwarmEvent::StreamClosed {
+                conn_id, stream_id, ..
+            } => (*conn_id, *stream_id),
+            _ => return false,
+        };
+        if !self.promoted.contains_key(&key) {
+            return false;
+        }
+        match event {
+            SwarmEvent::StreamData { data, .. } => {
+                swarm
+                    .transport_mut()
+                    .inject_bridge_data(key.0, key.1, data.clone());
+            }
+            SwarmEvent::StreamRemoteWriteClosed { .. } => swarm
+                .transport_mut()
+                .inject_bridge_remote_write_closed(key.0, key.1),
+            SwarmEvent::StreamClosed { .. } => {
+                swarm.transport_mut().inject_bridge_closed(key.0, key.1);
+                self.promoted.remove(&key);
+            }
+            _ => unreachable!(),
+        }
+        true
+    }
+
     /// Keeps Identify's advertised set in sync with reservation state: a
     /// held reservation advertises `<relay>/p2p/<relay-id>/p2p-circuit`.
-    fn observe(&mut self, event: &NatEvent, swarm: &mut Swarm<QuicEndpoint>) {
+    fn observe(&mut self, event: &NatEvent, swarm: &mut EndpointSwarm) {
         match event {
             NatEvent::RelayReserved { relay, .. } => {
                 if self.reserved_relays.iter().any(|(peer, _)| peer == relay) {
@@ -182,7 +302,7 @@ impl NatDriver {
         }
     }
 
-    fn advertise(&self, swarm: &mut Swarm<QuicEndpoint>) {
+    fn advertise(&self, swarm: &mut EndpointSwarm) {
         let mut addrs = self.public_addrs.clone();
         for (_, addr) in &self.reserved_relays {
             if !addrs.contains(addr) {

--- a/crates/minip2p/src/nat.rs
+++ b/crates/minip2p/src/nat.rs
@@ -32,6 +32,8 @@ pub(crate) struct NatDriver {
     public_addrs: Vec<Multiaddr>,
     /// Exact adopted bridge keys mapped to their promoted circuit ids.
     promoted: BTreeMap<(ConnectionId, StreamId), ConnectionId>,
+    #[cfg(test)]
+    bridge_reset_attempts: Vec<(ConnectionId, StreamId)>,
 }
 
 impl NatDriver {
@@ -44,6 +46,8 @@ impl NatDriver {
             relay_addrs,
             public_addrs: Vec::new(),
             promoted: BTreeMap::new(),
+            #[cfg(test)]
+            bridge_reset_attempts: Vec::new(),
         }
     }
 
@@ -206,6 +210,8 @@ impl NatDriver {
                         };
                         self.agent.promote_result(token, Err(promote_error), now);
                         if !matches!(error, AdoptError::UnknownConnection) {
+                            #[cfg(test)]
+                            self.bridge_reset_attempts.push((inner_conn, stream_id));
                             let _ = swarm
                                 .transport_mut()
                                 .inner_mut()
@@ -316,7 +322,209 @@ impl NatDriver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Endpoint, NatConfig, ReachabilityState};
+    use crate::{Ed25519Keypair, Endpoint, Event, NatConfig, ReachabilityState};
+    use minip2p_nat::{NatToken, ReservationPolicy};
+    use minip2p_relay::{HOP_PROTOCOL_ID, HopMessage, HopMessageType, Status, encode_frame};
+
+    struct BridgePair {
+        local: Endpoint,
+        relay: Endpoint,
+        local_addr: minip2p_core::PeerAddr,
+        relay_addr: minip2p_core::PeerAddr,
+        inner_conn: ConnectionId,
+        stream: StreamId,
+    }
+
+    fn negotiated_bridge() -> BridgePair {
+        let mut relay = Endpoint::builder()
+            .identity(Ed25519Keypair::from_secret_key_bytes([72; 32]))
+            .protocol(HOP_PROTOCOL_ID)
+            .bind_quic("127.0.0.1:0")
+            .expect("bind relay");
+        let relay_addr = relay.listen().expect("relay listens");
+        let mut local = Endpoint::builder()
+            .identity(Ed25519Keypair::from_secret_key_bytes([71; 32]))
+            .protocol(HOP_PROTOCOL_ID)
+            .bind_quic("127.0.0.1:0")
+            .expect("bind local");
+        let local_addr = local.listen().expect("local listens");
+        local.dial(&relay_addr).expect("dial relay");
+
+        let deadline = Instant::now() + std::time::Duration::from_secs(5);
+        let mut inner_conn = None;
+        let mut local_ready = false;
+        let mut relay_ready = false;
+        while !local_ready || !relay_ready {
+            assert!(
+                Instant::now() < deadline,
+                "relay session did not become ready"
+            );
+            if let Some(event) = local
+                .next_event(std::time::Duration::from_millis(10))
+                .expect("drive local")
+            {
+                match event {
+                    Event::ConnectionEstablished { peer_id, conn_id }
+                        if peer_id == *relay_addr.peer_id() =>
+                    {
+                        inner_conn = Some(conn_id);
+                    }
+                    Event::PeerReady { peer_id, .. } if peer_id == *relay_addr.peer_id() => {
+                        local_ready = true;
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(Event::PeerReady { peer_id, .. }) = relay
+                .next_event(std::time::Duration::from_millis(10))
+                .expect("drive relay")
+                && peer_id == *local.peer_id()
+            {
+                relay_ready = true;
+            }
+        }
+        let inner_conn = inner_conn.expect("local connection id");
+        let stream = local
+            .open_stream(relay_addr.peer_id(), HOP_PROTOCOL_ID)
+            .expect("open bridge stream");
+        let mut local_stream_ready = false;
+        let mut relay_stream_ready = false;
+        while !local_stream_ready || !relay_stream_ready {
+            assert!(Instant::now() < deadline, "bridge stream did not negotiate");
+            if let Some(Event::StreamReady { stream_id, .. }) = local
+                .next_event(std::time::Duration::from_millis(10))
+                .expect("drive local stream")
+                && stream_id == stream
+            {
+                local_stream_ready = true;
+            }
+            if let Some(Event::StreamReady { stream_id, .. }) = relay
+                .next_event(std::time::Duration::from_millis(10))
+                .expect("drive relay stream")
+                && stream_id == stream
+            {
+                relay_stream_ready = true;
+            }
+        }
+        BridgePair {
+            local,
+            relay,
+            local_addr,
+            relay_addr,
+            inner_conn,
+            stream,
+        }
+    }
+
+    fn drain_actions(agent: &mut NatAgent) -> Vec<NatAction> {
+        core::iter::from_fn(|| agent.poll_action()).collect()
+    }
+
+    fn only_dial_token(actions: &[NatAction]) -> NatToken {
+        actions
+            .iter()
+            .find_map(|action| match action {
+                NatAction::Dial { token, .. } => Some(*token),
+                _ => None,
+            })
+            .expect("dial token")
+    }
+
+    fn only_open_token(actions: &[NatAction]) -> NatToken {
+        actions
+            .iter()
+            .find_map(|action| match action {
+                NatAction::OpenStream { token, .. } => Some(*token),
+                _ => None,
+            })
+            .expect("open token")
+    }
+
+    fn promotion_driver(pair: &BridgePair, remote_write_closed: bool) -> (NatDriver, NatAction) {
+        let target = Ed25519Keypair::from_secret_key_bytes([73; 32]).peer_id();
+        let relay_peer = pair.relay_addr.peer_id().clone();
+        let config = NatConfig {
+            relays: vec![pair.relay_addr.clone()],
+            force_relay: true,
+            reservation_policy: ReservationPolicy::Never,
+            ..NatConfig::default()
+        };
+        let mut agent = NatAgent::new(pair.local.peer_id().clone(), config);
+        agent.connect(target, Vec::new(), Now::from_mono(0));
+        let dial = drain_actions(&mut agent);
+        agent.dial_result(
+            only_dial_token(&dial),
+            Ok(pair.inner_conn),
+            Now::from_mono(1),
+        );
+        agent.handle_event(
+            &SwarmEvent::ConnectionEstablished {
+                peer_id: relay_peer.clone(),
+                conn_id: pair.inner_conn,
+            },
+            Now::from_mono(2),
+        );
+        agent.handle_event(
+            &SwarmEvent::PeerReady {
+                peer_id: relay_peer.clone(),
+                protocols: vec![HOP_PROTOCOL_ID.to_string()],
+            },
+            Now::from_mono(3),
+        );
+        let open = drain_actions(&mut agent);
+        agent.stream_open_result(only_open_token(&open), Ok(pair.stream), Now::from_mono(4));
+        agent.handle_event(
+            &SwarmEvent::StreamReady {
+                peer_id: relay_peer.clone(),
+                conn_id: pair.inner_conn,
+                stream_id: pair.stream,
+                protocol_id: HOP_PROTOCOL_ID.to_string(),
+                initiated_locally: true,
+            },
+            Now::from_mono(5),
+        );
+        drain_actions(&mut agent); // HOP CONNECT
+        let status = HopMessage {
+            kind: HopMessageType::Status,
+            peer: None,
+            reservation: None,
+            limit: None,
+            status: Some(Status::Ok),
+        };
+        agent.handle_event(
+            &SwarmEvent::StreamData {
+                peer_id: relay_peer.clone(),
+                conn_id: pair.inner_conn,
+                stream_id: pair.stream,
+                data: encode_frame(&status.encode()),
+            },
+            Now::from_mono(6),
+        );
+        let mut promotion = drain_actions(&mut agent)
+            .into_iter()
+            .find(|action| matches!(action, NatAction::PromoteBridge { .. }))
+            .expect("promotion action");
+        if let NatAction::PromoteBridge {
+            remote_write_closed: closed,
+            ..
+        } = &mut promotion
+        {
+            *closed = remote_write_closed;
+        }
+        let driver = NatDriver::new(
+            agent,
+            vec![(relay_peer, pair.relay_addr.transport().clone())],
+        );
+        (driver, promotion)
+    }
+
+    fn execute(driver: &mut NatDriver, action: NatAction, endpoint: &mut Endpoint) {
+        driver.execute(action, &mut endpoint.swarm);
+    }
+
+    fn circuit_id(driver: &NatDriver, key: (ConnectionId, StreamId)) -> ConnectionId {
+        *driver.promoted.get(&key).expect("promoted bridge entry")
+    }
 
     #[test]
     fn confirmed_public_addresses_are_advertised_and_cleared() {
@@ -351,5 +559,222 @@ mod tests {
         );
         swarm.poll().expect("refresh identify addresses");
         assert!(!swarm.core().local_addresses().contains(&public));
+    }
+
+    #[test]
+    fn driver_promotes_idempotently_routes_exact_stragglers_and_closes_idempotently() {
+        let mut pair = negotiated_bridge();
+        let key = (pair.inner_conn, pair.stream);
+        let (mut driver, promotion) = promotion_driver(&pair, false);
+        let duplicate = promotion.clone();
+
+        execute(&mut driver, promotion, &mut pair.local);
+        let promoted = circuit_id(&driver, key);
+        assert_eq!(pair.local.swarm.transport().circuit_ids(), vec![promoted]);
+
+        execute(&mut driver, duplicate, &mut pair.local);
+        assert_eq!(driver.promoted.len(), 1);
+        assert_eq!(pair.local.swarm.transport().circuit_ids(), vec![promoted]);
+        assert!(driver.bridge_reset_attempts.is_empty());
+
+        let mut header = vec![19];
+        header.extend_from_slice(b"/multistream/1.0.0\n");
+        assert!(driver.ingest(
+            &SwarmEvent::StreamData {
+                peer_id: pair.relay_addr.peer_id().clone(),
+                conn_id: pair.inner_conn,
+                stream_id: pair.stream,
+                data: header,
+            },
+            &mut pair.local.swarm,
+        ));
+        assert!(driver.promoted.contains_key(&key));
+        assert!(!driver.ingest(
+            &SwarmEvent::StreamData {
+                peer_id: pair.relay_addr.peer_id().clone(),
+                conn_id: ConnectionId::new(pair.inner_conn.as_u64() + 100),
+                stream_id: pair.stream,
+                data: vec![1],
+            },
+            &mut pair.local.swarm,
+        ));
+
+        execute(
+            &mut driver,
+            NatAction::CloseCircuit { conn_id: promoted },
+            &mut pair.local,
+        );
+        execute(
+            &mut driver,
+            NatAction::CloseCircuit { conn_id: promoted },
+            &mut pair.local,
+        );
+        assert!(driver.promoted.is_empty());
+        assert!(pair.local.swarm.transport().circuit_ids().is_empty());
+        let _ = pair.relay.next_event(std::time::Duration::from_millis(10));
+    }
+
+    #[test]
+    fn promotion_uses_action_connection_after_same_batch_relay_supersede() {
+        let mut pair = negotiated_bridge();
+        let old_conn = pair.inner_conn;
+        let stream = pair.stream;
+        let relay_peer = pair.relay_addr.peer_id().clone();
+        let (mut driver, promotion) = promotion_driver(&pair, false);
+
+        // Establish a replacement relay connection, but stop as soon as both
+        // public Established events have been delivered. At this seam the
+        // core points at B while its eager close of A is still deferred.
+        pair.relay
+            .dial(&pair.local_addr)
+            .expect("relay dials replacement");
+        let deadline = Instant::now() + std::time::Duration::from_secs(5);
+        let mut replacement = None;
+        let mut relay_established = false;
+        while replacement.is_none() || !relay_established {
+            assert!(Instant::now() < deadline, "replacement did not establish");
+            if replacement.is_none()
+                && let Some(Event::ConnectionEstablished { peer_id, conn_id }) = pair
+                    .local
+                    .next_event(std::time::Duration::from_millis(10))
+                    .expect("drive local replacement")
+                && peer_id == relay_peer
+                && conn_id != old_conn
+            {
+                replacement = Some(conn_id);
+            }
+            if !relay_established
+                && let Some(Event::ConnectionEstablished { peer_id, .. }) = pair
+                    .relay
+                    .next_event(std::time::Duration::from_millis(10))
+                    .expect("drive relay replacement")
+                && peer_id == *pair.local.peer_id()
+            {
+                relay_established = true;
+            }
+        }
+        let replacement = replacement.expect("replacement connection id");
+        assert_eq!(
+            pair.local.swarm.core().conn_for(&relay_peer),
+            Some(replacement)
+        );
+
+        execute(&mut driver, promotion, &mut pair.local);
+        assert!(driver.promoted.contains_key(&(old_conn, stream)));
+        assert!(!driver.promoted.contains_key(&(replacement, stream)));
+        assert!(!driver.ingest(
+            &SwarmEvent::StreamData {
+                peer_id: relay_peer,
+                conn_id: replacement,
+                stream_id: stream,
+                data: vec![1],
+            },
+            &mut pair.local.swarm,
+        ));
+    }
+
+    #[test]
+    fn driver_resets_failed_adoptions_but_not_unknown_connections() {
+        let mut failed_pair = negotiated_bridge();
+        let failed_key = (failed_pair.inner_conn, failed_pair.stream);
+        let (mut failed, action) = promotion_driver(&failed_pair, true);
+        execute(&mut failed, action, &mut failed_pair.local);
+        assert!(failed.promoted.is_empty());
+        assert_eq!(failed.bridge_reset_attempts, vec![failed_key]);
+
+        let mut unknown_pair = negotiated_bridge();
+        let (mut unknown, mut action) = promotion_driver(&unknown_pair, false);
+        let missing = ConnectionId::new(9_999);
+        if let NatAction::PromoteBridge { inner_conn, .. } = &mut action {
+            *inner_conn = missing;
+        }
+        execute(&mut unknown, action, &mut unknown_pair.local);
+        assert!(unknown.promoted.is_empty());
+        assert!(unknown.bridge_reset_attempts.is_empty());
+        assert!(
+            unknown_pair
+                .local
+                .swarm
+                .transport()
+                .circuit_ids()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn driver_prunes_promotions_on_every_external_cleanup_path() {
+        // A remote bridge FIN is routed through the promoted transport even
+        // though the raw stream was forgotten by the swarm at adoption.
+        let mut fin_pair = negotiated_bridge();
+        let (mut fin, action) = promotion_driver(&fin_pair, false);
+        execute(&mut fin, action, &mut fin_pair.local);
+        assert!(fin.ingest(
+            &SwarmEvent::StreamRemoteWriteClosed {
+                peer_id: fin_pair.relay_addr.peer_id().clone(),
+                conn_id: fin_pair.inner_conn,
+                stream_id: fin_pair.stream,
+            },
+            &mut fin_pair.local.swarm,
+        ));
+
+        // Exact bridge closure is terminal and removes the keyed adoption.
+        let mut closed_pair = negotiated_bridge();
+        let closed_key = (closed_pair.inner_conn, closed_pair.stream);
+        let (mut closed, action) = promotion_driver(&closed_pair, false);
+        execute(&mut closed, action, &mut closed_pair.local);
+        assert!(closed.ingest(
+            &SwarmEvent::StreamClosed {
+                peer_id: closed_pair.relay_addr.peer_id().clone(),
+                conn_id: closed_pair.inner_conn,
+                stream_id: closed_pair.stream,
+            },
+            &mut closed_pair.local.swarm,
+        ));
+        assert!(!closed.promoted.contains_key(&closed_key));
+
+        // An inner relay connection close drops every circuit riding it.
+        let mut inner_pair = negotiated_bridge();
+        let inner_key = (inner_pair.inner_conn, inner_pair.stream);
+        let (mut inner, action) = promotion_driver(&inner_pair, false);
+        execute(&mut inner, action, &mut inner_pair.local);
+        inner.ingest(
+            &SwarmEvent::ConnectionClosed {
+                peer_id: inner_pair.relay_addr.peer_id().clone(),
+                conn_id: inner_pair.inner_conn,
+            },
+            &mut inner_pair.local.swarm,
+        );
+        assert!(!inner.promoted.contains_key(&inner_key));
+
+        // A circuit lifecycle close also removes its reverse map entry.
+        let mut circuit_pair = negotiated_bridge();
+        let circuit_key = (circuit_pair.inner_conn, circuit_pair.stream);
+        let (mut circuit, action) = promotion_driver(&circuit_pair, false);
+        execute(&mut circuit, action, &mut circuit_pair.local);
+        let promoted = circuit_id(&circuit, circuit_key);
+        circuit.ingest(
+            &SwarmEvent::ConnectionClosed {
+                peer_id: Ed25519Keypair::from_secret_key_bytes([73; 32]).peer_id(),
+                conn_id: promoted,
+            },
+            &mut circuit_pair.local.swarm,
+        );
+        assert!(!circuit.promoted.contains_key(&circuit_key));
+
+        // Reconciliation catches transport-side removal even if no lifecycle
+        // event passed through the driver.
+        let mut swept_pair = negotiated_bridge();
+        let swept_key = (swept_pair.inner_conn, swept_pair.stream);
+        let (mut swept, action) = promotion_driver(&swept_pair, false);
+        execute(&mut swept, action, &mut swept_pair.local);
+        let promoted = circuit_id(&swept, swept_key);
+        swept_pair
+            .local
+            .swarm
+            .transport_mut()
+            .close(promoted)
+            .expect("transport-side close");
+        swept.pump(&mut swept_pair.local.swarm);
+        assert!(swept.promoted.is_empty());
     }
 }

--- a/crates/minip2p/src/pubsub.rs
+++ b/crates/minip2p/src/pubsub.rs
@@ -10,8 +10,9 @@ use std::collections::VecDeque;
 use std::time::Instant;
 
 use minip2p_pubsub::{FloodsubAgent, PubsubAction, PubsubEvent};
-use minip2p_quic::QuicEndpoint;
-use minip2p_swarm::{Swarm, SwarmEvent};
+use minip2p_swarm::SwarmEvent;
+
+use crate::EndpointSwarm;
 
 use crate::Error;
 
@@ -68,7 +69,7 @@ impl PubsubDriver {
     ///
     /// Returns `true` when the event belongs to a floodsub stream and must
     /// not be forwarded to the application.
-    pub(crate) fn ingest(&mut self, event: &SwarmEvent, swarm: &mut Swarm<QuicEndpoint>) -> bool {
+    pub(crate) fn ingest(&mut self, event: &SwarmEvent, swarm: &mut EndpointSwarm) -> bool {
         let handled = self.agent.handle_event(event, self.now_ms());
         self.pump(swarm);
         handled
@@ -76,7 +77,7 @@ impl PubsubDriver {
 
     /// Advances timers only when the agent reports a due deadline, then
     /// executes any resulting work.
-    pub(crate) fn tick(&mut self, swarm: &mut Swarm<QuicEndpoint>) {
+    pub(crate) fn tick(&mut self, swarm: &mut EndpointSwarm) {
         let now_ms = self.now_ms();
         if self.agent.next_timeout(now_ms) != Some(0) {
             return;
@@ -87,7 +88,7 @@ impl PubsubDriver {
 
     /// Drains agent actions into swarm calls (echoing synchronous results
     /// back) and collects application-visible pubsub events.
-    pub(crate) fn pump(&mut self, swarm: &mut Swarm<QuicEndpoint>) {
+    pub(crate) fn pump(&mut self, swarm: &mut EndpointSwarm) {
         loop {
             let mut progressed = false;
             while let Some(action) = self.agent.poll_action() {
@@ -104,7 +105,7 @@ impl PubsubDriver {
         }
     }
 
-    fn execute(&mut self, action: PubsubAction, swarm: &mut Swarm<QuicEndpoint>) {
+    fn execute(&mut self, action: PubsubAction, swarm: &mut EndpointSwarm) {
         match action {
             PubsubAction::OpenStream {
                 token,

--- a/crates/minip2p/tests/nat.rs
+++ b/crates/minip2p/tests/nat.rs
@@ -1,13 +1,18 @@
-//! Loopback e2e for the `nat` feature: two real QUIC endpoints, no relay —
-//! the direct leg of the race wins outright and the failure paths report
-//! cleanly. (Relay-path coverage lives at the agent level in
-//! `crates/nat/tests`; a full relay e2e needs an external relay server.)
+//! End-to-end coverage for the `nat` facade over direct QUIC and a real
+//! loopback Circuit Relay v2 bridge.
 
 #![cfg(feature = "nat")]
 
 use std::time::{Duration, Instant};
 
-use minip2p::{Endpoint, NatConfig, NatError, NatEvent, Path};
+use minip2p::{
+    ConnectionId, Endpoint, Event, NatConfig, NatError, NatEvent, Path, PeerId, ReservationPolicy,
+};
+
+#[path = "../../../tests/support/relay.rs"]
+mod relay_support;
+
+const ECHO_PROTOCOL: &str = "/minip2p/tests/nat-echo/1.0.0";
 
 fn nat_endpoint() -> Endpoint {
     Endpoint::builder()
@@ -151,4 +156,258 @@ fn wait_peer_ready_drives_nat_agent() {
     );
     let _ = stop_remote.send(());
     remote.join().expect("remote driver thread");
+}
+
+#[test]
+fn relay_promotion_runs_identify_ping_and_protocol_then_closes_on_relay_cut() {
+    let relay = relay_support::RelayServer::spawn();
+    let relay_addr = relay.addr().clone();
+
+    let mut responder = Endpoint::builder()
+        .protocol(ECHO_PROTOCOL)
+        .relay(relay_addr.clone())
+        .nat_config(NatConfig {
+            force_relay: true,
+            reservation_policy: ReservationPolicy::Always,
+            ..NatConfig::default()
+        })
+        .bind_quic("127.0.0.1:0")
+        .expect("bind responder");
+    responder.listen().expect("responder listens");
+    let responder_peer = responder.peer_id().clone();
+
+    let reservation_deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        assert!(
+            Instant::now() < reservation_deadline,
+            "responder did not reserve on relay"
+        );
+        let _ = responder
+            .next_event(Duration::from_millis(20))
+            .expect("drive responder reservation");
+        if responder.take_nat_events().iter().any(
+            |event| matches!(event, NatEvent::RelayReserved { relay, .. } if relay == relay_addr.peer_id()),
+        ) {
+            break;
+        }
+        relay.assert_healthy();
+    }
+
+    let mut initiator = Endpoint::builder()
+        .protocol(ECHO_PROTOCOL)
+        .relay(relay_addr)
+        .nat_config(NatConfig {
+            force_relay: true,
+            reservation_policy: ReservationPolicy::Never,
+            ..NatConfig::default()
+        })
+        .bind_quic("127.0.0.1:0")
+        .expect("bind initiator");
+    initiator.listen().expect("initiator listens");
+    let initiator_peer = initiator.peer_id().clone();
+    let connect_id = initiator
+        .connect(&responder_peer)
+        .expect("start relay-only connect");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut path = None;
+    let mut initiator_circuit = None;
+    let mut responder_circuit = None;
+    let mut initiator_ready = false;
+    let mut responder_ready = false;
+    let mut trace = Vec::new();
+    while path.is_none() || !initiator_ready || !responder_ready {
+        assert!(
+            Instant::now() < deadline,
+            "circuit did not become ready:\npeers={trace:#?}\nrelay={:#?}\ninitiator circuits={:?}\nresponder circuits={:?}",
+            relay.trace(),
+            initiator.swarm().transport().circuit_ids(),
+            responder.swarm().transport().circuit_ids(),
+        );
+        if let Some(event) = initiator
+            .next_event(Duration::from_millis(20))
+            .expect("drive initiator")
+        {
+            trace.push(format!("initiator swarm: {event:?}"));
+            observe_circuit_event(
+                event,
+                &responder_peer,
+                &mut initiator_circuit,
+                &mut initiator_ready,
+            );
+        }
+        if let Some(event) = responder
+            .next_event(Duration::from_millis(20))
+            .expect("drive responder")
+        {
+            trace.push(format!("responder swarm: {event:?}"));
+            observe_circuit_event(
+                event,
+                &initiator_peer,
+                &mut responder_circuit,
+                &mut responder_ready,
+            );
+        }
+        for event in initiator.take_nat_events() {
+            trace.push(format!("initiator nat: {event:?}"));
+            if let NatEvent::PathEstablished {
+                connect_id: found,
+                peer,
+                path: found_path,
+            } = event
+                && found == connect_id
+                && peer == responder_peer
+            {
+                path = Some(found_path);
+            }
+        }
+        for event in responder.take_nat_events() {
+            trace.push(format!("responder nat: {event:?}"));
+        }
+        relay.assert_healthy();
+    }
+
+    assert_eq!(
+        path,
+        Some(Path::Relayed {
+            relay: relay.addr().peer_id().clone()
+        })
+    );
+    let initiator_circuit = initiator_circuit.expect("initiator circuit id");
+    let responder_circuit = responder_circuit.expect("responder circuit id");
+    assert_ne!(initiator_circuit.as_u64() & (1 << 63), 0);
+    assert_ne!(responder_circuit.as_u64() & (1 << 63), 0);
+    assert!(initiator.peer_info(&responder_peer).is_some());
+    assert!(responder.peer_info(&initiator_peer).is_some());
+
+    initiator.ping(&responder_peer).expect("ping over circuit");
+    let ping_deadline = Instant::now() + Duration::from_secs(5);
+    let mut ping_rtt = None;
+    while ping_rtt.is_none() {
+        assert!(Instant::now() < ping_deadline, "circuit ping timed out");
+        if let Some(Event::PingRttMeasured { peer_id, rtt_ms }) = initiator
+            .next_event(Duration::from_millis(20))
+            .expect("drive initiator ping")
+            && peer_id == responder_peer
+        {
+            ping_rtt = Some(rtt_ms);
+        }
+        let _ = responder
+            .next_event(Duration::from_millis(20))
+            .expect("drive responder ping");
+        relay.assert_healthy();
+    }
+
+    let stream = initiator
+        .open_stream(&responder_peer, ECHO_PROTOCOL)
+        .expect("open echo stream over circuit");
+    let payload = b"echo across the promoted circuit".to_vec();
+    let echo_deadline = Instant::now() + Duration::from_secs(5);
+    let mut initiator_stream_ready = false;
+    let mut responder_stream = None;
+    let mut echoed = None;
+    while echoed.is_none() {
+        assert!(Instant::now() < echo_deadline, "circuit echo timed out");
+        if let Some(event) = initiator
+            .next_event(Duration::from_millis(20))
+            .expect("drive initiator echo")
+        {
+            match event {
+                Event::StreamReady {
+                    peer_id,
+                    stream_id,
+                    initiated_locally: true,
+                    ..
+                } if peer_id == responder_peer && stream_id == stream => {
+                    initiator_stream_ready = true;
+                    initiator
+                        .send_stream(&responder_peer, stream, payload.clone())
+                        .expect("send echo payload");
+                }
+                Event::StreamData {
+                    peer_id,
+                    stream_id,
+                    data,
+                    ..
+                } if peer_id == responder_peer && stream_id == stream => echoed = Some(data),
+                _ => {}
+            }
+        }
+        if let Some(event) = responder
+            .next_event(Duration::from_millis(20))
+            .expect("drive responder echo")
+        {
+            match event {
+                Event::StreamReady {
+                    peer_id,
+                    stream_id,
+                    initiated_locally: false,
+                    protocol_id,
+                    ..
+                } if peer_id == initiator_peer && protocol_id == ECHO_PROTOCOL => {
+                    responder_stream = Some(stream_id);
+                }
+                Event::StreamData {
+                    peer_id,
+                    stream_id,
+                    data,
+                    ..
+                } if peer_id == initiator_peer && Some(stream_id) == responder_stream => {
+                    responder
+                        .send_stream(&initiator_peer, stream_id, data)
+                        .expect("echo payload");
+                }
+                _ => {}
+            }
+        }
+        relay.assert_healthy();
+    }
+    assert!(initiator_stream_ready);
+    assert_eq!(echoed, Some(payload));
+
+    relay.cut_all();
+    let close_deadline = Instant::now() + Duration::from_secs(5);
+    let mut initiator_closed = false;
+    let mut responder_closed = false;
+    while !initiator_closed || !responder_closed {
+        assert!(
+            Instant::now() < close_deadline,
+            "circuit did not close after relay cut"
+        );
+        if let Some(Event::ConnectionClosed { peer_id, conn_id }) = initiator
+            .next_event(Duration::from_millis(20))
+            .expect("drive initiator close")
+            && peer_id == responder_peer
+            && conn_id == initiator_circuit
+        {
+            initiator_closed = true;
+        }
+        if let Some(Event::ConnectionClosed { peer_id, conn_id }) = responder
+            .next_event(Duration::from_millis(20))
+            .expect("drive responder close")
+            && peer_id == initiator_peer
+            && conn_id == responder_circuit
+        {
+            responder_closed = true;
+        }
+        relay.assert_healthy();
+    }
+}
+
+fn observe_circuit_event(
+    event: Event,
+    remote: &PeerId,
+    circuit: &mut Option<ConnectionId>,
+    ready: &mut bool,
+) {
+    match event {
+        Event::ConnectionEstablished { peer_id, conn_id } if peer_id == *remote => {
+            *circuit = Some(conn_id);
+        }
+        Event::PeerReady { peer_id, protocols } if peer_id == *remote => {
+            assert!(protocols.iter().any(|protocol| protocol == ECHO_PROTOCOL));
+            *ready = true;
+        }
+        _ => {}
+    }
 }

--- a/crates/minip2p/tests/pubsub.rs
+++ b/crates/minip2p/tests/pubsub.rs
@@ -8,6 +8,10 @@ use std::time::{Duration, Instant};
 
 use minip2p::{Endpoint, Event, PubsubError, PubsubEvent};
 
+#[cfg(feature = "nat")]
+#[path = "../../../tests/support/relay.rs"]
+mod relay_support;
+
 const TOPIC: &str = "loopback-chat";
 
 fn pubsub_endpoint() -> Endpoint {
@@ -245,4 +249,131 @@ fn next_pubsub_event_buffers_application_events() {
         }
     }
     assert!(saw_connect, "application events must be buffered, not lost");
+}
+
+#[cfg(feature = "nat")]
+#[test]
+fn pubsub_flows_over_relay_and_reannounces_after_direct_supersede() {
+    use minip2p::{NatConfig, NatEvent, Path, ReservationPolicy};
+
+    let relay = relay_support::RelayServer::spawn();
+    let relay_addr = relay.addr().clone();
+    let mut b = Endpoint::builder()
+        .pubsub()
+        .relay(relay_addr.clone())
+        .nat_config(NatConfig {
+            force_relay: true,
+            reservation_policy: ReservationPolicy::Always,
+            ..NatConfig::default()
+        })
+        .bind_quic("127.0.0.1:0")
+        .expect("bind responder");
+    let b_addr = b.listen().expect("responder listens");
+    let b_peer = b.peer_id().clone();
+    b.subscribe(TOPIC).expect("responder subscribes");
+
+    let reserve_deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        assert!(Instant::now() < reserve_deadline, "reservation timed out");
+        let _ = b
+            .next_event(Duration::from_millis(20))
+            .expect("drive reservation");
+        if b.take_nat_events().iter().any(
+            |event| matches!(event, NatEvent::RelayReserved { relay, .. } if relay == relay_addr.peer_id()),
+        ) {
+            break;
+        }
+        relay.assert_healthy();
+    }
+
+    let mut a = Endpoint::builder()
+        .pubsub()
+        .relay(relay_addr)
+        .nat_config(NatConfig {
+            force_relay: true,
+            reservation_policy: ReservationPolicy::Never,
+            ..NatConfig::default()
+        })
+        .bind_quic("127.0.0.1:0")
+        .expect("bind initiator");
+    a.listen().expect("initiator listens");
+    a.subscribe(TOPIC).expect("initiator subscribes");
+    let connect_id = a.connect(&b_peer).expect("relay-only connect");
+
+    drive_until(&mut [&mut a, &mut b], Duration::from_secs(15), |all| {
+        saw_subscription(&all[0], TOPIC) && saw_subscription(&all[1], TOPIC)
+    });
+    let nat = a.take_nat_events();
+    assert!(nat.iter().any(|event| matches!(
+        event,
+        NatEvent::PathEstablished {
+            connect_id: found,
+            peer,
+            path: Path::Relayed { relay: found_relay },
+        } if *found == connect_id && peer == &b_peer && found_relay == relay.addr().peer_id()
+    )));
+    let circuit_id = *a
+        .swarm()
+        .transport()
+        .circuit_ids()
+        .first()
+        .expect("active circuit");
+
+    a.publish(TOPIC, b"over relay").expect("publish over relay");
+    drive_until(&mut [&mut a, &mut b], Duration::from_secs(10), |all| {
+        saw_message(&all[1], b"over relay")
+    });
+
+    // A direct connection supersedes the ready circuit. The public sequence
+    // must close the old id before establishing the replacement, and the
+    // floodsub driver must re-open and re-announce subscriptions.
+    a.dial(&b_addr).expect("manual direct upgrade");
+    let upgrade_deadline = Instant::now() + Duration::from_secs(15);
+    let mut a_sequence = Vec::new();
+    let mut a_resubscribed = false;
+    let mut b_resubscribed = false;
+    while !a_resubscribed || !b_resubscribed {
+        assert!(
+            Instant::now() < upgrade_deadline,
+            "pubsub did not recover after supersede: {a_sequence:?}"
+        );
+        if let Some(event) = a
+            .next_event(Duration::from_millis(20))
+            .expect("drive initiator upgrade")
+        {
+            match event {
+                Event::ConnectionClosed { peer_id, conn_id } if peer_id == b_peer => {
+                    a_sequence.push(("closed", conn_id));
+                }
+                Event::ConnectionEstablished { peer_id, conn_id } if peer_id == b_peer => {
+                    a_sequence.push(("established", conn_id));
+                }
+                _ => {}
+            }
+        }
+        let _ = b
+            .next_event(Duration::from_millis(20))
+            .expect("drive responder upgrade");
+        a_resubscribed |= a.take_pubsub_events().iter().any(
+            |event| matches!(event, PubsubEvent::PeerSubscribed { topic, .. } if topic == TOPIC),
+        );
+        b_resubscribed |= b.take_pubsub_events().iter().any(
+            |event| matches!(event, PubsubEvent::PeerSubscribed { topic, .. } if topic == TOPIC),
+        );
+        relay.assert_healthy();
+    }
+    assert!(
+        matches!(
+            a_sequence.as_slice(),
+            [("closed", closed), ("established", direct), ..]
+                if *closed == circuit_id && direct.as_u64() & (1 << 63) == 0
+        ),
+        "supersede ordering: {a_sequence:?}"
+    );
+    assert!(a.swarm().transport().circuit_ids().is_empty());
+    a.publish(TOPIC, b"after upgrade")
+        .expect("publish after upgrade");
+    drive_until(&mut [&mut a, &mut b], Duration::from_secs(10), |all| {
+        saw_message(&all[1], b"after upgrade")
+    });
 }

--- a/crates/nat/README.md
+++ b/crates/nat/README.md
@@ -17,30 +17,28 @@ t0      direct leg: dial every validated candidate address
 t0+δ    relay leg (stagger δ, default 200 ms; 0 = fully parallel):
           ensure relay session → HOP CONNECT(target)
           → Bridged ⇒ DCUtR punch starts over the bridge
-          → after SYNC, release bridge ⇒ PathEstablished(Relayed)
+          → after SYNC, promote bridge through Noise + Yamux
+          → circuit Connected ⇒ PathEstablished(Relayed)
 first usable path wins
-a better path later  ⇒ PathUpgraded { from, to }  (+ the old bridge is reset)
-punch exhausted      ⇒ FellBackToRelay            (the bridge stays yours)
+a better path later  ⇒ PathUpgraded { from, to }  (+ the circuit closes)
+punch exhausted      ⇒ FellBackToRelay            (the circuit stays usable)
 nothing worked       ⇒ ConnectFailed { error }
 ```
 
 Ranking: `DirectDialed` ≈ `DirectPunched` > `Relayed`.
 
-## The relayed path is a raw bridge stream
+## Relayed paths are normal connections
 
-`Path::Relayed { relay, stream_id, pending_data, remote_write_closed }` is
-**not** a full swarm connection: no identify, ping, or multistream-select runs
-over the circuit. Exchange raw bytes on `stream_id` (addressed to the relay
-peer) with `Swarm::send_stream` and receive later bytes as ordinary
-`StreamData` events.
+`Path::Relayed { relay }` is metadata describing how the peer was reached.
+The bridge itself is promoted through end-to-end Noise XX and Yamux before
+`PathEstablished` is emitted. Identify, ping, pubsub, and application
+protocols can therefore use the ordinary swarm stream APIs without knowing
+whether the selected connection is direct or relayed.
 
-At handoff, consume `pending_data` before waiting for `StreamData`; it contains
-application bytes that arrived in the same transport read as the final DCUtR
-frame and is surfaced exactly once on the original `PathEstablished` event.
-When `remote_write_closed` is true, treat the remote read side as EOF after
-draining `pending_data`: the NAT agent already consumed that stream event, so
-the application will not receive it again. A circuit transport that makes
-relayed paths look like normal connections is future work.
+Set `NatConfig::force_relay` to skip direct candidates and DCUtR entirely.
+This is useful for deterministic relay-only deployments and tests. Stalled
+outbound promotions are bounded by `connect_deadline_ms`; inbound promotions
+are bounded by `circuit_handshake_timeout_ms`.
 
 ## Driving the agent
 
@@ -57,7 +55,12 @@ loop {
     // 1. Feed swarm events by reference. The disposition stays true even
     //    when handling claims or releases a control-plane stream, so only
     //    forward events for which it returns false to the application.
-    let consumed = agent.handle_event_with_disposition(&swarm_event, now());
+    let is_circuit = transport.is_circuit_connection(swarm_event.connection_id());
+    let consumed = agent.handle_event_with_disposition_classified(
+        &swarm_event,
+        is_circuit,
+        now(),
+    );
     if !consumed { /* forward swarm_event to the application */ }
     // 2. Execute actions, echoing synchronous results back.
     while let Some(action) = agent.poll_action() {
@@ -70,6 +73,8 @@ loop {
                     swarm.open_stream(&peer, &protocol_id).map_err(|e| e.to_string()),
                     now(),
                 ),
+            NatAction::PromoteBridge { token, .. } =>
+                agent.promote_result(token, promote_bridge(/* ... */), now()),
             // SendStream / ResetStream / ... map 1:1 onto Swarm methods.
             _ => { /* ... */ }
         }
@@ -120,9 +125,9 @@ DCUtR exchange is answered with our validated addresses, and on SYNC the
 agent emits `SendRandomUdp` blasts at the initiator's observed addresses
 to open its own NAT mapping (first after `responder_sync_delay_ms`, then
 every `blast_interval_ms` until `punch_deadline_ms`). Per DCUtR for QUIC
-only the initiator dials — the blasts make that dial land. The bridge
-stream is handed to the application via `InboundRelayCircuit`; a landed
-punch is announced with `InboundDirectUpgrade`.
+only the initiator dials — the blasts make that dial land. The bridge is
+promoted into a normal circuit connection; a landed punch is announced with
+`InboundDirectUpgrade` and supersedes that circuit.
 
 ## Status
 

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -13,7 +13,7 @@ use crate::config::NatConfig;
 use crate::events::{NatAction, NatEvent};
 use crate::housekeeping::Housekeeping;
 use crate::inbound::InboundCircuit;
-use crate::types::{ConnectId, NatToken, Now, ReachabilityState, ReservationInfo};
+use crate::types::{ConnectId, NatToken, Now, PromoteError, ReachabilityState, ReservationInfo};
 
 /// Roles a stream owned by the agent can play. Streams not in the registry
 /// belong to the application (`Released` is modeled as removal).
@@ -53,6 +53,10 @@ pub(crate) enum TokenPurpose {
     ReserveDial,
     /// HOP RESERVE stream open.
     OpenReserve(PeerId),
+    /// Relay bridge promotion for an outbound connect attempt.
+    PromoteAttempt(ConnectId),
+    /// Relay bridge promotion for an inbound circuit.
+    PromoteInbound(u64),
 }
 
 impl TokenPurpose {
@@ -61,7 +65,8 @@ impl TokenPurpose {
             Self::DirectDial(id)
             | Self::RelayDial(id)
             | Self::PunchDial(id)
-            | Self::OpenHop(id, _) => Some(*id),
+            | Self::OpenHop(id, _)
+            | Self::PromoteAttempt(id) => Some(*id),
             _ => None,
         }
     }
@@ -87,16 +92,17 @@ pub(crate) struct Shared {
     pub(crate) registry: BTreeMap<PeerId, BTreeMap<StreamId, StreamRole>>,
     pub(crate) tokens: BTreeMap<NatToken, TokenPurpose>,
     next_token: u64,
-    /// Peers with an established (identity-verified) connection. A QUIC
-    /// supersede re-emits `ConnectionEstablished` and the retired connection
-    /// emits no `ConnectionClosed`, so set semantics absorb both.
-    pub(crate) connected: BTreeSet<PeerId>,
+    /// Established connections per peer. Connection ids preserve concurrent
+    /// lifecycle provenance across eager supersession events.
+    pub(crate) connected: BTreeMap<PeerId, BTreeSet<ConnectionId>>,
+    /// Established connections classified as direct by the driver.
+    pub(crate) direct_connections: BTreeSet<ConnectionId>,
     /// Peers that reached `PeerReady`, with their advertised protocols.
     pub(crate) ready: BTreeMap<PeerId, Vec<String>>,
-    /// Bridges released to the application but still participating in a
-    /// direct-upgrade race. Data on these streams belongs to the app; only a
-    /// terminal close is routed back to the owning attempt.
-    released_bridges: BTreeMap<PeerId, BTreeMap<StreamId, ConnectId>>,
+    /// Exact connection provenance for agent-owned streams. Locally opened
+    /// streams enter the peer-scoped registry first and are bound here by
+    /// their `StreamReady` event before any bridge can be promoted.
+    stream_connections: BTreeMap<(PeerId, StreamId), ConnectionId>,
     /// Our validated external/listen addresses, advertised in DCUtR CONNECT.
     pub(crate) listen_addrs: Vec<Multiaddr>,
     /// Our transport address as observed by trusted reporters (Identify's
@@ -117,6 +123,16 @@ pub(crate) struct Shared {
 }
 
 impl Shared {
+    pub(crate) fn is_connected(&self, peer: &PeerId) -> bool {
+        self.connected.get(peer).is_some_and(|ids| !ids.is_empty())
+    }
+
+    pub(crate) fn is_directly_connected(&self, peer: &PeerId) -> bool {
+        self.connected
+            .get(peer)
+            .is_some_and(|ids| ids.iter().any(|id| self.direct_connections.contains(id)))
+    }
+
     pub(crate) fn alloc_token(&mut self, purpose: TokenPurpose) -> NatToken {
         let token = NatToken(self.next_token);
         self.next_token += 1;
@@ -183,41 +199,32 @@ impl Shared {
                 self.registry.remove(peer);
             }
         }
+        self.stream_connections.remove(&(peer.clone(), stream));
     }
 
-    pub(crate) fn track_released_bridge(
+    pub(crate) fn bind_stream(
         &mut self,
         peer: &PeerId,
         stream: StreamId,
-        attempt: ConnectId,
-    ) {
-        self.released_bridges
-            .entry(peer.clone())
-            .or_default()
-            .insert(stream, attempt);
-    }
-
-    pub(crate) fn take_released_bridge(
-        &mut self,
-        peer: &PeerId,
-        stream: StreamId,
-    ) -> Option<ConnectId> {
-        let attempt = self
-            .released_bridges
-            .get_mut(peer)
-            .and_then(|streams| streams.remove(&stream));
-        if self
-            .released_bridges
-            .get(peer)
-            .is_some_and(BTreeMap::is_empty)
-        {
-            self.released_bridges.remove(peer);
+        conn_id: ConnectionId,
+    ) -> bool {
+        match self.stream_connections.entry((peer.clone(), stream)) {
+            alloc::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(conn_id);
+                true
+            }
+            alloc::collections::btree_map::Entry::Occupied(entry) => *entry.get() == conn_id,
         }
-        attempt
     }
 
-    pub(crate) fn forget_released_bridge(&mut self, peer: &PeerId, stream: StreamId) {
-        let _ = self.take_released_bridge(peer, stream);
+    pub(crate) fn stream_connection(
+        &self,
+        peer: &PeerId,
+        stream: StreamId,
+    ) -> Option<ConnectionId> {
+        self.stream_connections
+            .get(&(peer.clone(), stream))
+            .copied()
     }
 
     /// Records `reporter`'s Identify claim of our transport address.
@@ -295,9 +302,10 @@ impl NatAgent {
                 registry: BTreeMap::new(),
                 tokens: BTreeMap::new(),
                 next_token: 0,
-                connected: BTreeSet::new(),
+                connected: BTreeMap::new(),
+                direct_connections: BTreeSet::new(),
                 ready: BTreeMap::new(),
-                released_bridges: BTreeMap::new(),
+                stream_connections: BTreeMap::new(),
                 listen_addrs: Vec::new(),
                 observed_addrs: BTreeMap::new(),
                 pending_session_dials: BTreeMap::new(),
@@ -328,7 +336,7 @@ impl NatAgent {
         // A connection that is already identity-verified is the best path
         // available. Do not manufacture a new race which can only waste
         // work (and, with no candidates or relay, falsely report failure).
-        if self.shared.connected.contains(&peer) {
+        if self.shared.is_directly_connected(&peer) {
             self.shared.push_event(NatEvent::PathEstablished {
                 connect_id: id,
                 peer,
@@ -366,10 +374,22 @@ impl NatAgent {
     /// control plane even when the event did not leave a stream registered.
     /// Drivers use this to consume rejected inbound control streams.
     pub fn handle_event_with_disposition(&mut self, event: &SwarmEvent, now: Now) -> bool {
+        self.handle_event_with_disposition_classified(event, false, now)
+    }
+
+    /// Feeds one swarm event with the driver's transport classification.
+    /// Circuit connection lifecycle events are correlated with promotions;
+    /// direct events continue to drive the direct-first race.
+    pub fn handle_event_with_disposition_classified(
+        &mut self,
+        event: &SwarmEvent,
+        is_circuit: bool,
+        now: Now,
+    ) -> bool {
         let mut handled = false;
         let mut touched_state = false;
         match event {
-            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+            SwarmEvent::ConnectionEstablished { peer_id, conn_id } => {
                 touched_state = true;
                 // Any session dial toward this peer has done its job (ours
                 // landed, or another machine's did — either way the peer is
@@ -377,56 +397,61 @@ impl NatAgent {
                 self.shared
                     .pending_session_dials
                     .retain(|_, (dialed, _)| dialed != peer_id);
-                let superseded = !self.shared.connected.insert(peer_id.clone());
-                if superseded {
-                    // The swarm's last-connection-wins policy emits a second
-                    // establishment without closing the retired connection.
-                    // Stream ids are peer-scoped here, so scrub them before
-                    // any event from the replacement connection can collide.
-                    self.shared.ready.remove(peer_id);
-                    self.shared.registry.remove(peer_id);
-                    self.shared.released_bridges.remove(peer_id);
-                    self.shared.tokens.retain(|_, purpose| {
-                        !matches!(
-                            purpose,
-                            TokenPurpose::OpenHop(_, peer)
-                                | TokenPurpose::OpenProbe(peer)
-                                | TokenPurpose::OpenReserve(peer)
-                                if peer == peer_id
-                        )
-                    });
-                    for attempt in self.attempts.values_mut() {
-                        attempt.on_peer_superseded(peer_id, &mut self.shared, now);
-                    }
-                    self.housekeeping
-                        .on_peer_superseded(peer_id, &mut self.shared, now);
-                    for circuit in self.inbound.values_mut() {
-                        circuit.on_relay_disconnected(peer_id, &mut self.shared);
-                    }
+                self.shared
+                    .connected
+                    .entry(peer_id.clone())
+                    .or_default()
+                    .insert(*conn_id);
+                if !is_circuit {
+                    self.shared.direct_connections.insert(*conn_id);
                 }
                 for attempt in self.attempts.values_mut() {
-                    attempt.on_peer_connected(peer_id, &mut self.shared, now);
+                    attempt.on_connection_established(
+                        peer_id,
+                        *conn_id,
+                        is_circuit,
+                        &mut self.shared,
+                        now,
+                    );
                 }
                 for circuit in self.inbound.values_mut() {
-                    circuit.on_peer_connected(peer_id, &mut self.shared, now);
+                    circuit.on_connection_established(
+                        peer_id,
+                        *conn_id,
+                        is_circuit,
+                        &mut self.shared,
+                        now,
+                    );
                 }
             }
-            SwarmEvent::ConnectionClosed { peer_id, .. } => {
+            SwarmEvent::ConnectionClosed { peer_id, conn_id } => {
                 touched_state = true;
-                self.shared.connected.remove(peer_id);
-                self.shared.ready.remove(peer_id);
+                self.shared.direct_connections.remove(conn_id);
+                if let Some(ids) = self.shared.connected.get_mut(peer_id) {
+                    ids.remove(conn_id);
+                    if ids.is_empty() {
+                        self.shared.connected.remove(peer_id);
+                        self.shared.ready.remove(peer_id);
+                    }
+                }
                 for attempt in self.attempts.values_mut() {
-                    attempt.on_peer_disconnected(peer_id, &mut self.shared, now);
+                    attempt.on_connection_closed(peer_id, *conn_id, &mut self.shared, now);
                 }
                 self.housekeeping
                     .on_peer_disconnected(peer_id, &mut self.shared, now);
                 for circuit in self.inbound.values_mut() {
-                    circuit.on_relay_disconnected(peer_id, &mut self.shared);
+                    circuit.on_connection_closed(peer_id, *conn_id, &mut self.shared);
                 }
-                // Streams on the closed connection are gone; drop any the
-                // attempts have not already cleaned up.
-                self.shared.registry.remove(peer_id);
-                self.shared.released_bridges.remove(peer_id);
+                let closed_streams: Vec<_> = self
+                    .shared
+                    .stream_connections
+                    .iter()
+                    .filter(|(_, owner)| **owner == *conn_id)
+                    .map(|((peer, stream), _)| (peer.clone(), *stream))
+                    .collect();
+                for (peer, stream) in closed_streams {
+                    self.shared.release_stream(&peer, stream);
+                }
                 self.shared.observed_addrs.remove(peer_id);
                 self.shared
                     .pending_session_dials
@@ -452,6 +477,7 @@ impl NatAgent {
                     .on_peer_ready(peer_id, protocols, &mut self.shared, now);
             }
             SwarmEvent::StreamReady {
+                conn_id,
                 peer_id,
                 stream_id,
                 protocol_id,
@@ -459,6 +485,16 @@ impl NatAgent {
                 ..
             } => {
                 if !initiated_locally && protocol_id == STOP_PROTOCOL_ID {
+                    if !self.shared.bind_stream(peer_id, *stream_id, *conn_id) {
+                        // An old connection still owns this peer-scoped id.
+                        // Reject the colliding replacement stream without
+                        // overwriting the old stream's exact provenance.
+                        self.shared.push_action(NatAction::ResetStream {
+                            peer: peer_id.clone(),
+                            stream_id: *stream_id,
+                        });
+                        return true;
+                    }
                     // STOP is a relay control protocol, but registration of
                     // its id makes it possible for any connected peer to
                     // negotiate it. Only relays explicitly configured by
@@ -492,44 +528,68 @@ impl NatAgent {
                             .own_stream(peer_id, *stream_id, StreamRole::StopInbound(id));
                         self.inbound.insert(
                             id,
-                            InboundCircuit::new(peer_id.clone(), *stream_id, &self.shared, now),
+                            InboundCircuit::new(
+                                id,
+                                *conn_id,
+                                peer_id.clone(),
+                                *stream_id,
+                                &self.shared,
+                                now,
+                            ),
                         );
                         handled = true;
                     }
                 } else {
-                    handled = self.route_stream(peer_id, *stream_id, StreamInput::Ready, now);
+                    if self.owns_stream(peer_id, *stream_id)
+                        && self.shared.bind_stream(peer_id, *stream_id, *conn_id)
+                    {
+                        handled = self.route_stream(
+                            *conn_id,
+                            peer_id,
+                            *stream_id,
+                            StreamInput::Ready,
+                            now,
+                        );
+                    }
                 }
                 touched_state = handled;
             }
             SwarmEvent::StreamData {
+                conn_id,
                 peer_id,
                 stream_id,
                 data,
                 ..
             } => {
-                handled = self.route_stream(peer_id, *stream_id, StreamInput::Data(data), now);
+                handled =
+                    self.route_stream(*conn_id, peer_id, *stream_id, StreamInput::Data(data), now);
                 touched_state = handled;
             }
             SwarmEvent::StreamRemoteWriteClosed {
-                peer_id, stream_id, ..
+                conn_id,
+                peer_id,
+                stream_id,
+                ..
             } => {
-                handled =
-                    self.route_stream(peer_id, *stream_id, StreamInput::RemoteWriteClosed, now);
+                handled = self.route_stream(
+                    *conn_id,
+                    peer_id,
+                    *stream_id,
+                    StreamInput::RemoteWriteClosed,
+                    now,
+                );
                 touched_state = handled;
             }
             SwarmEvent::StreamClosed {
-                peer_id, stream_id, ..
+                conn_id,
+                peer_id,
+                stream_id,
+                ..
             } => {
-                if let Some(id) = self.shared.take_released_bridge(peer_id, *stream_id) {
-                    handled = true;
-                    if let Some(attempt) = self.attempts.get_mut(&id) {
-                        attempt.on_released_bridge_closed(*stream_id, &mut self.shared, now);
-                    }
-                } else {
-                    handled = self.route_stream(peer_id, *stream_id, StreamInput::Closed, now);
-                    if handled {
-                        self.shared.release_stream(peer_id, *stream_id);
-                    }
+                handled =
+                    self.route_stream(*conn_id, peer_id, *stream_id, StreamInput::Closed, now);
+                if handled {
+                    self.shared.release_stream(peer_id, *stream_id);
                 }
                 touched_state = handled;
             }
@@ -641,6 +701,33 @@ impl NatAgent {
         }
     }
 
+    /// Reports the result of a [`NatAction::PromoteBridge`] executed by the
+    /// driver.
+    pub fn promote_result(
+        &mut self,
+        token: NatToken,
+        result: Result<ConnectionId, PromoteError>,
+        now: Now,
+    ) {
+        let Some(purpose) = self.shared.tokens.remove(&token) else {
+            return;
+        };
+        match purpose {
+            TokenPurpose::PromoteAttempt(id) => {
+                if let Some(attempt) = self.attempts.get_mut(&id) {
+                    attempt.on_promote_result(result, &mut self.shared, now);
+                }
+            }
+            TokenPurpose::PromoteInbound(id) => {
+                if let Some(circuit) = self.inbound.get_mut(&id) {
+                    circuit.on_promote_result(result, &mut self.shared, now);
+                }
+            }
+            _ => {}
+        }
+        self.reap_done();
+    }
+
     /// Returns the next queued command for the driver.
     pub fn poll_action(&mut self) -> Option<NatAction> {
         self.shared.actions.pop_front()
@@ -701,6 +788,7 @@ impl NatAgent {
 
     fn route_stream(
         &mut self,
+        conn_id: ConnectionId,
         peer: &PeerId,
         stream: StreamId,
         input: StreamInput<'_>,
@@ -713,10 +801,13 @@ impl NatAgent {
         let Some(role) = streams.get(&stream).copied() else {
             return false;
         };
+        if self.shared.stream_connection(peer, stream) != Some(conn_id) {
+            return false;
+        }
         match role {
             StreamRole::HopConnect(id) => {
                 if let Some(attempt) = self.attempts.get_mut(&id) {
-                    attempt.on_stream_input(stream, input, &mut self.shared, now);
+                    attempt.on_stream_input(conn_id, stream, input, &mut self.shared, now);
                 }
             }
             StreamRole::HopReserve | StreamRole::AutonatProbe => {
@@ -725,7 +816,7 @@ impl NatAgent {
             }
             StreamRole::StopInbound(id) => {
                 if let Some(circuit) = self.inbound.get_mut(&id) {
-                    circuit.on_stream_input(stream, input, &mut self.shared, now);
+                    circuit.on_stream_input(conn_id, stream, input, &mut self.shared, now);
                 }
             }
             StreamRole::RejectedStop => {}

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -6,7 +6,9 @@ use minip2p_core::{Multiaddr, PeerAddr, PeerId, select_direct_candidates};
 use minip2p_swarm::SwarmEvent;
 use minip2p_transport::{ConnectionId, StreamId};
 
-use minip2p_relay::STOP_PROTOCOL_ID;
+use minip2p_autonat::AUTONAT_PROTOCOL_ID;
+use minip2p_dcutr::DCUTR_PROTOCOL_ID;
+use minip2p_relay::{HOP_PROTOCOL_ID, STOP_PROTOCOL_ID};
 
 use crate::attempt::ConnectAttempt;
 use crate::config::NatConfig;
@@ -28,9 +30,9 @@ pub(crate) enum StreamRole {
     AutonatProbe,
     /// Inbound STOP stream from a relay (responder-side circuit).
     StopInbound(u64),
-    /// Inbound STOP stream from an untrusted peer. Kept owned until terminal
-    /// close so its reset lifecycle cannot leak into the application.
-    RejectedStop,
+    /// Inbound NAT control stream this node does not serve. Kept owned until
+    /// terminal close so its reset lifecycle cannot leak into the application.
+    RejectedControl,
 }
 
 /// What a pending `Dial` / `OpenStream` token was issued for.
@@ -285,6 +287,12 @@ pub struct NatAgent {
     attempts: BTreeMap<ConnectId, ConnectAttempt>,
     housekeeping: Housekeeping,
     inbound: BTreeMap<u64, InboundCircuit>,
+    /// Peers whose last known connection closed. Swarm reports an eager
+    /// `ConnectionClosed(old)` before `ConnectionEstablished(replacement)`
+    /// during supersession, so peer-scoped housekeeping is first staged and
+    /// reconciled only if a second tick arrives without the replacement.
+    pending_peer_disconnects: BTreeSet<PeerId>,
+    reconcile_peer_disconnects: BTreeSet<PeerId>,
     next_connect_id: u64,
     next_inbound_id: u64,
 }
@@ -313,6 +321,8 @@ impl NatAgent {
             attempts: BTreeMap::new(),
             housekeeping,
             inbound: BTreeMap::new(),
+            pending_peer_disconnects: BTreeSet::new(),
+            reconcile_peer_disconnects: BTreeSet::new(),
             next_connect_id: 0,
             next_inbound_id: 0,
         }
@@ -391,6 +401,8 @@ impl NatAgent {
         match event {
             SwarmEvent::ConnectionEstablished { peer_id, conn_id } => {
                 touched_state = true;
+                self.pending_peer_disconnects.remove(peer_id);
+                self.reconcile_peer_disconnects.remove(peer_id);
                 // Any session dial toward this peer has done its job (ours
                 // landed, or another machine's did — either way the peer is
                 // reachable now and further dials would supersede).
@@ -427,9 +439,11 @@ impl NatAgent {
             SwarmEvent::ConnectionClosed { peer_id, conn_id } => {
                 touched_state = true;
                 self.shared.direct_connections.remove(conn_id);
+                let mut peer_disconnected = false;
                 if let Some(ids) = self.shared.connected.get_mut(peer_id) {
                     ids.remove(conn_id);
-                    if ids.is_empty() {
+                    peer_disconnected = ids.is_empty();
+                    if peer_disconnected {
                         self.shared.connected.remove(peer_id);
                         self.shared.ready.remove(peer_id);
                     }
@@ -437,8 +451,9 @@ impl NatAgent {
                 for attempt in self.attempts.values_mut() {
                     attempt.on_connection_closed(peer_id, *conn_id, &mut self.shared, now);
                 }
-                self.housekeeping
-                    .on_peer_disconnected(peer_id, &mut self.shared, now);
+                if peer_disconnected {
+                    self.pending_peer_disconnects.insert(peer_id.clone());
+                }
                 for circuit in self.inbound.values_mut() {
                     circuit.on_connection_closed(peer_id, *conn_id, &mut self.shared);
                 }
@@ -452,7 +467,6 @@ impl NatAgent {
                 for (peer, stream) in closed_streams {
                     self.shared.release_stream(&peer, stream);
                 }
-                self.shared.observed_addrs.remove(peer_id);
                 self.shared
                     .pending_session_dials
                     .retain(|_, (dialed, _)| dialed != peer_id);
@@ -484,7 +498,15 @@ impl NatAgent {
                 initiated_locally,
                 ..
             } => {
-                if !initiated_locally && protocol_id == STOP_PROTOCOL_ID {
+                if !initiated_locally
+                    && matches!(
+                        protocol_id.as_str(),
+                        HOP_PROTOCOL_ID
+                            | STOP_PROTOCOL_ID
+                            | DCUTR_PROTOCOL_ID
+                            | AUTONAT_PROTOCOL_ID
+                    )
+                {
                     if !self.shared.bind_stream(peer_id, *stream_id, *conn_id) {
                         // An old connection still owns this peer-scoped id.
                         // Reject the colliding replacement stream without
@@ -495,29 +517,26 @@ impl NatAgent {
                         });
                         return true;
                     }
-                    // STOP is a relay control protocol, but registration of
-                    // its id makes it possible for any connected peer to
-                    // negotiate it. Only relays explicitly configured by
-                    // the application are trusted to request an inbound
-                    // circuit; otherwise a peer could make us punch its
-                    // chosen addresses.
-                    if !self
-                        .shared
-                        .config
-                        .relays
-                        .iter()
-                        .any(|relay| relay.peer_id() == peer_id)
-                    {
-                        // STOP is registered only for the NAT control plane.
-                        // Reject untrusted opens here instead of leaking them
-                        // to the application and leaving their stream credit
-                        // occupied until the remote closes them.
+                    let trusted_stop = protocol_id == STOP_PROTOCOL_ID
+                        && self
+                            .shared
+                            .config
+                            .relays
+                            .iter()
+                            .any(|relay| relay.peer_id() == peer_id);
+                    if !trusted_stop {
+                        // All four ids are registered so the client-side NAT
+                        // machines can negotiate outbound streams and advertise
+                        // support through Identify. This node serves only STOP,
+                        // and only for explicitly configured relays; accepting
+                        // the other inbound control protocols would leak them as
+                        // application streams despite reserving their ids.
                         self.shared.push_action(NatAction::ResetStream {
                             peer: peer_id.clone(),
                             stream_id: *stream_id,
                         });
                         self.shared
-                            .own_stream(peer_id, *stream_id, StreamRole::RejectedStop);
+                            .own_stream(peer_id, *stream_id, StreamRole::RejectedControl);
                         handled = true;
                     } else {
                         // A relay is bridging an inbound circuit to us: claim
@@ -607,6 +626,19 @@ impl NatAgent {
     /// Advances time-based state: stagger expiry, leg deadlines, punch
     /// windows, connect deadlines.
     pub fn handle_tick(&mut self, now: Now) {
+        // The std driver may tick after each individual event. Age newly
+        // closed peers for one complete tick so an eager Close(old) can be
+        // followed by Established(replacement) on the next poll turn.
+        let disconnected = core::mem::take(&mut self.reconcile_peer_disconnects);
+        for peer in disconnected {
+            if !self.shared.is_connected(&peer) {
+                self.housekeeping
+                    .on_peer_disconnected(&peer, &mut self.shared, now);
+                self.shared.observed_addrs.remove(&peer);
+            }
+        }
+        self.reconcile_peer_disconnects
+            .append(&mut self.pending_peer_disconnects);
         for attempt in self.attempts.values_mut() {
             attempt.on_tick(&mut self.shared, now);
         }
@@ -741,6 +773,10 @@ impl NatAgent {
     /// Milliseconds until the earliest pending deadline, if any. Drivers
     /// fold this into their poll budget, mirroring `SwarmCore::next_timeout`.
     pub fn next_timeout(&self, now_ms: u64) -> Option<u64> {
+        if !self.pending_peer_disconnects.is_empty() || !self.reconcile_peer_disconnects.is_empty()
+        {
+            return Some(0);
+        }
         self.attempts
             .values()
             .filter_map(ConnectAttempt::next_deadline)
@@ -783,6 +819,8 @@ impl NatAgent {
             && self.shared.events.is_empty()
             && self.attempts.is_empty()
             && self.inbound.is_empty()
+            && self.pending_peer_disconnects.is_empty()
+            && self.reconcile_peer_disconnects.is_empty()
             && self.housekeeping.is_quiet()
     }
 
@@ -819,7 +857,7 @@ impl NatAgent {
                     circuit.on_stream_input(conn_id, stream, input, &mut self.shared, now);
                 }
             }
-            StreamRole::RejectedStop => {}
+            StreamRole::RejectedControl => {}
         }
         true
     }

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -10,8 +10,8 @@ use minip2p_relay::{
 use minip2p_transport::{ConnectionId, StreamId};
 
 use crate::agent::{Shared, StreamInput, StreamRole, TokenPurpose};
-use crate::events::{NatAction, NatEvent};
-use crate::types::{ConnectId, NatError, Now, Path};
+use crate::events::{BridgeRole, NatAction, NatEvent};
+use crate::types::{ConnectId, NatError, Now, Path, PromoteError};
 
 /// Progress of the relay leg of a connect attempt.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -55,8 +55,14 @@ pub(crate) struct ConnectAttempt {
     dcutr_sent_at: Option<u64>,
     /// The bridge exists and has not been torn down by a close/disconnect.
     bridge_alive: bool,
-    /// The bridge stream has been handed back to the application.
+    /// The bridge stream has been handed to the circuit transport.
     bridge_released: bool,
+    /// Exact wrapped connection learned from the bridge stream's ready event.
+    bridge_inner_conn: Option<ConnectionId>,
+    /// Circuit connection returned by the promotion driver echo.
+    promoted: Option<ConnectionId>,
+    /// Promotion has been requested and its synchronous echo may be pending.
+    promotion_requested: bool,
     /// The remote write half reached EOF while the bridge was agent-owned.
     bridge_remote_write_closed: bool,
     /// Application bytes coalesced behind the initiator-side DCUtR reply.
@@ -69,6 +75,9 @@ pub(crate) struct ConnectAttempt {
     /// 1-based index of the current punch window.
     punch_window: u32,
     best: Option<Path>,
+    /// All direct punch windows have settled; once the circuit establishes,
+    /// it is the final path and `FellBackToRelay` may be emitted.
+    punch_settled: bool,
     last_error: Option<NatError>,
     done: bool,
 }
@@ -84,7 +93,11 @@ impl ConnectAttempt {
         shared: &mut Shared,
         now: Now,
     ) -> Option<Self> {
-        let candidates = select_direct_candidates(&direct_addrs, None, None).into_addrs();
+        let candidates = if shared.config.force_relay {
+            Vec::new()
+        } else {
+            select_direct_candidates(&direct_addrs, None, None).into_addrs()
+        };
         let relay = shared.config.relays.first().cloned();
 
         if candidates.is_empty() && relay.is_none() {
@@ -109,6 +122,9 @@ impl ConnectAttempt {
             dcutr_sent_at: None,
             bridge_alive: false,
             bridge_released: false,
+            bridge_inner_conn: None,
+            promoted: None,
+            promotion_requested: false,
             bridge_remote_write_closed: false,
             bridge_pending_data: Vec::new(),
             punch_addrs: Vec::new(),
@@ -116,6 +132,7 @@ impl ConnectAttempt {
             punch_deadline: None,
             punch_window: 0,
             best: None,
+            punch_settled: false,
             last_error: None,
             done: false,
         };
@@ -135,7 +152,11 @@ impl ConnectAttempt {
         }
 
         if attempt.relay.is_some() {
-            let stagger = shared.config.relay_stagger_ms;
+            let stagger = if shared.config.force_relay {
+                0
+            } else {
+                shared.config.relay_stagger_ms
+            };
             if stagger == 0 || attempt.direct_live == 0 {
                 // Nothing to give a head start to (or none requested).
                 attempt.begin_relay_leg(shared, now);
@@ -184,8 +205,28 @@ impl ConnectAttempt {
     // Inputs routed from the agent
     // -----------------------------------------------------------------------
 
-    pub(crate) fn on_peer_connected(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
+    pub(crate) fn on_connection_established(
+        &mut self,
+        peer: &PeerId,
+        conn_id: ConnectionId,
+        is_circuit: bool,
+        shared: &mut Shared,
+        now: Now,
+    ) {
         if self.done || *peer != self.peer {
+            return;
+        }
+        if is_circuit {
+            if self.promoted == Some(conn_id) {
+                self.announce_relay_path(shared);
+                if self.punch_settled || shared.config.force_relay {
+                    shared.push_event(NatEvent::FellBackToRelay {
+                        connect_id: self.id,
+                        peer: self.peer.clone(),
+                    });
+                    self.done = true;
+                }
+            }
             return;
         }
         // `ConnectionEstablished` carries no dial/connection correlation.
@@ -225,43 +266,47 @@ impl ConnectAttempt {
         self.done = true;
     }
 
-    pub(crate) fn on_peer_disconnected(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
-        if self.done || !self.is_relay_peer(peer) {
+    pub(crate) fn on_connection_closed(
+        &mut self,
+        peer: &PeerId,
+        conn_id: ConnectionId,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        if self.done {
             return;
         }
-        match self.leg {
-            RelayLeg::WaitRelayReady
-            | RelayLeg::OpeningHop
-            | RelayLeg::WaitHopReady { .. }
-            | RelayLeg::AwaitHopStatus { .. } => {
-                self.fail_relay_leg(
+        if self.promoted == Some(conn_id) {
+            self.promoted = None;
+            self.bridge_alive = false;
+            if self.best.is_none() && self.direct_live == 0 {
+                self.fail(
                     shared,
-                    NatError::DialFailed("relay connection closed".into()),
+                    NatError::DialFailed("promoted circuit closed".into()),
                 );
             }
-            RelayLeg::Bridged { .. } => self.on_bridge_lost(shared, now),
-            _ => {}
+            return;
         }
-    }
-
-    /// Invalidates relay state carried by a connection that the swarm
-    /// superseded. Unlike an ordinary close, cleanup must not emit stream
-    /// resets: peer-scoped stream ids now address the replacement connection.
-    pub(crate) fn on_peer_superseded(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
-        if self.done || !self.is_relay_peer(peer) {
+        if !self.is_relay_peer(peer) || self.bridge_inner_conn.is_some_and(|id| id != conn_id) {
             return;
         }
         match self.leg {
-            RelayLeg::WaitRelayReady
-            | RelayLeg::OpeningHop
-            | RelayLeg::WaitHopReady { .. }
-            | RelayLeg::AwaitHopStatus { .. } => {
+            RelayLeg::WaitRelayReady | RelayLeg::OpeningHop => {
                 self.leg = RelayLeg::Failed;
                 self.relay_deadline = None;
                 self.hop = None;
-                self.last_error = Some(NatError::DialFailed(
-                    "relay connection was superseded".into(),
-                ));
+                self.last_error = Some(NatError::DialFailed("relay connection closed".into()));
+                self.fail_if_no_legs_remain(shared);
+            }
+            RelayLeg::WaitHopReady { stream } | RelayLeg::AwaitHopStatus { stream } => {
+                // The exact owning connection is terminal. Release local
+                // state without a peer-scoped reset that could target its
+                // eager replacement.
+                shared.release_stream(peer, stream);
+                self.leg = RelayLeg::Failed;
+                self.relay_deadline = None;
+                self.hop = None;
+                self.last_error = Some(NatError::DialFailed("relay connection closed".into()));
                 self.fail_if_no_legs_remain(shared);
             }
             RelayLeg::Bridged { .. } => self.on_bridge_lost(shared, now),
@@ -322,7 +367,7 @@ impl ConnectAttempt {
             return;
         };
         let relay_peer = relay.peer_id();
-        if shared.connected.contains(relay_peer) || shared.session_dial_pending(relay_peer, now) {
+        if shared.is_connected(relay_peer) || shared.session_dial_pending(relay_peer, now) {
             // The shared connection landed anyway, or an earlier-woken
             // waiter already re-dialed; keep waiting on that.
             return;
@@ -412,6 +457,7 @@ impl ConnectAttempt {
 
     pub(crate) fn on_stream_input(
         &mut self,
+        conn_id: ConnectionId,
         stream: StreamId,
         input: StreamInput<'_>,
         shared: &mut Shared,
@@ -419,6 +465,9 @@ impl ConnectAttempt {
     ) {
         if self.done {
             return;
+        }
+        if matches!(input, StreamInput::Ready) {
+            self.bridge_inner_conn = Some(conn_id);
         }
         match (self.leg, input) {
             (RelayLeg::WaitHopReady { stream: s }, StreamInput::Ready) if s == stream => {
@@ -481,6 +530,11 @@ impl ConnectAttempt {
                 // on the relay.
                 self.punch_deadline = None;
                 self.settle_after_punch(shared);
+            } else if self.promotion_requested {
+                if let Some(conn_id) = self.promoted.take() {
+                    shared.push_action(NatAction::CloseCircuit { conn_id });
+                }
+                self.fail(shared, NatError::Timeout);
             } else {
                 self.fail(shared, NatError::Timeout);
             }
@@ -508,8 +562,7 @@ impl ConnectAttempt {
                     NatError::Protocol("relay does not advertise the HOP protocol".into()),
                 );
             }
-        } else if shared.connected.contains(&relay_peer)
-            || shared.session_dial_pending(&relay_peer, now)
+        } else if shared.is_connected(&relay_peer) || shared.session_dial_pending(&relay_peer, now)
         {
             // Connected, or another machine (reservation, probe) is already
             // dialing this relay: wait for `PeerReady` on that connection.
@@ -618,13 +671,18 @@ impl ConnectAttempt {
         self.bridge_alive = true;
         self.hop = None;
 
+        if shared.config.force_relay {
+            self.punch_settled = true;
+            self.promote_bridge(stream, shared);
+            return;
+        }
+
         let mut dcutr = DcutrInitiator::new(&shared.punch_candidates());
         if let Err(e) = dcutr.handle_input(DcutrInitiatorInput::Flush) {
             // Deferred construction error (e.g. oversized CONNECT): the
             // punch cannot even start, but the relayed path stands and is
             // already safe to hand to the application.
-            self.release_bridge(shared);
-            self.announce_relay_path(stream, shared);
+            self.promote_bridge(stream, shared);
             self.punch_failed_permanently(shared, e.to_string(), now);
             return;
         }
@@ -753,8 +811,7 @@ impl ConnectAttempt {
                 reason: "relay bridge reached EOF before the DCUtR reply completed".into(),
             });
             self.punch_deadline = None;
-            self.release_bridge(shared);
-            self.announce_relay_path(stream, shared);
+            self.promote_bridge(stream, shared);
             if self.direct_live == 0 {
                 self.settle_after_punch(shared);
             }
@@ -809,8 +866,7 @@ impl ConnectAttempt {
         // No further DCUtR frames are expected: from here every byte on the
         // bridge belongs to the application.
         self.dcutr = None;
-        self.release_bridge(shared);
-        self.announce_relay_path(stream, shared);
+        self.promote_bridge(stream, shared);
 
         if self.punch_addrs.is_empty() {
             self.punch_failed_permanently(
@@ -875,20 +931,17 @@ impl ConnectAttempt {
             return;
         }
         if self.bridge_alive {
-            self.release_bridge(shared);
+            self.punch_settled = true;
             if let RelayLeg::Bridged { stream } = self.leg {
-                self.announce_relay_path(stream, shared);
-                // The app now owns the final relay stream outright. Stop
-                // intercepting its terminal events with this settled attempt.
-                if let Some(relay_peer) = self.relay_peer().cloned() {
-                    shared.forget_released_bridge(&relay_peer, stream);
+                self.promote_bridge(stream, shared);
+                if self.best.is_some() {
+                    shared.push_event(NatEvent::FellBackToRelay {
+                        connect_id: self.id,
+                        peer: self.peer.clone(),
+                    });
+                    self.done = true;
                 }
             }
-            shared.push_event(NatEvent::FellBackToRelay {
-                connect_id: self.id,
-                peer: self.peer.clone(),
-            });
-            self.done = true;
         } else {
             let error = self
                 .last_error
@@ -898,44 +951,42 @@ impl ConnectAttempt {
         }
     }
 
-    /// Stops consuming the bridge stream; subsequent `StreamData` on it is
-    /// forwarded to the application by the driver.
-    fn release_bridge(&mut self, shared: &mut Shared) {
+    /// Relinquishes the exact bridge stream to the circuit transport.
+    fn promote_bridge(&mut self, requested_stream: StreamId, shared: &mut Shared) {
         if self.bridge_released {
             return;
         }
         if let RelayLeg::Bridged { stream } = self.leg
+            && stream == requested_stream
             && let Some(relay_peer) = self.relay_peer().cloned()
+            && let Some(inner_conn) = self.bridge_inner_conn
         {
             self.bridge_released = true;
             shared.release_stream(&relay_peer, stream);
-            shared.track_released_bridge(&relay_peer, stream, self.id);
+            let token = shared.alloc_token(TokenPurpose::PromoteAttempt(self.id));
+            self.promotion_requested = true;
+            shared.push_action(NatAction::PromoteBridge {
+                token,
+                inner_conn,
+                relay: relay_peer,
+                stream_id: stream,
+                remote_peer: self.peer.clone(),
+                role: BridgeRole::Initiator,
+                pending_data: core::mem::take(&mut self.bridge_pending_data),
+                remote_write_closed: self.bridge_remote_write_closed,
+            });
         }
     }
 
-    fn announce_relay_path(&mut self, stream: StreamId, shared: &mut Shared) {
+    fn announce_relay_path(&mut self, shared: &mut Shared) {
         if self.best.is_some() {
             return;
         }
         let Some(relay) = self.relay_peer().cloned() else {
             return;
         };
-        let remote_write_closed = self.bridge_remote_write_closed;
-        let path = Path::Relayed {
-            relay: relay.clone(),
-            stream_id: stream,
-            pending_data: core::mem::take(&mut self.bridge_pending_data),
-            remote_write_closed,
-        };
-        // `pending_data` is a one-shot handoff. Keep only stable path
-        // identity in `best`, so a later PathUpgraded event cannot surface
-        // the same bytes a second time.
-        self.best = Some(Path::Relayed {
-            relay,
-            stream_id: stream,
-            pending_data: Vec::new(),
-            remote_write_closed,
-        });
+        let path = Path::Relayed { relay };
+        self.best = Some(path.clone());
         shared.push_event(NatEvent::PathEstablished {
             connect_id: self.id,
             peer: self.peer.clone(),
@@ -992,16 +1043,29 @@ impl ConnectAttempt {
         // the rest.
     }
 
-    /// Handles a terminal event for a bridge that was released to the app
-    /// while the direct-upgrade race was still active.
-    pub(crate) fn on_released_bridge_closed(
+    pub(crate) fn on_promote_result(
         &mut self,
-        stream: StreamId,
+        result: Result<ConnectionId, PromoteError>,
         shared: &mut Shared,
-        now: Now,
+        _now: Now,
     ) {
-        if matches!(self.leg, RelayLeg::Bridged { stream: s } if s == stream) {
-            self.on_bridge_lost(shared, now);
+        match result {
+            Ok(conn_id) => self.promoted = Some(conn_id),
+            Err(PromoteError::PeerAlreadyDirect) => {
+                self.bridge_alive = false;
+                self.leg = RelayLeg::Failed;
+                if self.direct_live == 0 {
+                    self.last_error = Some(NatError::DialFailed(
+                        "direct connection won before circuit promotion".into(),
+                    ));
+                }
+            }
+            Err(error) => {
+                self.bridge_alive = false;
+                self.leg = RelayLeg::Failed;
+                self.last_error = Some(NatError::Protocol(error.to_string()));
+                self.fail_if_no_legs_remain(shared);
+            }
         }
     }
 
@@ -1048,18 +1112,24 @@ impl ConnectAttempt {
     /// caller emits the explaining event first).
     fn teardown_relay_leg(&mut self, shared: &mut Shared) {
         match self.leg {
-            RelayLeg::WaitHopReady { stream }
-            | RelayLeg::AwaitHopStatus { stream }
-            | RelayLeg::Bridged { stream } => {
+            RelayLeg::WaitHopReady { stream } | RelayLeg::AwaitHopStatus { stream } => {
                 if let Some(relay_peer) = self.relay_peer().cloned() {
-                    if self.bridge_alive || !matches!(self.leg, RelayLeg::Bridged { .. }) {
+                    shared.push_action(NatAction::ResetStream {
+                        peer: relay_peer.clone(),
+                        stream_id: stream,
+                    });
+                    shared.release_stream(&relay_peer, stream);
+                }
+            }
+            RelayLeg::Bridged { stream } => {
+                if let Some(relay_peer) = self.relay_peer().cloned() {
+                    if !self.bridge_released && self.bridge_alive {
                         shared.push_action(NatAction::ResetStream {
                             peer: relay_peer.clone(),
                             stream_id: stream,
                         });
                     }
                     shared.release_stream(&relay_peer, stream);
-                    shared.forget_released_bridge(&relay_peer, stream);
                 }
             }
             _ => {}
@@ -1070,6 +1140,9 @@ impl ConnectAttempt {
         self.hop = None;
         self.dcutr = None;
         self.bridge_alive = false;
+        if let Some(conn_id) = self.promoted.take() {
+            shared.push_action(NatAction::CloseCircuit { conn_id });
+        }
     }
 
     fn relay_peer(&self) -> Option<&PeerId> {

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -11,6 +11,7 @@ use minip2p_transport::{ConnectionId, StreamId};
 
 use crate::agent::{Shared, StreamInput, StreamRole, TokenPurpose};
 use crate::events::{BridgeRole, NatAction, NatEvent};
+use crate::inbound::select_global_punch_candidates;
 use crate::types::{ConnectId, NatError, Now, Path, PromoteError};
 
 /// Progress of the relay leg of a connect attempt.
@@ -279,15 +280,22 @@ impl ConnectAttempt {
         if self.promoted == Some(conn_id) {
             self.promoted = None;
             self.bridge_alive = false;
-            if self.best.is_none() && self.direct_live == 0 {
-                self.fail(
-                    shared,
-                    NatError::DialFailed("promoted circuit closed".into()),
-                );
-            }
+            self.last_error = Some(NatError::DialFailed("promoted circuit closed".into()));
+            self.settle_after_punch(shared);
             return;
         }
         if !self.is_relay_peer(peer) || self.bridge_inner_conn.is_some_and(|id| id != conn_id) {
+            return;
+        }
+        // Waiting for relay readiness and issuing OpenStream are peer-scoped,
+        // so a connection close has no exact ownership signal. In particular,
+        // Swarm reports Closed(old) before Established(new) for a QUIC
+        // supersede. Keep both pre-allocation phases alive: PeerReady or the
+        // open result continues them on the replacement, while a real loss is
+        // still bounded by the relay deadline (and usually an open error).
+        // Allocated stream phases retain conservative teardown until
+        // StreamReady records exact ownership in `bridge_inner_conn`.
+        if matches!(self.leg, RelayLeg::WaitRelayReady | RelayLeg::OpeningHop) {
             return;
         }
         match self.leg {
@@ -525,6 +533,9 @@ impl ConnectAttempt {
         }
 
         if !self.done && now.mono_ms >= self.connect_deadline {
+            // Accepted direct dials that never produced a connection are no
+            // longer viable past the overall attempt deadline.
+            self.direct_live = 0;
             if self.best.is_some() {
                 // A relayed path exists but the punch never resolved; settle
                 // on the relay.
@@ -847,7 +858,10 @@ impl ConnectAttempt {
         shared: &mut Shared,
         now: Now,
     ) {
-        self.punch_addrs = select_direct_candidates(&remote_addrs, None, None).into_addrs();
+        // Unlike caller-configured direct candidates, these addresses are
+        // supplied by the remote peer. Restrict them to global IP QUIC
+        // endpoints before allowing either a dial or UDP punch traffic.
+        self.punch_addrs = select_global_punch_candidates(&remote_addrs);
 
         // Per the spec the initiator dials first, then signals SYNC.
         if !self.punch_addrs.is_empty() {
@@ -962,6 +976,17 @@ impl ConnectAttempt {
                     self.done = true;
                 }
             }
+        } else if self.best.is_some() {
+            // PathEstablished is terminal success for this connect id. If
+            // the promoted circuit is subsequently lost, a still-live
+            // direct leg may upgrade that result, but the loss must never
+            // turn the already-reported success into ConnectFailed.
+            if self.direct_live == 0 && self.punch_deadline.is_none() {
+                self.done = true;
+            }
+        } else if self.direct_live > 0 || self.punch_deadline.is_some() {
+            // The relay leg is gone, but a direct candidate or an active
+            // punch window can still establish the first usable path.
         } else {
             let error = self
                 .last_error

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -625,6 +625,7 @@ impl ConnectAttempt {
         while let Some(output) = hop.poll_output() {
             outputs.push(output);
         }
+        self.capture_force_relay_bridge_data(&outputs, shared);
         // `HopConnect` yields `Outcome(Bridged)` before any `BridgeData`, so
         // pipelined peer bytes reach the DCUtR machine created below inside
         // this same cascade — before any later `StreamData` event.
@@ -650,7 +651,9 @@ impl ConnectAttempt {
                     return;
                 }
                 HopConnectOutput::BridgeData(bytes) => {
-                    self.on_bridge_data(stream, &bytes, shared, now);
+                    if !shared.config.force_relay {
+                        self.on_bridge_data(stream, &bytes, shared, now);
+                    }
                 }
             }
         }
@@ -717,6 +720,20 @@ impl ConnectAttempt {
         self.drain_dcutr_outputs(stream, shared, now);
     }
 
+    /// In relay-only mode promotion happens as soon as HOP accepts. Capture
+    /// bytes coalesced behind STATUS:OK before processing the preceding
+    /// `Outcome(Bridged)`, which queues the promotion action.
+    fn capture_force_relay_bridge_data(&mut self, outputs: &[HopConnectOutput], shared: &Shared) {
+        if !shared.config.force_relay {
+            return;
+        }
+        for output in outputs {
+            if let HopConnectOutput::BridgeData(bytes) = output {
+                self.bridge_pending_data.extend_from_slice(bytes);
+            }
+        }
+    }
+
     fn drain_dcutr_outputs(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
         let Some(dcutr) = self.dcutr.as_mut() else {
             return;
@@ -760,6 +777,7 @@ impl ConnectAttempt {
         while let Some(output) = hop.poll_output() {
             outputs.push(output);
         }
+        self.capture_force_relay_bridge_data(&outputs, shared);
         for output in outputs {
             match output {
                 HopConnectOutput::Outbound(data) => {
@@ -782,7 +800,9 @@ impl ConnectAttempt {
                     return;
                 }
                 HopConnectOutput::BridgeData(bytes) => {
-                    self.on_bridge_data(stream, &bytes, shared, now);
+                    if !shared.config.force_relay {
+                        self.on_bridge_data(stream, &bytes, shared, now);
+                    }
                 }
             }
         }

--- a/crates/nat/src/config.rs
+++ b/crates/nat/src/config.rs
@@ -37,6 +37,12 @@ pub struct NatConfig {
     pub relay_stagger_ms: u64,
     /// Overall deadline for a connect attempt.
     pub connect_deadline_ms: u64,
+    /// Deadline for an inbound promoted circuit to finish its Noise and
+    /// Yamux handshake. The deadline is disarmed once the circuit connection
+    /// is established.
+    pub circuit_handshake_timeout_ms: u64,
+    /// Use relayed circuits without racing direct dials or attempting DCUtR.
+    pub force_relay: bool,
     /// Deadline for the relay leg to reach `Bridged` (measured from when the
     /// leg starts, i.e. after the stagger).
     pub relay_leg_deadline_ms: u64,
@@ -83,6 +89,8 @@ impl Default for NatConfig {
             autonat_servers: Vec::new(),
             relay_stagger_ms: 200,
             connect_deadline_ms: 60_000,
+            circuit_handshake_timeout_ms: 20_000,
+            force_relay: false,
             relay_leg_deadline_ms: 12_000,
             punch_deadline_ms: 3_000,
             punch_max_retries: 2,

--- a/crates/nat/src/events.rs
+++ b/crates/nat/src/events.rs
@@ -6,6 +6,15 @@ use minip2p_transport::StreamId;
 
 use crate::types::{ConnectId, NatError, NatToken, Path, ReachabilityState};
 
+/// Local role used when promoting a relay bridge into a circuit connection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BridgeRole {
+    /// The local endpoint initiated the HOP CONNECT request.
+    Initiator,
+    /// The local endpoint accepted the STOP CONNECT request.
+    Responder,
+}
+
 /// Commands the agent asks its driver to execute against the swarm.
 ///
 /// `Dial` and `OpenStream` are synchronous swarm calls; the driver echoes
@@ -44,6 +53,23 @@ pub enum NatAction {
         target: Multiaddr,
         payload_len: usize,
     },
+    /// Relinquish a negotiated relay bridge to the circuit transport and
+    /// report the synchronous adoption result with `token`.
+    PromoteBridge {
+        token: NatToken,
+        inner_conn: minip2p_transport::ConnectionId,
+        relay: PeerId,
+        stream_id: StreamId,
+        remote_peer: PeerId,
+        role: BridgeRole,
+        pending_data: Vec<u8>,
+        remote_write_closed: bool,
+    },
+    /// Close a promoted circuit connection. Closing an already-gone circuit
+    /// is successful cleanup.
+    CloseCircuit {
+        conn_id: minip2p_transport::ConnectionId,
+    },
 }
 
 /// Events the agent surfaces to the application.
@@ -80,8 +106,7 @@ pub enum NatEvent {
         path: Path,
     },
     /// A better path replaced the previously announced one. When `from` was
-    /// [`Path::Relayed`], its bridge stream has been reset and must no
-    /// longer be used.
+    /// [`Path::Relayed`], its circuit connection is closed automatically.
     PathUpgraded {
         connect_id: ConnectId,
         peer: PeerId,
@@ -96,32 +121,14 @@ pub enum NatEvent {
         attempt: u32,
         reason: String,
     },
-    /// All punch windows are exhausted; the relayed path announced earlier
-    /// remains the final path for this attempt, and its bridge stream now
-    /// belongs entirely to the application.
+    /// All punch windows are exhausted; the established relayed connection
+    /// remains the final path for this attempt.
     FellBackToRelay { connect_id: ConnectId, peer: PeerId },
     /// The attempt ended with no usable path.
     ConnectFailed {
         connect_id: ConnectId,
         peer: PeerId,
         error: NatError,
-    },
-    /// A remote peer opened a relay circuit to us (responder side). The
-    /// stream is a raw bridge; `pending_data` holds any bytes that arrived
-    /// pipelined behind the circuit setup.
-    InboundRelayCircuit {
-        /// The initiating peer on the far end of the circuit.
-        peer: PeerId,
-        /// The relay the bridge runs through. The bridge stream lives on the
-        /// connection to this peer: `send_stream` / `close_stream_write` on
-        /// `stream_id` must address `relay`, not `peer`.
-        relay: PeerId,
-        stream_id: StreamId,
-        pending_data: Vec<u8>,
-        /// `true` when the remote write half reached EOF before handoff. The
-        /// original swarm event was consumed by the NAT control plane and
-        /// will not be emitted again for the application.
-        remote_write_closed: bool,
     },
     /// An inbound circuit's hole punch succeeded; the peer is now directly
     /// connected.

--- a/crates/nat/src/housekeeping.rs
+++ b/crates/nat/src/housekeeping.rs
@@ -1024,7 +1024,9 @@ impl Housekeeping {
                 self.reservations
                     .on_stream_input(stream, input, shared, now);
             }
-            StreamRole::HopConnect(_) | StreamRole::StopInbound(_) | StreamRole::RejectedStop => {}
+            StreamRole::HopConnect(_)
+            | StreamRole::StopInbound(_)
+            | StreamRole::RejectedControl => {}
         }
     }
 

--- a/crates/nat/src/housekeeping.rs
+++ b/crates/nat/src/housekeeping.rs
@@ -128,7 +128,7 @@ impl Prober {
                 self.next_probe_at = Some(now.mono_ms + shared.config.probe_interval_unsettled_ms);
                 return;
             }
-        } else if shared.connected.contains(&server_peer)
+        } else if shared.is_connected(&server_peer)
             || shared.session_dial_pending(&server_peer, now)
         {
             // Connected, or another machine is already dialing this peer
@@ -179,19 +179,14 @@ impl Prober {
         if let Some(flight) = &self.flight
             && flight.server.peer_id() == peer
         {
-            self.abort_flight(shared, now);
-        }
-    }
-
-    fn on_peer_superseded(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
-        if self
-            .flight
-            .as_ref()
-            .is_some_and(|flight| flight.server.peer_id() == peer)
-        {
-            // The old connection's stream ids are invalid, but resetting
-            // them would target the replacement connection.
-            self.flight = None;
+            if let Some(flight) = self.flight.take()
+                && let Some(stream) = flight.stage.stream()
+            {
+                // The owning connection is already gone. Releasing local
+                // bookkeeping is sufficient; a peer-scoped reset could hit
+                // a replacement connection that reused the stream id.
+                shared.release_stream(peer, stream);
+            }
             self.server_idx += 1;
             self.next_probe_at = Some(now.mono_ms + shared.config.probe_interval_unsettled_ms);
         }
@@ -596,8 +591,7 @@ impl ReservationManager {
                 self.fail_acquire(shared, now);
                 return;
             }
-        } else if shared.connected.contains(&relay_peer)
-            || shared.session_dial_pending(&relay_peer, now)
+        } else if shared.is_connected(&relay_peer) || shared.session_dial_pending(&relay_peer, now)
         {
             // Connected, or a connect attempt's relay leg is already dialing
             // this relay: share that connection instead of superseding it.
@@ -680,29 +674,15 @@ impl ReservationManager {
                 };
             }
             ResState::Acquiring { relay, .. } if relay.peer_id() == peer => {
-                self.fail_acquire(shared, now);
-            }
-            _ => {}
-        }
-    }
-
-    fn on_peer_superseded(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
-        match &self.state {
-            ResState::Reserved { relay, .. } if relay.peer_id() == peer => {
-                shared.push_event(NatEvent::RelayReservationLost {
-                    relay: peer.clone(),
-                });
-                self.relay_idx += 1;
-                self.state = ResState::Backoff {
-                    until: now.mono_ms + shared.config.reservation_retry_backoff_ms,
-                };
-            }
-            ResState::Acquiring { relay, .. } if relay.peer_id() == peer => {
-                // Do not reset the retired stream id on the new connection.
-                // A renewal keeps the old reservation in `held` while its
-                // replacement exchange runs. Superseding the relay connection
-                // invalidates that reservation even though the exchange did
-                // not fail through the normal stream path.
+                if let ResState::Acquiring { stage, .. } =
+                    core::mem::replace(&mut self.state, ResState::Idle)
+                    && let Some(stream) = stage.stream()
+                {
+                    // As above, the connection is terminal. Never reset by
+                    // peer after eager supersession has installed a
+                    // replacement connection.
+                    shared.release_stream(peer, stream);
+                }
                 if let Some(held) = self.held.take() {
                     shared.push_event(NatEvent::RelayReservationLost { relay: held });
                 }
@@ -982,11 +962,6 @@ impl Housekeeping {
     pub(crate) fn on_peer_disconnected(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
         self.prober.on_peer_disconnected(peer, shared, now);
         self.reservations.on_peer_disconnected(peer, shared, now);
-    }
-
-    pub(crate) fn on_peer_superseded(&mut self, peer: &PeerId, shared: &mut Shared, now: Now) {
-        self.prober.on_peer_superseded(peer, shared, now);
-        self.reservations.on_peer_superseded(peer, shared, now);
     }
 
     pub(crate) fn on_probe_dial_result(

--- a/crates/nat/src/inbound.rs
+++ b/crates/nat/src/inbound.rs
@@ -14,7 +14,7 @@
 
 use alloc::vec::Vec;
 
-use minip2p_core::{Multiaddr, PeerId, SansIoProtocol, select_direct_candidates};
+use minip2p_core::{Multiaddr, PeerId, Protocol, SansIoProtocol, select_direct_candidates};
 use minip2p_dcutr::{DcutrResponder, DcutrResponderInput, DcutrResponderOutput, ResponderEvent};
 use minip2p_relay::{Status, StopResponder, StopResponderInput, StopResponderOutput};
 use minip2p_transport::{ConnectionId, StreamId};
@@ -231,6 +231,11 @@ impl InboundCircuit {
         }
 
         if shared.config.force_relay {
+            // STOP yields the CONNECT request before the bytes trailing its
+            // frame. In force-relay mode there is no DCUtR machine to consume
+            // that remainder: it is already circuit transport data and must
+            // cross the ownership boundary with the promoted bridge.
+            self.pending_data = pipelined;
             self.promote(shared);
             return;
         }
@@ -275,8 +280,7 @@ impl InboundCircuit {
                     remote_addrs,
                     ..
                 }) => {
-                    self.remote_addrs =
-                        select_direct_candidates(&remote_addrs, None, None).into_addrs();
+                    self.remote_addrs = select_global_punch_candidates(&remote_addrs);
                 }
                 DcutrResponderOutput::Event(ResponderEvent::SyncReceived) => {
                     sync_received = true;
@@ -483,4 +487,79 @@ impl InboundCircuit {
             Err(_) => self.done = true,
         }
     }
+}
+
+/// Selects peer-supplied DCUtR targets that are safe to dial or blast.
+///
+/// The general direct-candidate selector intentionally accepts DNS and LAN
+/// addresses because those are useful when configured by the local
+/// application. DCUtR addresses instead come from an untrusted remote peer:
+/// resolving or sending traffic to private/special-use targets would turn the
+/// NAT agent into an SSRF primitive. Keep only strict QUIC-v1 addresses whose
+/// first component is a globally routable unicast IP.
+pub(crate) fn select_global_punch_candidates(addrs: &[Multiaddr]) -> Vec<Multiaddr> {
+    select_direct_candidates(addrs, None, None)
+        .into_addrs()
+        .into_iter()
+        .filter(is_global_unicast_quic)
+        .collect()
+}
+
+fn is_global_unicast_quic(addr: &Multiaddr) -> bool {
+    match addr.protocols().first() {
+        Some(Protocol::Ip4(octets)) => is_global_unicast_v4(*octets),
+        Some(Protocol::Ip6(octets)) => is_global_unicast_v6(*octets),
+        Some(Protocol::Dns(_) | Protocol::Dns4(_) | Protocol::Dns6(_)) | None => false,
+        Some(_) => false,
+    }
+}
+
+fn is_global_unicast_v4([a, b, c, d]: [u8; 4]) -> bool {
+    !(a == 0
+        // RFC 1918 private space.
+        || a == 10
+        || (a == 172 && (16..=31).contains(&b))
+        || (a == 192 && b == 168)
+        // RFC 6598 shared carrier-grade NAT space.
+        || (a == 100 && (64..=127).contains(&b))
+        || a == 127
+        || (a == 169 && b == 254)
+        // IETF protocol assignments. .9 and .10 are globally reachable
+        // anycast addresses and therefore remain eligible.
+        || (a == 192 && b == 0 && c == 0 && d != 9 && d != 10)
+        // Documentation ranges.
+        || (a == 192 && b == 0 && c == 2)
+        || (a == 198 && b == 51 && c == 100)
+        || (a == 203 && b == 0 && c == 113)
+        // Benchmarking, multicast, reserved, and broadcast space.
+        || (a == 198 && (b == 18 || b == 19))
+        || a >= 224)
+}
+
+fn is_global_unicast_v6(octets: [u8; 16]) -> bool {
+    let segments = core::net::Ipv6Addr::from(octets).segments();
+    // The currently allocated global-unicast block is 2000::/3.
+    if segments[0] & 0xe000 != 0x2000 {
+        return false;
+    }
+
+    // Special-purpose allocations within 2000::/3 are not ordinary global
+    // unicast destinations. Keep the small set explicitly designated global
+    // by IANA inside 2001::/23.
+    if segments[0] == 0x2001 && segments[1] < 0x0200 {
+        let value = u128::from_be_bytes(octets);
+        let globally_reachable_exception = value == 0x2001_0001_0000_0000_0000_0000_0000_0001
+            || value == 0x2001_0001_0000_0000_0000_0000_0000_0002
+            || segments[1] == 0x0003
+            || (segments[1] == 0x0004 && segments[2] == 0x0112)
+            || (0x0020..=0x003f).contains(&segments[1]);
+        if !globally_reachable_exception {
+            return false;
+        }
+    }
+
+    // 6to4 and documentation ranges are not globally reachable endpoints.
+    segments[0] != 0x2002
+        && !(segments[0] == 0x2001 && segments[1] == 0x0db8)
+        && !(segments[0] == 0x3fff && segments[1] & 0xf000 == 0)
 }

--- a/crates/nat/src/inbound.rs
+++ b/crates/nat/src/inbound.rs
@@ -8,7 +8,7 @@
 //! relay opens STOP stream ──▶ CONNECT ──▶ auto-Accept (STATUS:OK)
 //!   ──▶ DCUtR CONNECT arrives ──▶ reply with our observed addresses
 //!   ──▶ SYNC arrives ──▶ schedule UDP blasts,
-//!       release the bridge to the app (InboundRelayCircuit)
+//!       promote the bridge into a circuit connection
 //! initiator's dial lands ──▶ cancel blasts, InboundDirectUpgrade
 //! ```
 
@@ -17,11 +17,12 @@ use alloc::vec::Vec;
 use minip2p_core::{Multiaddr, PeerId, SansIoProtocol, select_direct_candidates};
 use minip2p_dcutr::{DcutrResponder, DcutrResponderInput, DcutrResponderOutput, ResponderEvent};
 use minip2p_relay::{Status, StopResponder, StopResponderInput, StopResponderOutput};
-use minip2p_transport::StreamId;
+use minip2p_transport::{ConnectionId, StreamId};
 
+use crate::agent::TokenPurpose;
 use crate::agent::{Shared, StreamInput};
-use crate::events::{NatAction, NatEvent};
-use crate::types::Now;
+use crate::events::{BridgeRole, NatAction, NatEvent};
+use crate::types::{Now, PromoteError};
 
 /// Responder-side UDP blast schedule during the punch window.
 struct BlastSchedule {
@@ -33,6 +34,8 @@ struct BlastSchedule {
 /// One inbound relay circuit: STOP acceptance, DCUtR responder exchange,
 /// and the punch-window UDP blasts.
 pub(crate) struct InboundCircuit {
+    id: u64,
+    inner_conn: ConnectionId,
     /// The peer that opened the STOP stream to us (the relay).
     relay: PeerId,
     stream: StreamId,
@@ -42,7 +45,7 @@ pub(crate) struct InboundCircuit {
     dcutr: Option<DcutrResponder>,
     remote_addrs: Vec<Multiaddr>,
     /// Application bytes received after the final DCUtR SYNC frame in the
-    /// same stream read. These must accompany the raw bridge handoff.
+    /// same stream read. These must accompany circuit promotion.
     pending_data: Vec<u8>,
     /// The remote write half reached EOF while the control plane still owned
     /// the bridge. The transport will not repeat that event after handoff.
@@ -54,15 +57,26 @@ pub(crate) struct InboundCircuit {
     /// Keep the circuit alive for upgrade detection until this instant
     /// (covers the initiator's full retry window, not just our blasts).
     linger_until: Option<u64>,
-    /// The bridge stream has been handed to the application.
+    /// The bridge stream has been handed to the circuit transport.
     released: bool,
+    promoted: Option<ConnectionId>,
+    handshake_deadline: Option<u64>,
     done: bool,
 }
 
 impl InboundCircuit {
     /// Claims a freshly negotiated inbound STOP stream.
-    pub(crate) fn new(relay: PeerId, stream: StreamId, shared: &Shared, now: Now) -> Self {
+    pub(crate) fn new(
+        id: u64,
+        inner_conn: ConnectionId,
+        relay: PeerId,
+        stream: StreamId,
+        shared: &Shared,
+        now: Now,
+    ) -> Self {
         Self {
+            id,
+            inner_conn,
             relay,
             stream,
             source: None,
@@ -75,6 +89,8 @@ impl InboundCircuit {
             blast: None,
             linger_until: None,
             released: false,
+            promoted: None,
+            handshake_deadline: None,
             done: false,
         }
     }
@@ -98,17 +114,21 @@ impl InboundCircuit {
         if let Some(linger) = self.linger_until {
             due = Some(due.map_or(linger, |d| d.min(linger)));
         }
+        if let Some(handshake) = self.handshake_deadline {
+            due = Some(due.map_or(handshake, |d| d.min(handshake)));
+        }
         due
     }
 
     pub(crate) fn on_stream_input(
         &mut self,
+        conn_id: ConnectionId,
         stream: StreamId,
         input: StreamInput<'_>,
         shared: &mut Shared,
         now: Now,
     ) {
-        if self.done || stream != self.stream {
+        if self.done || conn_id != self.inner_conn || stream != self.stream {
             return;
         }
         match input {
@@ -210,6 +230,10 @@ impl InboundCircuit {
             });
         }
 
+        if shared.config.force_relay {
+            self.promote(shared);
+            return;
+        }
         self.dcutr = Some(DcutrResponder::new(&shared.punch_candidates()));
         if !pipelined.is_empty() {
             self.on_bridge_data(&pipelined, shared, now);
@@ -230,7 +254,7 @@ impl InboundCircuit {
             // oversized reply), but the bridge itself is fine: hand it to
             // the app without punching.
             self.dcutr = None;
-            self.release_to_app(shared);
+            self.promote(shared);
             return;
         }
         let mut outputs = Vec::new();
@@ -293,27 +317,28 @@ impl InboundCircuit {
         let window =
             shared.config.punch_deadline_ms * (1 + u64::from(shared.config.punch_max_retries));
         self.linger_until = Some(now.mono_ms + window);
-        self.release_to_app(shared);
+        self.promote(shared);
     }
 
-    /// Hands the bridge stream to the application, exactly once.
-    fn release_to_app(&mut self, shared: &mut Shared) {
+    /// Hands the exact bridge stream to the circuit transport, exactly once.
+    fn promote(&mut self, shared: &mut Shared) {
         if self.released {
             return;
         }
         self.released = true;
         shared.release_stream(&self.relay, self.stream);
         if let Some(source) = &self.source {
-            shared.push_event(NatEvent::InboundRelayCircuit {
-                peer: source.clone(),
+            let token = shared.alloc_token(TokenPurpose::PromoteInbound(self.id));
+            shared.push_action(NatAction::PromoteBridge {
+                token,
+                inner_conn: self.inner_conn,
                 relay: self.relay.clone(),
                 stream_id: self.stream,
+                remote_peer: source.clone(),
+                role: BridgeRole::Responder,
                 pending_data: core::mem::take(&mut self.pending_data),
                 remote_write_closed: self.remote_write_closed,
             });
-        }
-        if self.blast.is_none() && self.linger_until.is_none() {
-            self.done = true;
         }
     }
 
@@ -326,7 +351,7 @@ impl InboundCircuit {
                 // The punch exchange stalled, but the accepted bridge is
                 // perfectly usable: give it to the app without punching.
                 self.dcutr = None;
-                self.release_to_app(shared);
+                self.promote(shared);
             } else {
                 // The relay never even sent CONNECT.
                 self.abandon(shared, true);
@@ -364,12 +389,35 @@ impl InboundCircuit {
                 self.done = true;
             }
         }
+        if let Some(deadline) = self.handshake_deadline
+            && now.mono_ms >= deadline
+        {
+            self.handshake_deadline = None;
+            if let Some(conn_id) = self.promoted.take() {
+                shared.push_action(NatAction::CloseCircuit { conn_id });
+            }
+            self.done = true;
+        }
     }
 
-    /// The initiator's (or our) punch landed: the peer is directly
-    /// connected.
-    pub(crate) fn on_peer_connected(&mut self, peer: &PeerId, shared: &mut Shared, _now: Now) {
+    pub(crate) fn on_connection_established(
+        &mut self,
+        peer: &PeerId,
+        conn_id: ConnectionId,
+        is_circuit: bool,
+        shared: &mut Shared,
+        _now: Now,
+    ) {
         if self.done || self.source.as_ref() != Some(peer) {
+            return;
+        }
+        if is_circuit {
+            if self.promoted == Some(conn_id) {
+                self.handshake_deadline = None;
+                if self.blast.is_none() && self.linger_until.is_none() {
+                    self.done = true;
+                }
+            }
             return;
         }
         self.blast = None;
@@ -383,8 +431,20 @@ impl InboundCircuit {
     /// The relay connection died. Before release the circuit is gone; after
     /// release the app owns the (now dead) stream and the initiator's punch
     /// dial may still land, so the circuit lingers.
-    pub(crate) fn on_relay_disconnected(&mut self, peer: &PeerId, _shared: &mut Shared) {
-        if self.done || &self.relay != peer {
+    pub(crate) fn on_connection_closed(
+        &mut self,
+        peer: &PeerId,
+        conn_id: ConnectionId,
+        _shared: &mut Shared,
+    ) {
+        if self.done {
+            return;
+        }
+        if self.promoted == Some(conn_id) {
+            self.done = true;
+            return;
+        }
+        if &self.relay != peer || conn_id != self.inner_conn {
             return;
         }
         if !self.released {
@@ -406,5 +466,21 @@ impl InboundCircuit {
             shared.release_stream(&self.relay, self.stream);
         }
         self.done = true;
+    }
+
+    pub(crate) fn on_promote_result(
+        &mut self,
+        result: Result<ConnectionId, PromoteError>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        match result {
+            Ok(conn_id) => {
+                self.promoted = Some(conn_id);
+                self.handshake_deadline =
+                    Some(now.mono_ms + shared.config.circuit_handshake_timeout_ms);
+            }
+            Err(_) => self.done = true,
+        }
     }
 }

--- a/crates/nat/src/lib.rs
+++ b/crates/nat/src/lib.rs
@@ -14,7 +14,8 @@
 //! t0+δ    relay leg (stagger δ, 0 = fully parallel):
 //!           ensure relay session → HOP CONNECT(target)
 //!           → Bridged ⇒ start a DCUtR punch over the bridge
-//!           → after SYNC, release bridge ⇒ PathEstablished(Relayed)
+//!           → after SYNC, promote bridge through Noise + Yamux
+//!           → circuit Connected ⇒ PathEstablished(Relayed)
 //! first usable path wins; a better path later ⇒ explicit PathUpgraded
 //! "fallback" is not a phase — it is what remains when the punch leg
 //! exhausts (FellBackToRelay)
@@ -26,9 +27,10 @@
 //! (or any equivalent runtime). Events for streams the agent does not own
 //! cost one map lookup and zero clones.
 //!
-//! The relayed path is a **raw bridge stream**, not a full swarm connection:
-//! no identify, ping, or multistream-select runs over it. See
-//! [`Path::Relayed`].
+//! The driver executes [`NatAction::PromoteBridge`] against a circuit
+//! transport. Relayed paths are therefore ordinary identity-verified swarm
+//! connections: identify, ping, pubsub, and application protocols use the
+//! same stream APIs as direct paths.
 //!
 //! `no_std` + `alloc` compatible.
 
@@ -46,8 +48,10 @@ mod types;
 
 pub use agent::NatAgent;
 pub use config::{NatConfig, ReservationPolicy};
-pub use events::{NatAction, NatEvent};
-pub use types::{ConnectId, NatError, NatToken, Now, Path, ReachabilityState, ReservationInfo};
+pub use events::{BridgeRole, NatAction, NatEvent};
+pub use types::{
+    ConnectId, NatError, NatToken, Now, Path, PromoteError, ReachabilityState, ReservationInfo,
+};
 
 // Protocol ids for everything the agent drives, so a driver can register
 // them without depending on each protocol crate.

--- a/crates/nat/src/types.rs
+++ b/crates/nat/src/types.rs
@@ -1,7 +1,4 @@
-use alloc::vec::Vec;
-
 use minip2p_core::PeerId;
-use minip2p_transport::StreamId;
 
 /// Clock sample supplied by the driver with every input.
 ///
@@ -60,28 +57,10 @@ pub enum Path {
     /// A direct QUIC connection established by a DCUtR hole punch. Use the
     /// ordinary swarm APIs with the peer id.
     DirectPunched,
-    /// A raw bridged relay stream.
-    ///
-    /// **This is not a full swarm connection.** No identify, ping, or
-    /// multistream-select negotiation runs over the circuit; the application
-    /// exchanges raw bytes on `stream_id` (addressed to `relay`) with
-    /// `Swarm::send_stream` and receives them as ordinary `StreamData`
-    /// events. A circuit transport that makes a relayed path look like any
-    /// other connection is future work.
+    /// A full Noise- and Yamux-protected connection through a relay.
     Relayed {
-        /// The relay peer the bridge stream runs through.
+        /// The relay carrying the circuit connection.
         relay: PeerId,
-        /// The bridged stream (originally the HOP CONNECT stream).
-        stream_id: StreamId,
-        /// Application bytes received in the same transport read after the
-        /// final initiator-side DCUtR frame. Consume these before waiting for
-        /// later `StreamData` events; they are surfaced exactly once on the
-        /// original relayed `PathEstablished` event.
-        pending_data: Vec<u8>,
-        /// Whether the remote write half reached EOF while the NAT control
-        /// plane still owned the bridge. When true, the original stream event
-        /// was consumed and will not be delivered again.
-        remote_write_closed: bool,
     },
 }
 
@@ -135,4 +114,18 @@ pub enum NatError {
     /// The relay refused the circuit.
     #[error("relay refused: {0}")]
     RelayRefused(alloc::string::String),
+}
+
+/// Failure reported by the driver while promoting a relay bridge.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum PromoteError {
+    /// A verified direct connection won the race before promotion.
+    #[error("peer already has a direct connection")]
+    PeerAlreadyDirect,
+    /// The wrapped relay connection disappeared before adoption.
+    #[error("wrapped relay connection is unknown")]
+    UnknownConnection,
+    /// The bridge could not be adopted.
+    #[error("bridge promotion failed: {0}")]
+    Failed(alloc::string::String),
 }

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -49,7 +49,8 @@ fn drive_to_bridged(h: &mut Harness, t0: u64) -> (ConnectId, StreamId) {
 }
 
 /// Continues a bridged attempt through the DCUtR reply: punch dial + SYNC
-/// go out, then the bridge is handed back to the application and announced.
+/// go out, then the bridge is handed to the circuit transport and announced
+/// only after the promoted connection establishes.
 fn drive_to_sync(h: &mut Harness, stream: StreamId, now_ms: u64) -> Vec<NatAction> {
     h.stream_data(
         stream,
@@ -65,13 +66,17 @@ fn drive_to_sync(h: &mut Harness, stream: StreamId, now_ms: u64) -> Vec<NatActio
     assert_eq!(send_stream_count(&actions), 1, "SYNC must be sent");
     assert!(
         !h.agent.owns_stream(&h.relay, stream),
-        "bridge belongs to the app once SYNC is out"
+        "bridge belongs to the circuit transport once SYNC is out"
     );
+    let target = h.target.clone();
+    complete_promotion(&mut h.agent, &target, &actions, at(now_ms + 1));
     let events = drain_events(&mut h.agent);
     assert!(matches!(
         events.as_slice(),
-        [NatEvent::PathEstablished { path: Path::Relayed { stream_id, .. }, .. }]
-            if *stream_id == stream
+        [NatEvent::PathEstablished {
+            path: Path::Relayed { .. },
+            ..
+        }]
     ));
     actions
 }
@@ -142,6 +147,87 @@ fn zero_stagger_races_both_legs_in_parallel() {
 }
 
 #[test]
+fn force_relay_skips_direct_dials_and_dcutr() {
+    let mut h = Harness::with_relay(NatConfig {
+        force_relay: true,
+        ..NatConfig::default()
+    });
+    let id = h
+        .agent
+        .connect(h.target.clone(), vec![maddr(TARGET_ADDR)], at(0));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(dial_count_for(&actions, &h.target), 0);
+    assert_eq!(dial_count_for(&actions, &h.relay), 1);
+
+    let relay_token = dial_token_for(&actions, &h.relay);
+    h.agent
+        .dial_result(relay_token, Ok(ConnectionId::new(2)), at(5));
+    h.relay_session_ready(at(10));
+    let open = drain_actions(&mut h.agent);
+    let open_token = open_stream_token(&open);
+    let stream = StreamId::new(41);
+    h.agent.stream_open_result(open_token, Ok(stream), at(15));
+    h.stream_ready(stream, at(20));
+    drain_actions(&mut h.agent); // HOP CONNECT
+    h.stream_data(stream, hop_status(Status::Ok), at(30));
+
+    let promotion = drain_actions(&mut h.agent);
+    assert_eq!(send_stream_count(&promotion), 0, "DCUtR was skipped");
+    assert!(promotion.iter().any(|action| matches!(
+        action,
+        NatAction::PromoteBridge {
+            role: minip2p_nat::BridgeRole::Initiator,
+            ..
+        }
+    )));
+    let target = h.target.clone();
+    complete_promotion(&mut h.agent, &target, &promotion, at(31));
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [
+            NatEvent::PathEstablished {
+                connect_id,
+                path: Path::Relayed { .. },
+                ..
+            },
+            NatEvent::FellBackToRelay { connect_id: fallback, .. },
+        ] if *connect_id == id && *fallback == id
+    ));
+}
+
+#[test]
+fn stalled_promoted_outbound_circuit_is_closed_at_connect_deadline() {
+    let mut h = Harness::with_relay(NatConfig {
+        connect_deadline_ms: 1_000,
+        ..NatConfig::default()
+    });
+    let (id, stream) = drive_to_bridged(&mut h, 0);
+    drain_actions(&mut h.agent); // DCUtR CONNECT
+    h.stream_data(
+        stream,
+        dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]),
+        at(350),
+    );
+    let actions = drain_actions(&mut h.agent);
+    let conn_id = ConnectionId::new(TEST_CIRCUIT_ID);
+    h.agent
+        .promote_result(promote_token(&actions), Ok(conn_id), at(351));
+    assert!(!h.agent.owns_stream(&h.relay, stream));
+
+    h.agent.handle_tick(at(1_000));
+    assert!(
+        drain_actions(&mut h.agent).iter().any(
+            |action| matches!(action, NatAction::CloseCircuit { conn_id: id } if *id == conn_id)
+        )
+    );
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::ConnectFailed { connect_id, error: minip2p_nat::NatError::Timeout, .. }]
+            if *connect_id == id
+    ));
+}
+
+#[test]
 fn no_direct_candidates_skip_the_stagger() {
     let mut h = Harness::with_relay(NatConfig::default());
     h.agent.connect(h.target.clone(), Vec::new(), at(0));
@@ -183,8 +269,10 @@ fn relayed_path_upgrades_to_direct_without_misattribution() {
     ));
     let actions = drain_actions(&mut h.agent);
     assert!(
-        has_reset_for(&actions, stream),
-        "the superseded bridge must be reset, never silently leaked"
+        actions
+            .iter()
+            .any(|action| matches!(action, NatAction::CloseCircuit { .. })),
+        "the superseded promoted circuit must be closed, never silently leaked"
     );
     assert!(h.agent.is_idle());
 }
@@ -273,32 +361,25 @@ fn remote_write_close_during_dcutr_releases_relay_and_keeps_direct_dials_live() 
     );
 
     assert!(!h.agent.owns_stream(&h.relay, stream));
-    assert!(drain_actions(&mut h.agent).is_empty());
+    let actions = drain_actions(&mut h.agent);
+    assert!(promotion_remote_write_closed(&actions));
     assert!(matches!(
         drain_events(&mut h.agent).as_slice(),
-        [
-            NatEvent::HolePunchFailed { connect_id: failed, .. },
-            NatEvent::PathEstablished {
-                connect_id,
-                path: Path::Relayed {
-                    remote_write_closed: true,
-                    ..
-                },
-                ..
-            }
-        ] if *failed == id && *connect_id == id
+        [NatEvent::HolePunchFailed { connect_id: failed, .. }] if *failed == id
     ));
+
+    h.agent.promote_result(
+        promote_token(&actions),
+        Err(minip2p_nat::PromoteError::Failed("remote EOF".into())),
+        at(311),
+    );
 
     h.target_connected(at(320));
     assert!(matches!(
         drain_events(&mut h.agent).as_slice(),
-        [NatEvent::PathUpgraded {
+        [NatEvent::PathEstablished {
             connect_id,
-            from: Path::Relayed {
-                remote_write_closed: true,
-                ..
-            },
-            to: Path::DirectDialed,
+            path: Path::DirectDialed,
             ..
         }] if *connect_id == id
     ));
@@ -312,11 +393,18 @@ fn relay_supersede_scrubs_old_stream_ids_without_resetting_the_new_connection() 
     assert!(h.agent.owns_stream(&h.relay, stream));
 
     h.agent.handle_event(
-        &SwarmEvent::ConnectionEstablished {
+        &SwarmEvent::ConnectionClosed {
             conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: h.relay.clone(),
         },
         at(310),
+    );
+    h.agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            conn_id: minip2p_transport::ConnectionId::new(2),
+            peer_id: h.relay.clone(),
+        },
+        at(311),
     );
 
     assert!(!h.agent.owns_stream(&h.relay, stream));
@@ -329,7 +417,7 @@ fn relay_supersede_scrubs_old_stream_ids_without_resetting_the_new_connection() 
     // must not be routed into the retired attempt.
     h.agent.handle_event(
         &SwarmEvent::StreamData {
-            conn_id: minip2p_transport::ConnectionId::new(1),
+            conn_id: minip2p_transport::ConnectionId::new(2),
             peer_id: h.relay.clone(),
             stream_id: stream,
             data: b"new connection data".to_vec(),
@@ -374,14 +462,14 @@ fn released_bridge_close_cannot_be_reported_as_a_relay_fallback() {
     drain_actions(&mut h.agent);
     drive_to_sync(&mut h, stream, 350);
 
-    // The raw stream is application-owned, but the agent still observes its
-    // terminal event to keep the direct-upgrade race honest.
-    h.agent.handle_event(
-        &SwarmEvent::StreamClosed {
-            conn_id: minip2p_transport::ConnectionId::new(1),
-            peer_id: h.relay.clone(),
-            stream_id: stream,
+    // The circuit transport turns bridge termination into the promoted
+    // connection's terminal lifecycle event.
+    h.agent.handle_event_with_disposition_classified(
+        &SwarmEvent::ConnectionClosed {
+            conn_id: minip2p_transport::ConnectionId::new(TEST_CIRCUIT_ID),
+            peer_id: h.target.clone(),
         },
+        true,
         at(400),
     );
     h.agent.handle_tick(at(3_350));
@@ -568,16 +656,19 @@ fn initiator_reply_coalesced_with_application_data_preserves_remainder() {
     coalesced.extend_from_slice(app_data);
     h.stream_data(stream, coalesced, at(100));
 
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(promoted_pending_data(&actions), app_data);
+    let target = h.target.clone();
+    complete_promotion(&mut h.agent, &target, &actions, at(101));
     let events = drain_events(&mut h.agent);
     assert!(matches!(
         events.as_slice(),
         [NatEvent::PathEstablished {
             connect_id,
-            path: Path::Relayed { pending_data, .. },
+            path: Path::Relayed { .. },
             ..
-        }] if *connect_id == id && pending_data == app_data
+        }] if *connect_id == id
     ));
-    let actions = drain_actions(&mut h.agent);
     assert_eq!(
         dial_count_for(&actions, &h.target),
         1,
@@ -595,10 +686,10 @@ fn initiator_reply_coalesced_with_application_data_preserves_remainder() {
         drain_events(&mut h.agent).as_slice(),
         [NatEvent::PathUpgraded {
             connect_id,
-            from: Path::Relayed { pending_data, .. },
+            from: Path::Relayed { .. },
             to: Path::DirectPunched,
             ..
-        }] if *connect_id == id && pending_data.is_empty()
+        }] if *connect_id == id
     ));
 }
 
@@ -613,12 +704,15 @@ fn oversized_dcutr_connect_falls_back_to_relay() {
     h.agent.set_listen_addrs(&addrs);
 
     let (id, stream) = drive_to_bridged(&mut h, 0);
+    let actions = drain_actions(&mut h.agent);
+    let target = h.target.clone();
+    complete_promotion(&mut h.agent, &target, &actions, at(301));
     let events = drain_events(&mut h.agent);
     assert!(matches!(
         events.as_slice(),
         [
-            NatEvent::PathEstablished { path: Path::Relayed { .. }, .. },
             NatEvent::HolePunchFailed { .. },
+            NatEvent::PathEstablished { path: Path::Relayed { .. }, .. },
             NatEvent::FellBackToRelay { connect_id, .. },
         ] if *connect_id == id
     ));

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -7,7 +7,7 @@ use common::*;
 
 use minip2p_core::{Multiaddr, PeerAddr};
 use minip2p_nat::{ConnectId, NatAction, NatConfig, NatError, NatEvent, Path};
-use minip2p_relay::Status;
+use minip2p_relay::{HOP_PROTOCOL_ID, Status};
 use minip2p_swarm::SwarmEvent;
 use minip2p_transport::{ConnectionId, StreamId};
 
@@ -458,6 +458,81 @@ fn relay_supersede_scrubs_old_stream_ids_without_resetting_the_new_connection() 
 }
 
 #[test]
+fn relay_supersede_does_not_abort_waiting_for_peer_ready() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    h.agent.connect(h.target.clone(), Vec::new(), at(0));
+    drain_actions(&mut h.agent); // relay dial
+
+    h.agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            conn_id: ConnectionId::new(1),
+            peer_id: h.relay.clone(),
+        },
+        at(10),
+    );
+    h.agent.handle_event(
+        &SwarmEvent::ConnectionClosed {
+            conn_id: ConnectionId::new(1),
+            peer_id: h.relay.clone(),
+        },
+        at(11),
+    );
+    h.agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            conn_id: ConnectionId::new(2),
+            peer_id: h.relay.clone(),
+        },
+        at(12),
+    );
+    assert!(drain_events(&mut h.agent).is_empty());
+
+    h.agent.handle_event(
+        &SwarmEvent::PeerReady {
+            peer_id: h.relay.clone(),
+            protocols: vec![HOP_PROTOCOL_ID.into()],
+        },
+        at(13),
+    );
+    assert!(
+        has_hop_open(&drain_actions(&mut h.agent)),
+        "the replacement relay session must continue the waiting leg"
+    );
+}
+
+#[test]
+fn relay_supersede_does_not_abort_an_open_hop_request() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    h.agent.connect(h.target.clone(), Vec::new(), at(0));
+    drain_actions(&mut h.agent); // relay dial
+    h.relay_session_ready(at(10));
+    let open = drain_actions(&mut h.agent);
+    let open_token = open_stream_token(&open);
+
+    h.agent.handle_event(
+        &SwarmEvent::ConnectionClosed {
+            conn_id: ConnectionId::new(1),
+            peer_id: h.relay.clone(),
+        },
+        at(11),
+    );
+    h.agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            conn_id: ConnectionId::new(2),
+            peer_id: h.relay.clone(),
+        },
+        at(12),
+    );
+    assert!(drain_events(&mut h.agent).is_empty());
+
+    let stream = StreamId::new(19);
+    h.agent.stream_open_result(open_token, Ok(stream), at(13));
+    assert!(
+        h.agent.owns_stream(&h.relay, stream),
+        "the HOP open result must remain owned after relay supersession"
+    );
+}
+
+#[test]
 fn bridge_close_before_dcutr_finishes_waits_for_live_direct_dials() {
     let mut h = Harness::with_relay(NatConfig::default());
     let (id, stream) = drive_to_bridged(&mut h, 0);
@@ -482,7 +557,7 @@ fn bridge_close_before_dcutr_finishes_waits_for_live_direct_dials() {
 }
 
 #[test]
-fn released_bridge_close_cannot_be_reported_as_a_relay_fallback() {
+fn established_relay_loss_never_turns_success_into_connect_failed() {
     let mut h = Harness::with_relay(NatConfig {
         punch_max_retries: 0,
         ..NatConfig::default()
@@ -505,16 +580,92 @@ fn released_bridge_close_cannot_be_reported_as_a_relay_fallback() {
     let events = drain_events(&mut h.agent);
     assert!(matches!(
         events.as_slice(),
-        [
-            NatEvent::HolePunchFailed { .. },
-            NatEvent::ConnectFailed { connect_id, .. },
-        ] if *connect_id == id
+        [NatEvent::HolePunchFailed { connect_id, .. }] if *connect_id == id
     ));
     assert!(
         !events
             .iter()
             .any(|event| matches!(event, NatEvent::FellBackToRelay { .. }))
     );
+
+    // Once the still-live original dial expires there is nothing left to
+    // upgrade, but PathEstablished remains the terminal result for this id.
+    h.agent.handle_tick(at(60_000));
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn peer_already_direct_promotion_error_waits_for_the_direct_connection() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (id, stream) = drive_to_bridged(&mut h, 0);
+    drain_actions(&mut h.agent); // DCUtR CONNECT
+    h.stream_data(
+        stream,
+        dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]),
+        at(350),
+    );
+    let promotion = drain_actions(&mut h.agent);
+
+    // The swarm already knows a direct session won, but the NatAgent has
+    // not consumed its ConnectionEstablished event yet.
+    let token = promote_token(&promotion);
+    h.agent.promote_result(
+        token,
+        Err(minip2p_nat::PromoteError::PeerAlreadyDirect),
+        at(351),
+    );
+    assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(drain_events(&mut h.agent).is_empty());
+
+    h.target_connected(at(352));
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::PathEstablished {
+            connect_id,
+            path: Path::DirectDialed,
+            ..
+        }] if *connect_id == id
+    ));
+    assert!(h.agent.is_idle());
+
+    // The driver echo is tokenized exactly once; duplicates stay inert.
+    h.agent.promote_result(
+        token,
+        Err(minip2p_nat::PromoteError::PeerAlreadyDirect),
+        at(353),
+    );
+    assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(drain_events(&mut h.agent).is_empty());
+}
+
+#[test]
+fn initiator_dials_only_global_ip_targets_from_peer_dcutr_reply() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (_, stream) = drive_to_bridged(&mut h, 0);
+    drain_actions(&mut h.agent); // DCUtR CONNECT
+    let global = maddr("/ip4/9.9.9.9/udp/4002/quic-v1");
+    h.stream_data(
+        stream,
+        dcutr_connect_reply(&[
+            maddr("/ip4/10.0.0.7/udp/4002/quic-v1"),
+            maddr("/dns4/attacker.invalid/udp/4002/quic-v1"),
+            maddr("/ip4/192.0.2.7/udp/4002/quic-v1"),
+            global.clone(),
+        ]),
+        at(350),
+    );
+
+    let dials: Vec<_> = drain_actions(&mut h.agent)
+        .into_iter()
+        .filter_map(|action| match action {
+            NatAction::Dial { addr, .. } if addr.peer_id() == &h.target => {
+                Some(addr.transport().clone())
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(dials, vec![global]);
 }
 
 #[test]
@@ -953,6 +1104,13 @@ fn reporter_disconnect_drops_its_observation() {
     // The relay reports a mapping, then its connection closes; the attempt
     // reconnects the relay, but the stale observation must not come back.
     let relay = h.relay.clone();
+    h.agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            conn_id: ConnectionId::new(1),
+            peer_id: relay.clone(),
+        },
+        at(0),
+    );
     identify_observed(&mut h.agent, &relay, &maddr(departed), at(0));
     h.agent.handle_event(
         &SwarmEvent::ConnectionClosed {
@@ -961,6 +1119,8 @@ fn reporter_disconnect_drops_its_observation() {
         },
         at(1),
     );
+    h.agent.handle_tick(at(1));
+    h.agent.handle_tick(at(1));
 
     let (_id, stream) = drive_to_bridged(&mut h, 10);
     let actions = drain_actions(&mut h.agent);

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -196,6 +196,35 @@ fn force_relay_skips_direct_dials_and_dcutr() {
 }
 
 #[test]
+fn force_relay_preserves_bytes_coalesced_behind_hop_success() {
+    let mut h = Harness::with_relay(NatConfig {
+        force_relay: true,
+        ..NatConfig::default()
+    });
+    h.agent
+        .connect(h.target.clone(), vec![maddr(TARGET_ADDR)], at(0));
+    let actions = drain_actions(&mut h.agent);
+    let relay_token = dial_token_for(&actions, &h.relay);
+    h.agent
+        .dial_result(relay_token, Ok(ConnectionId::new(2)), at(5));
+    h.relay_session_ready(at(10));
+    let open = drain_actions(&mut h.agent);
+    let open_token = open_stream_token(&open);
+    let stream = StreamId::new(41);
+    h.agent.stream_open_result(open_token, Ok(stream), at(15));
+    h.stream_ready(stream, at(20));
+    drain_actions(&mut h.agent);
+
+    let first_circuit_bytes = b"first noise-selection bytes".to_vec();
+    let mut coalesced = hop_status(Status::Ok);
+    coalesced.extend_from_slice(&first_circuit_bytes);
+    h.stream_data(stream, coalesced, at(30));
+
+    let promotion = drain_actions(&mut h.agent);
+    assert_eq!(promoted_pending_data(&promotion), first_circuit_bytes);
+}
+
+#[test]
 fn stalled_promoted_outbound_circuit_is_closed_at_connect_deadline() {
     let mut h = Harness::with_relay(NatConfig {
         connect_deadline_ms: 1_000,
@@ -691,6 +720,13 @@ fn initiator_reply_coalesced_with_application_data_preserves_remainder() {
             ..
         }] if *connect_id == id
     ));
+    let actions = drain_actions(&mut h.agent);
+    assert!(
+        actions.iter().any(
+            |action| matches!(action, NatAction::CloseCircuit { conn_id } if conn_id.as_u64() == TEST_CIRCUIT_ID)
+        ),
+        "the punched direct connection must retire the promoted circuit"
+    );
 }
 
 #[test]
@@ -934,6 +970,22 @@ fn reporter_disconnect_drops_its_observation() {
         vec![maddr(LISTEN_ADDR)],
         "dropped observation leaks into the CONNECT"
     );
+}
+
+#[test]
+fn untracked_connection_close_is_ignored() {
+    let mut h = Harness::without_relay(NatConfig::default());
+    h.agent.handle_event(
+        &SwarmEvent::ConnectionClosed {
+            conn_id: ConnectionId::new(999),
+            peer_id: peer(b"untracked-peer"),
+        },
+        at(1),
+    );
+
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(h.agent.is_idle());
 }
 
 #[test]

--- a/crates/nat/tests/common/mod.rs
+++ b/crates/nat/tests/common/mod.rs
@@ -24,7 +24,7 @@ pub const TEST_CIRCUIT_ID: u64 = (1 << 63) | 77;
 pub const TARGET_ADDR: &str = "/ip4/192.0.2.10/udp/4001/quic-v1";
 pub const RELAY_TRANSPORT_ADDR: &str = "/ip4/203.0.113.1/udp/4001/quic-v1";
 pub const LISTEN_ADDR: &str = "/ip4/198.51.100.5/udp/4500/quic-v1";
-pub const REMOTE_OBSERVED_ADDR: &str = "/ip4/192.0.2.99/udp/4002/quic-v1";
+pub const REMOTE_OBSERVED_ADDR: &str = "/ip4/8.8.8.8/udp/4002/quic-v1";
 /// A public mapping of our own socket, as a peer would report it.
 pub const OUR_OBSERVED_ADDR: &str = "/ip4/203.0.113.77/udp/45678/quic-v1";
 

--- a/crates/nat/tests/common/mod.rs
+++ b/crates/nat/tests/common/mod.rs
@@ -17,7 +17,9 @@ use minip2p_relay::{
     StopMessageType, encode_frame as relay_encode_frame,
 };
 use minip2p_swarm::{IdentifyMessage, SwarmEvent};
-use minip2p_transport::StreamId;
+use minip2p_transport::{ConnectionId, StreamId};
+
+pub const TEST_CIRCUIT_ID: u64 = (1 << 63) | 77;
 
 pub const TARGET_ADDR: &str = "/ip4/192.0.2.10/udp/4001/quic-v1";
 pub const RELAY_TRANSPORT_ADDR: &str = "/ip4/203.0.113.1/udp/4001/quic-v1";
@@ -257,6 +259,57 @@ pub fn has_reset_for(actions: &[NatAction], stream: StreamId) -> bool {
     actions.iter().any(
         |action| matches!(action, NatAction::ResetStream { stream_id, .. } if *stream_id == stream),
     )
+}
+
+pub fn promote_token(actions: &[NatAction]) -> NatToken {
+    let mut tokens = actions.iter().filter_map(|action| match action {
+        NatAction::PromoteBridge { token, .. } => Some(*token),
+        _ => None,
+    });
+    let token = tokens.next().expect("expected PromoteBridge action");
+    assert!(tokens.next().is_none(), "more than one promotion action");
+    token
+}
+
+pub fn promoted_pending_data(actions: &[NatAction]) -> &[u8] {
+    actions
+        .iter()
+        .find_map(|action| match action {
+            NatAction::PromoteBridge { pending_data, .. } => Some(pending_data.as_slice()),
+            _ => None,
+        })
+        .expect("expected PromoteBridge action")
+}
+
+pub fn promotion_remote_write_closed(actions: &[NatAction]) -> bool {
+    actions.iter().any(|action| {
+        matches!(
+            action,
+            NatAction::PromoteBridge {
+                remote_write_closed: true,
+                ..
+            }
+        )
+    })
+}
+
+pub fn complete_promotion(
+    agent: &mut NatAgent,
+    target: &PeerId,
+    actions: &[NatAction],
+    now: Now,
+) -> ConnectionId {
+    let conn_id = ConnectionId::new(TEST_CIRCUIT_ID);
+    agent.promote_result(promote_token(actions), Ok(conn_id), now);
+    agent.handle_event_with_disposition_classified(
+        &SwarmEvent::ConnectionEstablished {
+            peer_id: target.clone(),
+            conn_id,
+        },
+        true,
+        now,
+    );
+    conn_id
 }
 
 /// Scripted world around one agent: a local node, a target peer, and one

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -535,6 +535,22 @@ fn lost_relay_connection_emits_lost_and_reacquires() {
         },
         at(5_000),
     );
+    assert_eq!(
+        hk.agent.next_timeout(5_000),
+        Some(0),
+        "the possible peer disconnect must be reconciled promptly"
+    );
+    assert!(
+        drain_events(&mut hk.agent).is_empty(),
+        "peer-scoped loss waits for same-batch replacements"
+    );
+    hk.agent.handle_tick(at(5_000));
+    assert!(
+        drain_events(&mut hk.agent).is_empty(),
+        "the first driver tick only stages peer-disconnect reconciliation"
+    );
+    assert_eq!(hk.agent.next_timeout(5_000), Some(0));
+    hk.agent.handle_tick(at(5_000));
     let events = drain_events(&mut hk.agent);
     assert!(matches!(
         events.as_slice(),
@@ -549,7 +565,46 @@ fn lost_relay_connection_emits_lost_and_reacquires() {
 }
 
 #[test]
-fn relay_supersede_during_renewal_emits_reservation_lost() {
+fn retiring_one_relay_connection_keeps_reservation_on_live_replacement() {
+    let mut hk = build(ReservationPolicy::Always, 1, 0);
+    let (events, _) = reserve_via_relay(&mut hk, hop_reserve_ok(None), at_unix(10, 1_000));
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::RelayReserved { .. }]
+    ));
+    drain_actions(&mut hk.agent); // completed exchange's close-write
+
+    // The replacement is already known before the retired connection's
+    // terminal event arrives. Losing one connection id must not be treated
+    // as losing the relay peer itself.
+    let relay = hk.relay.clone();
+    hk.agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            conn_id: ConnectionId::new(2),
+            peer_id: relay.clone(),
+        },
+        at(20),
+    );
+    hk.agent.handle_event(
+        &SwarmEvent::ConnectionClosed {
+            conn_id: ConnectionId::new(1),
+            peer_id: relay,
+        },
+        at(21),
+    );
+
+    assert!(drain_events(&mut hk.agent).is_empty());
+    assert!(hk.agent.active_reservation().is_some());
+    hk.agent.handle_tick(at(1_000));
+    assert_eq!(
+        dial_count_for(&drain_actions(&mut hk.agent), &hk.relay),
+        0,
+        "a live replacement must not trigger reservation reacquisition"
+    );
+}
+
+#[test]
+fn close_then_establish_relay_supersede_preserves_the_reservation() {
     let mut hk = build(ReservationPolicy::Always, 1, 0);
     let (events, _) = reserve_via_relay(&mut hk, hop_reserve_ok(Some(1_900)), at_unix(10, 1_000));
     assert!(matches!(
@@ -559,8 +614,9 @@ fn relay_supersede_during_renewal_emits_reservation_lost() {
     drain_actions(&mut hk.agent); // completed exchange's close-write
 
     // Start renewal, then replace the relay connection before the new
-    // reservation exchange completes. The old reservation died with the
-    // retired connection and must be withdrawn immediately.
+    // reservation exchange completes. Swarm exposes the eager close before
+    // the replacement establishment; that ordering must not manufacture a
+    // peer disconnect while the replacement session is live.
     let renew_at = 10 + 780 * 1_000;
     hk.agent.handle_tick(at_unix(renew_at, 1_790));
     let relay = hk.relay.clone();
@@ -571,6 +627,11 @@ fn relay_supersede_during_renewal_emits_reservation_lost() {
         },
         at_unix(renew_at + 1, 1_790),
     );
+    // `Endpoint::poll_new_event_driven` ticks immediately after this one
+    // close event, before it asks Swarm for the buffered replacement.
+    hk.agent.handle_tick(at_unix(renew_at + 1, 1_790));
+    assert!(drain_events(&mut hk.agent).is_empty());
+    assert_eq!(hk.agent.next_timeout(renew_at + 1), Some(0));
     hk.agent.handle_event(
         &SwarmEvent::ConnectionEstablished {
             conn_id: minip2p_transport::ConnectionId::new(2),
@@ -578,13 +639,9 @@ fn relay_supersede_during_renewal_emits_reservation_lost() {
         },
         at_unix(renew_at + 2, 1_790),
     );
+    hk.agent.handle_tick(at_unix(renew_at + 2, 1_790));
 
-    let events = drain_events(&mut hk.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [NatEvent::RelayReservationLost { relay: lost }] if *lost == relay
-    ));
-    assert!(hk.agent.active_reservation().is_none());
+    assert!(drain_events(&mut hk.agent).is_empty());
     assert!(
         !drain_actions(&mut hk.agent)
             .iter()

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -565,11 +565,18 @@ fn relay_supersede_during_renewal_emits_reservation_lost() {
     hk.agent.handle_tick(at_unix(renew_at, 1_790));
     let relay = hk.relay.clone();
     hk.agent.handle_event(
-        &SwarmEvent::ConnectionEstablished {
+        &SwarmEvent::ConnectionClosed {
             conn_id: minip2p_transport::ConnectionId::new(1),
             peer_id: relay.clone(),
         },
         at_unix(renew_at + 1, 1_790),
+    );
+    hk.agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            conn_id: minip2p_transport::ConnectionId::new(2),
+            peer_id: relay.clone(),
+        },
+        at_unix(renew_at + 2, 1_790),
     );
 
     let events = drain_events(&mut hk.agent);

--- a/crates/nat/tests/inbound.rs
+++ b/crates/nat/tests/inbound.rs
@@ -71,13 +71,18 @@ fn full_inbound_flow_blasts_and_upgrades() {
     drive_to_sync_ready(&mut h, stream);
 
     h.stream_data(stream, dcutr_sync(), at(30));
-    let events = drain_events(&mut h.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [NatEvent::InboundRelayCircuit { peer, relay, stream_id, .. }]
-            if *peer == h.target && *relay == h.relay && *stream_id == stream
-    ));
     let actions = drain_actions(&mut h.agent);
+    assert!(actions.iter().any(|action| matches!(
+        action,
+        NatAction::PromoteBridge {
+            relay,
+            stream_id,
+            remote_peer,
+            ..
+        } if relay == &h.relay && *stream_id == stream && remote_peer == &h.target
+    )));
+    let target = h.target.clone();
+    complete_promotion(&mut h.agent, &target, &actions, at(31));
     assert_eq!(
         dial_count_for(&actions, &h.target),
         0,
@@ -86,7 +91,7 @@ fn full_inbound_flow_blasts_and_upgrades() {
     );
     assert!(
         !h.agent.owns_stream(&h.relay, stream),
-        "bridge belongs to the app after SYNC"
+        "bridge belongs to the circuit transport after SYNC"
     );
 
     // First blast waits out the configured sync delay (50ms after SYNC).
@@ -120,6 +125,58 @@ fn full_inbound_flow_blasts_and_upgrades() {
 }
 
 #[test]
+fn force_relay_promotes_immediately_after_stop_acceptance() {
+    let mut h = inbound_harness(NatConfig {
+        force_relay: true,
+        ..NatConfig::default()
+    });
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+    let target = h.target.clone();
+    h.stream_data(stream, stop_connect(&target), at(10));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(
+        send_stream_count(&actions),
+        1,
+        "only STOP STATUS:OK is sent"
+    );
+    assert!(actions.iter().any(|action| matches!(
+        action,
+        NatAction::PromoteBridge {
+            role: minip2p_nat::BridgeRole::Responder,
+            ..
+        }
+    )));
+    complete_promotion(&mut h.agent, &target, &actions, at(11));
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn stalled_inbound_circuit_handshake_is_closed_at_its_deadline() {
+    let mut h = inbound_harness(NatConfig {
+        force_relay: true,
+        circuit_handshake_timeout_ms: 5,
+        ..NatConfig::default()
+    });
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+    let target = h.target.clone();
+    h.stream_data(stream, stop_connect(&target), at(10));
+    let actions = drain_actions(&mut h.agent);
+    let conn_id = minip2p_transport::ConnectionId::new(TEST_CIRCUIT_ID);
+    h.agent
+        .promote_result(promote_token(&actions), Ok(conn_id), at(11));
+
+    h.agent.handle_tick(at(16));
+    assert!(
+        drain_actions(&mut h.agent).iter().any(
+            |action| matches!(action, NatAction::CloseCircuit { conn_id: id } if *id == conn_id)
+        )
+    );
+    assert!(h.agent.is_idle());
+}
+
+#[test]
 fn sync_coalesced_with_application_data_preserves_the_bridge_remainder() {
     let mut h = inbound_harness(NatConfig::default());
     let stream = StreamId::new(STOP_STREAM);
@@ -131,16 +188,8 @@ fn sync_coalesced_with_application_data_preserves_the_bridge_remainder() {
     coalesced.extend_from_slice(&app_data);
     h.stream_data(stream, coalesced, at(30));
 
-    let events = drain_events(&mut h.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [NatEvent::InboundRelayCircuit {
-            peer,
-            stream_id,
-            pending_data,
-            ..
-        }] if *peer == h.target && *stream_id == stream && *pending_data == app_data
-    ));
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(promoted_pending_data(&actions), app_data);
 }
 
 #[test]
@@ -204,15 +253,17 @@ fn stalled_exchange_still_releases_the_bridge() {
     // The initiator never starts DCUtR; at the exchange deadline the
     // accepted bridge goes to the app punch-less.
     h.agent.handle_tick(at(12_000));
-    let events = drain_events(&mut h.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [NatEvent::InboundRelayCircuit { peer, .. }] if *peer == h.target
-    ));
     let actions = drain_actions(&mut h.agent);
+    assert!(
+        actions
+            .iter()
+            .any(|action| matches!(action, NatAction::PromoteBridge { .. }))
+    );
     assert_eq!(dial_count_for(&actions, &h.target), 0);
     assert_eq!(blast_count(&actions), 0);
     assert!(!h.agent.owns_stream(&h.relay, stream));
+    let target = h.target.clone();
+    complete_promotion(&mut h.agent, &target, &actions, at(12_001));
     assert!(h.agent.is_idle());
 }
 
@@ -239,14 +290,8 @@ fn remote_write_close_keeps_an_accepted_bridge_alive_until_handoff() {
     // The half-close does not kill the local write half; hand the accepted
     // bridge to the app once the DCUtR exchange deadline expires.
     h.agent.handle_tick(at(12_000));
-    assert!(matches!(
-        drain_events(&mut h.agent).as_slice(),
-        [NatEvent::InboundRelayCircuit {
-            peer,
-            remote_write_closed: true,
-            ..
-        }] if *peer == h.target
-    ));
+    let actions = drain_actions(&mut h.agent);
+    assert!(promotion_remote_write_closed(&actions));
 }
 
 #[test]

--- a/crates/nat/tests/inbound.rs
+++ b/crates/nat/tests/inbound.rs
@@ -177,6 +177,32 @@ fn stalled_inbound_circuit_handshake_is_closed_at_its_deadline() {
 }
 
 #[test]
+fn established_inbound_circuit_disarms_its_handshake_deadline() {
+    let mut h = inbound_harness(NatConfig {
+        force_relay: true,
+        circuit_handshake_timeout_ms: 5,
+        ..NatConfig::default()
+    });
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+    let target = h.target.clone();
+    h.stream_data(stream, stop_connect(&target), at(10));
+    let actions = drain_actions(&mut h.agent);
+    let conn_id = complete_promotion(&mut h.agent, &target, &actions, at(11));
+    drain_events(&mut h.agent);
+    drain_actions(&mut h.agent);
+
+    h.agent.handle_tick(at(100));
+    assert!(
+        !drain_actions(&mut h.agent).iter().any(
+            |action| matches!(action, NatAction::CloseCircuit { conn_id: id } if *id == conn_id)
+        ),
+        "a ready inbound circuit must not be reclaimed by its old handshake deadline"
+    );
+    assert!(h.agent.is_idle());
+}
+
+#[test]
 fn sync_coalesced_with_application_data_preserves_the_bridge_remainder() {
     let mut h = inbound_harness(NatConfig::default());
     let stream = StreamId::new(STOP_STREAM);

--- a/crates/nat/tests/inbound.rs
+++ b/crates/nat/tests/inbound.rs
@@ -6,8 +6,10 @@ mod common;
 use common::*;
 
 use minip2p_core::PeerAddr;
-use minip2p_nat::{NatAction, NatConfig, NatEvent};
-use minip2p_relay::STOP_PROTOCOL_ID;
+use minip2p_nat::{
+    AUTONAT_PROTOCOL_ID, DCUTR_PROTOCOL_ID, HOP_PROTOCOL_ID, NatAction, NatConfig, NatEvent,
+    STOP_PROTOCOL_ID,
+};
 use minip2p_swarm::SwarmEvent;
 use minip2p_transport::StreamId;
 
@@ -152,6 +154,25 @@ fn force_relay_promotes_immediately_after_stop_acceptance() {
 }
 
 #[test]
+fn force_relay_preserves_bytes_coalesced_behind_stop_connect() {
+    let mut h = inbound_harness(NatConfig {
+        force_relay: true,
+        ..NatConfig::default()
+    });
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+
+    let application_data = b"first circuit transport bytes".to_vec();
+    let mut coalesced = stop_connect(&h.target);
+    coalesced.extend_from_slice(&application_data);
+    h.stream_data(stream, coalesced, at(10));
+
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(send_stream_count(&actions), 1, "STOP STATUS:OK is sent");
+    assert_eq!(promoted_pending_data(&actions), application_data);
+}
+
+#[test]
 fn stalled_inbound_circuit_handshake_is_closed_at_its_deadline() {
     let mut h = inbound_harness(NatConfig {
         force_relay: true,
@@ -268,6 +289,50 @@ fn blast_schedule_exhausts_at_the_punch_deadline() {
 }
 
 #[test]
+fn peer_supplied_punch_targets_must_be_global_unicast_ips() {
+    let mut h = inbound_harness(NatConfig::default());
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+    let target = h.target.clone();
+    h.stream_data(stream, stop_connect(&target), at(10));
+    drain_actions(&mut h.agent);
+
+    let global_v4 = maddr("/ip4/8.8.8.8/udp/4001/quic-v1");
+    let global_v6 = maddr("/ip6/2606:4700:4700::1111/udp/4001/quic-v1");
+    let supplied = vec![
+        global_v4.clone(),
+        global_v6.clone(),
+        maddr("/dns4/attacker.invalid/udp/4001/quic-v1"),
+        maddr("/ip4/10.0.0.1/udp/4001/quic-v1"),
+        maddr("/ip4/100.64.0.1/udp/4001/quic-v1"),
+        maddr("/ip4/127.0.0.1/udp/4001/quic-v1"),
+        maddr("/ip4/169.254.1.1/udp/4001/quic-v1"),
+        maddr("/ip4/192.0.2.1/udp/4001/quic-v1"),
+        maddr("/ip4/224.0.0.1/udp/4001/quic-v1"),
+        maddr("/ip6/::1/udp/4001/quic-v1"),
+        maddr("/ip6/fc00::1/udp/4001/quic-v1"),
+        maddr("/ip6/fe80::1/udp/4001/quic-v1"),
+        maddr("/ip6/2001:db8::1/udp/4001/quic-v1"),
+        maddr("/ip6/ff02::1/udp/4001/quic-v1"),
+    ];
+    h.stream_data(stream, dcutr_connect_reply(&supplied), at(20));
+    drain_actions(&mut h.agent);
+    h.stream_data(stream, dcutr_sync(), at(30));
+    drain_actions(&mut h.agent);
+
+    h.agent.handle_tick(at(80));
+    let actions = drain_actions(&mut h.agent);
+    let blasted: Vec<_> = actions
+        .iter()
+        .filter_map(|action| match action {
+            NatAction::SendRandomUdp { target, .. } => Some(target.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(blasted, vec![global_v4, global_v6]);
+}
+
+#[test]
 fn stalled_exchange_still_releases_the_bridge() {
     let mut h = inbound_harness(NatConfig::default());
     let stream = StreamId::new(STOP_STREAM);
@@ -369,6 +434,70 @@ fn inbound_application_streams_are_never_claimed() {
     );
     assert!(!h.agent.owns_stream(&h.relay, stream));
     assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn inbound_unserved_nat_control_streams_are_reset_owned_and_consumed() {
+    let mut h = inbound_harness(NatConfig::default());
+
+    for (offset, protocol_id) in [
+        HOP_PROTOCOL_ID,
+        DCUTR_PROTOCOL_ID,
+        AUTONAT_PROTOCOL_ID,
+        STOP_PROTOCOL_ID,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let stream = StreamId::new(STOP_STREAM + offset as u64);
+        // Even the configured relay may open only STOP. Use an untrusted
+        // peer for STOP to cover its additional trust gate.
+        let remote = if protocol_id == STOP_PROTOCOL_ID {
+            h.target.clone()
+        } else {
+            h.relay.clone()
+        };
+        let conn_id = minip2p_transport::ConnectionId::new(10 + offset as u64);
+        assert!(h.agent.handle_event_with_disposition(
+            &SwarmEvent::StreamReady {
+                conn_id,
+                peer_id: remote.clone(),
+                stream_id: stream,
+                protocol_id: protocol_id.to_string(),
+                initiated_locally: false,
+            },
+            at(offset as u64),
+        ));
+        assert!(h.agent.owns_stream(&remote, stream));
+        let actions = drain_actions(&mut h.agent);
+        assert!(
+            has_reset_for(&actions, stream),
+            "inbound {protocol_id} was not reset"
+        );
+
+        assert!(h.agent.handle_event_with_disposition(
+            &SwarmEvent::StreamData {
+                conn_id,
+                peer_id: remote.clone(),
+                stream_id: stream,
+                data: b"rejected control data".to_vec(),
+            },
+            at(10 + offset as u64),
+        ));
+        assert!(drain_actions(&mut h.agent).is_empty());
+        assert!(h.agent.handle_event_with_disposition(
+            &SwarmEvent::StreamClosed {
+                conn_id,
+                peer_id: remote.clone(),
+                stream_id: stream,
+            },
+            at(20 + offset as u64),
+        ));
+        assert!(!h.agent.owns_stream(&remote, stream));
+    }
+
+    assert!(drain_events(&mut h.agent).is_empty());
     assert!(h.agent.is_idle());
 }
 

--- a/crates/nat/tests/two_agents.rs
+++ b/crates/nat/tests/two_agents.rs
@@ -435,8 +435,12 @@ fn two_agents_punch_to_a_direct_connection() {
     assert!(
         matches!(
             events.as_slice(),
-            [NatEvent::PathEstablished { connect_id, path: Path::Relayed { .. }, .. }]
-                if *connect_id == id
+            [NatEvent::PathEstablished {
+                connect_id,
+                peer,
+                path: Path::Relayed { relay },
+            }]
+                if *connect_id == id && peer == &world.b_id && relay == &world.relay_id
         ),
         "A settles a relayed path first, got {events:?}"
     );
@@ -475,10 +479,12 @@ fn two_agents_punch_to_a_direct_connection() {
         matches!(
             events.as_slice(),
             [NatEvent::PathUpgraded {
-                from: Path::Relayed { .. },
+                connect_id,
+                peer,
+                from: Path::Relayed { relay },
                 to: Path::DirectPunched,
-                ..
             }]
+                if *connect_id == id && peer == &world.b_id && relay == &world.relay_id
         ),
         "A upgrades explicitly, got {events:?}"
     );

--- a/crates/nat/tests/two_agents.rs
+++ b/crates/nat/tests/two_agents.rs
@@ -21,8 +21,8 @@ use minip2p_transport::{ConnectionId, StreamId};
 const A_LISTEN: &str = "/ip4/198.51.100.10/udp/4100/quic-v1";
 const RELAY_ADDR: &str = "/ip4/203.0.113.1/udp/4001/quic-v1";
 /// Each side's public NAT mapping, as the relay's identify reports it.
-const A_PUBLIC: &str = "/ip4/203.0.113.201/udp/40001/quic-v1";
-const B_PUBLIC: &str = "/ip4/203.0.113.202/udp/40002/quic-v1";
+const A_PUBLIC: &str = "/ip4/8.8.4.4/udp/40001/quic-v1";
+const B_PUBLIC: &str = "/ip4/1.1.1.1/udp/40002/quic-v1";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Side {
@@ -445,8 +445,8 @@ fn two_agents_punch_to_a_direct_connection() {
         "A settles a relayed path first, got {events:?}"
     );
     assert_eq!(
-        world.punch_dials_from_a, 2,
-        "A dialed B's listen address and B's relay-observed public mapping"
+        world.punch_dials_from_a, 1,
+        "A dialed only B's global relay-observed public mapping"
     );
     assert!(
         world.punch_dial_addrs_from_a.contains(&maddr(B_PUBLIC)),

--- a/crates/nat/tests/two_agents.rs
+++ b/crates/nat/tests/two_agents.rs
@@ -247,6 +247,23 @@ impl World {
                     self.blasts_from_b += 1;
                 }
             }
+            NatAction::PromoteBridge {
+                token, remote_peer, ..
+            } => {
+                self.next_conn += 1;
+                let conn_id = ConnectionId::new((1 << 63) | self.next_conn);
+                let agent = self.agent(side);
+                agent.promote_result(token, Ok(conn_id), now);
+                agent.handle_event_with_disposition_classified(
+                    &SwarmEvent::ConnectionEstablished {
+                        peer_id: remote_peer,
+                        conn_id,
+                    },
+                    true,
+                    now,
+                );
+            }
+            NatAction::CloseCircuit { .. } => {}
             NatAction::CloseStreamWrite { .. }
             | NatAction::ResetStream { .. }
             | NatAction::Disconnect { .. } => {}
@@ -432,13 +449,9 @@ fn two_agents_punch_to_a_direct_connection() {
         "A's punch targets B's public mapping: {:?}",
         world.punch_dial_addrs_from_a
     );
-    let events = drain_events(&mut world.b);
     assert!(
-        matches!(
-            events.as_slice(),
-            [NatEvent::InboundRelayCircuit { peer, .. }] if *peer == world.a_id
-        ),
-        "B released the inbound bridge, got {events:?}"
+        drain_events(&mut world.b).is_empty(),
+        "inbound circuits surface through normal swarm lifecycle events"
     );
 
     // B's punch-back is blast-only (DCUtR for QUIC: the initiator dials).

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -15,3 +15,7 @@ path = "src/main.rs"
 [dependencies]
 minip2p = { path = "../../crates/minip2p", features = ["discovery"] }
 minip2p-example-common = { path = "../common" }
+
+[dev-dependencies]
+minip2p-relay = { path = "../../crates/relay" }
+minip2p-test-support = { path = "../../crates/test-support" }

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -103,8 +103,13 @@ Two deployment details surfaced during live validation:
    from the `listen-addr=` line by substituting the machine's public IP:
    `join /ip4/<public-ip>/udp/4001/quic-v1/p2p/<host-peer-id>`. Kill and
    rejoin one peer: the subscription snapshot is resent on reconnect.
-2. **NAT'd host**: host behind a NAT with `--relay <aws-relay>`, joiners
-   paste the `circuit=` address and hole-punch in.
+2. **Relay-only room**: start the NAT'd host with
+   `host --relay <aws-relay> --relay-only`, then have joiners paste its
+   `circuit=` address and run
+   `join '<circuit-addr>' --relay-only --nick alice`. Verify both sides
+   report subscriptions and exchange messages while `path=relayed`; cutting
+   the relay must disconnect the room. Remove `--relay-only` from both peers
+   in a second run to validate the relayed → direct-punched upgrade.
 3. **go-libp2p interop**: a go floodsub peer (Ed25519 identity) on the
    same topic chats both ways in strict mode.
 4. **rust-libp2p interop**: a rust-libp2p floodsub peer, with this side
@@ -119,4 +124,5 @@ open-internet star (hotspot + home-network leaves, kill/rejoin,
 75 s idle survival), a NAT'd host punched into from a hotspot
 (relayed → direct-punched upgrade, then chat over the punched path),
 and both interop directions against real go-libp2p and rust-libp2p
-peers.
+peers. The deterministic relay-only room is also covered by the loopback
+binary e2e test in `tests/chat.rs`.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -54,23 +54,18 @@ $ minip2p-chat host --relay /ip6/…/udp/4001/quic-v1/p2p/<relay-id>
 ```
 
 A joiner pastes the circuit address; the NAT agent connects through the
-relay, runs DCUtR, and the chat starts once the hole punch lands:
+relay and chat starts immediately on the promoted relayed connection while
+DCUtR attempts a direct upgrade in the background:
 
 ```console
 $ minip2p-chat join '<circuit-addr>' --nick alice
 [join] path=relayed
-[join] waiting for the hole punch (chat needs a direct path)
-[join] nat-path-upgraded … to=direct-punched
 [join] subscribed topic=minip2p-chat nick=alice
 ```
 
-### Known v1 limitation: no chat over the relay bridge
-
-The relayed path is a raw bridge stream — no multistream negotiation runs
-over it, so floodsub cannot open its streams there. If the hole punch
-fails, `join` exits with an error instead of silently sitting in a dead
-room. A circuit transport that makes relayed paths look like normal
-connections is future work at the stack level.
+Pass `--relay-only` to skip direct dialing and DCUtR entirely. This gives a
+deterministic way to exercise Noise, Yamux, Identify, discovery, and floodsub
+over the relay circuit.
 
 ## Message format
 

--- a/examples/chat/src/cli.rs
+++ b/examples/chat/src/cli.rs
@@ -4,7 +4,7 @@
 //!
 //! ```text
 //! minip2p-chat host        [--topic <t>] [--nick <n>] [--relay <relay-peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
-//! minip2p-chat join <addr> [--topic <t>] [--nick <n>] [--relay <peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
+//! minip2p-chat join <addr> [--topic <t>] [--nick <n>] [--relay <peer-addr>] [--relay-only] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
 //! ```
 //!
 //! `<addr>` is either the host's printed `bound=` peer-addr, or its
@@ -60,6 +60,8 @@ pub struct ChatOptions {
     pub allow_unsigned: bool,
     /// Disable peer discovery and preserve the host-forwarded star topology.
     pub no_mesh: bool,
+    /// Skip direct dialing and DCUtR so relay-only behavior is deterministic.
+    pub relay_only: bool,
 }
 
 /// Parse error surfaced back to `main` so the binary exits with a readable
@@ -105,7 +107,7 @@ fn parse_join(args: Vec<String>) -> Result<Mode, CliError> {
     let mut i = 0;
     while i < args.len() {
         let arg = &args[i];
-        if arg == "--allow-unsigned" || arg == "--no-mesh" {
+        if arg == "--allow-unsigned" || arg == "--no-mesh" || arg == "--relay-only" {
             // Boolean flag: no value follows.
             rest.push(arg.clone());
             i += 1;
@@ -203,6 +205,14 @@ impl Flags {
                     i += 1;
                     continue;
                 }
+                "--relay-only" => {
+                    if chat.relay_only {
+                        return Err(CliError("--relay-only specified twice".into()));
+                    }
+                    chat.relay_only = true;
+                    i += 1;
+                    continue;
+                }
                 "--topic" => {
                     let value = flag_value(args, i, key)?;
                     if chat.topic.is_some() {
@@ -296,12 +306,12 @@ pub fn usage() -> String {
 
 USAGE:
     minip2p-chat host        [--topic <t>] [--nick <n>] [--relay <relay-peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
-    minip2p-chat join <addr> [--topic <t>] [--nick <n>] [--relay <peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
+    minip2p-chat join <addr> [--topic <t>] [--nick <n>] [--relay <peer-addr>] [--relay-only] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
 
 NOTES:
     <addr>    the host's printed `bound=` peer-addr, or its `circuit=`
               address (/…/p2p/<relay>/p2p-circuit/p2p/<peer>) when the host
-              is behind a NAT (joiners then hole-punch a direct path)
+              is behind a NAT
     --topic   chat room name (default: minip2p-chat)
     --nick    display name (default: first 8 chars of the peer id)
     --relay   relay peer-addr for NAT traversal / reservations
@@ -312,6 +322,9 @@ NOTES:
               accept unsigned messages (rust-libp2p floodsub interop;
               signed messages are still verified)
     --no-mesh preserve the host-forwarded star by disabling peer discovery
+    --relay-only
+              skip direct dialing and hole punching; use the promoted relay
+              circuit for deterministic relay-only testing
 
     Type lines on stdin to chat; EOF (Ctrl-D) exits.
 
@@ -384,6 +397,26 @@ mod tests {
             assert!(chat.no_mesh);
         }
         let duplicate = vec!["host", "--no-mesh", "--no-mesh"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        assert!(parse(duplicate).is_err());
+    }
+
+    #[test]
+    fn relay_only_is_a_boolean_join_flag() {
+        let target = format!("{RELAY}/p2p/{PEER_ID}");
+        for args in [
+            vec!["join", "--relay-only", target.as_str()],
+            vec!["join", target.as_str(), "--relay-only"],
+        ] {
+            let parsed = parse(args.into_iter().map(str::to_string).collect()).unwrap();
+            let Mode::Join { chat, .. } = parsed else {
+                panic!()
+            };
+            assert!(chat.relay_only);
+        }
+        let duplicate = vec!["join", target.as_str(), "--relay-only", "--relay-only"]
             .into_iter()
             .map(str::to_string)
             .collect();

--- a/examples/chat/src/modes.rs
+++ b/examples/chat/src/modes.rs
@@ -1,7 +1,6 @@
 //! The chat runner: endpoint construction, host/join startup flows, and
 //! the shared stdin-driven chat loop.
 
-use std::collections::BTreeMap;
 use std::error::Error;
 use std::io::BufRead;
 use std::sync::mpsc;
@@ -10,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use minip2p::{
     DISCOVERY_TOPIC, DiscoveryConfig, DiscoveryEvent, Endpoint, Event, FloodsubConfig, NatConfig,
-    NatEvent, Path, PeerAddr, PeerId, PublishError, PubsubError, PubsubEvent, StreamId,
+    NatEvent, PeerAddr, PeerId, PublishError, PubsubError, PubsubEvent,
 };
 
 use minip2p_example_common::{
@@ -25,19 +24,11 @@ const DEFAULT_TOPIC: &str = "minip2p-chat";
 const CONNECT_DEADLINE: Duration = Duration::from_secs(65);
 /// How long the host waits for its relay reservation before warning.
 const RESERVATION_DEADLINE: Duration = Duration::from_secs(30);
-/// After a relayed path, how long a joiner waits for the hole punch.
-const PUNCH_WAIT: Duration = Duration::from_secs(30);
 /// Identify must complete before floodsub can open streams.
 const READY_DEADLINE: Duration = Duration::from_secs(15);
 
-struct ResponderBridge {
-    target_peer: PeerId,
-    cleanup_deadline: Instant,
-}
-
 struct ChatEndpoint {
     endpoint: Endpoint,
-    responder_bridge_lifetime: Duration,
 }
 
 // --- endpoint construction --------------------------------------------------
@@ -48,8 +39,10 @@ fn build_endpoint(
     options: &ChatOptions,
 ) -> Result<ChatEndpoint, Box<dyn Error>> {
     let keypair = load_keypair(options.key_path.as_deref(), role)?;
-    let nat_config = NatConfig::default();
-    let responder_bridge_lifetime = responder_bridge_lifetime(&nat_config);
+    let nat_config = NatConfig {
+        force_relay: options.relay_only,
+        ..NatConfig::default()
+    };
     let mut builder = Endpoint::builder()
         .identity(keypair)
         .agent_version(AGENT)
@@ -81,19 +74,7 @@ fn build_endpoint(
             .bind_quic_dual_stack()
             .map_err(|e| format!("quic dual-stack bind: {e}"))?,
     };
-    Ok(ChatEndpoint {
-        endpoint,
-        responder_bridge_lifetime,
-    })
-}
-
-fn responder_bridge_lifetime(config: &NatConfig) -> Duration {
-    Duration::from_millis(
-        config
-            .punch_deadline_ms
-            .saturating_mul(1 + u64::from(config.punch_max_retries))
-            .saturating_add(1_000),
-    )
+    Ok(ChatEndpoint { endpoint })
 }
 
 fn topic_and_nick(options: &ChatOptions, endpoint: &Endpoint) -> (String, String) {
@@ -115,10 +96,7 @@ fn topic_and_nick(options: &ChatOptions, endpoint: &Endpoint) -> (String, String
 /// joiners use.
 pub fn run_host(relay: Option<PeerAddr>, options: ChatOptions) -> Result<(), Box<dyn Error>> {
     let relays: Vec<PeerAddr> = relay.into_iter().collect();
-    let ChatEndpoint {
-        mut endpoint,
-        responder_bridge_lifetime,
-    } = build_endpoint("host", &relays, &options)?;
+    let ChatEndpoint { mut endpoint } = build_endpoint("host", &relays, &options)?;
     let peer_addrs = endpoint
         .listen_all()
         .map_err(|e| format!("listen failed: {e}"))?;
@@ -145,14 +123,7 @@ pub fn run_host(relay: Option<PeerAddr>, options: ChatOptions) -> Result<(), Box
         .map_err(|e| format!("subscribe: {e}"))?;
     println!("[host] subscribed topic={topic} nick={nick}");
 
-    run_chat(
-        &mut endpoint,
-        &topic,
-        &nick,
-        "host",
-        relays.first(),
-        responder_bridge_lifetime,
-    )
+    run_chat(&mut endpoint, &topic, &nick, "host", relays.first())
 }
 
 /// Drives the endpoint until the relay reservation lands, printing the
@@ -180,9 +151,8 @@ fn wait_for_reservation(endpoint: &mut Endpoint, relay: &PeerAddr) -> Result<(),
 
 // --- join -------------------------------------------------------------------
 
-/// Joins a room through the NAT agent, insisting on a direct path (pubsub
-/// cannot run over a raw relay bridge; see the README), then chats until
-/// stdin EOF.
+/// Joins a room through the NAT agent, then chats over either a direct or
+/// promoted relay-circuit connection until stdin EOF.
 pub fn run_join(
     target: JoinTarget,
     relay: Option<PeerAddr>,
@@ -199,10 +169,7 @@ pub fn run_join(
         relays.push(extra);
     }
 
-    let ChatEndpoint {
-        mut endpoint,
-        responder_bridge_lifetime,
-    } = build_endpoint("join", &relays, &options)?;
+    let ChatEndpoint { mut endpoint } = build_endpoint("join", &relays, &options)?;
     // Listening seeds the agent's bound addresses — the local half of the
     // DCUtR candidate set.
     endpoint
@@ -238,17 +205,10 @@ pub fn run_join(
     };
     println!("[join] path={}", path_name(&path));
 
-    // Floodsub negotiates real streams, which a raw relay bridge cannot
-    // carry: hold out for the hole punch.
-    if matches!(path, Path::Relayed { .. }) {
-        println!("[join] waiting for the hole punch (chat needs a direct path)");
-        wait_for_direct_upgrade(&mut endpoint, &host_peer)?;
-    }
-
     endpoint
         .wait_peer_ready(&host_peer, READY_DEADLINE)
         .map_err(|e| format!("waiting for identify: {e}"))?
-        .ok_or("identify never completed on the direct connection")?;
+        .ok_or("identify never completed on the selected connection")?;
 
     let (topic, nick) = topic_and_nick(&options, &endpoint);
     endpoint
@@ -256,39 +216,7 @@ pub fn run_join(
         .map_err(|e| format!("subscribe: {e}"))?;
     println!("[join] subscribed topic={topic} nick={nick}");
 
-    run_chat(
-        &mut endpoint,
-        &topic,
-        &nick,
-        "join",
-        None,
-        responder_bridge_lifetime,
-    )
-}
-
-fn wait_for_direct_upgrade(
-    endpoint: &mut Endpoint,
-    host_peer: &PeerId,
-) -> Result<(), Box<dyn Error>> {
-    let deadline = Instant::now() + PUNCH_WAIT;
-    loop {
-        for event in endpoint.take_nat_events() {
-            print_nat_event("join", &event);
-            if matches!(&event, NatEvent::PathUpgraded { peer, to, .. }
-                if peer == host_peer && !matches!(to, Path::Relayed { .. }))
-            {
-                return Ok(());
-            }
-        }
-        if Instant::now() >= deadline {
-            return Err(
-                "the hole punch did not complete; chat cannot run over the relay bridge \
-                 (known v1 limitation, see examples/chat/README.md)"
-                    .into(),
-            );
-        }
-        let _ = endpoint.next_event(Duration::from_millis(100))?;
-    }
+    run_chat(&mut endpoint, &topic, &nick, "join", None)
 }
 
 // --- the chat loop ----------------------------------------------------------
@@ -317,7 +245,6 @@ fn run_chat(
     nick: &str,
     role: &str,
     relay: Option<&PeerAddr>,
-    responder_bridge_lifetime: Duration,
 ) -> Result<(), Box<dyn Error>> {
     let input = spawn_stdin_reader();
     eprintln!("[{role}] type to chat; Ctrl-D to leave");
@@ -332,18 +259,7 @@ fn run_chat(
     // every connected peer well inside that window.
     const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
     let mut last_keepalive = Instant::now();
-    let mut responder_bridges: BTreeMap<(PeerId, StreamId), ResponderBridge> = BTreeMap::new();
-
     loop {
-        let expired: Vec<_> = responder_bridges
-            .iter()
-            .filter(|(_, bridge)| Instant::now() >= bridge.cleanup_deadline)
-            .map(|(key, _)| key.clone())
-            .collect();
-        for (relay_peer, stream_id) in expired {
-            let _ = endpoint.abandon_stream(&relay_peer, stream_id);
-            responder_bridges.remove(&(relay_peer, stream_id));
-        }
         if last_keepalive.elapsed() >= KEEPALIVE_INTERVAL {
             last_keepalive = Instant::now();
             for peer in endpoint.connected_peers() {
@@ -381,11 +297,9 @@ fn run_chat(
             match &event {
                 Event::ConnectionEstablished { peer_id, .. } => {
                     println!("[{role}] connected peer={peer_id}");
-                    abandon_responder_bridges(endpoint, &mut responder_bridges, peer_id);
                 }
                 Event::ConnectionClosed { peer_id, .. } => {
                     println!("[{role}] disconnected peer={peer_id}");
-                    responder_bridges.retain(|(relay_peer, _), _| relay_peer != peer_id);
                 }
                 Event::Error(error) => {
                     eprintln!("[{role}] error {:?}: {}", error.kind, error.detail);
@@ -420,26 +334,6 @@ fn run_chat(
 
         for event in endpoint.take_nat_events() {
             print_nat_event(role, &event);
-            match &event {
-                NatEvent::InboundRelayCircuit {
-                    peer,
-                    relay,
-                    stream_id,
-                    ..
-                } => {
-                    responder_bridges.insert(
-                        (relay.clone(), *stream_id),
-                        ResponderBridge {
-                            target_peer: peer.clone(),
-                            cleanup_deadline: Instant::now() + responder_bridge_lifetime,
-                        },
-                    );
-                }
-                NatEvent::InboundDirectUpgrade { peer } => {
-                    abandon_responder_bridges(endpoint, &mut responder_bridges, peer);
-                }
-                _ => {}
-            }
             // A reservation that lands late (after the startup wait warned)
             // or is re-acquired after a loss still needs its circuit
             // address printed -- joiners have nothing to paste otherwise.
@@ -490,22 +384,6 @@ fn run_chat(
     }
 }
 
-fn abandon_responder_bridges(
-    endpoint: &mut Endpoint,
-    bridges: &mut BTreeMap<(PeerId, StreamId), ResponderBridge>,
-    target: &PeerId,
-) {
-    let matches: Vec<_> = bridges
-        .iter()
-        .filter(|(_, bridge)| &bridge.target_peer == target)
-        .map(|(key, _)| key.clone())
-        .collect();
-    for (relay, stream_id) in matches {
-        let _ = endpoint.abandon_stream(&relay, stream_id);
-        bridges.remove(&(relay, stream_id));
-    }
-}
-
 fn short(peer: &PeerId) -> String {
     const DISPLAY_LEN: usize = 8;
 
@@ -529,19 +407,5 @@ mod tests {
         assert_ne!(short(&first), short(&second));
         assert!(first.to_base58().ends_with(&short(&first)));
         assert!(second.to_base58().ends_with(&short(&second)));
-    }
-
-    #[test]
-    fn responder_bridge_lifetime_comes_from_the_endpoint_nat_config() {
-        let config = NatConfig {
-            punch_deadline_ms: 7,
-            punch_max_retries: 4,
-            ..NatConfig::default()
-        };
-
-        assert_eq!(
-            responder_bridge_lifetime(&config),
-            Duration::from_millis(1_035)
-        );
     }
 }

--- a/examples/chat/tests/chat.rs
+++ b/examples/chat/tests/chat.rs
@@ -11,6 +11,11 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
+#[path = "../../../tests/support/relay.rs"]
+mod relay_support;
+
+use relay_support::RelayServer;
+
 /// Hard cap on the entire flow; loopback runs finish in a few seconds.
 const TEST_DEADLINE: Duration = Duration::from_secs(30);
 
@@ -220,6 +225,54 @@ fn three_peer_star_chats_end_to_end() {
     alice.leave(deadline);
     bob.leave(deadline);
     host.leave(deadline);
+}
+
+#[test]
+fn relay_only_room_chats_over_a_real_circuit() {
+    let deadline = Instant::now() + TEST_DEADLINE;
+    let relay = RelayServer::spawn();
+    let relay_addr = relay.addr().to_string();
+
+    let mut host = Peer::spawn(
+        "relay-host",
+        &[
+            "host",
+            "--relay",
+            &relay_addr,
+            "--nick",
+            "hostess",
+            "--relay-only",
+            "--no-mesh",
+        ],
+    );
+    let circuit = host
+        .wait_line(deadline, |line| line.starts_with("[host] circuit="))
+        .trim_start_matches("[host] circuit=")
+        .to_string();
+
+    let mut alice = Peer::spawn(
+        "relay-alice",
+        &[
+            "join",
+            &circuit,
+            "--nick",
+            "alice",
+            "--relay-only",
+            "--no-mesh",
+        ],
+    );
+    alice.wait_line(deadline, |line| line == "[join] path=relayed");
+    alice.wait_line(deadline, |line| line.contains("peer-subscribed"));
+    host.wait_line(deadline, |line| line.contains("peer-subscribed"));
+
+    alice.say("through the relay");
+    host.wait_line(deadline, |line| line.contains("alice: through the relay"));
+    host.say("relay reply");
+    alice.wait_line(deadline, |line| line.contains("hostess: relay reply"));
+
+    alice.leave(deadline);
+    host.leave(deadline);
+    relay.assert_healthy();
 }
 
 #[test]

--- a/examples/common/src/lib.rs
+++ b/examples/common/src/lib.rs
@@ -186,19 +186,6 @@ pub fn print_nat_event(role: &str, event: &NatEvent) {
         NatEvent::ConnectFailed { peer, error, .. } => {
             println!("[{role}] nat-connect-failed peer={peer} error={error}");
         }
-        NatEvent::InboundRelayCircuit {
-            peer,
-            relay,
-            stream_id,
-            pending_data,
-            remote_write_closed,
-        } => {
-            println!(
-                "[{role}] nat-inbound-circuit peer={peer} relay={relay} stream={stream_id} \
-                 pending-bytes={} remote-write-closed={remote_write_closed}",
-                pending_data.len()
-            );
-        }
         NatEvent::InboundDirectUpgrade { peer } => {
             println!("[{role}] nat-inbound-direct-upgrade peer={peer}");
         }

--- a/examples/peer/README.md
+++ b/examples/peer/README.md
@@ -126,9 +126,9 @@ If the punch cannot land (e.g. UDP blocked between the peers), you'll see
   big-endian seq followed by an 8-byte send timestamp. The listener never
   parses them — it echoes raw bytes, which also exercises frame
   fragmentation/coalescing on the dialer's reassembly path.
-- A relayed path is a raw bridged stream, not a full connection: no
-  identify or ping runs across it, and both ends must speak minip2p (the
-  bridge carries this demo's echo frames, not multistream-select).
+- A relayed path is an end-to-end Noise connection multiplexed with Yamux.
+  Identify, ping, and the echo protocol use the same negotiated stream APIs
+  as a direct connection.
 - Exit paths: `--count` is the graceful shutdown (half-close, 3 s drain,
   summary); Ctrl-C is the blunt one. The listener runs until interrupted.
 - The previous `direct`/`relay`/`autonat` modes (hand-rolled protocol

--- a/examples/peer/src/modes.rs
+++ b/examples/peer/src/modes.rs
@@ -156,14 +156,14 @@ pub fn run_listen(relay: Option<PeerAddr>, options: RunOptions) -> Result<(), Bo
     let mut echo_streams: HashSet<(PeerId, StreamId)> = HashSet::new();
 
     if let Some(relay) = relays.first() {
-        wait_for_reservation(&mut endpoint, relay, &mut echo_streams)?;
+        wait_for_reservation(&mut endpoint, relay)?;
     }
     eprintln!("[listen] echoing on {ECHO_PROTOCOL} (Ctrl-C to stop)");
 
     loop {
         for nat_event in endpoint.take_nat_events() {
             print_nat_event("listen", &nat_event);
-            handle_listen_nat_event(&mut endpoint, &nat_event, relays.first(), &mut echo_streams);
+            handle_listen_nat_event(&mut endpoint, &nat_event, relays.first());
         }
         let Some(event) = endpoint
             .next_event(Duration::from_millis(200))
@@ -179,11 +179,7 @@ pub fn run_listen(relay: Option<PeerAddr>, options: RunOptions) -> Result<(), Bo
 /// Pumps NAT events until the first reservation confirms (printing the
 /// paste-ready `circuit=` line) or the deadline passes with a warning; the
 /// agent keeps retrying either way and renewals re-print via the main loop.
-fn wait_for_reservation(
-    endpoint: &mut Endpoint,
-    relay: &PeerAddr,
-    echo_streams: &mut HashSet<(PeerId, StreamId)>,
-) -> Result<(), Box<dyn Error>> {
+fn wait_for_reservation(endpoint: &mut Endpoint, relay: &PeerAddr) -> Result<(), Box<dyn Error>> {
     let deadline = Instant::now() + RESERVATION_DEADLINE;
     loop {
         let Some(event) = endpoint
@@ -198,47 +194,21 @@ fn wait_for_reservation(
         };
         print_nat_event("listen", &event);
         let reserved = matches!(event, NatEvent::RelayReserved { .. });
-        handle_listen_nat_event(endpoint, &event, Some(relay), echo_streams);
+        handle_listen_nat_event(endpoint, &event, Some(relay));
         if reserved {
             return Ok(());
         }
     }
 }
 
-fn handle_listen_nat_event(
-    endpoint: &mut Endpoint,
-    event: &NatEvent,
-    relay: Option<&PeerAddr>,
-    echo_streams: &mut HashSet<(PeerId, StreamId)>,
-) {
-    match event {
-        NatEvent::RelayReserved { .. } => {
-            if let Some(relay) = relay {
-                println!(
-                    "[listen] circuit={}",
-                    circuit_addr(relay, endpoint.peer_id())
-                );
-            }
-        }
-        NatEvent::InboundRelayCircuit {
-            relay,
-            stream_id,
-            pending_data,
-            remote_write_closed,
-            ..
-        } => {
-            echo_streams.insert((relay.clone(), *stream_id));
-            // Bytes pipelined behind the circuit setup are surfaced exactly
-            // once here and never reappear as `StreamData`.
-            if !pending_data.is_empty() {
-                echo_bytes(endpoint, relay, *stream_id, pending_data, echo_streams);
-            }
-            if *remote_write_closed {
-                let _ = endpoint.close_stream_write(relay, *stream_id);
-                echo_streams.remove(&(relay.clone(), *stream_id));
-            }
-        }
-        _ => {}
+fn handle_listen_nat_event(endpoint: &mut Endpoint, event: &NatEvent, relay: Option<&PeerAddr>) {
+    if let NatEvent::RelayReserved { .. } = event
+        && let Some(relay) = relay
+    {
+        println!(
+            "[listen] circuit={}",
+            circuit_addr(relay, endpoint.peer_id())
+        );
     }
 }
 
@@ -422,28 +392,11 @@ pub fn run_dial(
         start.elapsed().as_millis()
     );
 
-    let mut frames = FrameBuf::new();
-    let channel = match path {
-        Path::Relayed {
-            relay,
-            stream_id,
-            pending_data,
-            remote_write_closed,
-        } => {
-            if remote_write_closed {
-                return Err("relay bridge arrived already write-closed".into());
-            }
-            frames.push(&pending_data);
-            Channel {
-                send_peer: relay,
-                stream: stream_id,
-                direct: false,
-            }
-        }
-        Path::DirectDialed | Path::DirectPunched => {
-            establish_direct_channel(&mut endpoint, &peer, &BTreeSet::new(), None, start)?
-        }
-    };
+    let relayed = matches!(path, Path::Relayed { .. });
+    let frames = FrameBuf::new();
+    let mut channel =
+        establish_direct_channel(&mut endpoint, &peer, &BTreeSet::new(), None, start)?;
+    channel.direct = !relayed;
 
     ping_loop(&mut endpoint, &peer, channel, frames, count, start)
 }

--- a/tests/support/relay.rs
+++ b/tests/support/relay.rs
@@ -1,0 +1,392 @@
+#![allow(dead_code)]
+
+//! Loopback Circuit Relay v2 service used by facade and example tests.
+//!
+//! This is deliberately an application built from public `minip2p` APIs:
+//! HOP and STOP are negotiated as ordinary protocols, relay messages are
+//! validated by `RelayEmulator`, and the accepted streams are then copied
+//! byte-for-byte in both directions. The peers on either side therefore run
+//! the production NAT driver, Noise, Yamux, Identify, ping, and protocols.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread;
+use std::time::Duration;
+
+use minip2p::{Endpoint, Event, PeerAddr, PeerId, StreamId};
+use minip2p_relay::{FrameDecode, HOP_PROTOCOL_ID, HopMessage, HopMessageType, STOP_PROTOCOL_ID};
+use minip2p_test_support::{ConnectRequestOutcome, PendingConnectId, RelayEmulator};
+
+type StreamKey = (PeerId, StreamId);
+
+enum Command {
+    CutAll,
+    Stop,
+}
+
+struct PendingStop {
+    pending_id: PendingConnectId,
+    hop: StreamKey,
+    target: PeerId,
+    connect_bytes: Vec<u8>,
+    hop_trailing: Vec<u8>,
+    response: Vec<u8>,
+}
+
+#[derive(Default)]
+struct RelayMachine {
+    protocol: RelayEmulator,
+    hop_buffers: BTreeMap<StreamKey, Vec<u8>>,
+    pending_stops: BTreeMap<StreamKey, PendingStop>,
+    hop_to_stop: BTreeMap<StreamKey, StreamKey>,
+    bridges: BTreeMap<StreamKey, StreamKey>,
+    trace: Vec<String>,
+}
+
+impl RelayMachine {
+    fn handle(&mut self, endpoint: &mut Endpoint, event: Event) -> Result<(), String> {
+        match event {
+            Event::StreamReady {
+                peer_id,
+                stream_id,
+                protocol_id,
+                initiated_locally,
+                ..
+            } if protocol_id == HOP_PROTOCOL_ID && !initiated_locally => {
+                self.hop_buffers.entry((peer_id, stream_id)).or_default();
+            }
+            Event::StreamReady {
+                peer_id,
+                stream_id,
+                protocol_id,
+                initiated_locally,
+                ..
+            } if protocol_id == STOP_PROTOCOL_ID && initiated_locally => {
+                let key = (peer_id.clone(), stream_id);
+                let bytes = self
+                    .pending_stops
+                    .get(&key)
+                    .ok_or_else(|| format!("STOP stream ready without pending CONNECT: {key:?}"))?
+                    .connect_bytes
+                    .clone();
+                endpoint
+                    .send_stream(&peer_id, stream_id, bytes)
+                    .map_err(|e| format!("send STOP CONNECT: {e}"))?;
+            }
+            Event::StreamData {
+                peer_id,
+                stream_id,
+                data,
+                ..
+            } => self.on_data(endpoint, (peer_id, stream_id), data)?,
+            Event::StreamRemoteWriteClosed {
+                peer_id, stream_id, ..
+            } => {
+                let key = (peer_id, stream_id);
+                if let Some((other_peer, other_stream)) = self.bridges.get(&key).cloned() {
+                    let _ = endpoint.close_stream_write(&other_peer, other_stream);
+                }
+            }
+            Event::StreamClosed {
+                peer_id, stream_id, ..
+            } => self.drop_stream(endpoint, &(peer_id, stream_id)),
+            Event::ConnectionClosed { peer_id, .. } => {
+                let dead: Vec<_> = self
+                    .bridges
+                    .keys()
+                    .filter(|(peer, _)| peer == &peer_id)
+                    .cloned()
+                    .collect();
+                for key in dead {
+                    self.drop_stream(endpoint, &key);
+                }
+                self.hop_buffers.retain(|(peer, _), _| peer != &peer_id);
+                self.pending_stops.retain(|(peer, _), _| peer != &peer_id);
+                self.hop_to_stop
+                    .retain(|(peer, _), stop| peer != &peer_id && stop.0 != peer_id);
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn on_data(
+        &mut self,
+        endpoint: &mut Endpoint,
+        key: StreamKey,
+        data: Vec<u8>,
+    ) -> Result<(), String> {
+        if let Some((other_peer, other_stream)) = self.bridges.get(&key).cloned() {
+            self.trace.push(format!(
+                "forward {} bytes {:?} -> ({other_peer}, {other_stream})",
+                data.len(),
+                key
+            ));
+            endpoint
+                .send_stream(&other_peer, other_stream, data)
+                .map_err(|e| format!("forward bridge data: {e}"))?;
+            return Ok(());
+        }
+
+        if let Some(stop_key) = self.hop_to_stop.get(&key).cloned() {
+            let pending = self
+                .pending_stops
+                .get_mut(&stop_key)
+                .expect("hop-to-stop index points at pending STOP");
+            pending.hop_trailing.extend(data);
+            return Ok(());
+        }
+
+        if self.pending_stops.contains_key(&key) {
+            return self.on_stop_data(endpoint, key, data);
+        }
+
+        let Some(buffer) = self.hop_buffers.get_mut(&key) else {
+            return Ok(());
+        };
+        buffer.extend(data);
+        let FrameDecode::Complete { payload, .. } = minip2p_relay::decode_frame(buffer) else {
+            return Ok(());
+        };
+        let message =
+            HopMessage::decode(payload).map_err(|e| format!("decode HOP request: {e}"))?;
+        let request = self
+            .hop_buffers
+            .remove(&key)
+            .expect("complete HOP buffer exists");
+
+        match message.kind {
+            HopMessageType::Reserve => {
+                let trailing = self
+                    .protocol
+                    .on_reserve_request(&key.0, &request)
+                    .map_err(|e| format!("handle RESERVE: {e}"))?;
+                if !trailing.is_empty() {
+                    return Err("unexpected bytes trailing RESERVE".into());
+                }
+                let response = self.protocol.drain_hop_bytes_for(&key.0);
+                endpoint
+                    .send_stream(&key.0, key.1, response)
+                    .map_err(|e| format!("send RESERVE response: {e}"))?;
+            }
+            HopMessageType::Connect => {
+                let mut response = Vec::new();
+                match self
+                    .protocol
+                    .on_connect_request(&key.0, &request, &mut response)
+                    .map_err(|e| format!("handle CONNECT: {e}"))?
+                {
+                    ConnectRequestOutcome::Refused { trailing } => {
+                        if !trailing.is_empty() {
+                            return Err("unexpected bytes trailing refused CONNECT".into());
+                        }
+                        endpoint
+                            .send_stream(&key.0, key.1, response)
+                            .map_err(|e| format!("send CONNECT refusal: {e}"))?;
+                    }
+                    ConnectRequestOutcome::Bridging {
+                        pending_id,
+                        target,
+                        trailing,
+                    } => {
+                        let stop_stream = endpoint
+                            .open_stream(&target, STOP_PROTOCOL_ID)
+                            .map_err(|e| format!("open STOP stream to {target}: {e}"))?;
+                        let stop_key = (target.clone(), stop_stream);
+                        let connect_bytes = self.protocol.drain_stop_bytes_for(&target);
+                        self.hop_to_stop.insert(key.clone(), stop_key.clone());
+                        self.pending_stops.insert(
+                            stop_key,
+                            PendingStop {
+                                pending_id,
+                                hop: key,
+                                target,
+                                connect_bytes,
+                                hop_trailing: trailing,
+                                response,
+                            },
+                        );
+                    }
+                }
+            }
+            other => return Err(format!("unexpected HOP request kind: {other:?}")),
+        }
+        Ok(())
+    }
+
+    fn on_stop_data(
+        &mut self,
+        endpoint: &mut Endpoint,
+        key: StreamKey,
+        data: Vec<u8>,
+    ) -> Result<(), String> {
+        {
+            let pending = self
+                .pending_stops
+                .get_mut(&key)
+                .expect("pending STOP exists");
+            pending.response.extend(data);
+            if !matches!(
+                minip2p_relay::decode_frame(&pending.response),
+                FrameDecode::Complete { .. }
+            ) {
+                return Ok(());
+            }
+        }
+
+        let pending = self
+            .pending_stops
+            .remove(&key)
+            .expect("complete pending STOP exists");
+        self.hop_to_stop.remove(&pending.hop);
+        let mut initiator_response = Vec::new();
+        let stop_trailing = self
+            .protocol
+            .on_stop_ack_from_target(
+                pending.pending_id,
+                &pending.target,
+                &pending.response,
+                &mut initiator_response,
+            )
+            .map_err(|e| format!("handle STOP response: {e}"))?;
+
+        endpoint
+            .send_stream(&pending.hop.0, pending.hop.1, initiator_response)
+            .map_err(|e| format!("send HOP success: {e}"))?;
+        if !pending.hop_trailing.is_empty() {
+            endpoint
+                .send_stream(&key.0, key.1, pending.hop_trailing)
+                .map_err(|e| format!("forward pipelined initiator bytes: {e}"))?;
+        }
+        if !stop_trailing.is_empty() {
+            endpoint
+                .send_stream(&pending.hop.0, pending.hop.1, stop_trailing)
+                .map_err(|e| format!("forward pipelined responder bytes: {e}"))?;
+        }
+        self.bridges.insert(pending.hop.clone(), key.clone());
+        self.bridges.insert(key, pending.hop);
+        self.trace.push("bridge active".into());
+        Ok(())
+    }
+
+    fn drop_stream(&mut self, endpoint: &mut Endpoint, key: &StreamKey) {
+        self.hop_buffers.remove(key);
+        if let Some(stop) = self.hop_to_stop.remove(key) {
+            self.pending_stops.remove(&stop);
+            let _ = endpoint.reset_stream(&stop.0, stop.1);
+        }
+        if let Some(other) = self.bridges.remove(key) {
+            self.bridges.remove(&other);
+            let _ = endpoint.reset_stream(&other.0, other.1);
+        }
+    }
+}
+
+/// Background loopback relay with an address suitable for NAT configuration.
+pub struct RelayServer {
+    addr: PeerAddr,
+    commands: mpsc::Sender<Command>,
+    failure: Arc<Mutex<Option<String>>>,
+    trace: Arc<Mutex<VecDeque<String>>>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl RelayServer {
+    pub fn spawn() -> Self {
+        let mut endpoint = Endpoint::builder()
+            .protocol(HOP_PROTOCOL_ID)
+            .protocol(STOP_PROTOCOL_ID)
+            .bind_quic("127.0.0.1:0")
+            .expect("bind relay endpoint");
+        let addr = endpoint.listen().expect("relay listens");
+        let (commands, receiver) = mpsc::channel();
+        let failure = Arc::new(Mutex::new(None));
+        let failure_sink = Arc::clone(&failure);
+        let trace = Arc::new(Mutex::new(VecDeque::new()));
+        let trace_sink = Arc::clone(&trace);
+        let thread = thread::spawn(move || {
+            let mut machine = RelayMachine::default();
+            loop {
+                match receiver.try_recv() {
+                    Ok(Command::CutAll) => {
+                        for peer in endpoint.connected_peers() {
+                            let _ = endpoint.disconnect(&peer);
+                        }
+                    }
+                    Ok(Command::Stop) => break,
+                    Err(mpsc::TryRecvError::Disconnected) => break,
+                    Err(mpsc::TryRecvError::Empty) => {}
+                }
+                match endpoint.next_event(Duration::from_millis(10)) {
+                    Ok(Some(event)) => {
+                        let mut trace = trace_sink.lock().expect("relay trace lock");
+                        if trace.len() == 256 {
+                            trace.pop_front();
+                        }
+                        trace.push_back(format!("{event:?}"));
+                        drop(trace);
+                        if let Err(error) = machine.handle(&mut endpoint, event) {
+                            *failure_sink.lock().expect("relay failure lock") = Some(error);
+                            break;
+                        }
+                        let mut trace = trace_sink.lock().expect("relay trace lock");
+                        for entry in machine.trace.drain(..) {
+                            if trace.len() == 256 {
+                                trace.pop_front();
+                            }
+                            trace.push_back(entry);
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        *failure_sink.lock().expect("relay failure lock") =
+                            Some(format!("relay endpoint: {error}"));
+                        break;
+                    }
+                }
+            }
+        });
+        Self {
+            addr,
+            commands,
+            failure,
+            trace,
+            thread: Some(thread),
+        }
+    }
+
+    pub fn addr(&self) -> &PeerAddr {
+        &self.addr
+    }
+
+    /// Closes both underlying relay sessions while leaving the relay loop up
+    /// long enough for peers to observe transport closure.
+    pub fn cut_all(&self) {
+        self.commands.send(Command::CutAll).expect("relay is alive");
+    }
+
+    pub fn assert_healthy(&self) {
+        if let Some(error) = self.failure.lock().expect("relay failure lock").clone() {
+            panic!("loopback relay failed: {error}");
+        }
+    }
+
+    pub fn trace(&self) -> Vec<String> {
+        self.trace
+            .lock()
+            .expect("relay trace lock")
+            .iter()
+            .cloned()
+            .collect()
+    }
+}
+
+impl Drop for RelayServer {
+    fn drop(&mut self) {
+        let _ = self.commands.send(Command::Stop);
+        if let Some(thread) = self.thread.take() {
+            thread.join().expect("relay thread joins");
+        }
+        self.assert_healthy();
+    }
+}


### PR DESCRIPTION
## Summary

- promote relay bridge streams into authenticated Noise/Yamux circuit connections
- make NAT path selection and teardown connection-aware across direct and relayed sessions
- integrate circuit transport into the minip2p NAT facade, discovery, examples, and documentation
- add force-relay mode plus promotion, timeout, supersession, and two-agent regression coverage

## Verification

- cargo test --workspace
- cargo test -p minip2p --features discovery
- cargo test -p minip2p-nat
- cargo clippy --workspace --all-targets -- -D warnings
- full facade feature matrix, no_std checks, fuzz clippy/formatting, docs, and benchmark compilation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes relay bridges into end-to-end Noise + Yamux circuit connections so relayed paths behave like normal connections, and hardens promotion/upgrade handling. Updates the `minip2p` facade, discovery/pubsub, examples, and tests to use circuit transport, with a loopback relay server for end-to-end coverage.

- **New Features**
  - Relay bridges promoted via `minip2p-circuit`; `Path::Relayed` is a full encrypted, multiplexed connection.
  - With `nat`, `EndpointTransport` is `CircuitTransport<QuicEndpoint, OsEntropy>` and `EndpointSwarm` names the concrete swarm; discovery/pubsub now use `EndpointSwarm`.
  - NAT adds `NatAction::PromoteBridge` (with adoption result) and `BridgeRole`, connection-aware upgrade/teardown, and improved supersession/reservation handling. Relayed paths are announced only after the circuit is Connected.
  - New `NatConfig` options: `circuit_handshake_timeout_ms` and `force_relay`.
  - Examples: chat starts immediately on relayed circuits, adds `--relay-only`; peer demo updated; docs revised.
  - Tests: loopback Circuit Relay v2 server (`tests/support/relay.rs`); end-to-end coverage for relayed circuits in NAT, pubsub, and chat; dev-deps `minip2p-relay` and `minip2p-test-support`.

- **Migration**
  - Relayed paths are normal connections; the raw-bridge flow and `NatEvent::InboundRelayCircuit` are removed.
  - If you handled bridge stream IDs or delayed protocol use until a punch landed, switch to ordinary streams on `Path::Relayed`.
  - Code relying on the exact `EndpointTransport` alias should account for `CircuitTransport` when `nat` is enabled.

<sup>Written for commit 5bff50976b7921f58752ced898d22e0c9b039c66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

