### PR TITLE
feat(pubsub): add gossipsub agent

### DIFF
--- a/crates/minip2p/src/pubsub.rs
+++ b/crates/minip2p/src/pubsub.rs
@@ -119,6 +119,7 @@ impl PubsubDriver {
                 self.agent.stream_open_result(&peer, token, result, now_ms);
             }
             PubsubAction::SendStream {
+                token,
                 peer,
                 stream_id,
                 data,
@@ -126,11 +127,12 @@ impl PubsubDriver {
                 // A synchronously rejected write must reach the agent:
                 // otherwise the stream's eventual close would commit work
                 // whose frame was never accepted.
-                if let Err(e) = swarm.send_stream(&peer, stream_id, data) {
-                    let now_ms = self.now_ms();
-                    self.agent
-                        .send_failed(&peer, stream_id, &e.to_string(), now_ms);
-                }
+                let result = swarm
+                    .send_stream(&peer, stream_id, data)
+                    .map_err(|e| e.to_string());
+                let now_ms = self.now_ms();
+                self.agent
+                    .send_result(&peer, stream_id, token, result, now_ms);
             }
             // A failed half-close after an accepted write is left to the
             // send deadline / close machinery: the frame may well have

--- a/crates/pubsub/README.md
+++ b/crates/pubsub/README.md
@@ -1,33 +1,78 @@
 # minip2p-pubsub
 
-Sans-I/O libp2p pubsub for minip2p: a shared floodsub/meshsub RPC wire codec
-with StrictSign message signing, plus the `FloodsubAgent` state machine that
-routes published messages to subscribed peers by flooding.
+Sans-I/O libp2p pubsub for minip2p. The crate provides two routing engines
+over a shared RPC codec:
 
-The codec exposes floodsub message fields, meshsub IHAVE/IWANT/GRAFT/PRUNE
-control fields, and protocol ids for `/floodsub/1.0.0`, `/meshsub/1.0.0`, and
-`/meshsub/1.1.0`. The router is still floodsub-only in this release:
-`FloodsubAgent` negotiates `/floodsub/1.0.0` and skips meshsub control fields.
+- `GossipsubAgent` implements mesh-based routing over `/meshsub/1.1.0` and
+  `/meshsub/1.0.0`.
+- `FloodsubAgent` implements flood routing over `/floodsub/1.0.0`.
+- `PubsubAgent` and `PubsubConfig` provide static engine selection without
+  trait objects.
 
-`no_std + alloc`, no I/O, no clocks, no async.
+The core is `no_std + alloc`: it performs no I/O, reads no clock, and uses no
+async runtime. Callers feed swarm events and timestamps, execute emitted
+actions, and echo stream-operation results.
 
-## Wire compatibility
+## Stream and delivery model
 
-- RPC framing: varint length prefix per RPC. The codec is stream-model
-  independent; `FloodsubAgent` accepts many RPCs per inbound stream and uses
-  one RPC per outbound stream.
-- `Rpc::control` preserves meshsub v1.0 controls plus the v1.1 `PeerInfo` and
-  prune-backoff additions. Message ids are opaque bytes, matching upstream
-  behavior despite their protobuf `string` declaration.
-- Messages are signed by default (libp2p StrictSign): Ed25519 over
-  `"libp2p-pubsub:" ++ Message` with `signature`/`key` omitted, re-encoded
-  canonically from the decoded fields — exactly how go-libp2p and
-  rust-libp2p verify. The `key` field is omitted on the wire; verifiers
-  recover the public key from the inline-Ed25519 `from` peer id.
-- minip2p emits exactly one topic per published message (current go-libp2p
-  singular `topic` field); the repeated `topic_ids` form is decoded for
-  legacy compatibility.
-Delivered message events include a `signed` flag. It is `true` only when a
-signature was present and verified; accepted unsigned interoperability messages
-carry `false`, allowing higher-level protocols such as peer discovery to require
-authentication independently of application-message policy.
+Gossipsub keeps one long-lived outbound stream per ready peer and writes
+varint-framed RPCs back-to-back. At most one write is awaiting its synchronous
+result. A successful result commits exactly that frame; a failed result resets
+the stream while retaining unsent messages and logical control work for a
+later retry. Subscription state is resynchronized whenever a stream reopens.
+
+Floodsub retains its one-RPC-per-outbound-stream model: open, negotiate, write,
+half-close, and commit on terminal close. Both engines accept multiple framed
+RPCs on each inbound stream and bound reassembly, peer subscriptions, pending
+messages, and concurrent inbound streams.
+
+Publishing uses all-or-nothing backpressure across the selected recipients.
+Forwarding, gossip replies, and cache serving are best effort within the
+configured per-peer queue bound. `OutboundFailure` means work never reached an
+accepted stream write; it is not an end-to-end delivery receipt.
+
+## Gossipsub scope
+
+The gossipsub router implements the interoperability core used by meshsub v1.0
+and the v1.1 PRUNE extension:
+
+- subscription exchange, mesh GRAFT/PRUNE, degree repair, prune backoff, and
+  fanout for publishes made while locally unsubscribed;
+- heartbeat gossip through IHAVE/IWANT, with per-heartbeat spam budgets;
+- a heartbeat-windowed and capacity-bounded message cache;
+- StrictSign validation before deduplication, delivery, forwarding, or cache
+  insertion;
+- negotiated-version-aware PRUNE encoding: v1.1 streams include backoff and
+  v1.0 streams omit it;
+- deterministic tests and reproducible peer selection through the constructor's
+  injected entropy seed.
+
+This is deliberately a focused compatibility implementation, not a claim of
+complete gossipsub conformance. Peer scoring, opportunistic grafting, peer
+exchange dialing, flood-publish, gossip promises/penalties, and v1.2 extensions
+are not implemented. Decoded PRUNE peer-exchange records are preserved by the
+wire codec but ignored by the router.
+
+`GossipsubConfig` exposes mesh degrees, heartbeat/cache/fanout lifetimes,
+backoff limits, spam budgets, memory bounds, stream-establishment timeout, and
+unsigned-message policy. Call `validate()` before constructing an agent
+directly; `PubsubAgent::new` validates automatically. `d_lazy = 0` disables
+gossip emission, while `fanout_ttl_ms = 0` disables fanout reuse.
+
+## Wire compatibility and signing
+
+`Rpc` covers floodsub message fields plus meshsub IHAVE, IWANT, GRAFT, PRUNE,
+peer-exchange, and prune-backoff fields. Message ids are opaque bytes, matching
+upstream behavior despite their protobuf `string` declaration. Frames use a
+varint length prefix and enforce a 64 KiB RPC-body limit.
+
+Messages use libp2p StrictSign by default: Ed25519 over
+`"libp2p-pubsub:" ++ Message`, with `signature` and `key` omitted and the
+decoded fields canonically re-encoded. The wire message is preserved verbatim
+for forwarding. minip2p omits the key field because its Ed25519 public key is
+recoverable from the inline peer id.
+
+Delivered `PubsubEvent::Message` values include a `signed` flag. It is true
+only when a signature was present and verified. With `allow_unsigned`, accepted
+unsigned messages carry `signed = false`, so higher-level protocols can still
+require authentication independently of the router policy.

--- a/crates/pubsub/src/agent.rs
+++ b/crates/pubsub/src/agent.rs
@@ -23,7 +23,7 @@ use crate::message::{
     FLOODSUB_PROTOCOL_ID, FrameDecode, MAX_RPC_SIZE, MAX_TOPIC_LEN, RawMessage, Rpc, SubOpts,
     decode_frame, encode_frame,
 };
-use crate::seen::{MessageId, SeenCache};
+use crate::seen::{SeenCache, message_id};
 
 /// Longest possible frame prefix; bounds the inbound reassembly buffers.
 const MAX_PREFIX_LEN: usize = 10;
@@ -85,12 +85,14 @@ enum SendState {
     },
     /// Stream allocated; waiting for multistream negotiation.
     Negotiating {
+        send_token: PubsubToken,
         stream_id: StreamId,
         since_ms: u64,
         work: OutboundWork,
     },
     /// Frame written and write half closed; waiting for the close.
     AwaitingClose {
+        send_token: PubsubToken,
         stream_id: StreamId,
         since_ms: u64,
         work: OutboundWork,
@@ -270,7 +272,7 @@ impl FloodsubAgent {
         }
         self.next_seqno = self.next_seqno.wrapping_add(1);
 
-        let id: MessageId = (self.local_peer_id.to_bytes(), seqno.to_be_bytes().to_vec());
+        let id = message_id(&self.local_peer_id.to_bytes(), &seqno.to_be_bytes());
         self.seen.insert(
             id,
             now_ms,
@@ -332,33 +334,40 @@ impl FloodsubAgent {
         }
     }
 
-    /// Reports a synchronous failure of a [`PubsubAction::SendStream`].
-    ///
-    /// Without this feedback, the in-flight sender would sit in
-    /// `AwaitingClose` and the stream's eventual close would **commit**
-    /// work whose frame was never accepted by the swarm. The failed work
-    /// is discarded with an [`PubsubEvent::OutboundFailure`] and the
-    /// stream is reset; successful sends need no echo.
-    pub fn send_failed(&mut self, peer: &PeerId, stream_id: StreamId, reason: &str, now_ms: u64) {
+    /// Echoes the synchronous result of a [`PubsubAction::SendStream`].
+    /// Stale stream/token pairs are ignored. A matching success needs no
+    /// state transition for floodsub; close remains its commit point.
+    pub fn send_result(
+        &mut self,
+        peer: &PeerId,
+        stream_id: StreamId,
+        token: PubsubToken,
+        result: Result<(), String>,
+        now_ms: u64,
+    ) {
+        let is_current = self.peers.get(peer).is_some_and(|state| {
+            matches!(
+                &state.sender,
+                SendState::AwaitingClose {
+                    send_token,
+                    stream_id: expected,
+                    ..
+                } if *expected == stream_id && *send_token == token
+            )
+        });
+        if !is_current || result.is_ok() {
+            return;
+        }
+        let reason = result.expect_err("checked error");
         let Some(state) = self.peers.get_mut(peer) else {
             return;
         };
-        match core::mem::take(&mut state.sender) {
-            SendState::AwaitingClose {
-                stream_id: expected,
-                work,
-                ..
-            } if expected == stream_id => {
-                self.reject_stream(peer, stream_id);
-                self.fail_in_flight(peer, work, &format!("send failed: {reason}"));
-                self.drive_sender(peer, now_ms);
-            }
-            other => {
-                // Not the in-flight send (stale stream): leave the sender
-                // untouched.
-                state.sender = other;
-            }
-        }
+        let SendState::AwaitingClose { work, .. } = core::mem::take(&mut state.sender) else {
+            return;
+        };
+        self.reject_stream(peer, stream_id);
+        self.fail_in_flight(peer, work, &format!("send failed: {reason}"));
+        self.drive_sender(peer, now_ms);
     }
 
     /// Reports the result of a [`PubsubAction::OpenStream`]. `peer` and
@@ -393,7 +402,12 @@ impl FloodsubAgent {
         let Some(state) = self.peers.get_mut(peer) else {
             return;
         };
-        let SendState::Opening { since_ms, work, .. } = core::mem::take(&mut state.sender) else {
+        let SendState::Opening {
+            token: send_token,
+            since_ms,
+            work,
+        } = core::mem::take(&mut state.sender)
+        else {
             return;
         };
         match result {
@@ -402,6 +416,7 @@ impl FloodsubAgent {
                 // close): keep the original timestamp, or each state
                 // transition would grant the deadline anew.
                 state.sender = SendState::Negotiating {
+                    send_token,
                     stream_id,
                     since_ms,
                     work,
@@ -561,8 +576,14 @@ impl FloodsubAgent {
                 return self.owns_stream(peer, stream_id);
             };
             match core::mem::take(&mut state.sender) {
-                SendState::Negotiating { since_ms, work, .. } => {
+                SendState::Negotiating {
+                    send_token,
+                    since_ms,
+                    work,
+                    ..
+                } => {
                     self.actions.push_back(PubsubAction::SendStream {
+                        token: send_token,
                         peer: peer.clone(),
                         stream_id,
                         data: work.frame().to_vec(),
@@ -573,6 +594,7 @@ impl FloodsubAgent {
                     });
                     if let Some(state) = self.peers.get_mut(peer) {
                         state.sender = SendState::AwaitingClose {
+                            send_token,
                             stream_id,
                             since_ms,
                             work,
@@ -875,7 +897,7 @@ impl FloodsubAgent {
             }
         };
 
-        let id: MessageId = (from.to_bytes(), seqno.clone());
+        let id = message_id(&from.to_bytes(), &seqno);
         if self.seen.contains(&id) {
             return; // duplicate: silent
         }

--- a/crates/pubsub/src/engine.rs
+++ b/crates/pubsub/src/engine.rs
@@ -1,0 +1,246 @@
+//! Static dispatch across the supported pubsub routing engines.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use minip2p_core::PeerId;
+use minip2p_identity::Ed25519Keypair;
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::StreamId;
+
+use crate::{
+    FLOODSUB_PROTOCOL_ID, FloodsubAgent, FloodsubConfig, GossipsubAgent, GossipsubConfig,
+    MESHSUB_PROTOCOL_ID_V10, MESHSUB_PROTOCOL_ID_V11, PublishError, PubsubAction,
+    PubsubConfigError, PubsubEvent, PubsubToken, TopicError,
+};
+
+const FLOODSUB_PROTOCOLS: &[&str] = &[FLOODSUB_PROTOCOL_ID];
+const GOSSIPSUB_PROTOCOLS: &[&str] = &[MESHSUB_PROTOCOL_ID_V11, MESHSUB_PROTOCOL_ID_V10];
+
+/// Selects and configures the pubsub routing engine.
+#[derive(Clone, Debug)]
+pub enum PubsubConfig {
+    /// Mesh-based gossipsub routing.
+    Gossipsub(GossipsubConfig),
+    /// Flood-to-all-subscribers floodsub routing.
+    Floodsub(FloodsubConfig),
+}
+
+impl Default for PubsubConfig {
+    fn default() -> Self {
+        Self::Gossipsub(GossipsubConfig::default())
+    }
+}
+
+impl From<GossipsubConfig> for PubsubConfig {
+    fn from(config: GossipsubConfig) -> Self {
+        Self::Gossipsub(config)
+    }
+}
+
+impl From<FloodsubConfig> for PubsubConfig {
+    fn from(config: FloodsubConfig) -> Self {
+        Self::Floodsub(config)
+    }
+}
+
+impl PubsubConfig {
+    /// Protocol ids this engine must advertise, in preference order.
+    pub fn protocol_ids(&self) -> &'static [&'static str] {
+        match self {
+            Self::Gossipsub(_) => GOSSIPSUB_PROTOCOLS,
+            Self::Floodsub(_) => FLOODSUB_PROTOCOLS,
+        }
+    }
+
+    /// Validates engine-specific configuration.
+    pub fn validate(&self) -> Result<(), PubsubConfigError> {
+        match self {
+            Self::Gossipsub(config) => config.validate(),
+            Self::Floodsub(_) => Ok(()),
+        }
+    }
+}
+
+/// A statically dispatched pubsub router.
+// Keeping both concrete agents inline preserves the no-allocation dispatch
+// contract; their size difference is modest and this object is long-lived.
+#[allow(clippy::large_enum_variant)]
+pub enum PubsubAgent {
+    /// Gossipsub router.
+    Gossipsub(GossipsubAgent),
+    /// Floodsub router.
+    Floodsub(FloodsubAgent),
+}
+
+impl PubsubAgent {
+    /// Validates `config` and constructs its selected engine.
+    pub fn new(
+        keypair: Ed25519Keypair,
+        config: PubsubConfig,
+        initial_seqno: u64,
+        entropy_seed: u64,
+    ) -> Result<Self, PubsubConfigError> {
+        config.validate()?;
+        Ok(match config {
+            PubsubConfig::Gossipsub(config) => Self::Gossipsub(GossipsubAgent::new(
+                keypair,
+                config,
+                initial_seqno,
+                entropy_seed,
+            )),
+            PubsubConfig::Floodsub(config) => {
+                let _ = entropy_seed;
+                Self::Floodsub(FloodsubAgent::new(keypair, config, initial_seqno))
+            }
+        })
+    }
+
+    /// The peer id this agent publishes as.
+    pub fn local_peer_id(&self) -> &PeerId {
+        match self {
+            Self::Gossipsub(agent) => agent.local_peer_id(),
+            Self::Floodsub(agent) => agent.local_peer_id(),
+        }
+    }
+
+    /// Our current subscriptions.
+    pub fn subscriptions(&self) -> Vec<String> {
+        match self {
+            Self::Gossipsub(agent) => agent.subscriptions(),
+            Self::Floodsub(agent) => agent.subscriptions(),
+        }
+    }
+
+    /// Subscribes to a topic.
+    pub fn subscribe(&mut self, topic: &str, now_ms: u64) -> Result<bool, TopicError> {
+        match self {
+            Self::Gossipsub(agent) => agent.subscribe(topic, now_ms),
+            Self::Floodsub(agent) => agent.subscribe(topic, now_ms),
+        }
+    }
+
+    /// Unsubscribes from a topic.
+    pub fn unsubscribe(&mut self, topic: &str, now_ms: u64) -> bool {
+        match self {
+            Self::Gossipsub(agent) => agent.unsubscribe(topic, now_ms),
+            Self::Floodsub(agent) => agent.unsubscribe(topic, now_ms),
+        }
+    }
+
+    /// Publishes a message.
+    pub fn publish(&mut self, topic: &str, data: Vec<u8>, now_ms: u64) -> Result<(), PublishError> {
+        match self {
+            Self::Gossipsub(agent) => agent.publish(topic, data, now_ms),
+            Self::Floodsub(agent) => agent.publish(topic, data, now_ms),
+        }
+    }
+
+    /// Feeds a swarm event.
+    pub fn handle_event(&mut self, event: &SwarmEvent, now_ms: u64) -> bool {
+        match self {
+            Self::Gossipsub(agent) => agent.handle_event(event, now_ms),
+            Self::Floodsub(agent) => agent.handle_event(event, now_ms),
+        }
+    }
+
+    /// Echoes an outbound stream-open result.
+    pub fn stream_open_result(
+        &mut self,
+        peer: &PeerId,
+        token: PubsubToken,
+        result: Result<StreamId, String>,
+        now_ms: u64,
+    ) {
+        match self {
+            Self::Gossipsub(agent) => agent.stream_open_result(peer, token, result, now_ms),
+            Self::Floodsub(agent) => agent.stream_open_result(peer, token, result, now_ms),
+        }
+    }
+
+    /// Echoes a synchronous stream-write result.
+    pub fn send_result(
+        &mut self,
+        peer: &PeerId,
+        stream_id: StreamId,
+        token: PubsubToken,
+        result: Result<(), String>,
+        now_ms: u64,
+    ) {
+        match self {
+            Self::Gossipsub(agent) => agent.send_result(peer, stream_id, token, result, now_ms),
+            Self::Floodsub(agent) => agent.send_result(peer, stream_id, token, result, now_ms),
+        }
+    }
+
+    /// Advances engine timers.
+    pub fn handle_tick(&mut self, now_ms: u64) {
+        match self {
+            Self::Gossipsub(agent) => agent.handle_tick(now_ms),
+            Self::Floodsub(agent) => agent.handle_tick(now_ms),
+        }
+    }
+
+    /// Milliseconds until the next due timer.
+    pub fn next_timeout(&self, now_ms: u64) -> Option<u64> {
+        match self {
+            Self::Gossipsub(agent) => agent.next_timeout(now_ms),
+            Self::Floodsub(agent) => agent.next_timeout(now_ms),
+        }
+    }
+
+    /// Next driver action.
+    pub fn poll_action(&mut self) -> Option<PubsubAction> {
+        match self {
+            Self::Gossipsub(agent) => agent.poll_action(),
+            Self::Floodsub(agent) => agent.poll_action(),
+        }
+    }
+
+    /// Next application event.
+    pub fn poll_event(&mut self) -> Option<PubsubEvent> {
+        match self {
+            Self::Gossipsub(agent) => agent.poll_event(),
+            Self::Floodsub(agent) => agent.poll_event(),
+        }
+    }
+
+    /// Whether this engine owns a stream lifecycle.
+    pub fn owns_stream(&self, peer: &PeerId, stream_id: StreamId) -> bool {
+        match self {
+            Self::Gossipsub(agent) => agent.owns_stream(peer, stream_id),
+            Self::Floodsub(agent) => agent.owns_stream(peer, stream_id),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_selects_only_meshsub_protocols() {
+        assert_eq!(PubsubConfig::default().protocol_ids(), GOSSIPSUB_PROTOCOLS);
+        assert_eq!(
+            PubsubConfig::from(FloodsubConfig::default()).protocol_ids(),
+            FLOODSUB_PROTOCOLS
+        );
+    }
+
+    #[test]
+    fn constructor_rejects_invalid_gossipsub_config() {
+        let config = GossipsubConfig {
+            heartbeat_interval_ms: 0,
+            ..GossipsubConfig::default()
+        };
+        let error = PubsubAgent::new(
+            Ed25519Keypair::from_secret_key_bytes([1; 32]),
+            config.into(),
+            1,
+            2,
+        )
+        .err()
+        .expect("invalid config");
+        assert_eq!(error.field, "heartbeat_interval_ms");
+    }
+}

--- a/crates/pubsub/src/events.rs
+++ b/crates/pubsub/src/events.rs
@@ -7,8 +7,7 @@ use alloc::vec::Vec;
 use minip2p_core::PeerId;
 use minip2p_transport::StreamId;
 
-/// Correlates a [`PubsubAction::OpenStream`] with its
-/// [`FloodsubAgent::stream_open_result`](crate::FloodsubAgent::stream_open_result) echo.
+/// Correlates an outbound open or write with its agent result echo.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct PubsubToken(pub(crate) u64);
 
@@ -23,11 +22,15 @@ pub enum PubsubAction {
         token: PubsubToken,
         /// The peer to open toward.
         peer: PeerId,
-        /// Always [`FLOODSUB_PROTOCOL_ID`](crate::FLOODSUB_PROTOCOL_ID).
+        /// Engine-selected protocol id: floodsub or a meshsub version.
         protocol_id: String,
     },
-    /// Call `Swarm::send_stream(&peer, stream_id, data)`. Fire-and-forget.
+    /// Call `Swarm::send_stream(&peer, stream_id, data)` and synchronously
+    /// echo its result through `send_result`.
     SendStream {
+        /// Token the host echoes through `send_result` after attempting the
+        /// synchronous write.
+        token: PubsubToken,
         /// The stream's peer.
         peer: PeerId,
         /// The stream to write to.
@@ -83,10 +86,10 @@ pub enum PubsubEvent {
         /// The topic it unsubscribed from.
         topic: String,
     },
-    /// Already-accepted outbound work was discarded: per item for open
-    /// failures, send timeouts, and streams closed before the frame went
-    /// out; one aggregated event per peer when a disconnect or supersede
-    /// drops the queue (the reason names the dropped count).
+    /// Outbound work that never reached an accepted stream write was
+    /// discarded: per item for establishment failures/timeouts, or one
+    /// aggregate when a disconnect/supersede drops queued work. An accepted
+    /// write is committed; later delivery cannot be observed here.
     OutboundFailure {
         /// The peer the work was addressed to.
         peer: PeerId,
@@ -114,9 +117,8 @@ pub enum TopicError {
     /// Topics are bounded by [`MAX_TOPIC_LEN`](crate::MAX_TOPIC_LEN) bytes.
     #[error("topic exceeds the maximum length")]
     TooLong,
-    /// Adding this topic would make the encoded subscription snapshot
-    /// exceed half of [`MAX_RPC_SIZE`](crate::MAX_RPC_SIZE) — the bound
-    /// that keeps every snapshot/diff RPC inside one legal frame.
+    /// Floodsub only: adding this topic would make its single-frame encoded
+    /// subscription snapshot exceed half of [`MAX_RPC_SIZE`](crate::MAX_RPC_SIZE).
     #[error("the subscription set would no longer fit in one RPC")]
     SetTooLarge,
 }

--- a/crates/pubsub/src/gossipsub/agent.rs
+++ b/crates/pubsub/src/gossipsub/agent.rs
@@ -1,0 +1,1703 @@
+//! Deterministic, sans-I/O gossipsub routing and stream management.
+
+use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use minip2p_core::PeerId;
+use minip2p_identity::Ed25519Keypair;
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::StreamId;
+
+use super::config::GossipsubConfig;
+use super::mcache::MessageCache;
+use crate::events::{PublishError, PubsubAction, PubsubEvent, PubsubToken, TopicError};
+use crate::message::{
+    ControlGraft, ControlIHave, ControlIWant, ControlMessage, ControlPrune, FrameDecode,
+    MAX_RPC_SIZE, MAX_TOPIC_LEN, MESHSUB_PROTOCOL_ID_V10, MESHSUB_PROTOCOL_ID_V11, RawMessage, Rpc,
+    SubOpts, decode_frame, encode_frame,
+};
+use crate::seen::{MessageId, SeenCache, message_id};
+
+const MAX_PREFIX_LEN: usize = 10;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MeshsubVersion {
+    V10,
+    V11,
+}
+
+impl MeshsubVersion {
+    fn protocol_id(self) -> &'static str {
+        match self {
+            Self::V10 => MESHSUB_PROTOCOL_ID_V10,
+            Self::V11 => MESHSUB_PROTOCOL_ID_V11,
+        }
+    }
+
+    fn from_protocol_id(protocol_id: &str) -> Option<Self> {
+        match protocol_id {
+            MESHSUB_PROTOCOL_ID_V10 => Some(Self::V10),
+            MESHSUB_PROTOCOL_ID_V11 => Some(Self::V11),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StreamRole {
+    Outbound,
+    Inbound,
+    Rejected,
+}
+
+#[derive(Clone, Debug)]
+enum ControlItem {
+    Graft(String),
+    Prune { topic: String, backoff_ms: u64 },
+    IHave { topic: String, id: MessageId },
+    IWant(MessageId),
+}
+
+#[derive(Clone, Debug, Default)]
+struct ControlBuffer {
+    graft: BTreeSet<String>,
+    prune: BTreeMap<String, u64>,
+    ihave: BTreeMap<String, BTreeSet<MessageId>>,
+    iwant: BTreeSet<MessageId>,
+}
+
+impl ControlBuffer {
+    fn is_empty(&self) -> bool {
+        self.graft.is_empty()
+            && self.prune.is_empty()
+            && self.ihave.is_empty()
+            && self.iwant.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.graft.len()
+            + self.prune.len()
+            + self.ihave.values().map(BTreeSet::len).sum::<usize>()
+            + self.iwant.len()
+    }
+
+    fn push(&mut self, item: ControlItem) {
+        match item {
+            ControlItem::Graft(topic) => {
+                if !self.prune.contains_key(&topic) {
+                    self.graft.insert(topic);
+                }
+            }
+            ControlItem::Prune { topic, backoff_ms } => {
+                self.graft.remove(&topic);
+                self.prune.insert(topic, backoff_ms);
+            }
+            ControlItem::IHave { topic, id } => {
+                self.ihave.entry(topic).or_default().insert(id);
+            }
+            ControlItem::IWant(id) => {
+                self.iwant.insert(id);
+            }
+        }
+    }
+
+    fn merge(&mut self, items: Vec<ControlItem>) {
+        for item in items {
+            self.push(item);
+        }
+    }
+
+    fn pop_first(&mut self) -> Option<ControlItem> {
+        if let Some(topic) = self.graft.iter().next().cloned() {
+            self.graft.remove(&topic);
+            return Some(ControlItem::Graft(topic));
+        }
+        if let Some((topic, backoff_ms)) = self
+            .prune
+            .iter()
+            .next()
+            .map(|(topic, backoff)| (topic.clone(), *backoff))
+        {
+            self.prune.remove(&topic);
+            return Some(ControlItem::Prune { topic, backoff_ms });
+        }
+        if let Some((topic, id)) = self
+            .ihave
+            .iter()
+            .find_map(|(topic, ids)| ids.iter().next().cloned().map(|id| (topic.clone(), id)))
+        {
+            if let Some(ids) = self.ihave.get_mut(&topic) {
+                ids.remove(&id);
+                if ids.is_empty() {
+                    self.ihave.remove(&topic);
+                }
+            }
+            return Some(ControlItem::IHave { topic, id });
+        }
+        if let Some(id) = self.iwant.iter().next().cloned() {
+            self.iwant.remove(&id);
+            return Some(ControlItem::IWant(id));
+        }
+        None
+    }
+
+    fn take_frame(&mut self, version: MeshsubVersion) -> Option<(Vec<u8>, Vec<ControlItem>)> {
+        if self.is_empty() {
+            return None;
+        }
+        let mut items = Vec::new();
+        while let Some(item) = self.pop_first() {
+            items.push(item);
+            let body = encode_control_items(&items, version);
+            if body.len() > MAX_RPC_SIZE {
+                let item = items.pop().expect("just pushed");
+                self.push(item);
+                break;
+            }
+        }
+        if items.is_empty() {
+            // This can only be reached for a hostile, nearly-frame-sized
+            // message id. Such ids are filtered before entering the buffer.
+            return None;
+        }
+        Some((encode_control_items(&items, version), items))
+    }
+}
+
+fn encode_control_items(items: &[ControlItem], version: MeshsubVersion) -> Vec<u8> {
+    let mut control = ControlMessage::default();
+    for item in items {
+        match item {
+            ControlItem::Graft(topic) => control.graft.push(ControlGraft {
+                topic_id: Some(topic.clone()),
+            }),
+            ControlItem::Prune { topic, backoff_ms } => control.prune.push(ControlPrune {
+                topic_id: Some(topic.clone()),
+                peers: Vec::new(),
+                backoff: (version == MeshsubVersion::V11)
+                    .then_some(backoff_ms.saturating_add(999) / 1_000),
+            }),
+            ControlItem::IHave { topic, id } => {
+                if let Some(last) = control.ihave.last_mut()
+                    && last.topic_id.as_deref() == Some(topic.as_str())
+                {
+                    last.message_ids.push(id.clone());
+                } else {
+                    control.ihave.push(ControlIHave {
+                        topic_id: Some(topic.clone()),
+                        message_ids: alloc::vec![id.clone()],
+                    });
+                }
+            }
+            ControlItem::IWant(id) => {
+                if let Some(iwant) = control.iwant.first_mut() {
+                    iwant.message_ids.push(id.clone());
+                } else {
+                    control.iwant.push(ControlIWant {
+                        message_ids: alloc::vec![id.clone()],
+                    });
+                }
+            }
+        }
+    }
+    Rpc {
+        subscriptions: Vec::new(),
+        publish: Vec::new(),
+        control: Some(control),
+    }
+    .encode()
+}
+
+#[derive(Clone, Debug)]
+enum FrameCommit {
+    Subscriptions(Vec<SubOpts>),
+    Control(Vec<ControlItem>),
+    Message,
+}
+
+#[derive(Clone, Debug, Default)]
+enum SendState {
+    #[default]
+    Idle,
+    Opening {
+        token: PubsubToken,
+        since_ms: u64,
+    },
+    Negotiating {
+        stream_id: StreamId,
+        since_ms: u64,
+    },
+    Ready {
+        stream_id: StreamId,
+        in_flight: Option<(PubsubToken, FrameCommit)>,
+    },
+}
+
+impl SendState {
+    fn establishment_since(&self) -> Option<u64> {
+        match self {
+            Self::Opening { since_ms, .. } | Self::Negotiating { since_ms, .. } => Some(*since_ms),
+            Self::Idle | Self::Ready { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct PeerState {
+    sender: SendState,
+    pending_messages: VecDeque<Vec<u8>>,
+    acknowledged_topics: BTreeSet<String>,
+    announced_topics: BTreeSet<String>,
+    subscription_queue: VecDeque<SubOpts>,
+    inbound: BTreeMap<StreamId, Vec<u8>>,
+    remote_topics: BTreeSet<String>,
+    advertised_version: Option<MeshsubVersion>,
+    outbound_version: Option<MeshsubVersion>,
+    pending_control: ControlBuffer,
+}
+
+impl PeerState {
+    fn queued_work(&self, topics: &BTreeSet<String>) -> usize {
+        self.pending_messages.len()
+            + self.pending_control.len()
+            + usize::from(
+                self.acknowledged_topics != *topics || !self.subscription_queue.is_empty(),
+            )
+    }
+}
+
+/// A deterministic, sans-I/O gossipsub router supporting meshsub v1.0 and
+/// the v1.1 PRUNE backoff extension.
+pub struct GossipsubAgent {
+    keypair: Ed25519Keypair,
+    local_peer_id: PeerId,
+    config: GossipsubConfig,
+    actions: VecDeque<PubsubAction>,
+    events: VecDeque<PubsubEvent>,
+    topics: BTreeSet<String>,
+    peers: BTreeMap<PeerId, PeerState>,
+    roles: BTreeMap<PeerId, BTreeMap<StreamId, StreamRole>>,
+    mesh: BTreeMap<String, BTreeSet<PeerId>>,
+    fanout: BTreeMap<String, BTreeSet<PeerId>>,
+    fanout_last_pub: BTreeMap<String, u64>,
+    backoff: BTreeMap<(String, PeerId), u64>,
+    mcache: MessageCache,
+    seen: SeenCache,
+    iwant_requested: BTreeSet<MessageId>,
+    ihave_budget: BTreeMap<PeerId, usize>,
+    iwant_served: BTreeMap<PeerId, usize>,
+    next_heartbeat_ms: Option<u64>,
+    next_token: u64,
+    next_seqno: u64,
+    rng: SplitMix64,
+}
+
+impl GossipsubAgent {
+    /// Creates a router. `initial_seqno` must not repeat across restarts;
+    /// `entropy_seed` controls deterministic peer selection. Call
+    /// [`GossipsubConfig::validate`] first when constructing this concrete
+    /// agent directly; [`PubsubAgent::new`](crate::PubsubAgent::new) does so
+    /// automatically.
+    pub fn new(
+        keypair: Ed25519Keypair,
+        config: GossipsubConfig,
+        initial_seqno: u64,
+        entropy_seed: u64,
+    ) -> Self {
+        let local_peer_id = keypair.peer_id();
+        let mcache = MessageCache::new(config.mcache_len, config.max_mcache_messages);
+        Self {
+            keypair,
+            local_peer_id,
+            config,
+            actions: VecDeque::new(),
+            events: VecDeque::new(),
+            topics: BTreeSet::new(),
+            peers: BTreeMap::new(),
+            roles: BTreeMap::new(),
+            mesh: BTreeMap::new(),
+            fanout: BTreeMap::new(),
+            fanout_last_pub: BTreeMap::new(),
+            backoff: BTreeMap::new(),
+            mcache,
+            seen: SeenCache::default(),
+            iwant_requested: BTreeSet::new(),
+            ihave_budget: BTreeMap::new(),
+            iwant_served: BTreeMap::new(),
+            next_heartbeat_ms: None,
+            next_token: 0,
+            next_seqno: initial_seqno,
+            rng: SplitMix64::new(entropy_seed),
+        }
+    }
+
+    /// The peer id this agent publishes as.
+    pub fn local_peer_id(&self) -> &PeerId {
+        &self.local_peer_id
+    }
+
+    /// Our current subscriptions.
+    pub fn subscriptions(&self) -> Vec<String> {
+        self.topics.iter().cloned().collect()
+    }
+
+    /// Current mesh peers for `topic`, in deterministic peer-id order.
+    pub fn mesh_peers(&self, topic: &str) -> Vec<PeerId> {
+        self.mesh
+            .get(topic)
+            .map(|peers| peers.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Joins a topic and immediately promotes already-known eligible peers.
+    pub fn subscribe(&mut self, topic: &str, now_ms: u64) -> Result<bool, TopicError> {
+        validate_topic(topic)?;
+        if !self.topics.insert(String::from(topic)) {
+            return Ok(false);
+        }
+
+        let mut selected = self.fanout.remove(topic).unwrap_or_default();
+        selected.retain(|peer| self.peer_is_eligible(peer, topic, now_ms));
+        if selected.len() > self.config.d {
+            let keep = self.select_peers(selected.iter().cloned().collect(), self.config.d);
+            selected = keep.into_iter().collect();
+        }
+        if selected.len() < self.config.d {
+            let candidates = self
+                .eligible_topic_peers(topic, now_ms)
+                .into_iter()
+                .filter(|peer| !selected.contains(peer))
+                .collect();
+            for peer in self.select_peers(candidates, self.config.d - selected.len()) {
+                selected.insert(peer);
+            }
+        }
+        self.fanout_last_pub.remove(topic);
+        for peer in &selected {
+            self.queue_control(peer, ControlItem::Graft(String::from(topic)), now_ms);
+        }
+        self.mesh.insert(String::from(topic), selected);
+        self.drive_all_senders(now_ms);
+        Ok(true)
+    }
+
+    /// Leaves a topic and PRUNEs every current mesh member.
+    pub fn unsubscribe(&mut self, topic: &str, now_ms: u64) -> bool {
+        if !self.topics.remove(topic) {
+            return false;
+        }
+        let peers = self.mesh.remove(topic).unwrap_or_default();
+        for peer in peers {
+            self.record_backoff(topic, &peer, self.config.unsubscribe_backoff_ms, now_ms);
+            self.queue_control(
+                &peer,
+                ControlItem::Prune {
+                    topic: String::from(topic),
+                    backoff_ms: self.config.unsubscribe_backoff_ms,
+                },
+                now_ms,
+            );
+        }
+        self.drive_all_senders(now_ms);
+        true
+    }
+
+    /// Publishes a signed message using mesh, empty-mesh fallback, or fanout.
+    pub fn publish(&mut self, topic: &str, data: Vec<u8>, now_ms: u64) -> Result<(), PublishError> {
+        self.arm_heartbeat(now_ms);
+        validate_topic(topic).map_err(PublishError::Topic)?;
+
+        let recipients = if self.topics.contains(topic) {
+            let mesh = self.mesh.get(topic).cloned().unwrap_or_default();
+            if mesh.is_empty() {
+                let candidates = self.eligible_topic_peers(topic, now_ms);
+                self.select_peers(candidates, self.config.d)
+            } else {
+                mesh.into_iter().collect()
+            }
+        } else {
+            self.select_fanout(topic, now_ms)
+        };
+        if recipients.iter().any(|peer| {
+            self.peers.get(peer).is_some_and(|state| {
+                state.pending_messages.len() >= self.config.max_pending_per_peer
+            })
+        }) {
+            return Err(PublishError::Backpressure);
+        }
+
+        let seqno = self.next_seqno;
+        let message = RawMessage::build_signed(&self.keypair, topic, data, seqno);
+        let body = Rpc {
+            subscriptions: Vec::new(),
+            publish: alloc::vec![message.clone()],
+            control: None,
+        }
+        .encode();
+        if body.len() > MAX_RPC_SIZE {
+            return Err(PublishError::TooLarge);
+        }
+        self.next_seqno = self.next_seqno.wrapping_add(1);
+        let id = message_id(&self.local_peer_id.to_bytes(), &seqno.to_be_bytes());
+        self.seen.insert(
+            id.clone(),
+            now_ms,
+            self.config.seen_ttl_ms,
+            self.config.max_seen_messages,
+        );
+        self.mcache
+            .put(id, message, alloc::vec![String::from(topic)]);
+
+        let frame = encode_frame(&body);
+        for peer in recipients {
+            if let Some(state) = self.peers.get_mut(&peer) {
+                state.pending_messages.push_back(frame.clone());
+            }
+            self.drive_sender(&peer, now_ms);
+        }
+        Ok(())
+    }
+
+    /// Feeds one swarm event. Returns whether this agent owns the event.
+    pub fn handle_event(&mut self, event: &SwarmEvent, now_ms: u64) -> bool {
+        self.arm_heartbeat(now_ms);
+        match event {
+            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                self.on_connection_established(peer_id);
+                false
+            }
+            SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                self.remove_peer(peer_id, "connection closed");
+                false
+            }
+            SwarmEvent::PeerReady { peer_id, protocols } => {
+                let version = if protocols.iter().any(|p| p == MESHSUB_PROTOCOL_ID_V11) {
+                    Some(MeshsubVersion::V11)
+                } else if protocols.iter().any(|p| p == MESHSUB_PROTOCOL_ID_V10) {
+                    Some(MeshsubVersion::V10)
+                } else {
+                    None
+                };
+                if let Some(version) = version {
+                    self.peers
+                        .entry(peer_id.clone())
+                        .or_default()
+                        .advertised_version = Some(version);
+                    self.drive_sender(peer_id, now_ms);
+                }
+                false
+            }
+            SwarmEvent::StreamReady {
+                peer_id,
+                stream_id,
+                protocol_id,
+                initiated_locally,
+                ..
+            } => self.on_stream_ready(peer_id, *stream_id, protocol_id, *initiated_locally, now_ms),
+            SwarmEvent::StreamData {
+                peer_id,
+                stream_id,
+                data,
+                ..
+            } => self.on_stream_data(peer_id, *stream_id, data, now_ms),
+            SwarmEvent::StreamRemoteWriteClosed {
+                peer_id, stream_id, ..
+            } => self.on_remote_write_closed(peer_id, *stream_id),
+            SwarmEvent::StreamClosed {
+                peer_id, stream_id, ..
+            } => self.on_stream_closed(peer_id, *stream_id),
+            _ => false,
+        }
+    }
+
+    /// Echoes a synchronous stream-write result.
+    pub fn send_result(
+        &mut self,
+        peer: &PeerId,
+        stream_id: StreamId,
+        token: PubsubToken,
+        result: Result<(), String>,
+        now_ms: u64,
+    ) {
+        let current = self.peers.get(peer).is_some_and(|state| {
+            matches!(
+                &state.sender,
+                SendState::Ready {
+                    stream_id: expected,
+                    in_flight: Some((expected_token, _)),
+                } if *expected == stream_id && *expected_token == token
+            )
+        });
+        if !current {
+            return;
+        }
+        let commit = {
+            let state = self.peers.get_mut(peer).expect("checked above");
+            let SendState::Ready { in_flight, .. } = &mut state.sender else {
+                return;
+            };
+            in_flight.take().expect("checked above").1
+        };
+        match result {
+            Ok(()) => {
+                self.commit_frame(peer, commit);
+                self.drive_sender(peer, now_ms);
+            }
+            Err(reason) => {
+                self.restore_commit(peer, commit);
+                self.actions.push_back(PubsubAction::ResetStream {
+                    peer: peer.clone(),
+                    stream_id,
+                });
+                if let Some(state) = self.peers.get_mut(peer) {
+                    state.sender = SendState::Idle;
+                    state.outbound_version = None;
+                    state.subscription_queue.clear();
+                }
+                self.events.push_back(PubsubEvent::OutboundFailure {
+                    peer: peer.clone(),
+                    reason: format!("send failed: {reason}"),
+                });
+            }
+        }
+    }
+
+    /// Echoes an outbound open result.
+    pub fn stream_open_result(
+        &mut self,
+        peer: &PeerId,
+        token: PubsubToken,
+        result: Result<StreamId, String>,
+        _now_ms: u64,
+    ) {
+        let current = self.peers.get(peer).is_some_and(|state| {
+            matches!(&state.sender, SendState::Opening { token: expected, .. } if *expected == token)
+        });
+        if !current {
+            if let Ok(stream_id) = result {
+                self.reject_stream(peer, stream_id);
+            }
+            return;
+        }
+        let since_ms = match &self.peers.get(peer).expect("checked").sender {
+            SendState::Opening { since_ms, .. } => *since_ms,
+            _ => return,
+        };
+        match result {
+            Ok(stream_id) => {
+                if let Some(state) = self.peers.get_mut(peer) {
+                    state.sender = SendState::Negotiating {
+                        stream_id,
+                        since_ms,
+                    };
+                }
+                self.roles
+                    .entry(peer.clone())
+                    .or_default()
+                    .insert(stream_id, StreamRole::Outbound);
+            }
+            Err(reason) => {
+                if let Some(state) = self.peers.get_mut(peer) {
+                    state.sender = SendState::Idle;
+                }
+                self.events.push_back(PubsubEvent::OutboundFailure {
+                    peer: peer.clone(),
+                    reason: format!("open failed: {reason}"),
+                });
+            }
+        }
+    }
+
+    /// Advances establishment timeouts and due heartbeats.
+    pub fn handle_tick(&mut self, now_ms: u64) {
+        let was_unarmed = self.next_heartbeat_ms.is_none();
+        self.arm_heartbeat(now_ms);
+        self.seen.gc(now_ms);
+
+        let timed_out: Vec<(PeerId, Option<StreamId>)> = self
+            .peers
+            .iter()
+            .filter_map(|(peer, state)| {
+                let since = state.sender.establishment_since()?;
+                (now_ms.saturating_sub(since) >= self.config.send_timeout_ms).then(|| {
+                    let stream = match state.sender {
+                        SendState::Negotiating { stream_id, .. } => Some(stream_id),
+                        _ => None,
+                    };
+                    (peer.clone(), stream)
+                })
+            })
+            .collect();
+        for (peer, stream) in timed_out {
+            if let Some(stream_id) = stream {
+                self.reject_stream(&peer, stream_id);
+            }
+            if let Some(state) = self.peers.get_mut(&peer) {
+                state.sender = SendState::Idle;
+                state.outbound_version = None;
+                state.subscription_queue.clear();
+            }
+            self.events.push_back(PubsubEvent::OutboundFailure {
+                peer,
+                reason: "stream establishment timed out".to_string(),
+            });
+        }
+
+        if !was_unarmed && self.next_heartbeat_ms.is_some_and(|due| now_ms >= due) {
+            self.heartbeat(now_ms);
+            self.next_heartbeat_ms = Some(now_ms.saturating_add(self.config.heartbeat_interval_ms));
+        }
+    }
+
+    /// Next action for the driver.
+    pub fn poll_action(&mut self) -> Option<PubsubAction> {
+        self.actions.pop_front()
+    }
+
+    /// Next application event.
+    pub fn poll_event(&mut self) -> Option<PubsubEvent> {
+        self.events.pop_front()
+    }
+
+    /// Milliseconds until the next due timer.
+    pub fn next_timeout(&self, now_ms: u64) -> Option<u64> {
+        let mut due = self.next_heartbeat_ms;
+        if let Some(expiry) = self.seen.next_expiry() {
+            due = Some(due.map_or(expiry, |current| current.min(expiry)));
+        }
+        for state in self.peers.values() {
+            if let Some(since) = state.sender.establishment_since() {
+                let expiry = since.saturating_add(self.config.send_timeout_ms);
+                due = Some(due.map_or(expiry, |current| current.min(expiry)));
+            }
+        }
+        due.map(|deadline| deadline.saturating_sub(now_ms))
+    }
+
+    /// Whether this agent owns a stream lifecycle.
+    pub fn owns_stream(&self, peer: &PeerId, stream_id: StreamId) -> bool {
+        self.roles
+            .get(peer)
+            .is_some_and(|streams| streams.contains_key(&stream_id))
+    }
+
+    fn arm_heartbeat(&mut self, now_ms: u64) {
+        if self.next_heartbeat_ms.is_none() {
+            self.next_heartbeat_ms = Some(now_ms.saturating_add(self.config.heartbeat_interval_ms));
+        }
+    }
+
+    fn on_connection_established(&mut self, peer: &PeerId) {
+        if self.peers.contains_key(peer) {
+            self.remove_peer(peer, "connection superseded");
+            self.peers.insert(peer.clone(), PeerState::default());
+        }
+    }
+
+    fn remove_peer(&mut self, peer: &PeerId, cause: &str) {
+        if let Some(state) = self.peers.get(peer) {
+            let dropped = state.queued_work(&self.topics);
+            if dropped > 0 {
+                self.events.push_back(PubsubEvent::OutboundFailure {
+                    peer: peer.clone(),
+                    reason: format!("{cause}; dropped {dropped} queued items"),
+                });
+            }
+        }
+        self.peers.remove(peer);
+        self.roles.remove(peer);
+        self.ihave_budget.remove(peer);
+        self.iwant_served.remove(peer);
+        for peers in self.mesh.values_mut() {
+            peers.remove(peer);
+        }
+        for peers in self.fanout.values_mut() {
+            peers.remove(peer);
+        }
+    }
+
+    fn on_stream_ready(
+        &mut self,
+        peer: &PeerId,
+        stream_id: StreamId,
+        protocol_id: &str,
+        initiated_locally: bool,
+        now_ms: u64,
+    ) -> bool {
+        let Some(version) = MeshsubVersion::from_protocol_id(protocol_id) else {
+            return self.owns_stream(peer, stream_id);
+        };
+        if initiated_locally {
+            let ours = self.peers.get(peer).is_some_and(|state| {
+                matches!(&state.sender, SendState::Negotiating { stream_id: expected, .. } if *expected == stream_id)
+            });
+            if !ours {
+                return self.owns_stream(peer, stream_id);
+            }
+            let current_topics: Vec<String> = self.topics.iter().cloned().collect();
+            if let Some(state) = self.peers.get_mut(peer) {
+                state.outbound_version = Some(version);
+                state.subscription_queue.clear();
+                for topic in current_topics {
+                    state.subscription_queue.push_back(SubOpts {
+                        subscribe: Some(true),
+                        topic_id: Some(topic),
+                    });
+                }
+                let withdrawals: Vec<String> = state
+                    .announced_topics
+                    .difference(&self.topics)
+                    .cloned()
+                    .collect();
+                for topic in withdrawals {
+                    state.subscription_queue.push_back(SubOpts {
+                        subscribe: Some(false),
+                        topic_id: Some(topic),
+                    });
+                }
+                state.sender = SendState::Ready {
+                    stream_id,
+                    in_flight: None,
+                };
+            }
+            self.drive_sender(peer, now_ms);
+            return true;
+        }
+
+        let state = self.peers.entry(peer.clone()).or_default();
+        if state.inbound.len() >= self.config.max_inbound_streams_per_peer {
+            self.events.push_back(PubsubEvent::ProtocolViolation {
+                peer: peer.clone(),
+                reason: "too many concurrent inbound streams".to_string(),
+            });
+            self.reject_stream(peer, stream_id);
+            return true;
+        }
+        state.inbound.insert(stream_id, Vec::new());
+        self.roles
+            .entry(peer.clone())
+            .or_default()
+            .insert(stream_id, StreamRole::Inbound);
+        true
+    }
+
+    fn on_stream_data(
+        &mut self,
+        peer: &PeerId,
+        stream_id: StreamId,
+        data: &[u8],
+        now_ms: u64,
+    ) -> bool {
+        match self.role(peer, stream_id) {
+            Some(StreamRole::Inbound) => {}
+            Some(_) => return true,
+            None => return false,
+        }
+        const CAP: usize = MAX_RPC_SIZE + MAX_PREFIX_LEN;
+        let mut offset = 0;
+        while offset < data.len() {
+            let Some(buf) = self
+                .peers
+                .get_mut(peer)
+                .and_then(|state| state.inbound.get_mut(&stream_id))
+            else {
+                return true;
+            };
+            let room = CAP.saturating_sub(buf.len());
+            if room == 0 {
+                self.violation_reset(peer, stream_id, "inbound buffer overflow");
+                return true;
+            }
+            let take = room.min(data.len() - offset);
+            buf.extend_from_slice(&data[offset..offset + take]);
+            offset += take;
+
+            let mut head = 0;
+            while let Some(step) = self.take_frame(peer, stream_id, &mut head) {
+                match step {
+                    Ok(payload) => match Rpc::decode(&payload) {
+                        Ok(rpc) => {
+                            if !self.process_rpc(peer, stream_id, rpc, now_ms) {
+                                return true;
+                            }
+                        }
+                        Err(error) => {
+                            self.violation_reset(
+                                peer,
+                                stream_id,
+                                &format!("malformed RPC: {error}"),
+                            );
+                            return true;
+                        }
+                    },
+                    Err(reason) => {
+                        self.violation_reset(peer, stream_id, &reason);
+                        return true;
+                    }
+                }
+            }
+            if head > 0
+                && let Some(buf) = self
+                    .peers
+                    .get_mut(peer)
+                    .and_then(|state| state.inbound.get_mut(&stream_id))
+            {
+                buf.drain(..head);
+            }
+        }
+        true
+    }
+
+    fn take_frame(
+        &mut self,
+        peer: &PeerId,
+        stream_id: StreamId,
+        head: &mut usize,
+    ) -> Option<Result<Vec<u8>, String>> {
+        let buf = self.peers.get_mut(peer)?.inbound.get_mut(&stream_id)?;
+        match decode_frame(&buf[*head..]) {
+            FrameDecode::Complete { payload, consumed } => {
+                let payload = payload.to_vec();
+                *head += consumed;
+                Some(Ok(payload))
+            }
+            FrameDecode::Incomplete => None,
+            FrameDecode::TooLarge { len } => Some(Err(format!("frame of {len} bytes"))),
+            FrameDecode::Error(error) => Some(Err(format!("malformed frame: {error}"))),
+        }
+    }
+
+    fn on_remote_write_closed(&mut self, peer: &PeerId, stream_id: StreamId) -> bool {
+        match self.role(peer, stream_id) {
+            Some(StreamRole::Inbound) => {}
+            Some(_) => return true,
+            None => return false,
+        }
+        let leftover = self
+            .peers
+            .get_mut(peer)
+            .and_then(|state| state.inbound.remove(&stream_id))
+            .is_some_and(|buf| !buf.is_empty());
+        if leftover {
+            self.violation_reset(peer, stream_id, "EOF inside a frame");
+        } else {
+            self.actions.push_back(PubsubAction::CloseStreamWrite {
+                peer: peer.clone(),
+                stream_id,
+            });
+        }
+        true
+    }
+
+    fn on_stream_closed(&mut self, peer: &PeerId, stream_id: StreamId) -> bool {
+        let Some(role) = self.role(peer, stream_id) else {
+            return false;
+        };
+        if let Some(streams) = self.roles.get_mut(peer) {
+            streams.remove(&stream_id);
+            if streams.is_empty() {
+                self.roles.remove(peer);
+            }
+        }
+        match role {
+            StreamRole::Outbound => {
+                let (commit, failed_establishment) = self
+                    .peers
+                    .get_mut(peer)
+                    .map(|state| {
+                        let sender = core::mem::take(&mut state.sender);
+                        state.outbound_version = None;
+                        state.subscription_queue.clear();
+                        match sender {
+                            SendState::Ready {
+                                stream_id: expected,
+                                in_flight,
+                            } if expected == stream_id => {
+                                (in_flight.map(|(_, commit)| commit), false)
+                            }
+                            SendState::Negotiating {
+                                stream_id: expected,
+                                ..
+                            } if expected == stream_id => (None, true),
+                            other => {
+                                state.sender = other;
+                                (None, false)
+                            }
+                        }
+                    })
+                    .unwrap_or((None, false));
+                if let Some(commit) = commit {
+                    self.restore_commit(peer, commit);
+                }
+                if failed_establishment {
+                    self.events.push_back(PubsubEvent::OutboundFailure {
+                        peer: peer.clone(),
+                        reason: "stream closed during negotiation".to_string(),
+                    });
+                }
+            }
+            StreamRole::Inbound => {
+                if let Some(state) = self.peers.get_mut(peer) {
+                    state.inbound.remove(&stream_id);
+                }
+            }
+            StreamRole::Rejected => {}
+        }
+        true
+    }
+
+    fn process_rpc(&mut self, peer: &PeerId, stream_id: StreamId, rpc: Rpc, now_ms: u64) -> bool {
+        if !self.apply_subscriptions(peer, stream_id, &rpc.subscriptions) {
+            return false;
+        }
+        for message in rpc.publish {
+            self.process_message(peer, message, now_ms);
+        }
+        if let Some(control) = rpc.control {
+            self.process_control(peer, control, now_ms);
+        }
+        self.drive_sender(peer, now_ms);
+        true
+    }
+
+    fn apply_subscriptions(
+        &mut self,
+        peer: &PeerId,
+        stream_id: StreamId,
+        subscriptions: &[SubOpts],
+    ) -> bool {
+        if subscriptions.is_empty() {
+            return true;
+        }
+        let Some(state) = self.peers.get_mut(peer) else {
+            return true;
+        };
+        let mut candidate = state.remote_topics.clone();
+        let mut invalid = false;
+        for sub in subscriptions {
+            let (Some(subscribe), Some(topic)) = (sub.subscribe, sub.topic_id.as_ref()) else {
+                continue;
+            };
+            if validate_topic(topic).is_err() {
+                invalid = true;
+                continue;
+            }
+            if subscribe {
+                candidate.insert(topic.clone());
+            } else {
+                candidate.remove(topic);
+            }
+        }
+        if candidate.len() > self.config.max_topics_per_peer {
+            self.violation_reset(peer, stream_id, "subscription set exceeds the bound");
+            return false;
+        }
+        let added: Vec<String> = candidate
+            .difference(&state.remote_topics)
+            .cloned()
+            .collect();
+        let removed: Vec<String> = state
+            .remote_topics
+            .difference(&candidate)
+            .cloned()
+            .collect();
+        state.remote_topics = candidate;
+        if invalid {
+            self.events.push_back(PubsubEvent::ProtocolViolation {
+                peer: peer.clone(),
+                reason: "subscription entries with invalid topics skipped".to_string(),
+            });
+        }
+        for topic in added {
+            self.events.push_back(PubsubEvent::PeerSubscribed {
+                peer: peer.clone(),
+                topic,
+            });
+        }
+        for topic in removed {
+            if let Some(mesh) = self.mesh.get_mut(&topic) {
+                mesh.remove(peer);
+            }
+            if let Some(fanout) = self.fanout.get_mut(&topic) {
+                fanout.remove(peer);
+            }
+            self.events.push_back(PubsubEvent::PeerUnsubscribed {
+                peer: peer.clone(),
+                topic,
+            });
+        }
+        true
+    }
+
+    fn process_control(&mut self, peer: &PeerId, control: ControlMessage, now_ms: u64) {
+        for graft in control.graft {
+            let Some(topic) = graft.topic_id else {
+                continue;
+            };
+            if !self.topics.contains(&topic) {
+                continue;
+            }
+            if self.is_backed_off(&topic, peer, now_ms) {
+                self.record_backoff(&topic, peer, self.config.prune_backoff_ms, now_ms);
+                self.queue_control(
+                    peer,
+                    ControlItem::Prune {
+                        topic,
+                        backoff_ms: self.config.prune_backoff_ms,
+                    },
+                    now_ms,
+                );
+            } else {
+                self.mesh.entry(topic).or_default().insert(peer.clone());
+            }
+        }
+        for prune in control.prune {
+            let Some(topic) = prune.topic_id else {
+                continue;
+            };
+            if validate_topic(&topic).is_err() || !self.topics.contains(&topic) {
+                continue;
+            }
+            if let Some(mesh) = self.mesh.get_mut(&topic) {
+                mesh.remove(peer);
+            }
+            let supplied = prune.backoff.unwrap_or(0).saturating_mul(1_000);
+            let backoff = if supplied == 0 {
+                self.config.prune_backoff_ms
+            } else {
+                supplied.min(self.config.max_backoff_ms)
+            };
+            self.record_backoff(&topic, peer, backoff, now_ms);
+        }
+        for ihave in control.ihave {
+            let count = self.ihave_budget.entry(peer.clone()).or_default();
+            if *count >= self.config.max_ihave_messages_per_heartbeat {
+                continue;
+            }
+            *count += 1;
+            let mut requested = Vec::new();
+            for id in ihave
+                .message_ids
+                .into_iter()
+                .take(self.config.max_ihave_length)
+            {
+                if self.iwant_requested.len() >= self.config.max_iwant_ids_per_heartbeat {
+                    break;
+                }
+                if self.seen.contains(&id) || self.iwant_requested.contains(&id) {
+                    continue;
+                }
+                if !control_item_fits(&ControlItem::IWant(id.clone())) {
+                    continue;
+                }
+                self.iwant_requested.insert(id.clone());
+                requested.push(id);
+            }
+            for id in requested {
+                self.queue_control(peer, ControlItem::IWant(id), now_ms);
+            }
+        }
+        for iwant in control.iwant {
+            for id in iwant.message_ids {
+                let served = *self.iwant_served.get(peer).unwrap_or(&0);
+                if served >= self.config.max_iwant_serves_per_heartbeat {
+                    break;
+                }
+                let Some(message) = self.mcache.get(&id).cloned() else {
+                    continue;
+                };
+                let body = Rpc {
+                    subscriptions: Vec::new(),
+                    publish: alloc::vec![message],
+                    control: None,
+                }
+                .encode();
+                if body.len() <= MAX_RPC_SIZE && self.queue_message(peer, encode_frame(&body)) {
+                    *self.iwant_served.entry(peer.clone()).or_default() += 1;
+                }
+            }
+        }
+    }
+
+    fn process_message(&mut self, arrival: &PeerId, message: RawMessage, now_ms: u64) {
+        let (from, seqno, signed) = match message.verify(self.config.allow_unsigned) {
+            Ok(value) => value,
+            Err(error) => {
+                self.events.push_back(PubsubEvent::ProtocolViolation {
+                    peer: arrival.clone(),
+                    reason: format!("message rejected: {error}"),
+                });
+                return;
+            }
+        };
+        let id = message_id(&from.to_bytes(), &seqno);
+        if self.seen.contains(&id) {
+            return;
+        }
+        self.seen.insert(
+            id.clone(),
+            now_ms,
+            self.config.seen_ttl_ms,
+            self.config.max_seen_messages,
+        );
+        if message
+            .topic_ids
+            .iter()
+            .any(|topic| self.topics.contains(topic))
+        {
+            self.events.push_back(PubsubEvent::Message {
+                from: from.clone(),
+                topics: message.topic_ids.clone(),
+                data: message.data.clone().unwrap_or_default(),
+                seqno,
+                signed,
+            });
+        }
+
+        let recipients: BTreeSet<PeerId> = message
+            .topic_ids
+            .iter()
+            .filter_map(|topic| self.mesh.get(topic))
+            .flatten()
+            .filter(|peer| **peer != *arrival && **peer != from)
+            .cloned()
+            .collect();
+        let frame = encode_frame(
+            &Rpc {
+                subscriptions: Vec::new(),
+                publish: alloc::vec![message.clone()],
+                control: None,
+            }
+            .encode(),
+        );
+        for peer in recipients {
+            if self.queue_message(&peer, frame.clone()) {
+                self.drive_sender(&peer, now_ms);
+            }
+        }
+        self.mcache.put(id, message.clone(), message.topic_ids);
+    }
+
+    fn heartbeat(&mut self, now_ms: u64) {
+        self.backoff.retain(|_, expiry| *expiry > now_ms);
+        self.ihave_budget.clear();
+        self.iwant_served.clear();
+        self.iwant_requested.clear();
+
+        let expired_fanout: Vec<String> = self
+            .fanout_last_pub
+            .iter()
+            .filter(|(_, last)| {
+                self.config.fanout_ttl_ms == 0
+                    || now_ms.saturating_sub(**last) >= self.config.fanout_ttl_ms
+            })
+            .map(|(topic, _)| topic.clone())
+            .collect();
+        for topic in expired_fanout {
+            self.fanout.remove(&topic);
+            self.fanout_last_pub.remove(&topic);
+        }
+
+        let topics: Vec<String> = self.topics.iter().cloned().collect();
+        for topic in topics {
+            let eligible: BTreeSet<PeerId> = self
+                .eligible_topic_peers(&topic, now_ms)
+                .into_iter()
+                .collect();
+            let mut current = self.mesh.remove(&topic).unwrap_or_default();
+            current.retain(|peer| eligible.contains(peer));
+            if current.len() < self.config.d_low {
+                let candidates = eligible
+                    .iter()
+                    .filter(|peer| !current.contains(*peer))
+                    .cloned()
+                    .collect();
+                for peer in
+                    self.select_peers(candidates, self.config.d.saturating_sub(current.len()))
+                {
+                    current.insert(peer.clone());
+                    self.queue_control(&peer, ControlItem::Graft(topic.clone()), now_ms);
+                }
+            } else if current.len() > self.config.d_high {
+                let retained: BTreeSet<PeerId> = self
+                    .select_peers(current.iter().cloned().collect(), self.config.d)
+                    .into_iter()
+                    .collect();
+                let pruned: Vec<PeerId> = current.difference(&retained).cloned().collect();
+                current = retained;
+                for peer in pruned {
+                    self.record_backoff(&topic, &peer, self.config.prune_backoff_ms, now_ms);
+                    self.queue_control(
+                        &peer,
+                        ControlItem::Prune {
+                            topic: topic.clone(),
+                            backoff_ms: self.config.prune_backoff_ms,
+                        },
+                        now_ms,
+                    );
+                }
+            }
+            self.mesh.insert(topic, current);
+        }
+
+        let fanout_topics: Vec<String> = self.fanout.keys().cloned().collect();
+        for topic in fanout_topics {
+            let eligible: BTreeSet<PeerId> = self
+                .eligible_topic_peers(&topic, now_ms)
+                .into_iter()
+                .collect();
+            let mut current = self.fanout.remove(&topic).unwrap_or_default();
+            current.retain(|peer| eligible.contains(peer));
+            if current.len() < self.config.d {
+                let candidates = eligible
+                    .iter()
+                    .filter(|peer| !current.contains(*peer))
+                    .cloned()
+                    .collect();
+                for peer in self.select_peers(candidates, self.config.d - current.len()) {
+                    current.insert(peer);
+                }
+            }
+            self.fanout.insert(topic, current);
+        }
+
+        let gossip_topics: Vec<String> = self
+            .peers
+            .values()
+            .flat_map(|state| state.remote_topics.iter().cloned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        for topic in gossip_topics {
+            let ids = self.mcache.gossip_ids(&topic, self.config.mcache_gossip);
+            if ids.is_empty() || self.config.d_lazy == 0 {
+                continue;
+            }
+            let mesh = self.mesh.get(&topic).cloned().unwrap_or_default();
+            let fanout = self.fanout.get(&topic).cloned().unwrap_or_default();
+            let candidates: Vec<PeerId> = self
+                .peers
+                .iter()
+                .filter(|(peer, state)| {
+                    state.advertised_version.is_some()
+                        && state.remote_topics.contains(&topic)
+                        && !mesh.contains(*peer)
+                        && !fanout.contains(*peer)
+                })
+                .map(|(peer, _)| peer.clone())
+                .collect();
+            for peer in self.select_peers(candidates, self.config.d_lazy) {
+                for id in ids.iter().take(self.config.max_ihave_length) {
+                    self.queue_control(
+                        &peer,
+                        ControlItem::IHave {
+                            topic: topic.clone(),
+                            id: id.clone(),
+                        },
+                        now_ms,
+                    );
+                }
+            }
+        }
+        self.mcache.shift();
+        self.drive_all_senders(now_ms);
+    }
+
+    fn drive_all_senders(&mut self, now_ms: u64) {
+        let peers: Vec<PeerId> = self.peers.keys().cloned().collect();
+        for peer in peers {
+            self.drive_sender(&peer, now_ms);
+        }
+    }
+
+    fn drive_sender(&mut self, peer: &PeerId, now_ms: u64) {
+        let state_kind = self.peers.get(peer).map(|state| match state.sender {
+            SendState::Idle => 0,
+            SendState::Ready {
+                in_flight: None, ..
+            } => 1,
+            _ => 2,
+        });
+        match state_kind {
+            Some(0) => {
+                let Some(version) = self
+                    .peers
+                    .get(peer)
+                    .and_then(|state| state.advertised_version)
+                else {
+                    return;
+                };
+                let token = self.allocate_token();
+                if let Some(state) = self.peers.get_mut(peer) {
+                    state.sender = SendState::Opening {
+                        token,
+                        since_ms: now_ms,
+                    };
+                }
+                self.actions.push_back(PubsubAction::OpenStream {
+                    token,
+                    peer: peer.clone(),
+                    protocol_id: String::from(version.protocol_id()),
+                });
+            }
+            Some(1) => self.emit_next_frame(peer),
+            _ => {}
+        }
+    }
+
+    fn emit_next_frame(&mut self, peer: &PeerId) {
+        let (stream_id, version) = match self.peers.get(peer) {
+            Some(PeerState {
+                sender:
+                    SendState::Ready {
+                        stream_id,
+                        in_flight: None,
+                    },
+                outbound_version: Some(version),
+                ..
+            }) => (*stream_id, *version),
+            _ => return,
+        };
+
+        let work = if self
+            .peers
+            .get(peer)
+            .is_some_and(|state| !state.subscription_queue.is_empty())
+        {
+            let mut subscriptions = Vec::new();
+            while let Some(next) = self
+                .peers
+                .get(peer)
+                .and_then(|state| state.subscription_queue.front().cloned())
+            {
+                subscriptions.push(next);
+                let body = Rpc {
+                    subscriptions: subscriptions.clone(),
+                    publish: Vec::new(),
+                    control: None,
+                }
+                .encode();
+                if body.len() > MAX_RPC_SIZE {
+                    subscriptions.pop();
+                    break;
+                }
+                self.peers
+                    .get_mut(peer)
+                    .expect("peer exists")
+                    .subscription_queue
+                    .pop_front();
+            }
+            let body = Rpc {
+                subscriptions: subscriptions.clone(),
+                publish: Vec::new(),
+                control: None,
+            }
+            .encode();
+            Some((
+                encode_frame(&body),
+                FrameCommit::Subscriptions(subscriptions),
+            ))
+        } else {
+            self.enqueue_live_subscription_diff(peer);
+            if self
+                .peers
+                .get(peer)
+                .is_some_and(|state| !state.subscription_queue.is_empty())
+            {
+                self.emit_next_frame(peer);
+                return;
+            }
+            if let Some((body, items)) = self
+                .peers
+                .get_mut(peer)
+                .and_then(|state| state.pending_control.take_frame(version))
+            {
+                Some((encode_frame(&body), FrameCommit::Control(items)))
+            } else {
+                self.peers
+                    .get(peer)
+                    .and_then(|state| state.pending_messages.front().cloned())
+                    .map(|frame| (frame, FrameCommit::Message))
+            }
+        };
+        let Some((frame, commit)) = work else { return };
+        let token = self.allocate_token();
+        if let Some(state) = self.peers.get_mut(peer)
+            && let SendState::Ready { in_flight, .. } = &mut state.sender
+        {
+            *in_flight = Some((token, commit));
+        }
+        self.actions.push_back(PubsubAction::SendStream {
+            token,
+            peer: peer.clone(),
+            stream_id,
+            data: frame,
+        });
+    }
+
+    fn enqueue_live_subscription_diff(&mut self, peer: &PeerId) {
+        let Some(state) = self.peers.get_mut(peer) else {
+            return;
+        };
+        for topic in self.topics.difference(&state.acknowledged_topics) {
+            state.subscription_queue.push_back(SubOpts {
+                subscribe: Some(true),
+                topic_id: Some(topic.clone()),
+            });
+        }
+        for topic in state.acknowledged_topics.difference(&self.topics) {
+            state.subscription_queue.push_back(SubOpts {
+                subscribe: Some(false),
+                topic_id: Some(topic.clone()),
+            });
+        }
+    }
+
+    fn commit_frame(&mut self, peer: &PeerId, commit: FrameCommit) {
+        let Some(state) = self.peers.get_mut(peer) else {
+            return;
+        };
+        match commit {
+            FrameCommit::Subscriptions(subscriptions) => {
+                for sub in subscriptions {
+                    let (Some(subscribe), Some(topic)) = (sub.subscribe, sub.topic_id) else {
+                        continue;
+                    };
+                    if subscribe {
+                        state.acknowledged_topics.insert(topic.clone());
+                        state.announced_topics.insert(topic);
+                    } else {
+                        state.acknowledged_topics.remove(&topic);
+                        state.announced_topics.insert(topic);
+                    }
+                }
+            }
+            FrameCommit::Control(_) => {}
+            FrameCommit::Message => {
+                state.pending_messages.pop_front();
+            }
+        }
+    }
+
+    fn restore_commit(&mut self, peer: &PeerId, commit: FrameCommit) {
+        if let FrameCommit::Control(items) = commit
+            && let Some(state) = self.peers.get_mut(peer)
+        {
+            state.pending_control.merge(items);
+        }
+    }
+
+    fn queue_control(&mut self, peer: &PeerId, item: ControlItem, _now_ms: u64) {
+        if let Some(state) = self.peers.get_mut(peer) {
+            state.pending_control.push(item);
+        }
+    }
+
+    fn queue_message(&mut self, peer: &PeerId, frame: Vec<u8>) -> bool {
+        let Some(state) = self.peers.get_mut(peer) else {
+            return false;
+        };
+        if state.pending_messages.len() >= self.config.max_pending_per_peer {
+            self.events.push_back(PubsubEvent::OutboundFailure {
+                peer: peer.clone(),
+                reason: "outbound message dropped: queue is full".to_string(),
+            });
+            return false;
+        }
+        state.pending_messages.push_back(frame);
+        true
+    }
+
+    fn select_fanout(&mut self, topic: &str, now_ms: u64) -> Vec<PeerId> {
+        let reusable = self.config.fanout_ttl_ms != 0
+            && self
+                .fanout_last_pub
+                .get(topic)
+                .is_some_and(|last| now_ms.saturating_sub(*last) < self.config.fanout_ttl_ms);
+        let mut peers = if reusable {
+            self.fanout.remove(topic).unwrap_or_default()
+        } else {
+            BTreeSet::new()
+        };
+        peers.retain(|peer| self.peer_is_eligible(peer, topic, now_ms));
+        if peers.len() < self.config.d {
+            let candidates = self
+                .eligible_topic_peers(topic, now_ms)
+                .into_iter()
+                .filter(|peer| !peers.contains(peer))
+                .collect();
+            for peer in self.select_peers(candidates, self.config.d - peers.len()) {
+                peers.insert(peer);
+            }
+        }
+        self.fanout.insert(String::from(topic), peers.clone());
+        self.fanout_last_pub.insert(String::from(topic), now_ms);
+        peers.into_iter().collect()
+    }
+
+    fn eligible_topic_peers(&self, topic: &str, now_ms: u64) -> Vec<PeerId> {
+        self.peers
+            .iter()
+            .filter(|(peer, state)| {
+                state.advertised_version.is_some()
+                    && state.remote_topics.contains(topic)
+                    && !self.is_backed_off(topic, peer, now_ms)
+            })
+            .map(|(peer, _)| peer.clone())
+            .collect()
+    }
+
+    fn peer_is_eligible(&self, peer: &PeerId, topic: &str, now_ms: u64) -> bool {
+        self.peers.get(peer).is_some_and(|state| {
+            state.advertised_version.is_some()
+                && state.remote_topics.contains(topic)
+                && !self.is_backed_off(topic, peer, now_ms)
+        })
+    }
+
+    fn select_peers(&mut self, mut peers: Vec<PeerId>, count: usize) -> Vec<PeerId> {
+        for index in (1..peers.len()).rev() {
+            let chosen = (self.rng.next() as usize) % (index + 1);
+            peers.swap(index, chosen);
+        }
+        peers.truncate(count.min(peers.len()));
+        peers
+    }
+
+    fn is_backed_off(&self, topic: &str, peer: &PeerId, now_ms: u64) -> bool {
+        self.backoff
+            .get(&(String::from(topic), peer.clone()))
+            .is_some_and(|expiry| *expiry > now_ms)
+    }
+
+    fn record_backoff(&mut self, topic: &str, peer: &PeerId, duration_ms: u64, now_ms: u64) {
+        let expiry = now_ms.saturating_add(duration_ms);
+        self.backoff
+            .entry((String::from(topic), peer.clone()))
+            .and_modify(|current| *current = (*current).max(expiry))
+            .or_insert(expiry);
+    }
+
+    fn allocate_token(&mut self) -> PubsubToken {
+        let token = PubsubToken(self.next_token);
+        self.next_token = self.next_token.wrapping_add(1);
+        token
+    }
+
+    fn role(&self, peer: &PeerId, stream_id: StreamId) -> Option<StreamRole> {
+        self.roles
+            .get(peer)
+            .and_then(|streams| streams.get(&stream_id))
+            .copied()
+    }
+
+    fn reject_stream(&mut self, peer: &PeerId, stream_id: StreamId) {
+        self.roles
+            .entry(peer.clone())
+            .or_default()
+            .insert(stream_id, StreamRole::Rejected);
+        self.actions.push_back(PubsubAction::ResetStream {
+            peer: peer.clone(),
+            stream_id,
+        });
+    }
+
+    fn violation_reset(&mut self, peer: &PeerId, stream_id: StreamId, reason: &str) {
+        if let Some(state) = self.peers.get_mut(peer) {
+            state.inbound.remove(&stream_id);
+        }
+        self.events.push_back(PubsubEvent::ProtocolViolation {
+            peer: peer.clone(),
+            reason: reason.to_string(),
+        });
+        self.reject_stream(peer, stream_id);
+    }
+}
+
+fn control_item_fits(item: &ControlItem) -> bool {
+    encode_control_items(core::slice::from_ref(item), MeshsubVersion::V11).len() <= MAX_RPC_SIZE
+}
+
+fn validate_topic(topic: &str) -> Result<(), TopicError> {
+    if topic.is_empty() {
+        Err(TopicError::Empty)
+    } else if topic.len() > MAX_TOPIC_LEN {
+        Err(TopicError::TooLong)
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut value = self.0;
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        value ^ (value >> 31)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_flight_control_ownership_preserves_later_aliases() {
+        let mut buffer = ControlBuffer::default();
+        buffer.push(ControlItem::Graft(String::from("topic")));
+        let (_, in_flight) = buffer.take_frame(MeshsubVersion::V11).unwrap();
+        buffer.push(ControlItem::Graft(String::from("topic")));
+        assert_eq!(buffer.len(), 1, "later alias remains independently queued");
+
+        // Failure merges the owned item back and deterministically coalesces
+        // it with the later alias.
+        buffer.merge(in_flight);
+        assert_eq!(buffer.len(), 1);
+
+        let (_, in_flight) = buffer.take_frame(MeshsubVersion::V11).unwrap();
+        buffer.push(ControlItem::Prune {
+            topic: String::from("topic"),
+            backoff_ms: 10_000,
+        });
+        buffer.merge(in_flight);
+        let (body, _) = buffer.take_frame(MeshsubVersion::V11).unwrap();
+        let control = Rpc::decode(&body).unwrap().control.unwrap();
+        assert!(control.graft.is_empty());
+        assert_eq!(control.prune.len(), 1, "later PRUNE supersedes GRAFT");
+    }
+
+    #[test]
+    fn oversized_control_buffer_splits_without_dropping_ids() {
+        let mut buffer = ControlBuffer::default();
+        for index in 0..3_000u32 {
+            let mut id = alloc::vec![0xA5; 32];
+            id[..4].copy_from_slice(&index.to_be_bytes());
+            buffer.push(ControlItem::IWant(id));
+        }
+
+        let mut frames = 0;
+        let mut ids = 0;
+        while let Some((body, _)) = buffer.take_frame(MeshsubVersion::V11) {
+            assert!(body.len() <= MAX_RPC_SIZE);
+            let control = Rpc::decode(&body).unwrap().control.unwrap();
+            ids += control
+                .iwant
+                .iter()
+                .map(|iwant| iwant.message_ids.len())
+                .sum::<usize>();
+            frames += 1;
+        }
+        assert!(frames > 1);
+        assert_eq!(ids, 3_000);
+    }
+}

--- a/crates/pubsub/src/gossipsub/agent.rs
+++ b/crates/pubsub/src/gossipsub/agent.rs
@@ -148,6 +148,10 @@ impl ControlBuffer {
             return None;
         }
         let mut items = Vec::new();
+        // Re-encoding is deliberately exact across nested protobuf-varint
+        // boundaries. The configured control budgets bound this quadratic
+        // packing pass; replace it with size accounting only if profiling
+        // shows it matters.
         while let Some(item) = self.pop_first() {
             items.push(item);
             let body = encode_control_items(&items, version);
@@ -259,12 +263,18 @@ struct PeerState {
 }
 
 impl PeerState {
-    fn queued_work(&self, topics: &BTreeSet<String>) -> usize {
-        self.pending_messages.len()
-            + self.pending_control.len()
-            + usize::from(
-                self.acknowledged_topics != *topics || !self.subscription_queue.is_empty(),
-            )
+    fn queued_work(&self) -> usize {
+        // Subscription resync is connection-scoped bookkeeping rather than
+        // dropped application/control payload. Messages remain at the queue
+        // front while in flight; only control moves into the commit record.
+        let in_flight_control = match &self.sender {
+            SendState::Ready {
+                in_flight: Some((_, FrameCommit::Control(items))),
+                ..
+            } => items.len(),
+            _ => 0,
+        };
+        self.pending_messages.len() + self.pending_control.len() + in_flight_control
     }
 }
 
@@ -698,7 +708,7 @@ impl GossipsubAgent {
 
     fn remove_peer(&mut self, peer: &PeerId, cause: &str) {
         if let Some(state) = self.peers.get(peer) {
-            let dropped = state.queued_work(&self.topics);
+            let dropped = state.queued_work();
             if dropped > 0 {
                 self.events.push_back(PubsubEvent::OutboundFailure {
                     peer: peer.clone(),
@@ -1050,6 +1060,10 @@ impl GossipsubAgent {
                     now_ms,
                 );
             } else {
+                // GRAFT itself asserts mesh interest. Spec-following peers
+                // announce the subscription first; an unannounced GRAFT is
+                // accepted optimistically and heartbeat eligibility later
+                // reconciles it.
                 self.mesh.entry(topic).or_default().insert(peer.clone());
             }
         }
@@ -1057,7 +1071,7 @@ impl GossipsubAgent {
             let Some(topic) = prune.topic_id else {
                 continue;
             };
-            if validate_topic(&topic).is_err() || !self.topics.contains(&topic) {
+            if validate_topic(&topic).is_err() {
                 continue;
             }
             if let Some(mesh) = self.mesh.get_mut(&topic) {
@@ -1367,6 +1381,10 @@ impl GossipsubAgent {
             .is_some_and(|state| !state.subscription_queue.is_empty())
         {
             let mut subscriptions = Vec::new();
+            // Subscription and control commits intentionally occupy separate
+            // RPCs. This keeps each acknowledgement atomic at the cost of one
+            // extra write after a reopen; each category is still packed
+            // greedily to the exact wire limit.
             while let Some(next) = self
                 .peers
                 .get(peer)

--- a/crates/pubsub/src/gossipsub/agent.rs
+++ b/crates/pubsub/src/gossipsub/agent.rs
@@ -5,7 +5,7 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use minip2p_core::PeerId;
+use minip2p_core::{PeerId, uvarint_len};
 use minip2p_identity::Ed25519Keypair;
 use minip2p_swarm::SwarmEvent;
 use minip2p_transport::StreamId;
@@ -83,30 +83,96 @@ impl ControlBuffer {
             + self.iwant.len()
     }
 
-    fn push(&mut self, item: ControlItem) {
+    /// Inserts newer logical work with last-writer-wins topology semantics.
+    /// Returns `false` only when a new item would exceed `max_items`.
+    fn insert(&mut self, item: ControlItem, max_items: usize) -> bool {
         match item {
             ControlItem::Graft(topic) => {
-                if !self.prune.contains_key(&topic) {
-                    self.graft.insert(topic);
+                if self.graft.contains(&topic) {
+                    return true;
                 }
+                if self.prune.remove(&topic).is_some() {
+                    self.graft.insert(topic);
+                    return true;
+                }
+                if self.len() >= max_items {
+                    return false;
+                }
+                self.graft.insert(topic);
             }
             ControlItem::Prune { topic, backoff_ms } => {
-                self.graft.remove(&topic);
+                if let Some(existing) = self.prune.get_mut(&topic) {
+                    *existing = backoff_ms;
+                    return true;
+                }
+                if self.graft.remove(&topic) {
+                    self.prune.insert(topic, backoff_ms);
+                    return true;
+                }
+                if self.len() >= max_items {
+                    return false;
+                }
                 self.prune.insert(topic, backoff_ms);
             }
             ControlItem::IHave { topic, id } => {
+                if self.ihave.get(&topic).is_some_and(|ids| ids.contains(&id)) {
+                    return true;
+                }
+                if self.len() >= max_items {
+                    return false;
+                }
                 self.ihave.entry(topic).or_default().insert(id);
             }
             ControlItem::IWant(id) => {
+                if self.iwant.contains(&id) {
+                    return true;
+                }
+                if self.len() >= max_items {
+                    return false;
+                }
                 self.iwant.insert(id);
             }
         }
+        true
     }
 
-    fn merge(&mut self, items: Vec<ControlItem>) {
+    /// Restores failed in-flight items ahead of the newer pending buffer.
+    /// Newer topology decisions therefore win when the two are coalesced.
+    fn restore_older(&mut self, items: Vec<ControlItem>, max_items: usize) -> usize {
+        let mut newer = core::mem::take(self);
+        let mut merged = Self::default();
+        let mut dropped = 0;
         for item in items {
-            self.push(item);
+            dropped += usize::from(!merged.insert(item, max_items));
         }
+        while let Some(item) = newer.pop_first() {
+            dropped += usize::from(!merged.insert(item, max_items));
+        }
+        *self = merged;
+        dropped
+    }
+
+    /// Evicts one low-priority gossip id to make room for topology control.
+    fn evict_gossip(&mut self) -> bool {
+        if let Some(id) = self.iwant.iter().next_back().cloned() {
+            self.iwant.remove(&id);
+            return true;
+        }
+        let Some((topic, id)) = self.ihave.iter().next_back().and_then(|(topic, ids)| {
+            ids.iter()
+                .next_back()
+                .cloned()
+                .map(|id| (topic.clone(), id))
+        }) else {
+            return false;
+        };
+        if let Some(ids) = self.ihave.get_mut(&topic) {
+            ids.remove(&id);
+            if ids.is_empty() {
+                self.ihave.remove(&topic);
+            }
+        }
+        true
     }
 
     fn pop_first(&mut self) -> Option<ControlItem> {
@@ -148,26 +214,84 @@ impl ControlBuffer {
             return None;
         }
         let mut items = Vec::new();
-        // Re-encoding is deliberately exact across nested protobuf-varint
-        // boundaries. The configured control budgets bound this quadratic
-        // packing pass; replace it with size accounting only if profiling
-        // shows it matters.
+        let mut size = ControlFrameSize::default();
         while let Some(item) = self.pop_first() {
-            items.push(item);
-            let body = encode_control_items(&items, version);
-            if body.len() > MAX_RPC_SIZE {
-                let item = items.pop().expect("just pushed");
-                self.push(item);
+            let mut next_size = size.clone();
+            next_size.add(&item, version);
+            if next_size.rpc_len() > MAX_RPC_SIZE {
+                debug_assert!(self.insert(item, usize::MAX));
                 break;
             }
+            size = next_size;
+            items.push(item);
         }
         if items.is_empty() {
             // This can only be reached for a hostile, nearly-frame-sized
             // message id. Such ids are filtered before entering the buffer.
             return None;
         }
-        Some((encode_control_items(&items, version), items))
+        let body = encode_control_items(&items, version);
+        debug_assert_eq!(body.len(), size.rpc_len());
+        Some((body, items))
     }
+}
+
+#[derive(Clone, Debug, Default)]
+struct ControlFrameSize {
+    control_body: usize,
+    ihave_topic: Option<String>,
+    ihave_body: usize,
+    iwant_body: usize,
+}
+
+impl ControlFrameSize {
+    fn add(&mut self, item: &ControlItem, version: MeshsubVersion) {
+        match item {
+            ControlItem::Graft(topic) => {
+                self.control_body += nested_field_len(bytes_field_len(topic.len()));
+            }
+            ControlItem::Prune { topic, backoff_ms } => {
+                let mut body = bytes_field_len(topic.len());
+                if version == MeshsubVersion::V11 {
+                    let seconds = backoff_ms.saturating_add(999) / 1_000;
+                    body += 1 + uvarint_len(seconds);
+                }
+                self.control_body += nested_field_len(body);
+            }
+            ControlItem::IHave { topic, id } => {
+                if self.ihave_topic.as_deref() == Some(topic.as_str()) {
+                    let old = nested_field_len(self.ihave_body);
+                    self.ihave_body += bytes_field_len(id.len());
+                    self.control_body += nested_field_len(self.ihave_body) - old;
+                } else {
+                    self.ihave_topic = Some(topic.clone());
+                    self.ihave_body = bytes_field_len(topic.len()) + bytes_field_len(id.len());
+                    self.control_body += nested_field_len(self.ihave_body);
+                }
+            }
+            ControlItem::IWant(id) => {
+                let old = (self.iwant_body != 0).then(|| nested_field_len(self.iwant_body));
+                self.iwant_body += bytes_field_len(id.len());
+                self.control_body += nested_field_len(self.iwant_body) - old.unwrap_or(0);
+            }
+        }
+    }
+
+    fn rpc_len(&self) -> usize {
+        if self.control_body == 0 {
+            0
+        } else {
+            nested_field_len(self.control_body)
+        }
+    }
+}
+
+fn bytes_field_len(len: usize) -> usize {
+    1 + uvarint_len(len as u64) + len
+}
+
+fn nested_field_len(body_len: usize) -> usize {
+    bytes_field_len(body_len)
 }
 
 fn encode_control_items(items: &[ControlItem], version: MeshsubVersion) -> Vec<u8> {
@@ -253,7 +377,10 @@ struct PeerState {
     sender: SendState,
     pending_messages: VecDeque<Vec<u8>>,
     acknowledged_topics: BTreeSet<String>,
-    announced_topics: BTreeSet<String>,
+    /// Recently acknowledged unsubscriptions replayed after stream reopen.
+    /// Bounded by `max_topics_per_peer`; active subscriptions are derived
+    /// from the agent's current topic set and need no history here.
+    unsubscribe_tombstones: BTreeSet<String>,
     subscription_queue: VecDeque<SubOpts>,
     inbound: BTreeMap<StreamId, Vec<u8>>,
     remote_topics: BTreeSet<String>,
@@ -275,6 +402,13 @@ impl PeerState {
             _ => 0,
         };
         self.pending_messages.len() + self.pending_control.len() + in_flight_control
+    }
+
+    fn record_unsubscribe(&mut self, topic: String, max_topics: usize) {
+        self.unsubscribe_tombstones.insert(topic);
+        while self.unsubscribe_tombstones.len() > max_topics {
+            self.unsubscribe_tombstones.pop_first();
+        }
     }
 }
 
@@ -385,10 +519,13 @@ impl GossipsubAgent {
             }
         }
         self.fanout_last_pub.remove(topic);
-        for peer in &selected {
-            self.queue_control(peer, ControlItem::Graft(String::from(topic)), now_ms);
+        let mut joined = BTreeSet::new();
+        for peer in selected {
+            if self.queue_control(&peer, ControlItem::Graft(String::from(topic)), now_ms) {
+                joined.insert(peer);
+            }
         }
-        self.mesh.insert(String::from(topic), selected);
+        self.mesh.insert(String::from(topic), joined);
         self.drive_all_senders(now_ms);
         Ok(true)
     }
@@ -757,7 +894,7 @@ impl GossipsubAgent {
                     });
                 }
                 let withdrawals: Vec<String> = state
-                    .announced_topics
+                    .unsubscribe_tombstones
                     .difference(&self.topics)
                     .cloned()
                     .collect();
@@ -1049,7 +1186,22 @@ impl GossipsubAgent {
             if !self.topics.contains(&topic) {
                 continue;
             }
-            if self.is_backed_off(&topic, peer, now_ms) {
+            let remote_subscribed = self
+                .peers
+                .get(peer)
+                .is_some_and(|state| state.remote_topics.contains(&topic));
+            let (already_meshed, mesh_len) = self
+                .mesh
+                .get(&topic)
+                .map(|mesh| (mesh.contains(peer), mesh.len()))
+                .unwrap_or((false, 0));
+            if already_meshed {
+                continue;
+            }
+            if !remote_subscribed
+                || self.is_backed_off(&topic, peer, now_ms)
+                || mesh_len >= self.config.d_high
+            {
                 self.record_backoff(&topic, peer, self.config.prune_backoff_ms, now_ms);
                 self.queue_control(
                     peer,
@@ -1060,10 +1212,6 @@ impl GossipsubAgent {
                     now_ms,
                 );
             } else {
-                // GRAFT itself asserts mesh interest. Spec-following peers
-                // announce the subscription first; an unannounced GRAFT is
-                // accepted optimistically and heartbeat eligibility later
-                // reconciles it.
                 self.mesh.entry(topic).or_default().insert(peer.clone());
             }
         }
@@ -1086,6 +1234,12 @@ impl GossipsubAgent {
             self.record_backoff(&topic, peer, backoff, now_ms);
         }
         for ihave in control.ihave {
+            let Some(topic) = ihave.topic_id.as_deref() else {
+                continue;
+            };
+            if validate_topic(topic).is_err() || !self.topics.contains(topic) {
+                continue;
+            }
             let count = self.ihave_budget.entry(peer.clone()).or_default();
             if *count >= self.config.max_ihave_messages_per_heartbeat {
                 continue;
@@ -1136,6 +1290,20 @@ impl GossipsubAgent {
     }
 
     fn process_message(&mut self, arrival: &PeerId, message: RawMessage, now_ms: u64) {
+        let (dedup_from, dedup_seqno) = match message.source_and_seqno() {
+            Ok(value) => value,
+            Err(error) => {
+                self.events.push_back(PubsubEvent::ProtocolViolation {
+                    peer: arrival.clone(),
+                    reason: format!("message rejected: {error}"),
+                });
+                return;
+            }
+        };
+        let id = message_id(&dedup_from.to_bytes(), &dedup_seqno);
+        if self.seen.contains(&id) {
+            return;
+        }
         let (from, seqno, signed) = match message.verify(self.config.allow_unsigned) {
             Ok(value) => value,
             Err(error) => {
@@ -1146,8 +1314,15 @@ impl GossipsubAgent {
                 return;
             }
         };
-        let id = message_id(&from.to_bytes(), &seqno);
-        if self.seen.contains(&id) {
+        debug_assert_eq!(from, dedup_from);
+        debug_assert_eq!(seqno, dedup_seqno);
+        let interested_topics: Vec<String> = message
+            .topic_ids
+            .iter()
+            .filter(|topic| self.topics.contains(*topic))
+            .cloned()
+            .collect();
+        if interested_topics.is_empty() {
             return;
         }
         self.seen.insert(
@@ -1156,22 +1331,15 @@ impl GossipsubAgent {
             self.config.seen_ttl_ms,
             self.config.max_seen_messages,
         );
-        if message
-            .topic_ids
-            .iter()
-            .any(|topic| self.topics.contains(topic))
-        {
-            self.events.push_back(PubsubEvent::Message {
-                from: from.clone(),
-                topics: message.topic_ids.clone(),
-                data: message.data.clone().unwrap_or_default(),
-                seqno,
-                signed,
-            });
-        }
+        self.events.push_back(PubsubEvent::Message {
+            from: from.clone(),
+            topics: message.topic_ids.clone(),
+            data: message.data.clone().unwrap_or_default(),
+            seqno,
+            signed,
+        });
 
-        let recipients: BTreeSet<PeerId> = message
-            .topic_ids
+        let recipients: BTreeSet<PeerId> = interested_topics
             .iter()
             .filter_map(|topic| self.mesh.get(topic))
             .flatten()
@@ -1191,7 +1359,7 @@ impl GossipsubAgent {
                 self.drive_sender(&peer, now_ms);
             }
         }
-        self.mcache.put(id, message.clone(), message.topic_ids);
+        self.mcache.put(id, message, interested_topics);
     }
 
     fn heartbeat(&mut self, now_ms: u64) {
@@ -1221,7 +1389,20 @@ impl GossipsubAgent {
                 .into_iter()
                 .collect();
             let mut current = self.mesh.remove(&topic).unwrap_or_default();
+            let stripped: Vec<PeerId> = current.difference(&eligible).cloned().collect();
             current.retain(|peer| eligible.contains(peer));
+            for peer in stripped {
+                if self.queue_control(
+                    &peer,
+                    ControlItem::Prune {
+                        topic: topic.clone(),
+                        backoff_ms: self.config.prune_backoff_ms,
+                    },
+                    now_ms,
+                ) {
+                    self.record_backoff(&topic, &peer, self.config.prune_backoff_ms, now_ms);
+                }
+            }
             if current.len() < self.config.d_low {
                 let candidates = eligible
                     .iter()
@@ -1231,8 +1412,9 @@ impl GossipsubAgent {
                 for peer in
                     self.select_peers(candidates, self.config.d.saturating_sub(current.len()))
                 {
-                    current.insert(peer.clone());
-                    self.queue_control(&peer, ControlItem::Graft(topic.clone()), now_ms);
+                    if self.queue_control(&peer, ControlItem::Graft(topic.clone()), now_ms) {
+                        current.insert(peer);
+                    }
                 }
             } else if current.len() > self.config.d_high {
                 let retained: BTreeSet<PeerId> = self
@@ -1240,17 +1422,18 @@ impl GossipsubAgent {
                     .into_iter()
                     .collect();
                 let pruned: Vec<PeerId> = current.difference(&retained).cloned().collect();
-                current = retained;
                 for peer in pruned {
-                    self.record_backoff(&topic, &peer, self.config.prune_backoff_ms, now_ms);
-                    self.queue_control(
+                    if self.queue_control(
                         &peer,
                         ControlItem::Prune {
                             topic: topic.clone(),
                             backoff_ms: self.config.prune_backoff_ms,
                         },
                         now_ms,
-                    );
+                    ) {
+                        current.remove(&peer);
+                        self.record_backoff(&topic, &peer, self.config.prune_backoff_ms, now_ms);
+                    }
                 }
             }
             self.mesh.insert(topic, current);
@@ -1381,6 +1564,7 @@ impl GossipsubAgent {
             .is_some_and(|state| !state.subscription_queue.is_empty())
         {
             let mut subscriptions = Vec::new();
+            let mut body_len = 0;
             // Subscription and control commits intentionally occupy separate
             // RPCs. This keeps each acknowledgement atomic at the cost of one
             // extra write after a reopen; each category is still packed
@@ -1390,17 +1574,12 @@ impl GossipsubAgent {
                 .get(peer)
                 .and_then(|state| state.subscription_queue.front().cloned())
             {
-                subscriptions.push(next);
-                let body = Rpc {
-                    subscriptions: subscriptions.clone(),
-                    publish: Vec::new(),
-                    control: None,
-                }
-                .encode();
-                if body.len() > MAX_RPC_SIZE {
-                    subscriptions.pop();
+                let next_len = nested_field_len(next.encode().len());
+                if body_len + next_len > MAX_RPC_SIZE {
                     break;
                 }
+                body_len += next_len;
+                subscriptions.push(next);
                 self.peers
                     .get_mut(peer)
                     .expect("peer exists")
@@ -1413,6 +1592,7 @@ impl GossipsubAgent {
                 control: None,
             }
             .encode();
+            debug_assert_eq!(body.len(), body_len);
             Some((
                 encode_frame(&body),
                 FrameCommit::Subscriptions(subscriptions),
@@ -1485,10 +1665,10 @@ impl GossipsubAgent {
                     };
                     if subscribe {
                         state.acknowledged_topics.insert(topic.clone());
-                        state.announced_topics.insert(topic);
+                        state.unsubscribe_tombstones.remove(&topic);
                     } else {
                         state.acknowledged_topics.remove(&topic);
-                        state.announced_topics.insert(topic);
+                        state.record_unsubscribe(topic, self.config.max_topics_per_peer);
                     }
                 }
             }
@@ -1503,14 +1683,32 @@ impl GossipsubAgent {
         if let FrameCommit::Control(items) = commit
             && let Some(state) = self.peers.get_mut(peer)
         {
-            state.pending_control.merge(items);
+            state
+                .pending_control
+                .restore_older(items, self.config.max_pending_per_peer);
         }
     }
 
-    fn queue_control(&mut self, peer: &PeerId, item: ControlItem, _now_ms: u64) {
-        if let Some(state) = self.peers.get_mut(peer) {
-            state.pending_control.push(item);
+    fn queue_control(&mut self, peer: &PeerId, item: ControlItem, _now_ms: u64) -> bool {
+        let Some(state) = self.peers.get_mut(peer) else {
+            return false;
+        };
+        let topology = matches!(item, ControlItem::Graft(_) | ControlItem::Prune { .. });
+        if state
+            .pending_control
+            .insert(item.clone(), self.config.max_pending_per_peer)
+        {
+            return true;
         }
+        if topology
+            && state.pending_control.evict_gossip()
+            && state
+                .pending_control
+                .insert(item, self.config.max_pending_per_peer)
+        {
+            return true;
+        }
+        false
     }
 
     fn queue_message(&mut self, peer: &PeerId, frame: Vec<u8>) -> bool {
@@ -1672,26 +1870,68 @@ mod tests {
     #[test]
     fn in_flight_control_ownership_preserves_later_aliases() {
         let mut buffer = ControlBuffer::default();
-        buffer.push(ControlItem::Graft(String::from("topic")));
+        assert!(buffer.insert(ControlItem::Graft(String::from("topic")), usize::MAX));
         let (_, in_flight) = buffer.take_frame(MeshsubVersion::V11).unwrap();
-        buffer.push(ControlItem::Graft(String::from("topic")));
+        assert!(buffer.insert(ControlItem::Graft(String::from("topic")), usize::MAX));
         assert_eq!(buffer.len(), 1, "later alias remains independently queued");
 
         // Failure merges the owned item back and deterministically coalesces
         // it with the later alias.
-        buffer.merge(in_flight);
+        assert_eq!(buffer.restore_older(in_flight, usize::MAX), 0);
         assert_eq!(buffer.len(), 1);
 
         let (_, in_flight) = buffer.take_frame(MeshsubVersion::V11).unwrap();
-        buffer.push(ControlItem::Prune {
-            topic: String::from("topic"),
-            backoff_ms: 10_000,
-        });
-        buffer.merge(in_flight);
+        assert!(buffer.insert(
+            ControlItem::Prune {
+                topic: String::from("topic"),
+                backoff_ms: 10_000,
+            },
+            usize::MAX,
+        ));
+        assert_eq!(buffer.restore_older(in_flight, usize::MAX), 0);
         let (body, _) = buffer.take_frame(MeshsubVersion::V11).unwrap();
         let control = Rpc::decode(&body).unwrap().control.unwrap();
         assert!(control.graft.is_empty());
         assert_eq!(control.prune.len(), 1, "later PRUNE supersedes GRAFT");
+    }
+
+    #[test]
+    fn later_graft_cancels_pending_prune() {
+        let mut buffer = ControlBuffer::default();
+        assert!(buffer.insert(
+            ControlItem::Prune {
+                topic: String::from("topic"),
+                backoff_ms: 10_000,
+            },
+            usize::MAX,
+        ));
+        assert!(buffer.insert(ControlItem::Graft(String::from("topic")), usize::MAX));
+
+        let (body, _) = buffer.take_frame(MeshsubVersion::V11).unwrap();
+        let control = Rpc::decode(&body).unwrap().control.unwrap();
+        assert_eq!(control.graft.len(), 1);
+        assert!(control.prune.is_empty());
+    }
+
+    #[test]
+    fn control_buffer_is_bounded_and_topology_evicts_gossip() {
+        let mut buffer = ControlBuffer::default();
+        assert!(buffer.insert(ControlItem::IWant(vec![1]), 2));
+        assert!(buffer.insert(ControlItem::IWant(vec![2]), 2));
+        assert!(!buffer.insert(ControlItem::IWant(vec![3]), 2));
+        assert!(buffer.evict_gossip());
+        assert!(buffer.insert(ControlItem::Graft(String::from("topic")), 2));
+        assert_eq!(buffer.len(), 2);
+    }
+
+    #[test]
+    fn unsubscribe_tombstones_are_bounded() {
+        let mut state = PeerState::default();
+        state.record_unsubscribe(String::from("a"), 2);
+        state.record_unsubscribe(String::from("b"), 2);
+        state.record_unsubscribe(String::from("c"), 2);
+        assert_eq!(state.unsubscribe_tombstones.len(), 2);
+        assert!(!state.unsubscribe_tombstones.contains("a"));
     }
 
     #[test]
@@ -1700,7 +1940,7 @@ mod tests {
         for index in 0..3_000u32 {
             let mut id = alloc::vec![0xA5; 32];
             id[..4].copy_from_slice(&index.to_be_bytes());
-            buffer.push(ControlItem::IWant(id));
+            assert!(buffer.insert(ControlItem::IWant(id), usize::MAX));
         }
 
         let mut frames = 0;

--- a/crates/pubsub/src/gossipsub/config.rs
+++ b/crates/pubsub/src/gossipsub/config.rs
@@ -49,7 +49,7 @@ pub struct GossipsubConfig {
     pub seen_ttl_ms: u64,
     /// Hard cap on seen-cache entries.
     pub max_seen_messages: usize,
-    /// Hard cap on queued message RPCs per peer.
+    /// Hard cap on queued message RPCs and logical control items per peer.
     pub max_pending_per_peer: usize,
     /// Hard cap on remote subscriptions tracked per peer.
     pub max_topics_per_peer: usize,

--- a/crates/pubsub/src/gossipsub/config.rs
+++ b/crates/pubsub/src/gossipsub/config.rs
@@ -1,0 +1,184 @@
+//! Gossipsub router configuration and validation.
+
+/// Invalid gossipsub configuration.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("invalid gossipsub config field `{field}`: {reason}")]
+pub struct PubsubConfigError {
+    /// Name of the invalid field.
+    pub field: &'static str,
+    /// Actionable description of the violated constraint.
+    pub reason: &'static str,
+}
+
+/// Tunables for [`GossipsubAgent`](crate::GossipsubAgent).
+#[derive(Clone, Debug)]
+pub struct GossipsubConfig {
+    /// Target mesh degree.
+    pub d: usize,
+    /// Mesh degree below which peers are grafted.
+    pub d_low: usize,
+    /// Mesh degree above which peers are pruned.
+    pub d_high: usize,
+    /// Minimum number of non-mesh peers selected for gossip.
+    pub d_lazy: usize,
+    /// Heartbeat interval in milliseconds.
+    pub heartbeat_interval_ms: u64,
+    /// Number of heartbeat windows retained in the message cache.
+    pub mcache_len: usize,
+    /// Number of newest cache windows advertised through IHAVE.
+    pub mcache_gossip: usize,
+    /// Hard cap on cached messages.
+    pub max_mcache_messages: usize,
+    /// Fanout reuse lifetime in milliseconds; zero disables reuse.
+    pub fanout_ttl_ms: u64,
+    /// Default prune backoff in milliseconds.
+    pub prune_backoff_ms: u64,
+    /// Backoff sent when leaving a topic, in milliseconds.
+    pub unsubscribe_backoff_ms: u64,
+    /// Clamp for remotely supplied backoffs, in milliseconds.
+    pub max_backoff_ms: u64,
+    /// Maximum ids accepted or emitted in one IHAVE item.
+    pub max_ihave_length: usize,
+    /// Maximum IHAVE items processed per peer per heartbeat.
+    pub max_ihave_messages_per_heartbeat: usize,
+    /// Maximum ids requested through IWANT per heartbeat.
+    pub max_iwant_ids_per_heartbeat: usize,
+    /// Maximum cached messages served per peer per heartbeat.
+    pub max_iwant_serves_per_heartbeat: usize,
+    /// Seen-cache retention in milliseconds.
+    pub seen_ttl_ms: u64,
+    /// Hard cap on seen-cache entries.
+    pub max_seen_messages: usize,
+    /// Hard cap on queued message RPCs per peer.
+    pub max_pending_per_peer: usize,
+    /// Hard cap on remote subscriptions tracked per peer.
+    pub max_topics_per_peer: usize,
+    /// Hard cap on concurrent inbound streams per peer.
+    pub max_inbound_streams_per_peer: usize,
+    /// Outbound stream-establishment deadline in milliseconds.
+    pub send_timeout_ms: u64,
+    /// Whether unsigned messages are accepted.
+    pub allow_unsigned: bool,
+}
+
+impl Default for GossipsubConfig {
+    fn default() -> Self {
+        Self {
+            d: 6,
+            d_low: 4,
+            d_high: 12,
+            d_lazy: 6,
+            heartbeat_interval_ms: 1_000,
+            mcache_len: 5,
+            mcache_gossip: 3,
+            max_mcache_messages: 512,
+            fanout_ttl_ms: 60_000,
+            prune_backoff_ms: 60_000,
+            unsubscribe_backoff_ms: 10_000,
+            max_backoff_ms: 3_600_000,
+            max_ihave_length: 5_000,
+            max_ihave_messages_per_heartbeat: 10,
+            max_iwant_ids_per_heartbeat: 5_000,
+            max_iwant_serves_per_heartbeat: 32,
+            seen_ttl_ms: 120_000,
+            max_seen_messages: 4_096,
+            max_pending_per_peer: 32,
+            max_topics_per_peer: 256,
+            max_inbound_streams_per_peer: 4,
+            send_timeout_ms: 10_000,
+            allow_unsigned: false,
+        }
+    }
+}
+
+impl GossipsubConfig {
+    /// Validates relationships and non-zero bounds without normalizing.
+    pub fn validate(&self) -> Result<(), PubsubConfigError> {
+        if self.d_low == 0 || self.d_low > self.d {
+            return invalid("d_low", "must be in 1..=d");
+        }
+        if self.d > self.d_high {
+            return invalid("d_high", "must be greater than or equal to d");
+        }
+        if self.mcache_gossip == 0 || self.mcache_gossip > self.mcache_len {
+            return invalid("mcache_gossip", "must be in 1..=mcache_len");
+        }
+        nonzero(self.heartbeat_interval_ms, "heartbeat_interval_ms")?;
+        nonzero(self.max_mcache_messages, "max_mcache_messages")?;
+        nonzero(self.max_ihave_length, "max_ihave_length")?;
+        nonzero(
+            self.max_ihave_messages_per_heartbeat,
+            "max_ihave_messages_per_heartbeat",
+        )?;
+        nonzero(
+            self.max_iwant_ids_per_heartbeat,
+            "max_iwant_ids_per_heartbeat",
+        )?;
+        nonzero(
+            self.max_iwant_serves_per_heartbeat,
+            "max_iwant_serves_per_heartbeat",
+        )?;
+        nonzero(self.seen_ttl_ms, "seen_ttl_ms")?;
+        nonzero(self.max_seen_messages, "max_seen_messages")?;
+        nonzero(self.max_pending_per_peer, "max_pending_per_peer")?;
+        nonzero(self.max_topics_per_peer, "max_topics_per_peer")?;
+        nonzero(
+            self.max_inbound_streams_per_peer,
+            "max_inbound_streams_per_peer",
+        )?;
+        nonzero(self.send_timeout_ms, "send_timeout_ms")?;
+        nonzero(self.prune_backoff_ms, "prune_backoff_ms")?;
+        if self.max_backoff_ms < self.prune_backoff_ms {
+            return invalid("max_backoff_ms", "must be at least prune_backoff_ms");
+        }
+        if self.max_backoff_ms < self.unsubscribe_backoff_ms {
+            return invalid("max_backoff_ms", "must be at least unsubscribe_backoff_ms");
+        }
+        Ok(())
+    }
+}
+
+fn nonzero<T>(value: T, field: &'static str) -> Result<(), PubsubConfigError>
+where
+    T: Default + PartialEq,
+{
+    if value == T::default() {
+        invalid(field, "must be non-zero")
+    } else {
+        Ok(())
+    }
+}
+
+fn invalid<T>(field: &'static str, reason: &'static str) -> Result<T, PubsubConfigError> {
+    Err(PubsubConfigError { field, reason })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_validate() {
+        GossipsubConfig::default().validate().unwrap();
+    }
+
+    #[test]
+    fn invalid_relationships_name_the_field() {
+        let mut config = GossipsubConfig::default();
+        config.d_low = config.d + 1;
+        assert_eq!(config.validate().unwrap_err().field, "d_low");
+
+        let mut config = GossipsubConfig::default();
+        config.mcache_gossip = config.mcache_len + 1;
+        assert_eq!(config.validate().unwrap_err().field, "mcache_gossip");
+
+        let config = GossipsubConfig {
+            heartbeat_interval_ms: 0,
+            ..GossipsubConfig::default()
+        };
+        assert_eq!(
+            config.validate().unwrap_err().field,
+            "heartbeat_interval_ms"
+        );
+    }
+}

--- a/crates/pubsub/src/gossipsub/mcache.rs
+++ b/crates/pubsub/src/gossipsub/mcache.rs
@@ -11,28 +11,31 @@ use crate::seen::MessageId;
 struct CacheEntry {
     message: RawMessage,
     topics: Vec<String>,
+    generation: u64,
 }
 
 /// Recent validated messages, indexed for IHAVE and IWANT.
 #[derive(Debug)]
 pub(super) struct MessageCache {
     messages: BTreeMap<MessageId, CacheEntry>,
-    history: VecDeque<Vec<MessageId>>,
-    insertion_order: VecDeque<MessageId>,
+    history: VecDeque<BTreeMap<MessageId, u64>>,
+    insertion_order: VecDeque<(MessageId, u64)>,
     history_len: usize,
     max_messages: usize,
+    next_generation: u64,
 }
 
 impl MessageCache {
     pub(super) fn new(history_len: usize, max_messages: usize) -> Self {
         let mut history = VecDeque::new();
-        history.push_front(Vec::new());
+        history.push_front(BTreeMap::new());
         Self {
             messages: BTreeMap::new(),
             history,
             insertion_order: VecDeque::new(),
             history_len,
             max_messages,
+            next_generation: 0,
         }
     }
 
@@ -40,18 +43,27 @@ impl MessageCache {
         if self.messages.contains_key(&id) {
             return;
         }
-        self.messages
-            .insert(id.clone(), CacheEntry { message, topics });
+        let generation = self.next_generation;
+        self.next_generation = self.next_generation.wrapping_add(1);
+        self.messages.insert(
+            id.clone(),
+            CacheEntry {
+                message,
+                topics,
+                generation,
+            },
+        );
         self.history
             .front_mut()
             .expect("message cache always has a current window")
-            .push(id.clone());
-        self.insertion_order.push_back(id);
+            .insert(id.clone(), generation);
+        self.insertion_order.push_back((id, generation));
         while self.messages.len() > self.max_messages {
-            if let Some(oldest) = self.insertion_order.pop_front() {
-                self.remove(&oldest);
+            if let Some((oldest, generation)) = self.insertion_order.pop_front() {
+                self.remove_generation(&oldest, generation);
             }
         }
+        self.discard_stale_order_front();
     }
 
     pub(super) fn get(&self, id: &MessageId) -> Option<&RawMessage> {
@@ -60,12 +72,11 @@ impl MessageCache {
 
     pub(super) fn gossip_ids(&self, topic: &str, windows: usize) -> Vec<MessageId> {
         let mut unique = BTreeSet::new();
-        for id in self.history.iter().take(windows).flatten() {
-            if self
-                .messages
-                .get(id)
-                .is_some_and(|entry| entry.topics.iter().any(|candidate| candidate == topic))
-            {
+        for (id, generation) in self.history.iter().take(windows).flatten() {
+            if self.messages.get(id).is_some_and(|entry| {
+                entry.generation == *generation
+                    && entry.topics.iter().any(|candidate| candidate == topic)
+            }) {
                 unique.insert(id.clone());
             }
         }
@@ -73,21 +84,52 @@ impl MessageCache {
     }
 
     pub(super) fn shift(&mut self) {
-        self.history.push_front(Vec::new());
+        self.history.push_front(BTreeMap::new());
         while self.history.len() > self.history_len {
             if let Some(expired) = self.history.pop_back() {
-                for id in expired {
-                    self.remove(&id);
+                for (id, generation) in expired {
+                    if self
+                        .messages
+                        .get(&id)
+                        .is_some_and(|entry| entry.generation == generation)
+                    {
+                        self.messages.remove(&id);
+                    }
                 }
+            }
+        }
+        self.discard_stale_order_front();
+    }
+
+    fn remove_generation(&mut self, id: &MessageId, generation: u64) {
+        if !self
+            .messages
+            .get(id)
+            .is_some_and(|entry| entry.generation == generation)
+        {
+            return;
+        }
+        self.messages.remove(id);
+        for window in &mut self.history {
+            if window.get(id) == Some(&generation) {
+                window.remove(id);
+                break;
             }
         }
     }
 
-    fn remove(&mut self, id: &MessageId) {
-        self.messages.remove(id);
-        self.insertion_order.retain(|candidate| candidate != id);
-        for window in &mut self.history {
-            window.retain(|candidate| candidate != id);
+    fn discard_stale_order_front(&mut self) {
+        while self
+            .insertion_order
+            .front()
+            .is_some_and(|(id, generation)| {
+                !self
+                    .messages
+                    .get(id)
+                    .is_some_and(|entry| entry.generation == *generation)
+            })
+        {
+            self.insertion_order.pop_front();
         }
     }
 }
@@ -124,5 +166,21 @@ mod tests {
         assert!(cache.get(&vec![1]).is_none());
         assert!(!cache.gossip_ids("t", 5).contains(&vec![1]));
         assert!(cache.get(&vec![2]).is_some());
+    }
+
+    #[test]
+    fn stale_windows_do_not_evict_a_reinserted_id() {
+        let mut cache = MessageCache::new(2, 1);
+        cache.put(vec![1], message(1), vec![String::from("t")]);
+        cache.put(vec![2], message(2), vec![String::from("t")]);
+        cache.put(vec![1], message(3), vec![String::from("t")]);
+
+        cache.shift();
+        assert_eq!(
+            cache.get(&vec![1]).map(|message| message.raw.as_slice()),
+            Some(&[3][..])
+        );
+        cache.shift();
+        assert!(cache.get(&vec![1]).is_none());
     }
 }

--- a/crates/pubsub/src/gossipsub/mcache.rs
+++ b/crates/pubsub/src/gossipsub/mcache.rs
@@ -1,0 +1,128 @@
+//! Heartbeat-windowed gossipsub message cache.
+
+use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::message::RawMessage;
+use crate::seen::MessageId;
+
+#[derive(Clone, Debug)]
+struct CacheEntry {
+    message: RawMessage,
+    topics: Vec<String>,
+}
+
+/// Recent validated messages, indexed for IHAVE and IWANT.
+#[derive(Debug)]
+pub(super) struct MessageCache {
+    messages: BTreeMap<MessageId, CacheEntry>,
+    history: VecDeque<Vec<MessageId>>,
+    insertion_order: VecDeque<MessageId>,
+    history_len: usize,
+    max_messages: usize,
+}
+
+impl MessageCache {
+    pub(super) fn new(history_len: usize, max_messages: usize) -> Self {
+        let mut history = VecDeque::new();
+        history.push_front(Vec::new());
+        Self {
+            messages: BTreeMap::new(),
+            history,
+            insertion_order: VecDeque::new(),
+            history_len,
+            max_messages,
+        }
+    }
+
+    pub(super) fn put(&mut self, id: MessageId, message: RawMessage, topics: Vec<String>) {
+        if self.messages.contains_key(&id) {
+            return;
+        }
+        self.messages
+            .insert(id.clone(), CacheEntry { message, topics });
+        self.history
+            .front_mut()
+            .expect("message cache always has a current window")
+            .push(id.clone());
+        self.insertion_order.push_back(id);
+        while self.messages.len() > self.max_messages {
+            if let Some(oldest) = self.insertion_order.pop_front() {
+                self.remove(&oldest);
+            }
+        }
+    }
+
+    pub(super) fn get(&self, id: &MessageId) -> Option<&RawMessage> {
+        self.messages.get(id).map(|entry| &entry.message)
+    }
+
+    pub(super) fn gossip_ids(&self, topic: &str, windows: usize) -> Vec<MessageId> {
+        let mut unique = BTreeSet::new();
+        for id in self.history.iter().take(windows).flatten() {
+            if self
+                .messages
+                .get(id)
+                .is_some_and(|entry| entry.topics.iter().any(|candidate| candidate == topic))
+            {
+                unique.insert(id.clone());
+            }
+        }
+        unique.into_iter().collect()
+    }
+
+    pub(super) fn shift(&mut self) {
+        self.history.push_front(Vec::new());
+        while self.history.len() > self.history_len {
+            if let Some(expired) = self.history.pop_back() {
+                for id in expired {
+                    self.remove(&id);
+                }
+            }
+        }
+    }
+
+    fn remove(&mut self, id: &MessageId) {
+        self.messages.remove(id);
+        self.insertion_order.retain(|candidate| candidate != id);
+        for window in &mut self.history {
+            window.retain(|candidate| candidate != id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message(byte: u8) -> RawMessage {
+        RawMessage {
+            raw: vec![byte],
+            ..RawMessage::default()
+        }
+    }
+
+    #[test]
+    fn gossip_and_serving_follow_window_lifetimes() {
+        let mut cache = MessageCache::new(5, 8);
+        cache.put(vec![1], message(1), vec![String::from("t")]);
+        for heartbeat in 0..5 {
+            assert_eq!(cache.get(&vec![1]).is_some(), heartbeat < 5);
+            assert_eq!(cache.gossip_ids("t", 3).contains(&vec![1]), heartbeat < 3);
+            cache.shift();
+        }
+        assert!(cache.get(&vec![1]).is_none());
+    }
+
+    #[test]
+    fn capacity_eviction_removes_both_indices() {
+        let mut cache = MessageCache::new(5, 2);
+        cache.put(vec![1], message(1), vec![String::from("t")]);
+        cache.put(vec![2], message(2), vec![String::from("t")]);
+        cache.put(vec![3], message(3), vec![String::from("t")]);
+        assert!(cache.get(&vec![1]).is_none());
+        assert!(!cache.gossip_ids("t", 5).contains(&vec![1]));
+        assert!(cache.get(&vec![2]).is_some());
+    }
+}

--- a/crates/pubsub/src/gossipsub/mod.rs
+++ b/crates/pubsub/src/gossipsub/mod.rs
@@ -1,0 +1,6 @@
+mod agent;
+mod config;
+mod mcache;
+
+pub use agent::GossipsubAgent;
+pub use config::{GossipsubConfig, PubsubConfigError};

--- a/crates/pubsub/src/lib.rs
+++ b/crates/pubsub/src/lib.rs
@@ -1,10 +1,11 @@
-//! Sans-I/O libp2p pubsub wire codec plus a floodsub router for minip2p.
+//! Sans-I/O libp2p pubsub wire codec and routing engines for minip2p.
 //!
-//! The shared codec covers floodsub message RPCs and meshsub control messages
-//! for `/meshsub/1.0.0` and `/meshsub/1.1.0`, with varint-length-prefixed
-//! framing and StrictSign message signing. [`FloodsubAgent`] remains the only
-//! router in this crate today; it speaks `/floodsub/1.0.0` and deliberately
-//! skips meshsub control fields.
+//! [`GossipsubAgent`] speaks `/meshsub/1.1.0` and `/meshsub/1.0.0` using a
+//! long-lived outbound stream, mesh/fanout routing, heartbeat gossip, and a
+//! bounded message cache. [`FloodsubAgent`] speaks `/floodsub/1.0.0` using
+//! one outbound stream per RPC. [`PubsubAgent`] provides static engine
+//! selection. Both share varint framing, RPC/control encoding, and StrictSign
+//! message signing and verification.
 //!
 //! No I/O, no clocks, no async: callers feed inputs and drain
 //! actions/events, exactly like the other minip2p protocol crates.
@@ -15,13 +16,17 @@ extern crate alloc;
 
 mod agent;
 mod config;
+mod engine;
 mod events;
+mod gossipsub;
 mod message;
 mod seen;
 
 pub use agent::FloodsubAgent;
 pub use config::FloodsubConfig;
+pub use engine::{PubsubAgent, PubsubConfig};
 pub use events::{PublishError, PubsubAction, PubsubEvent, PubsubToken, TopicError};
+pub use gossipsub::{GossipsubAgent, GossipsubConfig, PubsubConfigError};
 pub use message::{
     ControlGraft, ControlIHave, ControlIWant, ControlMessage, ControlPrune, FLOODSUB_PROTOCOL_ID,
     FrameDecode, MAX_RPC_SIZE, MAX_TOPIC_LEN, MESHSUB_PROTOCOL_ID_V10, MESHSUB_PROTOCOL_ID_V11,

--- a/crates/pubsub/src/message.rs
+++ b/crates/pubsub/src/message.rs
@@ -362,6 +362,24 @@ impl RawMessage {
         Ok(message)
     }
 
+    /// Parses only the fields needed for the default dedup id. Routers use
+    /// this cheap path to discard known replays before signature verification;
+    /// unseen messages still pass through [`Self::verify`] before acceptance.
+    pub(crate) fn source_and_seqno(&self) -> Result<(PeerId, Vec<u8>), MessageVerifyError> {
+        let from_bytes = self
+            .from
+            .as_deref()
+            .ok_or(MessageVerifyError::MissingFrom)?;
+        let from = PeerId::from_bytes(from_bytes).map_err(|_| MessageVerifyError::InvalidFrom)?;
+        let seqno = self
+            .seqno
+            .as_deref()
+            .filter(|seqno| !seqno.is_empty() && seqno.len() <= MAX_SEQNO_LEN)
+            .ok_or(MessageVerifyError::InvalidSeqno)?
+            .to_vec();
+        Ok((from, seqno))
+    }
+
     /// Verifies this message per StrictSign and returns its publisher,
     /// dedup seqno bytes, and whether it carried a verified signature.
     ///
@@ -380,19 +398,7 @@ impl RawMessage {
         &self,
         allow_unsigned: bool,
     ) -> Result<(PeerId, Vec<u8>, bool), MessageVerifyError> {
-        let from_bytes = self
-            .from
-            .as_deref()
-            .ok_or(MessageVerifyError::MissingFrom)?;
-        let from = PeerId::from_bytes(from_bytes).map_err(|_| MessageVerifyError::InvalidFrom)?;
-        let seqno_bytes = self
-            .seqno
-            .as_deref()
-            .ok_or(MessageVerifyError::InvalidSeqno)?;
-        if seqno_bytes.is_empty() || seqno_bytes.len() > MAX_SEQNO_LEN {
-            return Err(MessageVerifyError::InvalidSeqno);
-        }
-        let seqno = seqno_bytes.to_vec();
+        let (from, seqno) = self.source_and_seqno()?;
 
         let Some(signature) = self.signature.as_deref() else {
             if self.key.is_some() {

--- a/crates/pubsub/src/seen.rs
+++ b/crates/pubsub/src/seen.rs
@@ -3,8 +3,16 @@
 use alloc::collections::{BTreeSet, VecDeque};
 use alloc::vec::Vec;
 
-/// A message's dedup identity: (`from` bytes, `seqno` bytes).
-pub(crate) type MessageId = (Vec<u8>, Vec<u8>);
+/// A message's wire-compatible dedup identity: publisher bytes followed by
+/// sequence-number bytes, matching the default gossipsub message-id rule.
+pub(crate) type MessageId = Vec<u8>;
+
+pub(crate) fn message_id(from: &[u8], seqno: &[u8]) -> MessageId {
+    let mut id = Vec::with_capacity(from.len() + seqno.len());
+    id.extend_from_slice(from);
+    id.extend_from_slice(seqno);
+    id
+}
 
 /// Dedup cache for message ids.
 ///

--- a/crates/pubsub/tests/agent.rs
+++ b/crates/pubsub/tests/agent.rs
@@ -84,6 +84,15 @@ fn negotiate_send(
     stream_id: StreamId,
     now: u64,
 ) -> Option<Vec<u8>> {
+    negotiate_send_with_token(a, peer, stream_id, now).map(|(frame, _)| frame)
+}
+
+fn negotiate_send_with_token(
+    a: &mut FloodsubAgent,
+    peer: &PeerId,
+    stream_id: StreamId,
+    now: u64,
+) -> Option<(Vec<u8>, minip2p_pubsub::PubsubToken)> {
     let actions = drain_actions(a);
     let (token, to) = open_stream_action(&actions)?;
     assert_eq!(&to, peer);
@@ -100,8 +109,8 @@ fn negotiate_send(
     );
     assert!(claimed, "our outbound StreamReady must be claimed");
     let actions = drain_actions(a);
-    let frame = actions.iter().find_map(|a| match a {
-        PubsubAction::SendStream { data, .. } => Some(data.clone()),
+    let (frame, send_token) = actions.iter().find_map(|a| match a {
+        PubsubAction::SendStream { token, data, .. } => Some((data.clone(), *token)),
         _ => None,
     })?;
     assert!(
@@ -110,7 +119,7 @@ fn negotiate_send(
             .any(|a| matches!(a, PubsubAction::CloseStreamWrite { .. })),
         "one-shot send must half-close: {actions:?}"
     );
-    Some(frame)
+    Some((frame, send_token))
 }
 
 /// Full one-shot send cycle: open → send → close. Returns the sent frame.
@@ -1392,10 +1401,17 @@ fn send_failure_prevents_the_commit() {
     connect(&mut a, &b, 0);
     a.subscribe("t", 1).unwrap();
     let stream = StreamId::new(4);
-    negotiate_send(&mut a, &b, stream, 1).expect("snapshot in flight");
+    let (_, send_token) =
+        negotiate_send_with_token(&mut a, &b, stream, 1).expect("snapshot in flight");
 
     // The swarm rejected the write: the close that follows must not commit.
-    a.send_failed(&b, stream, "connection lost", 2);
+    a.send_result(
+        &b,
+        stream,
+        send_token,
+        Err("connection lost".to_string()),
+        2,
+    );
     let events = drain_events(&mut a);
     assert!(
         events
@@ -1458,8 +1474,50 @@ fn send_failure_prevents_the_commit() {
 
     // A stale-stream failure report must not disturb a healthy sender.
     a.publish("t", b"x".to_vec(), 6).ok();
-    a.send_failed(&b, StreamId::new(999), "stale", 7);
+    a.send_result(
+        &b,
+        StreamId::new(999),
+        send_token,
+        Err("stale".to_string()),
+        7,
+    );
     assert!(drain_events(&mut a).is_empty(), "stale report is a no-op");
+
+    // The right stream with an old token is stale too.
+    a.subscribe("u", 8).unwrap();
+    let (open_token, _) = open_stream_action(&drain_actions(&mut a)).expect("new diff open");
+    let current_stream = StreamId::new(12);
+    a.stream_open_result(&b, open_token, Ok(current_stream), 8);
+    a.handle_event(
+        &SwarmEvent::StreamReady {
+            conn_id: minip2p_transport::ConnectionId::new(1),
+            peer_id: b.clone(),
+            stream_id: current_stream,
+            protocol_id: FLOODSUB_PROTOCOL_ID.to_string(),
+            initiated_locally: true,
+        },
+        8,
+    );
+    let current = drain_actions(&mut a);
+    let current_token = current
+        .iter()
+        .find_map(|action| match action {
+            PubsubAction::SendStream { token, .. } => Some(*token),
+            _ => None,
+        })
+        .expect("current send token");
+    assert_ne!(current_token, send_token);
+    a.send_result(
+        &b,
+        current_stream,
+        send_token,
+        Err("stale token".to_string()),
+        9,
+    );
+    assert!(drain_events(&mut a).is_empty());
+    assert!(drain_actions(&mut a).is_empty());
+    a.send_result(&b, current_stream, current_token, Ok(()), 9);
+    assert!(drain_events(&mut a).is_empty());
 }
 
 #[test]

--- a/crates/pubsub/tests/gossipsub.rs
+++ b/crates/pubsub/tests/gossipsub.rs
@@ -425,6 +425,49 @@ fn heartbeat_repairs_mesh_and_received_prune_blocks_regraft() {
 }
 
 #[test]
+fn prune_backoff_is_recorded_before_local_subscription() {
+    let mut agent = agent();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+    assert!(
+        make_ready(
+            &mut agent,
+            &remote,
+            StreamId::new(4),
+            MESHSUB_PROTOCOL_ID_V11,
+            0,
+        )
+        .is_empty()
+    );
+    inbound_open(&mut agent, &remote, StreamId::new(5), 0);
+    remote_subscribe(&mut agent, &remote, StreamId::new(5), "future", 0);
+    drain_events(&mut agent);
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            control: Some(ControlMessage {
+                prune: vec![ControlPrune {
+                    topic_id: Some("future".to_string()),
+                    peers: Vec::new(),
+                    backoff: Some(120),
+                }],
+                ..ControlMessage::default()
+            }),
+            ..Rpc::default()
+        },
+        1,
+    );
+
+    agent.subscribe("future", 2).unwrap();
+    assert!(
+        agent.mesh_peers("future").is_empty(),
+        "the pre-subscription PRUNE backoff gates immediate GRAFT"
+    );
+}
+
+#[test]
 fn ihave_deduplicates_and_obeys_per_heartbeat_budgets() {
     let config = GossipsubConfig {
         max_ihave_messages_per_heartbeat: 1,

--- a/crates/pubsub/tests/gossipsub.rs
+++ b/crates/pubsub/tests/gossipsub.rs
@@ -157,6 +157,32 @@ fn sent(actions: &[PubsubAction]) -> Option<(Vec<u8>, minip2p_pubsub::PubsubToke
     })
 }
 
+fn open_for(
+    actions: &[PubsubAction],
+    expected_peer: &PeerId,
+) -> Option<minip2p_pubsub::PubsubToken> {
+    actions.iter().find_map(|action| match action {
+        PubsubAction::OpenStream { token, peer, .. } if peer == expected_peer => Some(*token),
+        _ => None,
+    })
+}
+
+fn ack_peer(agent: &mut GossipsubAgent, peer: &PeerId, actions: &[PubsubAction], now_ms: u64) {
+    let (token, stream_id) = actions
+        .iter()
+        .find_map(|action| match action {
+            PubsubAction::SendStream {
+                token,
+                peer: sent_peer,
+                stream_id,
+                ..
+            } if sent_peer == peer => Some((*token, *stream_id)),
+            _ => None,
+        })
+        .expect("send action for peer");
+    agent.send_result(peer, stream_id, token, Ok(()), now_ms);
+}
+
 fn ack(agent: &mut GossipsubAgent, peer: &PeerId, actions: &[PubsubAction], now_ms: u64) {
     let (_, token, stream_id) = sent(actions).expect("send action");
     agent.send_result(peer, stream_id, token, Ok(()), now_ms);
@@ -340,6 +366,120 @@ fn unknown_graft_is_ignored_without_amplification() {
 }
 
 #[test]
+fn unannounced_or_excess_graft_is_pruned_immediately() {
+    let config = GossipsubConfig {
+        d: 1,
+        d_low: 1,
+        d_high: 1,
+        ..GossipsubConfig::default()
+    };
+    let mut agent = agent_with(config);
+    agent.subscribe("room", 0).unwrap();
+
+    let first = peer(2);
+    connect(&mut agent, &first, &[MESHSUB_PROTOCOL_ID_V11], 1);
+    let subscription = make_ready(
+        &mut agent,
+        &first,
+        StreamId::new(4),
+        MESHSUB_PROTOCOL_ID_V11,
+        1,
+    );
+    ack(&mut agent, &first, &subscription, 1);
+    drain_actions(&mut agent);
+    inbound_open(&mut agent, &first, StreamId::new(5), 1);
+    remote_subscribe(&mut agent, &first, StreamId::new(5), "room", 1);
+    drain_events(&mut agent);
+    inbound_rpc(
+        &mut agent,
+        &first,
+        StreamId::new(5),
+        Rpc {
+            control: Some(ControlMessage {
+                graft: vec![ControlGraft {
+                    topic_id: Some("room".to_string()),
+                }],
+                ..ControlMessage::default()
+            }),
+            ..Rpc::default()
+        },
+        2,
+    );
+    assert_eq!(agent.mesh_peers("room"), vec![first.clone()]);
+
+    let excess = peer(3);
+    connect(&mut agent, &excess, &[MESHSUB_PROTOCOL_ID_V11], 3);
+    let subscription = make_ready(
+        &mut agent,
+        &excess,
+        StreamId::new(6),
+        MESHSUB_PROTOCOL_ID_V11,
+        3,
+    );
+    ack(&mut agent, &excess, &subscription, 3);
+    drain_actions(&mut agent);
+    inbound_open(&mut agent, &excess, StreamId::new(7), 3);
+    remote_subscribe(&mut agent, &excess, StreamId::new(7), "room", 3);
+    drain_events(&mut agent);
+    inbound_rpc(
+        &mut agent,
+        &excess,
+        StreamId::new(7),
+        Rpc {
+            control: Some(ControlMessage {
+                graft: vec![ControlGraft {
+                    topic_id: Some("room".to_string()),
+                }],
+                ..ControlMessage::default()
+            }),
+            ..Rpc::default()
+        },
+        4,
+    );
+    assert_eq!(agent.mesh_peers("room"), vec![first]);
+    let prune = drain_actions(&mut agent);
+    let control = decode_rpc(&sent(&prune).unwrap().0).control.unwrap();
+    assert_eq!(control.prune.len(), 1);
+
+    let unannounced = peer(4);
+    connect(&mut agent, &unannounced, &[MESHSUB_PROTOCOL_ID_V11], 5);
+    let subscription = make_ready(
+        &mut agent,
+        &unannounced,
+        StreamId::new(8),
+        MESHSUB_PROTOCOL_ID_V11,
+        5,
+    );
+    ack(&mut agent, &unannounced, &subscription, 5);
+    drain_actions(&mut agent);
+    inbound_open(&mut agent, &unannounced, StreamId::new(9), 5);
+    inbound_rpc(
+        &mut agent,
+        &unannounced,
+        StreamId::new(9),
+        Rpc {
+            control: Some(ControlMessage {
+                graft: vec![ControlGraft {
+                    topic_id: Some("room".to_string()),
+                }],
+                ..ControlMessage::default()
+            }),
+            ..Rpc::default()
+        },
+        6,
+    );
+    let prune = drain_actions(&mut agent);
+    assert_eq!(
+        decode_rpc(&sent(&prune).unwrap().0)
+            .control
+            .unwrap()
+            .prune
+            .len(),
+        1
+    );
+}
+
+#[test]
 fn empty_mesh_publish_falls_back_without_grafting() {
     let mut agent = agent();
     agent.subscribe("room", 0).unwrap();
@@ -475,15 +615,18 @@ fn ihave_deduplicates_and_obeys_per_heartbeat_budgets() {
         ..GossipsubConfig::default()
     };
     let mut agent = agent_with(config);
+    agent.subscribe("room", 0).unwrap();
     let remote = peer(2);
     connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
-    make_ready(
+    let subscription = make_ready(
         &mut agent,
         &remote,
         StreamId::new(4),
         MESHSUB_PROTOCOL_ID_V11,
         0,
     );
+    ack(&mut agent, &remote, &subscription, 0);
+    drain_actions(&mut agent);
     inbound_open(&mut agent, &remote, StreamId::new(5), 0);
     let ihave = |ids: Vec<Vec<u8>>| Rpc {
         control: Some(ControlMessage {
@@ -495,6 +638,23 @@ fn ihave_deduplicates_and_obeys_per_heartbeat_budgets() {
         }),
         ..Rpc::default()
     };
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            control: Some(ControlMessage {
+                ihave: vec![ControlIHave {
+                    topic_id: Some("other".to_string()),
+                    message_ids: vec![vec![0]],
+                }],
+                ..ControlMessage::default()
+            }),
+            ..Rpc::default()
+        },
+        1,
+    );
+    assert!(drain_actions(&mut agent).is_empty());
     inbound_rpc(
         &mut agent,
         &remote,
@@ -692,22 +852,32 @@ fn valid_message_delivers_once_and_invalid_signature_never_delivers() {
     inbound_open(&mut agent, &remote, StreamId::new(5), 0);
     let signer = keypair(9);
     let valid = RawMessage::build_signed(&signer, "room", b"hello".to_vec(), 1);
+    let mut replay_with_bad_signature = valid.clone();
+    replay_with_bad_signature.signature.as_mut().unwrap()[0] ^= 1;
+    replay_with_bad_signature.raw = Vec::new();
     inbound_rpc(
         &mut agent,
         &remote,
         StreamId::new(5),
         Rpc {
-            publish: vec![valid.clone(), valid],
+            publish: vec![valid, replay_with_bad_signature],
             ..Rpc::default()
         },
         1,
     );
+    let events = drain_events(&mut agent);
     assert_eq!(
-        drain_events(&mut agent)
-            .into_iter()
+        events
+            .iter()
             .filter(|event| matches!(event, PubsubEvent::Message { .. }))
             .count(),
         1
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, PubsubEvent::ProtocolViolation { .. })),
+        "a known replay is discarded before signature verification"
     );
 
     let mut invalid = RawMessage::build_signed(&signer, "room", b"bad".to_vec(), 2);
@@ -737,6 +907,58 @@ fn valid_message_delivers_once_and_invalid_signature_never_delivers() {
 }
 
 #[test]
+fn off_topic_message_is_not_cached_as_seen() {
+    let mut agent = agent();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+    assert!(
+        make_ready(
+            &mut agent,
+            &remote,
+            StreamId::new(4),
+            MESHSUB_PROTOCOL_ID_V11,
+            0,
+        )
+        .is_empty()
+    );
+    inbound_open(&mut agent, &remote, StreamId::new(5), 0);
+    let message = RawMessage::build_signed(&keypair(9), "room", b"hello".to_vec(), 1);
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            publish: vec![message.clone()],
+            ..Rpc::default()
+        },
+        1,
+    );
+    assert!(drain_events(&mut agent).is_empty());
+
+    agent.subscribe("room", 2).unwrap();
+    let subscription = drain_actions(&mut agent);
+    ack(&mut agent, &remote, &subscription, 2);
+    drain_actions(&mut agent);
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            publish: vec![message],
+            ..Rpc::default()
+        },
+        3,
+    );
+    assert_eq!(
+        drain_events(&mut agent)
+            .into_iter()
+            .filter(|event| matches!(event, PubsubEvent::Message { .. }))
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn v11_leave_prune_carries_backoff() {
     let mut agent = agent();
     agent.subscribe("room", 0).unwrap();
@@ -752,6 +974,8 @@ fn v11_leave_prune_carries_backoff() {
     ack(&mut agent, &remote, &subscription, 1);
     drain_actions(&mut agent);
     inbound_open(&mut agent, &remote, StreamId::new(5), 1);
+    remote_subscribe(&mut agent, &remote, StreamId::new(5), "room", 1);
+    drain_events(&mut agent);
     inbound_rpc(
         &mut agent,
         &remote,
@@ -806,4 +1030,245 @@ fn large_subscription_resync_is_split_without_dropping_entries() {
         actions = drain_actions(&mut agent);
     }
     assert_eq!(announced, 80);
+}
+
+#[test]
+fn open_failure_and_establishment_timeout_retry_only_after_stimulus() {
+    let config = GossipsubConfig {
+        heartbeat_interval_ms: 100_000,
+        send_timeout_ms: 10,
+        ..GossipsubConfig::default()
+    };
+    let mut agent = agent_with(config.clone());
+    agent.subscribe("room", 0).unwrap();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+    let opening = drain_actions(&mut agent);
+    let token = open_for(&opening, &remote).unwrap();
+    agent.stream_open_result(&remote, token, Err("refused".to_string()), 1);
+    assert!(
+        drain_actions(&mut agent).is_empty(),
+        "failure must not spin-retry"
+    );
+    assert!(drain_events(&mut agent).iter().any(|event| matches!(
+        event,
+        PubsubEvent::OutboundFailure { reason, .. } if reason.contains("open failed")
+    )));
+    agent.handle_event(
+        &SwarmEvent::PeerReady {
+            peer_id: remote.clone(),
+            protocols: vec![MESHSUB_PROTOCOL_ID_V11.to_string()],
+        },
+        2,
+    );
+    assert!(open_for(&drain_actions(&mut agent), &remote).is_some());
+
+    let mut agent = agent_with(config);
+    agent.subscribe("room", 0).unwrap();
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+    let opening = drain_actions(&mut agent);
+    let token = open_for(&opening, &remote).unwrap();
+    agent.stream_open_result(&remote, token, Ok(StreamId::new(4)), 0);
+    agent.handle_tick(10);
+    let timeout_actions = drain_actions(&mut agent);
+    assert!(timeout_actions.iter().any(|action| matches!(
+        action,
+        PubsubAction::ResetStream { stream_id, .. } if *stream_id == StreamId::new(4)
+    )));
+    assert!(open_for(&timeout_actions, &remote).is_none());
+    assert!(drain_events(&mut agent).iter().any(|event| matches!(
+        event,
+        PubsubEvent::OutboundFailure { reason, .. }
+            if reason.contains("establishment timed out")
+    )));
+    agent.handle_event(
+        &SwarmEvent::PeerReady {
+            peer_id: remote.clone(),
+            protocols: vec![MESHSUB_PROTOCOL_ID_V11.to_string()],
+        },
+        11,
+    );
+    assert!(open_for(&drain_actions(&mut agent), &remote).is_some());
+}
+
+#[test]
+fn disconnect_and_supersede_aggregate_queued_failures() {
+    let mut agent = agent();
+    agent.subscribe("room", 0).unwrap();
+    let first = peer(2);
+    let second = peer(3);
+    for (remote, outbound, inbound) in [
+        (&first, StreamId::new(4), StreamId::new(5)),
+        (&second, StreamId::new(6), StreamId::new(7)),
+    ] {
+        connect(&mut agent, remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+        let subscription = make_ready(&mut agent, remote, outbound, MESHSUB_PROTOCOL_ID_V11, 0);
+        ack(&mut agent, remote, &subscription, 0);
+        drain_actions(&mut agent);
+        inbound_open(&mut agent, remote, inbound, 0);
+        remote_subscribe(&mut agent, remote, inbound, "room", 0);
+    }
+    drain_events(&mut agent);
+    agent.publish("room", b"queued".to_vec(), 1).unwrap();
+    drain_actions(&mut agent);
+
+    agent.handle_event(
+        &SwarmEvent::ConnectionClosed {
+            peer_id: first.clone(),
+            conn_id: ConnectionId::new(1),
+        },
+        2,
+    );
+    agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            peer_id: second.clone(),
+            conn_id: ConnectionId::new(2),
+        },
+        2,
+    );
+    let failures: Vec<_> = drain_events(&mut agent)
+        .into_iter()
+        .filter_map(|event| match event {
+            PubsubEvent::OutboundFailure { peer, reason } => Some((peer, reason)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(failures.len(), 2);
+    assert!(failures.iter().any(|(peer, reason)| {
+        peer == &first && reason.contains("connection closed; dropped 1 queued items")
+    }));
+    assert!(failures.iter().any(|(peer, reason)| {
+        peer == &second && reason.contains("connection superseded; dropped 1 queued items")
+    }));
+}
+
+#[test]
+fn publish_backpressure_is_all_or_nothing_across_mesh_peers() {
+    let config = GossipsubConfig {
+        d: 2,
+        max_pending_per_peer: 1,
+        ..GossipsubConfig::default()
+    };
+    let mut agent = agent_with(config);
+    agent.subscribe("room", 0).unwrap();
+    let first = peer(2);
+    let second = peer(3);
+    for (remote, outbound, inbound) in [
+        (&first, StreamId::new(4), StreamId::new(5)),
+        (&second, StreamId::new(6), StreamId::new(7)),
+    ] {
+        connect(&mut agent, remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+        let subscription = make_ready(&mut agent, remote, outbound, MESHSUB_PROTOCOL_ID_V11, 0);
+        ack(&mut agent, remote, &subscription, 0);
+        drain_actions(&mut agent);
+        inbound_open(&mut agent, remote, inbound, 0);
+        remote_subscribe(&mut agent, remote, inbound, "room", 0);
+    }
+    drain_events(&mut agent);
+    agent.publish("room", b"first".to_vec(), 1).unwrap();
+    let first_publish = drain_actions(&mut agent);
+    ack_peer(&mut agent, &first, &first_publish, 1);
+    drain_actions(&mut agent);
+
+    assert!(agent.publish("room", b"rejected".to_vec(), 2).is_err());
+    assert!(
+        drain_actions(&mut agent).is_empty(),
+        "the peer with capacity must not receive a partial publish"
+    );
+}
+
+#[test]
+fn zero_gossip_degree_emits_no_ihave() {
+    let config = GossipsubConfig {
+        d: 1,
+        d_low: 1,
+        d_high: 2,
+        d_lazy: 0,
+        ..GossipsubConfig::default()
+    };
+    let mut agent = agent_with(config);
+    agent.subscribe("room", 0).unwrap();
+    let mesh_peer = peer(2);
+    let gossip_peer = peer(3);
+    for (remote, outbound, inbound) in [
+        (&mesh_peer, StreamId::new(4), StreamId::new(5)),
+        (&gossip_peer, StreamId::new(6), StreamId::new(7)),
+    ] {
+        connect(&mut agent, remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+        let subscription = make_ready(&mut agent, remote, outbound, MESHSUB_PROTOCOL_ID_V11, 0);
+        ack(&mut agent, remote, &subscription, 0);
+        drain_actions(&mut agent);
+        inbound_open(&mut agent, remote, inbound, 0);
+        remote_subscribe(&mut agent, remote, inbound, "room", 0);
+    }
+    drain_events(&mut agent);
+    inbound_rpc(
+        &mut agent,
+        &mesh_peer,
+        StreamId::new(5),
+        Rpc {
+            control: Some(ControlMessage {
+                graft: vec![ControlGraft {
+                    topic_id: Some("room".to_string()),
+                }],
+                ..ControlMessage::default()
+            }),
+            ..Rpc::default()
+        },
+        1,
+    );
+    agent.publish("room", b"cached".to_vec(), 2).unwrap();
+    let publish = drain_actions(&mut agent);
+    ack_peer(&mut agent, &mesh_peer, &publish, 2);
+    drain_actions(&mut agent);
+    agent.handle_tick(1_000);
+    assert!(drain_actions(&mut agent).is_empty());
+}
+
+#[test]
+fn zero_fanout_ttl_reselects_for_each_publish() {
+    let config = GossipsubConfig {
+        d: 1,
+        fanout_ttl_ms: 0,
+        ..GossipsubConfig::default()
+    };
+    let mut agent = agent_with(config);
+    let first = peer(2);
+    let second = peer(3);
+    for (remote, outbound, inbound) in [
+        (&first, StreamId::new(4), StreamId::new(5)),
+        (&second, StreamId::new(6), StreamId::new(7)),
+    ] {
+        connect(&mut agent, remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+        assert!(make_ready(&mut agent, remote, outbound, MESHSUB_PROTOCOL_ID_V11, 0,).is_empty());
+        inbound_open(&mut agent, remote, inbound, 0);
+        remote_subscribe(&mut agent, remote, inbound, "room", 0);
+    }
+    drain_events(&mut agent);
+
+    agent.publish("room", b"first".to_vec(), 1).unwrap();
+    let sent_first = drain_actions(&mut agent);
+    let selected = sent_first
+        .iter()
+        .find_map(|action| match action {
+            PubsubAction::SendStream { peer, .. } => Some(peer.clone()),
+            _ => None,
+        })
+        .unwrap();
+    ack_peer(&mut agent, &selected, &sent_first, 1);
+    drain_actions(&mut agent);
+
+    agent.publish("room", b"second".to_vec(), 2).unwrap();
+    let sent_second = drain_actions(&mut agent);
+    let reselected = sent_second
+        .iter()
+        .find_map(|action| match action {
+            PubsubAction::SendStream { peer, .. } => Some(peer.clone()),
+            _ => None,
+        })
+        .unwrap();
+    assert_ne!(
+        reselected, selected,
+        "the fixed RNG seed demonstrates that a zero TTL starts a fresh selection"
+    );
 }

--- a/crates/pubsub/tests/gossipsub.rs
+++ b/crates/pubsub/tests/gossipsub.rs
@@ -1,0 +1,766 @@
+//! Scripted no-I/O tests for the long-lived gossipsub router.
+
+use minip2p_core::PeerId;
+use minip2p_identity::Ed25519Keypair;
+use minip2p_pubsub::{
+    ControlGraft, ControlIHave, ControlIWant, ControlMessage, ControlPrune, FrameDecode,
+    GossipsubAgent, GossipsubConfig, MESHSUB_PROTOCOL_ID_V10, MESHSUB_PROTOCOL_ID_V11,
+    PubsubAction, PubsubEvent, RawMessage, Rpc, SubOpts, decode_frame, encode_frame,
+};
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::{ConnectionId, StreamId};
+
+fn keypair(seed: u8) -> Ed25519Keypair {
+    Ed25519Keypair::from_secret_key_bytes([seed; 32])
+}
+
+fn peer(seed: u8) -> PeerId {
+    keypair(seed).peer_id()
+}
+
+fn agent_with(config: GossipsubConfig) -> GossipsubAgent {
+    GossipsubAgent::new(keypair(1), config, 100, 7)
+}
+
+fn agent() -> GossipsubAgent {
+    agent_with(GossipsubConfig::default())
+}
+
+fn drain_actions(agent: &mut GossipsubAgent) -> Vec<PubsubAction> {
+    let mut actions = Vec::new();
+    while let Some(action) = agent.poll_action() {
+        actions.push(action);
+    }
+    actions
+}
+
+fn drain_events(agent: &mut GossipsubAgent) -> Vec<PubsubEvent> {
+    let mut events = Vec::new();
+    while let Some(event) = agent.poll_event() {
+        events.push(event);
+    }
+    events
+}
+
+fn connect(agent: &mut GossipsubAgent, peer: &PeerId, protocols: &[&str], now_ms: u64) {
+    agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            peer_id: peer.clone(),
+            conn_id: ConnectionId::new(1),
+        },
+        now_ms,
+    );
+    agent.handle_event(
+        &SwarmEvent::PeerReady {
+            peer_id: peer.clone(),
+            protocols: protocols.iter().map(|id| (*id).to_string()).collect(),
+        },
+        now_ms,
+    );
+}
+
+fn make_ready(
+    agent: &mut GossipsubAgent,
+    peer: &PeerId,
+    stream_id: StreamId,
+    negotiated: &str,
+    now_ms: u64,
+) -> Vec<PubsubAction> {
+    let actions = drain_actions(agent);
+    let (token, protocol_id) = actions
+        .iter()
+        .find_map(|action| match action {
+            PubsubAction::OpenStream {
+                token, protocol_id, ..
+            } => Some((*token, protocol_id.clone())),
+            _ => None,
+        })
+        .expect("outbound open");
+    assert!(protocol_id == MESHSUB_PROTOCOL_ID_V10 || protocol_id == MESHSUB_PROTOCOL_ID_V11);
+    agent.stream_open_result(peer, token, Ok(stream_id), now_ms);
+    assert!(agent.handle_event(
+        &SwarmEvent::StreamReady {
+            peer_id: peer.clone(),
+            conn_id: ConnectionId::new(1),
+            stream_id,
+            protocol_id: negotiated.to_string(),
+            initiated_locally: true,
+        },
+        now_ms,
+    ));
+    drain_actions(agent)
+}
+
+fn inbound_open(agent: &mut GossipsubAgent, peer: &PeerId, stream_id: StreamId, now_ms: u64) {
+    assert!(agent.handle_event(
+        &SwarmEvent::StreamReady {
+            peer_id: peer.clone(),
+            conn_id: ConnectionId::new(1),
+            stream_id,
+            protocol_id: MESHSUB_PROTOCOL_ID_V11.to_string(),
+            initiated_locally: false,
+        },
+        now_ms,
+    ));
+}
+
+fn inbound_rpc(
+    agent: &mut GossipsubAgent,
+    peer: &PeerId,
+    stream_id: StreamId,
+    rpc: Rpc,
+    now_ms: u64,
+) {
+    assert!(agent.handle_event(
+        &SwarmEvent::StreamData {
+            peer_id: peer.clone(),
+            conn_id: ConnectionId::new(1),
+            stream_id,
+            data: encode_frame(&rpc.encode()),
+        },
+        now_ms,
+    ));
+}
+
+fn remote_subscribe(
+    agent: &mut GossipsubAgent,
+    peer: &PeerId,
+    stream_id: StreamId,
+    topic: &str,
+    now_ms: u64,
+) {
+    inbound_rpc(
+        agent,
+        peer,
+        stream_id,
+        Rpc {
+            subscriptions: vec![SubOpts {
+                subscribe: Some(true),
+                topic_id: Some(topic.to_string()),
+            }],
+            publish: Vec::new(),
+            control: None,
+        },
+        now_ms,
+    );
+}
+
+fn sent(actions: &[PubsubAction]) -> Option<(Vec<u8>, minip2p_pubsub::PubsubToken, StreamId)> {
+    actions.iter().find_map(|action| match action {
+        PubsubAction::SendStream {
+            data,
+            token,
+            stream_id,
+            ..
+        } => Some((data.clone(), *token, *stream_id)),
+        _ => None,
+    })
+}
+
+fn ack(agent: &mut GossipsubAgent, peer: &PeerId, actions: &[PubsubAction], now_ms: u64) {
+    let (_, token, stream_id) = sent(actions).expect("send action");
+    agent.send_result(peer, stream_id, token, Ok(()), now_ms);
+}
+
+fn decode_rpc(frame: &[u8]) -> Rpc {
+    let FrameDecode::Complete { payload, consumed } = decode_frame(frame) else {
+        panic!("complete frame expected")
+    };
+    assert_eq!(consumed, frame.len());
+    Rpc::decode(payload).expect("valid emitted RPC")
+}
+
+#[test]
+fn build_time_subscribe_does_not_arm_heartbeat() {
+    let mut agent = agent();
+    agent.subscribe("room", 0).unwrap();
+    assert_eq!(agent.next_timeout(50_000), None);
+
+    let remote = peer(2);
+    connect(
+        &mut agent,
+        &remote,
+        &[MESHSUB_PROTOCOL_ID_V11, MESHSUB_PROTOCOL_ID_V10],
+        50_000,
+    );
+    assert_eq!(agent.next_timeout(50_000), Some(1_000));
+    assert!(agent.mesh_peers("room").is_empty());
+}
+
+#[test]
+fn prefers_v11_but_encodes_for_the_actually_negotiated_version() {
+    let mut agent = agent();
+    agent.subscribe("room", 0).unwrap();
+    let remote = peer(2);
+    connect(
+        &mut agent,
+        &remote,
+        &[MESHSUB_PROTOCOL_ID_V10, MESHSUB_PROTOCOL_ID_V11],
+        1,
+    );
+    let open = drain_actions(&mut agent);
+    assert!(open.iter().any(|action| matches!(
+        action,
+        PubsubAction::OpenStream { protocol_id, .. } if protocol_id == MESHSUB_PROTOCOL_ID_V11
+    )));
+    // Put the action back through the manual ready sequence using its token.
+    let token = open
+        .iter()
+        .find_map(|action| match action {
+            PubsubAction::OpenStream { token, .. } => Some(*token),
+            _ => None,
+        })
+        .unwrap();
+    let stream = StreamId::new(4);
+    agent.stream_open_result(&remote, token, Ok(stream), 1);
+    agent.handle_event(
+        &SwarmEvent::StreamReady {
+            peer_id: remote.clone(),
+            conn_id: ConnectionId::new(1),
+            stream_id: stream,
+            protocol_id: MESHSUB_PROTOCOL_ID_V10.to_string(),
+            initiated_locally: true,
+        },
+        1,
+    );
+    let subscription = drain_actions(&mut agent);
+    ack(&mut agent, &remote, &subscription, 1);
+    drain_actions(&mut agent);
+
+    inbound_open(&mut agent, &remote, StreamId::new(5), 2);
+    remote_subscribe(&mut agent, &remote, StreamId::new(5), "room", 2);
+    drain_events(&mut agent);
+    agent.handle_tick(1_001);
+    let graft = drain_actions(&mut agent);
+    ack(&mut agent, &remote, &graft, 1_001);
+    drain_actions(&mut agent);
+    agent.unsubscribe("room", 1_002);
+    let unsubscribe = drain_actions(&mut agent);
+    ack(&mut agent, &remote, &unsubscribe, 1_002);
+    let prune = drain_actions(&mut agent);
+    let rpc = decode_rpc(&sent(&prune).unwrap().0);
+    assert_eq!(rpc.control.unwrap().prune[0].backoff, None);
+}
+
+#[test]
+fn join_promotes_known_peer_and_sender_stays_long_lived() {
+    let mut agent = agent();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+    assert!(
+        make_ready(
+            &mut agent,
+            &remote,
+            StreamId::new(4),
+            MESHSUB_PROTOCOL_ID_V11,
+            0
+        )
+        .is_empty()
+    );
+    inbound_open(&mut agent, &remote, StreamId::new(5), 0);
+    remote_subscribe(&mut agent, &remote, StreamId::new(5), "room", 0);
+    drain_events(&mut agent);
+
+    agent.subscribe("room", 1).unwrap();
+    assert_eq!(agent.mesh_peers("room"), vec![remote.clone()]);
+    let subscription = drain_actions(&mut agent);
+    let rpc = decode_rpc(&sent(&subscription).unwrap().0);
+    assert_eq!(rpc.subscriptions[0].subscribe, Some(true));
+    assert!(
+        !subscription
+            .iter()
+            .any(|action| matches!(action, PubsubAction::CloseStreamWrite { .. }))
+    );
+    ack(&mut agent, &remote, &subscription, 1);
+    let graft = drain_actions(&mut agent);
+    assert_eq!(
+        decode_rpc(&sent(&graft).unwrap().0).control.unwrap().graft[0]
+            .topic_id
+            .as_deref(),
+        Some("room")
+    );
+    assert!(
+        !graft
+            .iter()
+            .any(|action| matches!(action, PubsubAction::OpenStream { .. }))
+    );
+
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            subscriptions: vec![SubOpts {
+                subscribe: Some(false),
+                topic_id: Some("room".to_string()),
+            }],
+            ..Rpc::default()
+        },
+        2,
+    );
+    assert!(
+        agent.mesh_peers("room").is_empty(),
+        "remote unsubscribe immediately removes its mesh membership"
+    );
+}
+
+#[test]
+fn unknown_graft_is_ignored_without_amplification() {
+    let mut agent = agent();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+    assert!(
+        make_ready(
+            &mut agent,
+            &remote,
+            StreamId::new(4),
+            MESHSUB_PROTOCOL_ID_V11,
+            0,
+        )
+        .is_empty()
+    );
+    inbound_open(&mut agent, &remote, StreamId::new(5), 0);
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            control: Some(ControlMessage {
+                graft: vec![ControlGraft {
+                    topic_id: Some("unknown".to_string()),
+                }],
+                ..ControlMessage::default()
+            }),
+            ..Rpc::default()
+        },
+        1,
+    );
+    assert!(agent.mesh_peers("unknown").is_empty());
+    assert!(drain_actions(&mut agent).is_empty());
+}
+
+#[test]
+fn empty_mesh_publish_falls_back_without_grafting() {
+    let mut agent = agent();
+    agent.subscribe("room", 0).unwrap();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 1);
+    let subscription = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(4),
+        MESHSUB_PROTOCOL_ID_V11,
+        1,
+    );
+    ack(&mut agent, &remote, &subscription, 1);
+    drain_actions(&mut agent);
+    inbound_open(&mut agent, &remote, StreamId::new(5), 1);
+    remote_subscribe(&mut agent, &remote, StreamId::new(5), "room", 1);
+    drain_events(&mut agent);
+
+    agent
+        .publish("room", b"before heartbeat".to_vec(), 2)
+        .unwrap();
+    assert!(agent.mesh_peers("room").is_empty());
+    let publish = drain_actions(&mut agent);
+    let rpc = decode_rpc(&sent(&publish).unwrap().0);
+    assert_eq!(
+        rpc.publish[0].data.as_deref(),
+        Some(&b"before heartbeat"[..])
+    );
+    assert!(rpc.control.is_none(), "fallback does not implicitly GRAFT");
+}
+
+#[test]
+fn heartbeat_repairs_mesh_and_received_prune_blocks_regraft() {
+    let config = GossipsubConfig {
+        d: 1,
+        d_low: 1,
+        d_high: 2,
+        ..GossipsubConfig::default()
+    };
+    let mut agent = agent_with(config);
+    agent.subscribe("room", 0).unwrap();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 10);
+    let subscription = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(4),
+        MESHSUB_PROTOCOL_ID_V11,
+        10,
+    );
+    ack(&mut agent, &remote, &subscription, 10);
+    drain_actions(&mut agent);
+    inbound_open(&mut agent, &remote, StreamId::new(5), 10);
+    remote_subscribe(&mut agent, &remote, StreamId::new(5), "room", 10);
+    drain_events(&mut agent);
+
+    agent.handle_tick(1_010);
+    assert_eq!(agent.mesh_peers("room"), vec![remote.clone()]);
+    let graft = drain_actions(&mut agent);
+    ack(&mut agent, &remote, &graft, 1_010);
+    drain_actions(&mut agent);
+
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            control: Some(ControlMessage {
+                prune: vec![ControlPrune {
+                    topic_id: Some("room".to_string()),
+                    backoff: Some(120),
+                    peers: Vec::new(),
+                }],
+                ..ControlMessage::default()
+            }),
+            ..Rpc::default()
+        },
+        1_011,
+    );
+    assert!(agent.mesh_peers("room").is_empty());
+    agent.handle_tick(2_010);
+    assert!(agent.mesh_peers("room").is_empty());
+}
+
+#[test]
+fn ihave_deduplicates_and_obeys_per_heartbeat_budgets() {
+    let config = GossipsubConfig {
+        max_ihave_messages_per_heartbeat: 1,
+        max_iwant_ids_per_heartbeat: 2,
+        ..GossipsubConfig::default()
+    };
+    let mut agent = agent_with(config);
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+    make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(4),
+        MESHSUB_PROTOCOL_ID_V11,
+        0,
+    );
+    inbound_open(&mut agent, &remote, StreamId::new(5), 0);
+    let ihave = |ids: Vec<Vec<u8>>| Rpc {
+        control: Some(ControlMessage {
+            ihave: vec![ControlIHave {
+                topic_id: Some("room".to_string()),
+                message_ids: ids,
+            }],
+            ..ControlMessage::default()
+        }),
+        ..Rpc::default()
+    };
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        ihave(vec![vec![1], vec![1], vec![2], vec![3]]),
+        1,
+    );
+    let want = drain_actions(&mut agent);
+    let ids = &decode_rpc(&sent(&want).unwrap().0).control.unwrap().iwant[0].message_ids;
+    assert_eq!(ids, &vec![vec![1], vec![2]]);
+    ack(&mut agent, &remote, &want, 1);
+    drain_actions(&mut agent);
+
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        ihave(vec![vec![4]]),
+        2,
+    );
+    assert!(drain_actions(&mut agent).is_empty());
+}
+
+#[test]
+fn iwant_serves_cached_message_bytes() {
+    let mut agent = agent();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+    assert!(
+        make_ready(
+            &mut agent,
+            &remote,
+            StreamId::new(4),
+            MESHSUB_PROTOCOL_ID_V11,
+            0,
+        )
+        .is_empty()
+    );
+    inbound_open(&mut agent, &remote, StreamId::new(5), 0);
+    agent.publish("room", b"cached".to_vec(), 1).unwrap();
+    assert!(drain_actions(&mut agent).is_empty(), "no topic peers");
+
+    let mut id = agent.local_peer_id().to_bytes();
+    id.extend_from_slice(&100u64.to_be_bytes());
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            control: Some(ControlMessage {
+                iwant: vec![ControlIWant {
+                    message_ids: vec![id],
+                }],
+                ..ControlMessage::default()
+            }),
+            ..Rpc::default()
+        },
+        2,
+    );
+    let served = drain_actions(&mut agent);
+    let rpc = decode_rpc(&sent(&served).unwrap().0);
+    assert_eq!(rpc.publish.len(), 1);
+    assert_eq!(rpc.publish[0].data.as_deref(), Some(&b"cached"[..]));
+}
+
+#[test]
+fn two_publishes_share_stream_and_failed_second_send_retries_in_order() {
+    let mut agent = agent();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+    make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(4),
+        MESHSUB_PROTOCOL_ID_V11,
+        0,
+    );
+    inbound_open(&mut agent, &remote, StreamId::new(5), 0);
+    remote_subscribe(&mut agent, &remote, StreamId::new(5), "room", 0);
+    drain_events(&mut agent);
+
+    agent.publish("room", b"one".to_vec(), 1).unwrap();
+    agent.publish("room", b"two".to_vec(), 1).unwrap();
+    let first = drain_actions(&mut agent);
+    assert_eq!(
+        decode_rpc(&sent(&first).unwrap().0).publish[0]
+            .data
+            .as_deref(),
+        Some(&b"one"[..])
+    );
+    assert!(
+        !first
+            .iter()
+            .any(|action| matches!(action, PubsubAction::OpenStream { .. }))
+    );
+    ack(&mut agent, &remote, &first, 2);
+    let second = drain_actions(&mut agent);
+    let (_, second_token, stream_id) = sent(&second).unwrap();
+    assert_eq!(
+        decode_rpc(&sent(&second).unwrap().0).publish[0]
+            .data
+            .as_deref(),
+        Some(&b"two"[..])
+    );
+    agent.send_result(
+        &remote,
+        stream_id,
+        second_token,
+        Err("blocked".to_string()),
+        2,
+    );
+    let reset = drain_actions(&mut agent);
+    assert_eq!(
+        reset
+            .iter()
+            .filter(|action| matches!(action, PubsubAction::ResetStream { .. }))
+            .count(),
+        1
+    );
+    agent.send_result(&remote, stream_id, second_token, Ok(()), 3);
+    assert!(drain_actions(&mut agent).is_empty(), "late result is stale");
+
+    agent.handle_tick(1_000);
+    let retry = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(8),
+        MESHSUB_PROTOCOL_ID_V11,
+        1_000,
+    );
+    assert_eq!(
+        decode_rpc(&sent(&retry).unwrap().0).publish[0]
+            .data
+            .as_deref(),
+        Some(&b"two"[..])
+    );
+}
+
+#[test]
+fn stream_reopen_resyncs_an_acked_unsubscribe() {
+    let mut agent = agent();
+    agent.subscribe("room", 0).unwrap();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 10);
+    let subscribed = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(4),
+        MESHSUB_PROTOCOL_ID_V11,
+        10,
+    );
+    ack(&mut agent, &remote, &subscribed, 10);
+    drain_actions(&mut agent);
+    agent.unsubscribe("room", 11);
+    let unsubscribed = drain_actions(&mut agent);
+    ack(&mut agent, &remote, &unsubscribed, 11);
+    drain_actions(&mut agent);
+    agent.handle_event(
+        &SwarmEvent::StreamClosed {
+            peer_id: remote.clone(),
+            conn_id: ConnectionId::new(1),
+            stream_id: StreamId::new(4),
+        },
+        12,
+    );
+    agent.handle_tick(1_010);
+    let resync = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(8),
+        MESHSUB_PROTOCOL_ID_V11,
+        1_010,
+    );
+    let rpc = decode_rpc(&sent(&resync).unwrap().0);
+    assert_eq!(rpc.subscriptions.len(), 1);
+    assert_eq!(rpc.subscriptions[0].subscribe, Some(false));
+    assert_eq!(rpc.subscriptions[0].topic_id.as_deref(), Some("room"));
+}
+
+#[test]
+fn valid_message_delivers_once_and_invalid_signature_never_delivers() {
+    let mut agent = agent();
+    agent.subscribe("room", 0).unwrap();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+    let subscription = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(4),
+        MESHSUB_PROTOCOL_ID_V11,
+        0,
+    );
+    ack(&mut agent, &remote, &subscription, 0);
+    drain_actions(&mut agent);
+    inbound_open(&mut agent, &remote, StreamId::new(5), 0);
+    let signer = keypair(9);
+    let valid = RawMessage::build_signed(&signer, "room", b"hello".to_vec(), 1);
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            publish: vec![valid.clone(), valid],
+            ..Rpc::default()
+        },
+        1,
+    );
+    assert_eq!(
+        drain_events(&mut agent)
+            .into_iter()
+            .filter(|event| matches!(event, PubsubEvent::Message { .. }))
+            .count(),
+        1
+    );
+
+    let mut invalid = RawMessage::build_signed(&signer, "room", b"bad".to_vec(), 2);
+    invalid.signature.as_mut().unwrap()[0] ^= 1;
+    invalid.raw = Vec::new();
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            publish: vec![invalid],
+            ..Rpc::default()
+        },
+        2,
+    );
+    let events = drain_events(&mut agent);
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, PubsubEvent::ProtocolViolation { .. }))
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, PubsubEvent::Message { .. }))
+    );
+}
+
+#[test]
+fn v11_leave_prune_carries_backoff() {
+    let mut agent = agent();
+    agent.subscribe("room", 0).unwrap();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 1);
+    let subscription = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(4),
+        MESHSUB_PROTOCOL_ID_V11,
+        1,
+    );
+    ack(&mut agent, &remote, &subscription, 1);
+    drain_actions(&mut agent);
+    inbound_open(&mut agent, &remote, StreamId::new(5), 1);
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            control: Some(ControlMessage {
+                graft: vec![ControlGraft {
+                    topic_id: Some("room".to_string()),
+                }],
+                ..ControlMessage::default()
+            }),
+            ..Rpc::default()
+        },
+        2,
+    );
+    assert_eq!(agent.mesh_peers("room"), vec![remote.clone()]);
+
+    agent.unsubscribe("room", 3);
+    let unsubscribe = drain_actions(&mut agent);
+    ack(&mut agent, &remote, &unsubscribe, 3);
+    let prune = drain_actions(&mut agent);
+    assert_eq!(
+        decode_rpc(&sent(&prune).unwrap().0).control.unwrap().prune[0].backoff,
+        Some(10)
+    );
+}
+
+#[test]
+fn large_subscription_resync_is_split_without_dropping_entries() {
+    let mut agent = agent();
+    for index in 0..80 {
+        let topic = format!("{index:02}-{}", "x".repeat(1_000));
+        agent.subscribe(&topic, 0).unwrap();
+    }
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 1);
+    let mut actions = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(4),
+        MESHSUB_PROTOCOL_ID_V11,
+        1,
+    );
+    let mut announced = 0;
+    while let Some((frame, _, _)) = sent(&actions) {
+        let FrameDecode::Complete { payload, .. } = decode_frame(&frame) else {
+            panic!("complete frame")
+        };
+        assert!(payload.len() <= minip2p_pubsub::MAX_RPC_SIZE);
+        announced += Rpc::decode(payload).unwrap().subscriptions.len();
+        ack(&mut agent, &remote, &actions, 1);
+        actions = drain_actions(&mut agent);
+    }
+    assert_eq!(announced, 80);
+}

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "minip2p-noise",
  "minip2p-pubsub",
  "minip2p-relay",
+ "minip2p-swarm",
  "minip2p-transport",
  "minip2p-yamux",
 ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,6 +25,7 @@ minip2p-multistream-select = { path = "../crates/multistream-select" }
 minip2p-noise = { path = "../crates/noise" }
 minip2p-pubsub = { path = "../crates/pubsub", default-features = false }
 minip2p-relay = { path = "../crates/relay" }
+minip2p-swarm = { path = "../crates/swarm", default-features = false }
 minip2p-transport = { path = "../crates/transport" }
 minip2p-yamux = { path = "../crates/yamux" }
 

--- a/fuzz/fuzz_targets/wire_inputs.rs
+++ b/fuzz/fuzz_targets/wire_inputs.rs
@@ -10,8 +10,12 @@ use minip2p_identify::{IdentifyConfig, IdentifyInput, IdentifyMessage, IdentifyP
 use minip2p_identity::{KeyType, PublicKey};
 use minip2p_multistream_select::{MultistreamInput, MultistreamSelect};
 use minip2p_noise::{NoiseConfig, NoiseHandshakePayload, NoiseInput, NoiseRole, NoiseSession};
-use minip2p_pubsub::{FrameDecode as PubsubFrame, RawMessage, Rpc};
+use minip2p_pubsub::{
+    FrameDecode as PubsubFrame, GossipsubAgent, GossipsubConfig, MESHSUB_PROTOCOL_ID_V11,
+    RawMessage, Rpc,
+};
 use minip2p_relay::{FrameDecode as RelayFrame, HopMessage, StopMessage};
+use minip2p_swarm::SwarmEvent;
 use minip2p_transport::{
     ConnectionEndpoint, ConnectionId, StreamId, Transport, TransportError, TransportEvent,
 };
@@ -58,6 +62,49 @@ fn fuzz_pubsub(data: &[u8]) {
         let _ = message.verify(false);
         let _ = message.verify(true);
     }
+
+    // Exercise the bounded incremental framing and RPC/control processing
+    // paths after a valid meshsub connection setup.
+    let identity = minip2p_identity::Ed25519Keypair::from_secret_key_bytes([11; 32]);
+    let remote = fuzz_peer_id();
+    let stream_id = StreamId::new(1);
+    let mut agent = GossipsubAgent::new(identity, GossipsubConfig::default(), 1, 7);
+    let _ = agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            peer_id: remote.clone(),
+            conn_id: ConnectionId::new(1),
+        },
+        0,
+    );
+    let _ = agent.handle_event(
+        &SwarmEvent::PeerReady {
+            peer_id: remote.clone(),
+            protocols: vec![MESHSUB_PROTOCOL_ID_V11.to_string()],
+        },
+        0,
+    );
+    let _ = agent.handle_event(
+        &SwarmEvent::StreamReady {
+            peer_id: remote.clone(),
+            conn_id: ConnectionId::new(1),
+            stream_id,
+            protocol_id: MESHSUB_PROTOCOL_ID_V11.to_string(),
+            initiated_locally: false,
+        },
+        0,
+    );
+    let _ = agent.handle_event(
+        &SwarmEvent::StreamData {
+            peer_id: remote,
+            conn_id: ConnectionId::new(1),
+            stream_id,
+            data: data.to_vec(),
+        },
+        1,
+    );
+    agent.handle_tick(1_000);
+    while agent.poll_action().is_some() {}
+    while agent.poll_event().is_some() {}
 }
 
 /// Feeds the input to both negotiation roles so `decode_message` and the


### PR DESCRIPTION
## Summary
- add a deterministic sans-I/O gossipsub router for meshsub v1.0 and v1.1
- add validated gossipsub configuration, bounded message cache, engine dispatch, and long-lived acknowledged stream sends
- preserve floodsub behavior while migrating the shared send-result contract
- add scripted router tests, fuzz state-machine coverage, and updated crate documentation

## Verification
- cargo fmt checks for workspace and fuzz workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --manifest-path fuzz/Cargo.toml --all-targets -- -D warnings
- cargo test --workspace
- minip2p nat, pubsub, nat+pubsub, and discovery feature test matrices
- thumbv7em-none-eabi no-std workspace check
- cargo doc --workspace --no-deps
- 30-second wire_inputs fuzz run (20,502 executions, no findings)

Part of #28.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic, sans‑I/O gossipsub router for meshsub v1.0/v1.1 with long‑lived streams, heartbeat gossip, and a bounded message cache. Introduces engine selection (gossipsub by default), updates the send‑result contract, and hardens routing state and dedup to match libp2p; floodsub behavior is preserved (part of #28).

- **New Features**
  - New gossipsub router: IHAVE/IWANT/GRAFT/PRUNE; `/meshsub/1.1.0` and `/meshsub/1.0.0`; StrictSign; long‑lived outbound stream with acknowledged writes.
  - Validated `GossipsubConfig`; bounded, windowed `MessageCache`; faster pre‑verify dedup using source+seqno.
  - Engine selection via `PubsubConfig` (default gossipsub); `OpenStream` uses engine‑selected protocol id; floodsub unchanged.
  - Shared send‑result across engines with per‑write tokens; `MessageId` matches libp2p default; hardened mesh/gossip state; updated README, tests, and fuzz in `minip2p-pubsub`.

- **Migration**
  - Echo the synchronous result of `PubsubAction::SendStream { token, ... }` back to the agent using the provided token (driver in `minip2p` updated).
  - Use `PubsubConfig` to pick the engine; default is gossipsub.
  - Fuzz workspace adds `minip2p-swarm` as a dependency; no app changes required.

<sup>Written for commit b0fa00ab8dd54b94b625e4b3f28767ed4e789198. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

