### PR TITLE
feat(minip2p): make gossipsub the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ The project is built around five non-negotiables:
 
 `unsafe` is forbidden workspace-wide.
 
+## Unreleased
+
+- The `pubsub` facade now selects gossipsub by default. This is a pre-1.0
+  behavior change: `EndpointBuilder::pubsub_config` accepts either
+  `GossipsubConfig` or `FloodsubConfig` through `PubsubConfig`; applications
+  that require the old engine must pass `FloodsubConfig::default()`
+  explicitly. Each engine advertises only its own protocol ids, so mixed
+  gossipsub/floodsub endpoints intentionally do not exchange pubsub traffic.
+
 ## Workspace status
 
 Sans-I/O protocol crates (`no_std + alloc`):
@@ -34,7 +43,7 @@ Sans-I/O protocol crates (`no_std + alloc`):
 - `crates/relay` (`minip2p-relay`): Circuit Relay v2 *client-side* state machines (`HopReservation`, `HopConnect`, `StopResponder`).
 - `crates/autonat` (`minip2p-autonat`): AutoNAT reachability probe state machines.
 - `crates/dcutr` (`minip2p-dcutr`): DCUtR hole-punch coordination state machines (`DcutrInitiator`, `DcutrResponder`).
-- `crates/pubsub` (`minip2p-pubsub`): floodsub (`/floodsub/1.0.0`) — the libp2p pubsub RPC wire codec with StrictSign message signing, and the `FloodsubAgent` flooding router. Interops with go-libp2p and rust-libp2p.
+- `crates/pubsub` (`minip2p-pubsub`): shared StrictSign pubsub RPC/control codec plus bounded gossipsub (`/meshsub/1.1.0`, `/meshsub/1.0.0`) and floodsub (`/floodsub/1.0.0`) routing engines.
 
 Sans-I/O orchestrators (`no_std + alloc`):
 
@@ -46,14 +55,14 @@ Runtime adapters (`std`):
 
 - `crates/minip2p` (`minip2p`): app-facing facade that glues identity, QUIC, and the std swarm driver into an `Endpoint` API. Opt-in cargo features layer on without changing the base API:
   - `nat` wires the traversal agent into `Endpoint` (`connect`/`wait_path`/`take_nat_events`, relay reservations, AutoNAT probing).
-  - `pubsub` adds floodsub (`subscribe`/`publish`/`take_pubsub_events`).
+  - `pubsub` adds gossipsub by default (`subscribe`/`publish`/`take_pubsub_events`), with explicit floodsub selection available.
   - `discovery` composes `nat` and `pubsub` into signed peer discovery (`known_peers`/`next_discovery_event`), with coordinated dialing and bridge cleanup.
 - `transports/quic` (`minip2p-quic`): QUIC transport adapter built on `quiche`, with libp2p TLS baked in. Owns UDP and DNS; exposes deadlines instead of running timers.
 
 Examples:
 
 - `examples/peer` (`minip2p-peer`): NAT-aware echo-ping demo — `listen` echoes pings (optionally holding a relay reservation), `dial` traverses NAT and shows the RTT drop when the hole punch upgrades the path mid-run.
-- `examples/chat` (`minip2p-chat`): group chat over floodsub with NAT traversal — peers join a room by dialing one address, hole-punch direct paths where needed, and flood StrictSign-verified messages. Live-validated across real networks and against real go-libp2p and rust-libp2p peers.
+- `examples/chat` (`minip2p-chat`): group chat over gossipsub with NAT traversal — peers join a room by dialing one address, hole-punch direct paths where needed, and route StrictSign-verified messages through the topic mesh.
 
 Current validated behavior:
 
@@ -63,7 +72,7 @@ Current validated behavior:
 - Ping round-trips with RTT measurement; identify exchange with observed-address plumbing.
 - End-to-end stack via `minip2p::Endpoint`: QUIC + multistream-select + identify + ping + registered app protocols through one facade.
 - NAT traversal live-validated end-to-end: relay reservation, circuit connect, DCUtR hole punch between two real NATs (home network ↔ mobile hotspot through a public relay), with explicit path events throughout.
-- Floodsub live-validated: loopback and open-internet chat stars, star-forwarding, a NAT'd host punched into through a relay, and wire interop both ways with real go-libp2p (StrictSign) and rust-libp2p (unsigned, behind an explicit allow flag) peers.
+- Pubsub is covered by real-QUIC loopback tests under the default gossipsub engine and explicit floodsub selection; floodsub also retains its prior live go-libp2p and rust-libp2p wire validation.
 - Pubsub peer discovery live-validated across a public host, home NAT, and mobile hotspot: automatic mesh formation, one-sided dial initiation, address updates, graceful punch-failure degradation, and leaf-to-leaf chat survival after host death.
 
 ## Architecture boundaries
@@ -159,7 +168,7 @@ cargo doc --workspace --no-deps --open
 - [x] Top-level `minip2p::Endpoint` facade for app authors.
 - [x] Circuit Relay v2 client, DCUtR, and AutoNAT state machines.
 - [x] NAT-traversal orchestration (`nat` feature), live-validated between two real NATs.
-- [x] Floodsub pubsub (`pubsub` feature) with libp2p wire interop, plus the chat example.
+- [x] Floodsub pubsub engine with libp2p wire interop and explicit facade selection.
 - [x] Signed pubsub peer discovery (`discovery` feature), including automatic mesh dialing and host-death survival.
-- [ ] Gossipsub, on the same pubsub API surface.
+- [x] Gossipsub, on the same pubsub API surface and selected by default.
 - [x] A circuit transport, so relayed paths are end-to-end encrypted, multiplexed normal connections.

--- a/crates/minip2p/README.md
+++ b/crates/minip2p/README.md
@@ -43,6 +43,14 @@ It implies the `nat` and `pubsub` features. Applications can inspect
 to select a room-scoped topic and policy. Unsigned discovery beacons are always
 rejected even if unsigned application pubsub messages are allowed.
 
+With the `pubsub` feature, `.pubsub()` enables gossipsub by default and
+advertises `/meshsub/1.1.0` plus `/meshsub/1.0.0`. Pass a
+`GossipsubConfig` to tune mesh policy, or
+`.pubsub_config(FloodsubConfig::default())` to select the legacy floodsub
+engine and advertise only `/floodsub/1.0.0`. This is a pre-1.0 API/default
+change: `pubsub_config` now accepts either engine through `PubsubConfig`, and
+gossipsub peers intentionally do not negotiate floodsub streams.
+
 Built-in protocol ids (`/ipfs/id/1.0.0`, `/ipfs/ping/1.0.0` -- see
 `minip2p::RESERVED_PROTOCOL_IDS`) belong to the endpoint's own handlers;
 registering one via `EndpointBuilder::protocol` makes the `bind_quic*` step

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -1260,14 +1260,22 @@ fn build_endpoint(parts: BuilderParts, transport: QuicEndpoint) -> Result<Endpoi
         .pubsub_config
         .map(|config| -> Result<pubsub::PubsubDriver, Error> {
             // Message ids are (from, seqno); a wall-clock seed keeps restarts
-            // from reusing ids the network may still remember. Fold both halves
-            // of the timestamp into the deterministic peer-selection seed.
+            // from reusing ids the network may still remember. Mix the local
+            // identity into the peer-selection seed so endpoints created in the
+            // same clock tick do not walk the same deterministic sequence.
             let timestamp = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|duration| duration.as_nanos())
                 .unwrap_or(0);
             let initial_seqno = timestamp as u64;
-            let entropy_seed = initial_seqno ^ (timestamp >> 64) as u64;
+            let entropy_seed = parts
+                .keypair
+                .peer_id()
+                .digest_bytes()
+                .iter()
+                .fold(initial_seqno ^ (timestamp >> 64) as u64, |seed, byte| {
+                    seed.rotate_left(5) ^ u64::from(*byte)
+                });
             let agent = minip2p_pubsub::PubsubAgent::new(
                 parts.keypair.clone(),
                 config,

--- a/crates/minip2p/src/lib.rs
+++ b/crates/minip2p/src/lib.rs
@@ -5,6 +5,11 @@
 //! Sans-I/O / `no_std + alloc` surface, while [`Endpoint`] gives applications a
 //! small batteries-included API for identity, QUIC, listen/dial, ping, and
 //! event polling.
+//!
+//! With the `pubsub` feature, `EndpointBuilder::pubsub` selects gossipsub by
+//! default. `EndpointBuilder::pubsub_config` accepts either a
+//! `GossipsubConfig` or `FloodsubConfig`; the selected engine controls which
+//! pubsub protocol ids are advertised.
 
 #[cfg(feature = "discovery")]
 mod discovery;
@@ -29,7 +34,9 @@ pub use minip2p_nat::{
 };
 #[cfg(feature = "pubsub")]
 pub use minip2p_pubsub::{
-    FLOODSUB_PROTOCOL_ID, FloodsubConfig, PublishError, PubsubEvent, TopicError,
+    FLOODSUB_PROTOCOL_ID, FloodsubConfig, GossipsubConfig, MESHSUB_PROTOCOL_ID_V10,
+    MESHSUB_PROTOCOL_ID_V11, PublishError, PubsubConfig, PubsubConfigError, PubsubEvent,
+    TopicError,
 };
 pub use minip2p_quic::QuicLimits;
 use minip2p_quic::{QuicEndpoint, QuicNodeConfig};
@@ -732,7 +739,8 @@ impl Endpoint {
     }
 
     /// Subscribes to a pubsub topic. Returns `Ok(false)` when already
-    /// subscribed. The subscription is announced to every floodsub peer.
+    /// subscribed. The subscription is announced through the configured
+    /// pubsub routing engine.
     ///
     /// Errors with [`PubsubError::NotEnabled`] unless the endpoint was
     /// built with [`EndpointBuilder::pubsub`].
@@ -770,8 +778,8 @@ impl Endpoint {
         Ok(removed)
     }
 
-    /// Publishes `data` on `topic`, signed with this endpoint's identity
-    /// and flooded to every subscribed peer.
+    /// Publishes `data` on `topic`, signed with this endpoint's identity and
+    /// routed through the configured pubsub engine.
     ///
     /// A successful return means the message was accepted and its outbound
     /// streams were initiated — the frames themselves go out as the
@@ -959,9 +967,7 @@ pub struct EndpointBuilder {
     #[cfg(feature = "nat")]
     autonat_servers: Vec<PeerAddr>,
     #[cfg(feature = "pubsub")]
-    pubsub_enabled: bool,
-    #[cfg(feature = "pubsub")]
-    pubsub_config: Option<FloodsubConfig>,
+    pubsub_config: Option<PubsubConfig>,
     #[cfg(feature = "discovery")]
     discovery_config: Option<DiscoveryConfig>,
 }
@@ -980,8 +986,6 @@ impl Default for EndpointBuilder {
             #[cfg(feature = "nat")]
             autonat_servers: Vec::new(),
             #[cfg(feature = "pubsub")]
-            pubsub_enabled: false,
-            #[cfg(feature = "pubsub")]
             pubsub_config: None,
             #[cfg(feature = "discovery")]
             discovery_config: None,
@@ -998,7 +1002,7 @@ struct BuilderParts {
     #[cfg(feature = "nat")]
     nat_config: Option<NatConfig>,
     #[cfg(feature = "pubsub")]
-    pubsub_config: Option<FloodsubConfig>,
+    pubsub_config: Option<PubsubConfig>,
     #[cfg(feature = "discovery")]
     discovery_config: Option<DiscoveryConfig>,
 }
@@ -1061,23 +1065,26 @@ impl EndpointBuilder {
         self
     }
 
-    /// Enables floodsub pubsub with the default configuration.
+    /// Enables pubsub with the default gossipsub configuration.
     ///
     /// Builder-time opt-in (rather than a lazy `subscribe`-time enable)
-    /// because `/floodsub/1.0.0` must be in Identify's advertised protocol
-    /// set from the first handshake — peers only open pubsub streams to
-    /// endpoints that advertise it.
+    /// because the selected engine's protocol ids must be in Identify's
+    /// advertised set from the first handshake.
     #[cfg(feature = "pubsub")]
     pub fn pubsub(mut self) -> Self {
-        self.pubsub_enabled = true;
+        self.pubsub_config.get_or_insert_with(PubsubConfig::default);
         self
     }
 
-    /// Enables floodsub pubsub with an explicit configuration.
+    /// Enables pubsub with an explicit gossipsub or floodsub configuration.
+    ///
+    /// [`GossipsubConfig`] and [`FloodsubConfig`] both convert into
+    /// [`PubsubConfig`]. The selected engine determines which protocol ids
+    /// the endpoint advertises. Invalid gossipsub relationships or zero
+    /// bounds fail the later `bind_quic*` call before a socket is allocated.
     #[cfg(feature = "pubsub")]
-    pub fn pubsub_config(mut self, config: FloodsubConfig) -> Self {
-        self.pubsub_enabled = true;
-        self.pubsub_config = Some(config);
+    pub fn pubsub_config(mut self, config: impl Into<PubsubConfig>) -> Self {
+        self.pubsub_config = Some(config.into());
         self
     }
 
@@ -1088,7 +1095,7 @@ impl EndpointBuilder {
     /// subscription events are consumed before reaching the application.
     #[cfg(feature = "discovery")]
     pub fn discovery(mut self) -> Self {
-        self.pubsub_enabled = true;
+        self.pubsub_config.get_or_insert_with(PubsubConfig::default);
         self.discovery_config = Some(DiscoveryConfig::default());
         self
     }
@@ -1105,7 +1112,7 @@ impl EndpointBuilder {
         config: DiscoveryConfig,
     ) -> Result<Self, DiscoveryConfigError> {
         config.validate()?;
-        self.pubsub_enabled = true;
+        self.pubsub_config.get_or_insert_with(PubsubConfig::default);
         self.discovery_config = Some(config);
         Ok(self)
     }
@@ -1153,6 +1160,14 @@ impl EndpointBuilder {
             }
             .into());
         }
+        #[cfg(feature = "pubsub")]
+        if let Some(config) = &self.pubsub_config {
+            config
+                .validate()
+                .map_err(|error| TransportError::InvalidConfig {
+                    reason: error.to_string(),
+                })?;
+        }
         #[cfg(feature = "nat")]
         let nat_config = {
             let enabled = self.nat_config.is_some()
@@ -1183,9 +1198,7 @@ impl EndpointBuilder {
             #[cfg(feature = "nat")]
             nat_config,
             #[cfg(feature = "pubsub")]
-            pubsub_config: self
-                .pubsub_enabled
-                .then(|| self.pubsub_config.unwrap_or_default()),
+            pubsub_config: self.pubsub_config,
             #[cfg(feature = "discovery")]
             discovery_config: self.discovery_config,
         })
@@ -1214,12 +1227,14 @@ fn build_endpoint(parts: BuilderParts, transport: QuicEndpoint) -> Result<Endpoi
         }
     }
     #[cfg(feature = "pubsub")]
-    if parts.pubsub_config.is_some() {
-        // Floodsub streams route as an ordinary user protocol, and the id
-        // must be advertised by Identify from the first handshake.
-        let id = FLOODSUB_PROTOCOL_ID;
-        if !protocols.iter().any(|existing| existing == id) {
-            protocols.push(id.to_string());
+    if let Some(config) = &parts.pubsub_config {
+        // Pubsub streams route as ordinary user protocols, and the selected
+        // engine's ids must be advertised by Identify from the first
+        // handshake.
+        for id in config.protocol_ids() {
+            if !protocols.iter().any(|existing| existing == id) {
+                protocols.push((*id).to_string());
+            }
         }
     }
     for protocol in protocols {
@@ -1241,17 +1256,30 @@ fn build_endpoint(parts: BuilderParts, transport: QuicEndpoint) -> Result<Endpoi
     #[cfg(feature = "discovery")]
     let discovery_config = parts.discovery_config;
     #[cfg(feature = "pubsub")]
-    let pubsub = parts.pubsub_config.map(|config| {
-        // Message ids are (from, seqno); a wall-clock seed keeps restarts
-        // from reusing ids the network may still remember.
-        let initial_seqno = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos() as u64)
-            .unwrap_or(0);
-        let agent =
-            minip2p_pubsub::FloodsubAgent::new(parts.keypair.clone(), config, initial_seqno);
-        pubsub::PubsubDriver::new(agent)
-    });
+    let pubsub = parts
+        .pubsub_config
+        .map(|config| -> Result<pubsub::PubsubDriver, Error> {
+            // Message ids are (from, seqno); a wall-clock seed keeps restarts
+            // from reusing ids the network may still remember. Fold both halves
+            // of the timestamp into the deterministic peer-selection seed.
+            let timestamp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|duration| duration.as_nanos())
+                .unwrap_or(0);
+            let initial_seqno = timestamp as u64;
+            let entropy_seed = initial_seqno ^ (timestamp >> 64) as u64;
+            let agent = minip2p_pubsub::PubsubAgent::new(
+                parts.keypair.clone(),
+                config,
+                initial_seqno,
+                entropy_seed,
+            )
+            .map_err(|error| TransportError::InvalidConfig {
+                reason: error.to_string(),
+            })?;
+            Ok(pubsub::PubsubDriver::new(agent))
+        })
+        .transpose()?;
     #[cfg(feature = "discovery")]
     let mut pubsub = pubsub;
     #[cfg(feature = "discovery")]

--- a/crates/minip2p/src/pubsub.rs
+++ b/crates/minip2p/src/pubsub.rs
@@ -1,4 +1,4 @@
-//! Std wiring that pumps a sans-I/O [`FloodsubAgent`] against the
+//! Std wiring that pumps a sans-I/O [`PubsubAgent`] against the
 //! endpoint's swarm: clock sampling, action execution, and stream-event
 //! interception. Mirrors the NAT driver (`crate::nat`).
 //!
@@ -9,7 +9,7 @@
 use std::collections::VecDeque;
 use std::time::Instant;
 
-use minip2p_pubsub::{FloodsubAgent, PubsubAction, PubsubEvent};
+use minip2p_pubsub::{PubsubAction, PubsubAgent, PubsubEvent};
 use minip2p_swarm::SwarmEvent;
 
 use crate::EndpointSwarm;
@@ -41,9 +41,9 @@ pub enum PubsubError {
     Driver(#[from] Error),
 }
 
-/// Drives a [`FloodsubAgent`] against the endpoint's swarm.
+/// Drives the configured [`PubsubAgent`] against the endpoint's swarm.
 pub(crate) struct PubsubDriver {
-    pub(crate) agent: FloodsubAgent,
+    pub(crate) agent: PubsubAgent,
     /// Pubsub events awaiting the application (drained via
     /// `Endpoint::take_pubsub_events` / `next_pubsub_event`).
     pub(crate) events: VecDeque<PubsubEvent>,
@@ -52,7 +52,7 @@ pub(crate) struct PubsubDriver {
 }
 
 impl PubsubDriver {
-    pub(crate) fn new(agent: FloodsubAgent) -> Self {
+    pub(crate) fn new(agent: PubsubAgent) -> Self {
         Self {
             agent,
             events: VecDeque::new(),
@@ -67,7 +67,7 @@ impl PubsubDriver {
 
     /// Feeds one swarm event to the agent and executes its cascade.
     ///
-    /// Returns `true` when the event belongs to a floodsub stream and must
+    /// Returns `true` when the event belongs to a pubsub stream and must
     /// not be forwarded to the application.
     pub(crate) fn ingest(&mut self, event: &SwarmEvent, swarm: &mut EndpointSwarm) -> bool {
         let handled = self.agent.handle_event(event, self.now_ms());

--- a/crates/minip2p/tests/discovery.rs
+++ b/crates/minip2p/tests/discovery.rs
@@ -4,12 +4,30 @@
 
 use std::time::{Duration, Instant};
 
-use minip2p::{DiscoveryConfig, DiscoveryEvent, Endpoint, Event, PubsubEvent};
+use minip2p::{DiscoveryConfig, DiscoveryEvent, Endpoint, Event, GossipsubConfig, PubsubEvent};
 
 const DISCOVERY_TOPIC: &str = "/minip2p/test/loopback-discovery";
 
 fn discovery_endpoint() -> Endpoint {
     Endpoint::builder()
+        .discovery_config(DiscoveryConfig {
+            topic: DISCOVERY_TOPIC.into(),
+            beacon_interval_ms: 100,
+            peer_ttl_ms: 2_000,
+            auto_dial: false,
+            ..DiscoveryConfig::default()
+        })
+        .expect("valid discovery config")
+        .bind_quic("127.0.0.1:0")
+        .expect("bind loopback endpoint")
+}
+
+fn slow_heartbeat_discovery_endpoint() -> Endpoint {
+    Endpoint::builder()
+        .pubsub_config(GossipsubConfig {
+            heartbeat_interval_ms: 60_000,
+            ..GossipsubConfig::default()
+        })
         .discovery_config(DiscoveryConfig {
             topic: DISCOVERY_TOPIC.into(),
             beacon_interval_ms: 100,
@@ -69,6 +87,42 @@ fn beacons_do_not_leak_to_the_application() {
         .expect("a knows b");
     assert!(a_seen_by_b.addrs.contains(a_addr.transport()));
     assert!(b_seen_by_a.addrs.contains(b_addr.transport()));
+    assert_no_discovery_pubsub(a.take_pubsub_events());
+    assert_no_discovery_pubsub(b.take_pubsub_events());
+}
+
+#[test]
+fn star_beacons_relay_before_the_first_gossipsub_heartbeat() {
+    let mut hub = slow_heartbeat_discovery_endpoint();
+    let mut a = slow_heartbeat_discovery_endpoint();
+    let mut b = slow_heartbeat_discovery_endpoint();
+    let hub_addr = hub.listen().expect("hub listens");
+    a.listen().expect("a listens");
+    b.listen().expect("b listens");
+    let hub_peer = hub.peer_id().clone();
+    let a_peer = a.peer_id().clone();
+    let b_peer = b.peer_id().clone();
+    a.dial(&hub_addr).expect("a dials hub");
+    b.dial(&hub_addr).expect("b dials hub");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while a.known_peers().iter().all(|known| known.peer != b_peer)
+        || b.known_peers().iter().all(|known| known.peer != a_peer)
+    {
+        assert!(
+            Instant::now() < deadline,
+            "cross-leaf discovery waited for a 60s heartbeat"
+        );
+        let _ = hub
+            .next_event(Duration::from_millis(20))
+            .expect("hub drives");
+        let _ = a.next_event(Duration::from_millis(20)).expect("a drives");
+        let _ = b.next_event(Duration::from_millis(20)).expect("b drives");
+    }
+
+    assert_eq!(a.connected_peers(), vec![hub_peer.clone()]);
+    assert_eq!(b.connected_peers(), vec![hub_peer]);
+    assert_no_discovery_pubsub(hub.take_pubsub_events());
     assert_no_discovery_pubsub(a.take_pubsub_events());
     assert_no_discovery_pubsub(b.take_pubsub_events());
 }

--- a/crates/minip2p/tests/pubsub.rs
+++ b/crates/minip2p/tests/pubsub.rs
@@ -1,12 +1,14 @@
 //! Loopback e2e for the `pubsub` feature: real QUIC endpoints exchanging
-//! floodsub RPCs. Agent-level edge cases live in `crates/pubsub/tests`;
-//! these prove the facade wiring (driver, event interception, API).
+//! pubsub RPCs. Agent-level edge cases live in `crates/pubsub/tests`; these
+//! prove default gossipsub and explicit floodsub facade wiring.
 
 #![cfg(feature = "pubsub")]
 
 use std::time::{Duration, Instant};
 
-use minip2p::{Endpoint, Event, PubsubError, PubsubEvent};
+use minip2p::{
+    Endpoint, Event, FloodsubConfig, GossipsubConfig, PubsubError, PubsubEvent, TransportError,
+};
 
 #[cfg(feature = "nat")]
 #[path = "../../../tests/support/relay.rs"]
@@ -21,8 +23,24 @@ fn pubsub_endpoint() -> Endpoint {
         .expect("bind loopback endpoint")
 }
 
+fn floodsub_endpoint() -> Endpoint {
+    Endpoint::builder()
+        .pubsub_config(FloodsubConfig::default())
+        .bind_quic("127.0.0.1:0")
+        .expect("bind loopback floodsub endpoint")
+}
+
+fn is_pubsub_protocol(protocol_id: &str) -> bool {
+    matches!(
+        protocol_id,
+        minip2p::FLOODSUB_PROTOCOL_ID
+            | minip2p::MESHSUB_PROTOCOL_ID_V10
+            | minip2p::MESHSUB_PROTOCOL_ID_V11
+    )
+}
+
 /// Drives all endpoints once with a short budget, collecting pubsub events
-/// and asserting no floodsub stream events leak to the application.
+/// and asserting no pubsub stream events leak to the application.
 fn drive(endpoints: &mut [&mut Endpoint]) -> Vec<Vec<PubsubEvent>> {
     let mut collected = vec![Vec::new(); endpoints.len()];
     for (i, endpoint) in endpoints.iter_mut().enumerate() {
@@ -34,9 +52,9 @@ fn drive(endpoints: &mut [&mut Endpoint]) -> Vec<Vec<PubsubEvent>> {
                 !matches!(
                     &event,
                     Event::StreamReady { protocol_id, .. }
-                        if protocol_id == minip2p::FLOODSUB_PROTOCOL_ID
+                        if is_pubsub_protocol(protocol_id)
                 ),
-                "floodsub streams must be invisible to the app: {event:?}"
+                "pubsub streams must be invisible to the app: {event:?}"
             );
         }
         collected[i].extend(endpoint.take_pubsub_events());
@@ -75,6 +93,13 @@ fn saw_subscription(events: &[PubsubEvent], topic: &str) -> bool {
         .any(|e| matches!(e, PubsubEvent::PeerSubscribed { topic: got, .. } if got == topic))
 }
 
+fn drive_for(endpoints: &mut [&mut Endpoint], duration: Duration) {
+    let until = Instant::now() + duration;
+    while Instant::now() < until {
+        let _ = drive(endpoints);
+    }
+}
+
 #[test]
 fn two_endpoints_exchange_messages_over_real_quic() {
     let mut a = pubsub_endpoint();
@@ -86,8 +111,7 @@ fn two_endpoints_exchange_messages_over_real_quic() {
     b.subscribe(TOPIC).expect("b subscribes");
     a.dial(&b_addr).expect("a dials b");
 
-    // Both sides learn of each other's subscription first (floodsub has no
-    // history: publishing before that would vanish).
+    // Both sides learn of each other's subscription first.
     drive_until(&mut [&mut a, &mut b], Duration::from_secs(15), |all| {
         saw_subscription(&all[0], TOPIC) && saw_subscription(&all[1], TOPIC)
     });
@@ -136,6 +160,13 @@ fn star_center_forwards_between_leaves() {
                 && saw_subscription(&all[1], TOPIC)
                 && saw_subscription(&all[2], TOPIC)
         },
+    );
+
+    // Gossipsub admits newly discovered topic peers on heartbeat. Let the
+    // star form before asserting leaf-to-leaf forwarding through the hub.
+    drive_for(
+        &mut [&mut hub, &mut alice, &mut bob],
+        Duration::from_millis(1_100),
     );
 
     // Alice's message reaches bob THROUGH the hub (they are not connected),
@@ -210,6 +241,99 @@ fn pubsub_methods_error_when_not_enabled() {
         Err(PubsubError::NotEnabled)
     ));
     assert!(plain.take_pubsub_events().is_empty());
+}
+
+#[test]
+fn invalid_gossipsub_config_fails_before_transport_bind() {
+    let error = Endpoint::builder()
+        .pubsub_config(GossipsubConfig {
+            heartbeat_interval_ms: 0,
+            ..GossipsubConfig::default()
+        })
+        .bind_quic("not a socket address")
+        .err()
+        .expect("invalid pubsub config");
+    assert!(matches!(
+        error,
+        minip2p::Error::Transport(TransportError::InvalidConfig { ref reason })
+            if reason.contains("heartbeat_interval_ms")
+    ));
+}
+
+#[test]
+fn explicit_floodsub_endpoints_still_exchange_messages() {
+    let mut a = floodsub_endpoint();
+    let mut b = floodsub_endpoint();
+    let b_addr = b.listen().expect("b listens");
+    a.listen().expect("a listens");
+    a.subscribe(TOPIC).expect("a subscribes");
+    b.subscribe(TOPIC).expect("b subscribes");
+    a.dial(&b_addr).expect("a dials b");
+    drive_until(&mut [&mut a, &mut b], Duration::from_secs(15), |all| {
+        saw_subscription(&all[0], TOPIC) && saw_subscription(&all[1], TOPIC)
+    });
+
+    a.publish(TOPIC, b"explicit floodsub").expect("a publishes");
+    drive_until(&mut [&mut a, &mut b], Duration::from_secs(15), |all| {
+        saw_message(&all[1], b"explicit floodsub")
+    });
+}
+
+#[test]
+fn gossipsub_and_floodsub_do_not_claim_compatibility() {
+    let mut gossip = pubsub_endpoint();
+    let mut flood = floodsub_endpoint();
+    let flood_addr = flood.listen().expect("floodsub endpoint listens");
+    let gossip_peer = gossip.peer_id().clone();
+    let flood_peer = flood.peer_id().clone();
+    gossip.listen().expect("gossipsub endpoint listens");
+    gossip.subscribe(TOPIC).expect("gossipsub subscribes");
+    flood.subscribe(TOPIC).expect("floodsub subscribes");
+    gossip.dial(&flood_addr).expect("transport connects");
+
+    let ready_deadline = Instant::now() + Duration::from_secs(10);
+    let mut advertised_by_gossip = None;
+    let mut advertised_by_flood = None;
+    while advertised_by_gossip.is_none() || advertised_by_flood.is_none() {
+        assert!(Instant::now() < ready_deadline, "identify did not complete");
+        if let Some(Event::PeerReady { peer_id, protocols }) = gossip
+            .next_event(Duration::from_millis(20))
+            .expect("gossipsub endpoint drives")
+            && peer_id == flood_peer
+        {
+            advertised_by_flood = Some(protocols);
+        }
+        if let Some(Event::PeerReady { peer_id, protocols }) = flood
+            .next_event(Duration::from_millis(20))
+            .expect("floodsub endpoint drives")
+            && peer_id == gossip_peer
+        {
+            advertised_by_gossip = Some(protocols);
+        }
+    }
+    let advertised_by_gossip = advertised_by_gossip.unwrap();
+    assert!(advertised_by_gossip.contains(&minip2p::MESHSUB_PROTOCOL_ID_V11.to_string()));
+    assert!(advertised_by_gossip.contains(&minip2p::MESHSUB_PROTOCOL_ID_V10.to_string()));
+    assert!(!advertised_by_gossip.contains(&minip2p::FLOODSUB_PROTOCOL_ID.to_string()));
+    let advertised_by_flood = advertised_by_flood.unwrap();
+    assert!(advertised_by_flood.contains(&minip2p::FLOODSUB_PROTOCOL_ID.to_string()));
+    assert!(!advertised_by_flood.contains(&minip2p::MESHSUB_PROTOCOL_ID_V11.to_string()));
+    assert!(!advertised_by_flood.contains(&minip2p::MESHSUB_PROTOCOL_ID_V10.to_string()));
+
+    let mut events = vec![Vec::new(), Vec::new()];
+    let until = Instant::now() + Duration::from_secs(1);
+    while Instant::now() < until {
+        for (all, new) in events.iter_mut().zip(drive(&mut [&mut gossip, &mut flood])) {
+            all.extend(new);
+        }
+    }
+    assert!(
+        events.iter().flatten().all(|event| !matches!(
+            event,
+            PubsubEvent::PeerSubscribed { .. } | PubsubEvent::Message { .. }
+        )),
+        "engines with no common protocol must not exchange pubsub state: {events:?}"
+    );
 }
 
 #[test]
@@ -326,7 +450,7 @@ fn pubsub_flows_over_relay_and_reannounces_after_direct_supersede() {
 
     // A direct connection supersedes the ready circuit. The public sequence
     // must close the old id before establishing the replacement, and the
-    // floodsub driver must re-open and re-announce subscriptions.
+    // pubsub driver must re-open and re-announce subscriptions.
     a.dial(&b_addr).expect("manual direct upgrade");
     let upgrade_deadline = Instant::now() + Duration::from_secs(15);
     let mut a_sequence = Vec::new();

--- a/crates/minip2p/tests/pubsub.rs
+++ b/crates/minip2p/tests/pubsub.rs
@@ -93,13 +93,6 @@ fn saw_subscription(events: &[PubsubEvent], topic: &str) -> bool {
         .any(|e| matches!(e, PubsubEvent::PeerSubscribed { topic: got, .. } if got == topic))
 }
 
-fn drive_for(endpoints: &mut [&mut Endpoint], duration: Duration) {
-    let until = Instant::now() + duration;
-    while Instant::now() < until {
-        let _ = drive(endpoints);
-    }
-}
-
 #[test]
 fn two_endpoints_exchange_messages_over_real_quic() {
     let mut a = pubsub_endpoint();
@@ -160,13 +153,6 @@ fn star_center_forwards_between_leaves() {
                 && saw_subscription(&all[1], TOPIC)
                 && saw_subscription(&all[2], TOPIC)
         },
-    );
-
-    // Gossipsub admits newly discovered topic peers on heartbeat. Let the
-    // star form before asserting leaf-to-leaf forwarding through the hub.
-    drive_for(
-        &mut [&mut hub, &mut alice, &mut bob],
-        Duration::from_millis(1_100),
     );
 
     // Alice's message reaches bob THROUGH the hub (they are not connected),

--- a/crates/pubsub/src/gossipsub/agent.rs
+++ b/crates/pubsub/src/gossipsub/agent.rs
@@ -1096,15 +1096,17 @@ impl GossipsubAgent {
     }
 
     fn process_rpc(&mut self, peer: &PeerId, stream_id: StreamId, rpc: Rpc, now_ms: u64) -> bool {
-        if !self.apply_subscriptions(peer, stream_id, &rpc.subscriptions) {
+        let Some(added_topics) = self.apply_subscriptions(peer, stream_id, &rpc.subscriptions)
+        else {
             return false;
-        }
+        };
         for message in rpc.publish {
             self.process_message(peer, message, now_ms);
         }
         if let Some(control) = rpc.control {
             self.process_control(peer, control, now_ms);
         }
+        self.graft_new_subscriptions(peer, added_topics, now_ms);
         self.drive_sender(peer, now_ms);
         true
     }
@@ -1114,12 +1116,12 @@ impl GossipsubAgent {
         peer: &PeerId,
         stream_id: StreamId,
         subscriptions: &[SubOpts],
-    ) -> bool {
+    ) -> Option<Vec<String>> {
         if subscriptions.is_empty() {
-            return true;
+            return Some(Vec::new());
         }
         let Some(state) = self.peers.get_mut(peer) else {
-            return true;
+            return Some(Vec::new());
         };
         let mut candidate = state.remote_topics.clone();
         let mut invalid = false;
@@ -1139,7 +1141,7 @@ impl GossipsubAgent {
         }
         if candidate.len() > self.config.max_topics_per_peer {
             self.violation_reset(peer, stream_id, "subscription set exceeds the bound");
-            return false;
+            return None;
         }
         let added: Vec<String> = candidate
             .difference(&state.remote_topics)
@@ -1157,10 +1159,10 @@ impl GossipsubAgent {
                 reason: "subscription entries with invalid topics skipped".to_string(),
             });
         }
-        for topic in added {
+        for topic in &added {
             self.events.push_back(PubsubEvent::PeerSubscribed {
                 peer: peer.clone(),
-                topic,
+                topic: topic.clone(),
             });
         }
         for topic in removed {
@@ -1175,7 +1177,21 @@ impl GossipsubAgent {
                 topic,
             });
         }
-        true
+        Some(added)
+    }
+
+    fn graft_new_subscriptions(&mut self, peer: &PeerId, topics: Vec<String>, now_ms: u64) {
+        for topic in topics {
+            let should_graft = self.topics.contains(&topic)
+                && self
+                    .mesh
+                    .get(&topic)
+                    .is_none_or(|mesh| mesh.len() < self.config.d_low && !mesh.contains(peer))
+                && self.peer_is_eligible(peer, &topic, now_ms);
+            if should_graft && self.queue_control(peer, ControlItem::Graft(topic.clone()), now_ms) {
+                self.mesh.entry(topic).or_default().insert(peer.clone());
+            }
+        }
     }
 
     fn process_control(&mut self, peer: &PeerId, control: ControlMessage, now_ms: u64) {

--- a/crates/pubsub/tests/gossipsub.rs
+++ b/crates/pubsub/tests/gossipsub.rs
@@ -480,7 +480,71 @@ fn unannounced_or_excess_graft_is_pruned_immediately() {
 }
 
 #[test]
-fn empty_mesh_publish_falls_back_without_grafting() {
+fn new_remote_subscriptions_graft_and_relay_before_heartbeat() {
+    let mut agent = agent_with(GossipsubConfig {
+        d: 2,
+        d_low: 2,
+        d_high: 4,
+        heartbeat_interval_ms: 100_000,
+        ..GossipsubConfig::default()
+    });
+    agent.subscribe("room", 0).unwrap();
+    let first = peer(2);
+    let second = peer(3);
+    for (remote, outbound, inbound) in [
+        (&first, StreamId::new(4), StreamId::new(5)),
+        (&second, StreamId::new(6), StreamId::new(7)),
+    ] {
+        connect(&mut agent, remote, &[MESHSUB_PROTOCOL_ID_V11], 1);
+        let subscription = make_ready(&mut agent, remote, outbound, MESHSUB_PROTOCOL_ID_V11, 1);
+        ack(&mut agent, remote, &subscription, 1);
+        drain_actions(&mut agent);
+        inbound_open(&mut agent, remote, inbound, 1);
+        remote_subscribe(&mut agent, remote, inbound, "room", 1);
+
+        assert!(agent.mesh_peers("room").contains(remote));
+        let graft = drain_actions(&mut agent);
+        let control = decode_rpc(&sent(&graft).expect("eager GRAFT").0)
+            .control
+            .expect("control frame");
+        assert_eq!(control.graft[0].topic_id.as_deref(), Some("room"));
+        ack(&mut agent, remote, &graft, 1);
+        drain_actions(&mut agent);
+    }
+    drain_events(&mut agent);
+
+    inbound_rpc(
+        &mut agent,
+        &first,
+        StreamId::new(5),
+        Rpc {
+            publish: vec![RawMessage::build_signed(
+                &keypair(2),
+                "room",
+                b"before heartbeat".to_vec(),
+                1,
+            )],
+            ..Rpc::default()
+        },
+        2,
+    );
+    let relay = drain_actions(&mut agent);
+    let (relay_peer, frame) = relay
+        .iter()
+        .find_map(|action| match action {
+            PubsubAction::SendStream { peer, data, .. } => Some((peer, data)),
+            _ => None,
+        })
+        .expect("relay before first heartbeat");
+    assert_eq!(relay_peer, &second);
+    assert_eq!(
+        decode_rpc(frame).publish[0].data.as_deref(),
+        Some(&b"before heartbeat"[..])
+    );
+}
+
+#[test]
+fn prune_in_subscription_rpc_blocks_opportunistic_graft() {
     let mut agent = agent();
     agent.subscribe("room", 0).unwrap();
     let remote = peer(2);
@@ -495,20 +559,33 @@ fn empty_mesh_publish_falls_back_without_grafting() {
     ack(&mut agent, &remote, &subscription, 1);
     drain_actions(&mut agent);
     inbound_open(&mut agent, &remote, StreamId::new(5), 1);
-    remote_subscribe(&mut agent, &remote, StreamId::new(5), "room", 1);
-    drain_events(&mut agent);
 
-    agent
-        .publish("room", b"before heartbeat".to_vec(), 2)
-        .unwrap();
-    assert!(agent.mesh_peers("room").is_empty());
-    let publish = drain_actions(&mut agent);
-    let rpc = decode_rpc(&sent(&publish).unwrap().0);
-    assert_eq!(
-        rpc.publish[0].data.as_deref(),
-        Some(&b"before heartbeat"[..])
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            subscriptions: vec![SubOpts {
+                subscribe: Some(true),
+                topic_id: Some("room".to_string()),
+            }],
+            control: Some(ControlMessage {
+                prune: vec![ControlPrune {
+                    topic_id: Some("room".to_string()),
+                    peers: Vec::new(),
+                    backoff: Some(120),
+                }],
+                ..ControlMessage::default()
+            }),
+            ..Rpc::default()
+        },
+        2,
     );
-    assert!(rpc.control.is_none(), "fallback does not implicitly GRAFT");
+
+    assert!(agent.mesh_peers("room").is_empty());
+    assert!(drain_actions(&mut agent).is_empty());
+    agent.handle_tick(1_002);
+    assert!(agent.mesh_peers("room").is_empty());
 }
 
 #[test]
@@ -976,6 +1053,9 @@ fn v11_leave_prune_carries_backoff() {
     inbound_open(&mut agent, &remote, StreamId::new(5), 1);
     remote_subscribe(&mut agent, &remote, StreamId::new(5), "room", 1);
     drain_events(&mut agent);
+    let graft = drain_actions(&mut agent);
+    ack(&mut agent, &remote, &graft, 1);
+    drain_actions(&mut agent);
     inbound_rpc(
         &mut agent,
         &remote,
@@ -1107,6 +1187,9 @@ fn disconnect_and_supersede_aggregate_queued_failures() {
         drain_actions(&mut agent);
         inbound_open(&mut agent, remote, inbound, 0);
         remote_subscribe(&mut agent, remote, inbound, "room", 0);
+        let graft = drain_actions(&mut agent);
+        ack(&mut agent, remote, &graft, 0);
+        drain_actions(&mut agent);
     }
     drain_events(&mut agent);
     agent.publish("room", b"queued".to_vec(), 1).unwrap();
@@ -1163,6 +1246,9 @@ fn publish_backpressure_is_all_or_nothing_across_mesh_peers() {
         drain_actions(&mut agent);
         inbound_open(&mut agent, remote, inbound, 0);
         remote_subscribe(&mut agent, remote, inbound, "room", 0);
+        let graft = drain_actions(&mut agent);
+        ack(&mut agent, remote, &graft, 0);
+        drain_actions(&mut agent);
     }
     drain_events(&mut agent);
     agent.publish("room", b"first".to_vec(), 1).unwrap();
@@ -1200,6 +1286,11 @@ fn zero_gossip_degree_emits_no_ihave() {
         drain_actions(&mut agent);
         inbound_open(&mut agent, remote, inbound, 0);
         remote_subscribe(&mut agent, remote, inbound, "room", 0);
+        let graft = drain_actions(&mut agent);
+        if sent(&graft).is_some() {
+            ack(&mut agent, remote, &graft, 0);
+            drain_actions(&mut agent);
+        }
     }
     drain_events(&mut agent);
     inbound_rpc(

--- a/crates/pubsub/tests/gossipsub.rs
+++ b/crates/pubsub/tests/gossipsub.rs
@@ -912,6 +912,212 @@ fn stream_reopen_resyncs_an_acked_unsubscribe() {
 }
 
 #[test]
+fn disconnect_preserves_backoff_and_supersede_reannounces_subscriptions() {
+    let mut agent = agent();
+    agent.subscribe("room", 0).unwrap();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+    let subscription = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(4),
+        MESHSUB_PROTOCOL_ID_V11,
+        0,
+    );
+    ack(&mut agent, &remote, &subscription, 0);
+    drain_actions(&mut agent);
+    inbound_open(&mut agent, &remote, StreamId::new(5), 0);
+    remote_subscribe(&mut agent, &remote, StreamId::new(5), "room", 1);
+    drain_events(&mut agent);
+    let graft = drain_actions(&mut agent);
+    ack(&mut agent, &remote, &graft, 1);
+    drain_actions(&mut agent);
+
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            control: Some(ControlMessage {
+                prune: vec![ControlPrune {
+                    topic_id: Some("room".to_string()),
+                    peers: Vec::new(),
+                    backoff: Some(120),
+                }],
+                ..ControlMessage::default()
+            }),
+            ..Rpc::default()
+        },
+        2,
+    );
+    assert!(agent.mesh_peers("room").is_empty());
+
+    agent.handle_event(
+        &SwarmEvent::ConnectionClosed {
+            peer_id: remote.clone(),
+            conn_id: ConnectionId::new(1),
+        },
+        3,
+    );
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 4);
+    let reconnected = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(8),
+        MESHSUB_PROTOCOL_ID_V11,
+        4,
+    );
+    let rpc = decode_rpc(
+        &sent(&reconnected)
+            .expect("reconnect subscription snapshot")
+            .0,
+    );
+    assert_eq!(rpc.subscriptions.len(), 1);
+    assert_eq!(rpc.subscriptions[0].subscribe, Some(true));
+    assert_eq!(rpc.subscriptions[0].topic_id.as_deref(), Some("room"));
+    ack(&mut agent, &remote, &reconnected, 4);
+    drain_actions(&mut agent);
+    inbound_open(&mut agent, &remote, StreamId::new(9), 4);
+    remote_subscribe(&mut agent, &remote, StreamId::new(9), "room", 5);
+    assert!(
+        agent.mesh_peers("room").is_empty(),
+        "disconnect must not erase the peer's topic backoff"
+    );
+    assert!(drain_actions(&mut agent).is_empty());
+
+    agent.handle_event(
+        &SwarmEvent::ConnectionEstablished {
+            peer_id: remote.clone(),
+            conn_id: ConnectionId::new(2),
+        },
+        6,
+    );
+    agent.handle_event(
+        &SwarmEvent::PeerReady {
+            peer_id: remote.clone(),
+            protocols: vec![MESHSUB_PROTOCOL_ID_V11.to_string()],
+        },
+        6,
+    );
+    let superseded = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(12),
+        MESHSUB_PROTOCOL_ID_V11,
+        6,
+    );
+    let rpc = decode_rpc(
+        &sent(&superseded)
+            .expect("supersede subscription snapshot")
+            .0,
+    );
+    assert_eq!(rpc.subscriptions.len(), 1);
+    assert_eq!(rpc.subscriptions[0].subscribe, Some(true));
+    assert_eq!(rpc.subscriptions[0].topic_id.as_deref(), Some("room"));
+    ack(&mut agent, &remote, &superseded, 6);
+    drain_actions(&mut agent);
+    inbound_open(&mut agent, &remote, StreamId::new(13), 6);
+    remote_subscribe(&mut agent, &remote, StreamId::new(13), "room", 7);
+    assert!(
+        agent.mesh_peers("room").is_empty(),
+        "supersede must rebuild peer state without erasing backoff"
+    );
+    assert!(drain_actions(&mut agent).is_empty());
+}
+
+#[test]
+fn queued_prune_reencodes_for_v10_after_stream_reopen() {
+    let mut agent = agent();
+    agent.subscribe("room", 0).unwrap();
+    let remote = peer(2);
+    connect(
+        &mut agent,
+        &remote,
+        &[MESHSUB_PROTOCOL_ID_V11, MESHSUB_PROTOCOL_ID_V10],
+        0,
+    );
+    let subscription = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(4),
+        MESHSUB_PROTOCOL_ID_V11,
+        0,
+    );
+    ack(&mut agent, &remote, &subscription, 0);
+    drain_actions(&mut agent);
+    inbound_open(&mut agent, &remote, StreamId::new(5), 0);
+    remote_subscribe(&mut agent, &remote, StreamId::new(5), "room", 1);
+    drain_events(&mut agent);
+    let graft = drain_actions(&mut agent);
+    ack(&mut agent, &remote, &graft, 1);
+    drain_actions(&mut agent);
+
+    agent.unsubscribe("room", 2);
+    let unsubscribe = drain_actions(&mut agent);
+    ack(&mut agent, &remote, &unsubscribe, 2);
+    let v11_prune = drain_actions(&mut agent);
+    assert_eq!(
+        decode_rpc(&sent(&v11_prune).expect("v1.1 PRUNE in flight").0)
+            .control
+            .expect("control frame")
+            .prune[0]
+            .backoff,
+        Some(10)
+    );
+
+    agent.handle_event(
+        &SwarmEvent::StreamClosed {
+            peer_id: remote.clone(),
+            conn_id: ConnectionId::new(1),
+            stream_id: StreamId::new(4),
+        },
+        3,
+    );
+    agent.handle_event(
+        &SwarmEvent::PeerReady {
+            peer_id: remote.clone(),
+            protocols: vec![MESHSUB_PROTOCOL_ID_V10.to_string()],
+        },
+        4,
+    );
+    let opening = drain_actions(&mut agent);
+    let token = opening
+        .iter()
+        .find_map(|action| match action {
+            PubsubAction::OpenStream {
+                token, protocol_id, ..
+            } if protocol_id == MESHSUB_PROTOCOL_ID_V10 => Some(*token),
+            _ => None,
+        })
+        .expect("reopen requests meshsub 1.0");
+    let stream = StreamId::new(8);
+    agent.stream_open_result(&remote, token, Ok(stream), 4);
+    agent.handle_event(
+        &SwarmEvent::StreamReady {
+            peer_id: remote.clone(),
+            conn_id: ConnectionId::new(1),
+            stream_id: stream,
+            protocol_id: MESHSUB_PROTOCOL_ID_V10.to_string(),
+            initiated_locally: true,
+        },
+        4,
+    );
+    let resync = drain_actions(&mut agent);
+    let rpc = decode_rpc(&sent(&resync).expect("unsubscribe resync").0);
+    assert_eq!(rpc.subscriptions.len(), 1);
+    assert_eq!(rpc.subscriptions[0].subscribe, Some(false));
+    ack(&mut agent, &remote, &resync, 4);
+
+    let v10_prune = drain_actions(&mut agent);
+    let prune = &decode_rpc(&sent(&v10_prune).expect("re-encoded PRUNE").0)
+        .control
+        .expect("control frame")
+        .prune[0];
+    assert_eq!(prune.topic_id.as_deref(), Some("room"));
+    assert_eq!(prune.backoff, None);
+}
+
+#[test]
 fn valid_message_delivers_once_and_invalid_signature_never_delivers() {
     let mut agent = agent();
     agent.subscribe("room", 0).unwrap();

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -69,12 +69,13 @@ over the relay circuit.
 
 ## Message format
 
-The payload is plain UTF-8, `"<nick>: <text>"`, formatted by the sender and
-interoperable with libp2p gossipsub peers on the same topic. go-libp2p and
-rust-libp2p gossipsub both sign by default and match this stack's StrictSign;
-`--allow-unsigned` is only needed for a peer explicitly configured to emit
-unsigned messages. Seqnos are implementation-defined opaque bytes (go: 8
-big-endian, rust: 20 random); anything 1..=64 bytes is accepted.
+The payload is plain UTF-8, `"<nick>: <text>"`, formatted by the sender. This
+stack uses libp2p StrictSign; configure other gossipsub peers for signed
+message authenticity and strict validation. `--allow-unsigned` is only needed
+when the remote intentionally emits unsigned messages. Seqnos are opaque:
+minip2p, go-libp2p gossipsub, and signed rust-libp2p gossipsub currently emit
+8-byte big-endian counters, while this implementation accepts any 1..=64-byte
+value.
 
 A quiet room generates no traffic, and the QUIC transport drops
 connections after 30 s of silence — the chat loop pings every connected
@@ -109,11 +110,13 @@ Two deployment details surfaced during live validation:
    report subscriptions and exchange messages while `path=relayed`; cutting
    the relay must disconnect the room. Remove `--relay-only` from both peers
    in a second run to validate the relayed → direct-punched upgrade.
-3. **go-libp2p interop**: an Ed25519 go peer using
-   `pubsub.NewGossipSub` on the same topic chats both ways in strict mode.
-4. **rust-libp2p interop**: a rust-libp2p gossipsub peer using its signed
-   default message-authenticity mode. The rust peer must include a `ping`
-   behaviour (to answer this side's keepalives) or raise its
-   `idle_connection_timeout` — by default rust-libp2p closes a
-   connection after 10 s when no behaviour keeps it alive, which reads
-   as an instant disconnect here.
+3. **Manual go-libp2p interop check (not covered by CI)**: configure an
+   Ed25519 go peer using `pubsub.NewGossipSub` for strict signing on the same
+   topic, then verify messages travel in both directions.
+4. **Manual rust-libp2p interop check (not covered by CI)**: configure a
+   rust-libp2p gossipsub peer with `MessageAuthenticity::Signed` and strict
+   validation, then verify messages travel in both directions. The rust peer
+   must include a `ping` behaviour (to answer this side's keepalives) or raise
+   its `idle_connection_timeout` — by default rust-libp2p closes a connection
+   after 10 s when no behaviour keeps it alive, which reads as an instant
+   disconnect here.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -1,9 +1,9 @@
 # minip2p-chat
 
-Group chat over floodsub with NAT traversal: the "finished product" demo
+Group chat over gossipsub with NAT traversal: the "finished product" demo
 for the minip2p stack. Peers join a room by dialing one address, the NAT
-agent hole-punches direct paths where needed, and messages flood the room
-signed end-to-end (libp2p StrictSign).
+agent hole-punches direct paths where needed, and messages flow through a
+bounded pubsub mesh signed end-to-end (libp2p StrictSign).
 
 ```text
 minip2p-chat host        [--topic <t>] [--nick <n>] [--relay <relay-peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
@@ -64,18 +64,17 @@ $ minip2p-chat join '<circuit-addr>' --nick alice
 ```
 
 Pass `--relay-only` to skip direct dialing and DCUtR entirely. This gives a
-deterministic way to exercise Noise, Yamux, Identify, discovery, and floodsub
+deterministic way to exercise Noise, Yamux, Identify, discovery, and gossipsub
 over the relay circuit.
 
 ## Message format
 
-The payload is plain UTF-8, `"<nick>: <text>"`, formatted by the sender —
-trivially interoperable with any libp2p floodsub peer on the same topic
-(go/js sign by default and match this stack's StrictSign; rust-libp2p's
-floodsub is unsigned — pass `--allow-unsigned` to chat with it; signed
-messages are still verified). Seqnos are implementation-defined opaque
-bytes (go: 8 big-endian, rust: 20 random); anything 1..=64 bytes is
-accepted.
+The payload is plain UTF-8, `"<nick>: <text>"`, formatted by the sender and
+interoperable with libp2p gossipsub peers on the same topic. go-libp2p and
+rust-libp2p gossipsub both sign by default and match this stack's StrictSign;
+`--allow-unsigned` is only needed for a peer explicitly configured to emit
+unsigned messages. Seqnos are implementation-defined opaque bytes (go: 8
+big-endian, rust: 20 random); anything 1..=64 bytes is accepted.
 
 A quiet room generates no traffic, and the QUIC transport drops
 connections after 30 s of silence — the chat loop pings every connected
@@ -110,10 +109,10 @@ Two deployment details surfaced during live validation:
    report subscriptions and exchange messages while `path=relayed`; cutting
    the relay must disconnect the room. Remove `--relay-only` from both peers
    in a second run to validate the relayed → direct-punched upgrade.
-3. **go-libp2p interop**: a go floodsub peer (Ed25519 identity) on the
-   same topic chats both ways in strict mode.
-4. **rust-libp2p interop**: a rust-libp2p floodsub peer, with this side
-   started with `--allow-unsigned`. The rust peer must include a `ping`
+3. **go-libp2p interop**: an Ed25519 go peer using
+   `pubsub.NewGossipSub` on the same topic chats both ways in strict mode.
+4. **rust-libp2p interop**: a rust-libp2p gossipsub peer using its signed
+   default message-authenticity mode. The rust peer must include a `ping`
    behaviour (to answer this side's keepalives) or raise its
    `idle_connection_timeout` — by default rust-libp2p closes a
    connection after 10 s when no behaviour keeps it alive, which reads

--- a/examples/chat/src/cli.rs
+++ b/examples/chat/src/cli.rs
@@ -22,7 +22,7 @@ use minip2p::{Multiaddr, PeerAddr, PeerId, Protocol};
 pub enum Mode {
     /// Bind, optionally reserve on a relay, and print the address(es)
     /// others join with. The host is an ordinary chat participant that
-    /// also forwards between leaves (floodsub does that for free).
+    /// also relays messages while the gossipsub mesh converges.
     Host {
         relay: Option<PeerAddr>,
         chat: ChatOptions,
@@ -55,8 +55,7 @@ pub struct ChatOptions {
     pub key_path: Option<PathBuf>,
     /// Optional QUIC listen/bind multiaddr. Defaults to dual-stack UDP/0.
     pub listen_addr: Option<Multiaddr>,
-    /// Accept unsigned messages (rust-libp2p floodsub interop; its
-    /// floodsub does not sign). Signed messages are still verified.
+    /// Accept unsigned pubsub messages. Signed messages are still verified.
     pub allow_unsigned: bool,
     /// Disable peer discovery and preserve the host-forwarded star topology.
     pub no_mesh: bool,
@@ -302,7 +301,7 @@ fn require_quic_transport(what: &str, raw: &str, addr: &PeerAddr) -> Result<(), 
 
 /// Usage text printed on `--help` and parse errors.
 pub fn usage() -> String {
-    "minip2p-chat -- group chat over floodsub with NAT traversal.
+    "minip2p-chat -- group chat over gossipsub with NAT traversal.
 
 USAGE:
     minip2p-chat host        [--topic <t>] [--nick <n>] [--relay <relay-peer-addr>] [--key <path>] [--listen <quic-multiaddr>] [--no-mesh]
@@ -319,8 +318,8 @@ NOTES:
     --listen  bind multiaddr; default is dual-stack UDP/0
 
     --allow-unsigned
-              accept unsigned messages (rust-libp2p floodsub interop;
-              signed messages are still verified)
+              accept unsigned pubsub messages; signed messages are still
+              verified
     --no-mesh preserve the host-forwarded star by disabling peer discovery
     --relay-only
               skip direct dialing and hole punching; use the promoted relay

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -1,4 +1,4 @@
-//! `minip2p-chat` — group chat over floodsub, NAT traversal included.
+//! `minip2p-chat` — group chat over gossipsub, NAT traversal included.
 
 mod cli;
 mod modes;

--- a/examples/chat/src/modes.rs
+++ b/examples/chat/src/modes.rs
@@ -215,8 +215,42 @@ pub fn run_join(
         .subscribe(&topic)
         .map_err(|e| format!("subscribe: {e}"))?;
     println!("[join] subscribed topic={topic} nick={nick}");
+    wait_for_topic_peer(&mut endpoint, &host_peer, &topic, "join")?;
 
     run_chat(&mut endpoint, &topic, &nick, "join", None)
+}
+
+/// Waits until the host's topic announcement has been applied. The
+/// gossipsub agent immediately admits an eligible new subscriber while the
+/// local mesh is below its low watermark, so observing this event means the
+/// joiner has a routing peer before stdin is consumed.
+fn wait_for_topic_peer(
+    endpoint: &mut Endpoint,
+    expected_peer: &PeerId,
+    expected_topic: &str,
+    role: &str,
+) -> Result<(), Box<dyn Error>> {
+    let deadline = Instant::now() + READY_DEADLINE;
+    loop {
+        let Some(event) = endpoint
+            .next_pubsub_event(deadline)
+            .map_err(|e| format!("waiting for pubsub readiness: {e}"))?
+        else {
+            return Err(
+                format!("peer {expected_peer} did not announce topic {expected_topic}").into(),
+            );
+        };
+        let ready = matches!(
+            &event,
+            PubsubEvent::PeerSubscribed { peer, topic }
+                if peer == expected_peer && topic == expected_topic
+        );
+        print_pubsub_event(role, event);
+        if ready {
+            println!("[{role}] pubsub-ready peer={expected_peer} topic={expected_topic}");
+            return Ok(());
+        }
+    }
 }
 
 // --- the chat loop ----------------------------------------------------------
@@ -309,27 +343,7 @@ fn run_chat(
         }
 
         for event in endpoint.take_pubsub_events() {
-            match event {
-                PubsubEvent::Message { data, from, .. } => {
-                    println!(
-                        "[chat] {} ({})",
-                        String::from_utf8_lossy(&data),
-                        short(&from)
-                    );
-                }
-                PubsubEvent::PeerSubscribed { peer, topic } => {
-                    println!("[{role}] peer-subscribed peer={peer} topic={topic}");
-                }
-                PubsubEvent::PeerUnsubscribed { peer, topic } => {
-                    println!("[{role}] peer-unsubscribed peer={peer} topic={topic}");
-                }
-                PubsubEvent::OutboundFailure { peer, reason } => {
-                    eprintln!("[{role}] outbound-failure peer={peer} reason={reason}");
-                }
-                PubsubEvent::ProtocolViolation { peer, reason } => {
-                    eprintln!("[{role}] violation peer={peer} reason={reason}");
-                }
-            }
+            print_pubsub_event(role, event);
         }
 
         for event in endpoint.take_nat_events() {
@@ -380,6 +394,30 @@ fn run_chat(
                     );
                 }
             }
+        }
+    }
+}
+
+fn print_pubsub_event(role: &str, event: PubsubEvent) {
+    match event {
+        PubsubEvent::Message { data, from, .. } => {
+            println!(
+                "[chat] {} ({})",
+                String::from_utf8_lossy(&data),
+                short(&from)
+            );
+        }
+        PubsubEvent::PeerSubscribed { peer, topic } => {
+            println!("[{role}] peer-subscribed peer={peer} topic={topic}");
+        }
+        PubsubEvent::PeerUnsubscribed { peer, topic } => {
+            println!("[{role}] peer-unsubscribed peer={peer} topic={topic}");
+        }
+        PubsubEvent::OutboundFailure { peer, reason } => {
+            eprintln!("[{role}] outbound-failure peer={peer} reason={reason}");
+        }
+        PubsubEvent::ProtocolViolation { peer, reason } => {
+            eprintln!("[{role}] violation peer={peer} reason={reason}");
         }
     }
 }

--- a/examples/chat/src/modes.rs
+++ b/examples/chat/src/modes.rs
@@ -8,7 +8,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use minip2p::{
-    DISCOVERY_TOPIC, DiscoveryConfig, DiscoveryEvent, Endpoint, Event, FloodsubConfig, NatConfig,
+    DISCOVERY_TOPIC, DiscoveryConfig, DiscoveryEvent, Endpoint, Event, GossipsubConfig, NatConfig,
     NatEvent, PeerAddr, PeerId, PublishError, PubsubError, PubsubEvent,
 };
 
@@ -24,7 +24,7 @@ const DEFAULT_TOPIC: &str = "minip2p-chat";
 const CONNECT_DEADLINE: Duration = Duration::from_secs(65);
 /// How long the host waits for its relay reservation before warning.
 const RESERVATION_DEADLINE: Duration = Duration::from_secs(30);
-/// Identify must complete before floodsub can open streams.
+/// Identify must complete before gossipsub can open streams.
 const READY_DEADLINE: Duration = Duration::from_secs(15);
 
 struct ChatEndpoint {
@@ -46,9 +46,9 @@ fn build_endpoint(
     let mut builder = Endpoint::builder()
         .identity(keypair)
         .agent_version(AGENT)
-        .pubsub_config(FloodsubConfig {
+        .pubsub_config(GossipsubConfig {
             allow_unsigned: options.allow_unsigned,
-            ..FloodsubConfig::default()
+            ..GossipsubConfig::default()
         })
         .nat_config(nat_config);
     if !options.no_mesh {

--- a/examples/chat/tests/chat.rs
+++ b/examples/chat/tests/chat.rs
@@ -188,13 +188,12 @@ fn three_peer_star_chats_end_to_end() {
     let mut alice = Peer::spawn("alice", &["join", &addr, "--nick", "alice", "--no-mesh"]);
     let mut bob = Peer::spawn("bob", &["join", &addr, "--nick", "bob", "--no-mesh"]);
 
-    // --- 3. Subscription handshakes settle, then one heartbeat admits the
-    //        announced peers into each topic mesh. ---
+    // --- 3. Each joiner gates stdin on the host's topic announcement, and
+    //        the hub eagerly admits both leaves before its first heartbeat. ---
     for peer in [&alice, &bob] {
-        peer.wait_line(deadline, |line| line.contains("peer-subscribed"));
+        peer.wait_line(deadline, |line| line.contains("pubsub-ready"));
     }
     host.wait_count(deadline, 2, |line| line.contains("peer-subscribed"));
-    thread::sleep(Duration::from_millis(1_500));
 
     // --- 4. Alice speaks: the host hears it directly, bob hears it
     //        THROUGH the host (they share no connection). ---
@@ -314,10 +313,8 @@ fn three_peer_mesh_survives_host_death() {
             && line.contains(&alice_id)
             && line.contains("minip2p-chat")
     });
-    // Direct connectivity and subscription exchange precede gossipsub's
-    // heartbeat-paced mesh admission. Do not kill the hub until that mesh
-    // has had one full repair cycle.
-    thread::sleep(Duration::from_millis(1_500));
+    // Subscription exchange now performs low-watermark mesh admission, so
+    // direct peers are routable without a heartbeat-sized sleep.
 
     host.kill();
     alice.say("still here");

--- a/examples/chat/tests/chat.rs
+++ b/examples/chat/tests/chat.rs
@@ -1,7 +1,7 @@
 //! CI-safe end-to-end test for `minip2p-chat` on loopback, relay-free.
 //!
 //! Spawns a host and two joiners in a star (the joiners only know the
-//! host), waits for the floodsub subscription handshakes, then proves the
+//! host), waits for the gossipsub subscription handshakes, then proves the
 //! product loop: a line typed on one peer's stdin reaches every other peer
 //! — including leaf-to-leaf THROUGH the host — and stdin EOF exits cleanly.
 
@@ -188,12 +188,13 @@ fn three_peer_star_chats_end_to_end() {
     let mut alice = Peer::spawn("alice", &["join", &addr, "--nick", "alice", "--no-mesh"]);
     let mut bob = Peer::spawn("bob", &["join", &addr, "--nick", "bob", "--no-mesh"]);
 
-    // --- 3. Subscription handshakes settle (floodsub has no history:
-    //        publishing earlier would vanish). ---
+    // --- 3. Subscription handshakes settle, then one heartbeat admits the
+    //        announced peers into each topic mesh. ---
     for peer in [&alice, &bob] {
         peer.wait_line(deadline, |line| line.contains("peer-subscribed"));
     }
     host.wait_count(deadline, 2, |line| line.contains("peer-subscribed"));
+    thread::sleep(Duration::from_millis(1_500));
 
     // --- 4. Alice speaks: the host hears it directly, bob hears it
     //        THROUGH the host (they share no connection). ---
@@ -313,6 +314,10 @@ fn three_peer_mesh_survives_host_death() {
             && line.contains(&alice_id)
             && line.contains("minip2p-chat")
     });
+    // Direct connectivity and subscription exchange precede gossipsub's
+    // heartbeat-paced mesh admission. Do not kill the hub until that mesh
+    // has had one full repair cycle.
+    thread::sleep(Duration::from_millis(1_500));
 
     host.kill();
     alice.say("still here");


### PR DESCRIPTION
## Summary

- switch the Endpoint pubsub facade to PubsubAgent with gossipsub as the default
- accept GossipsubConfig, FloodsubConfig, or PubsubConfig and advertise only the selected engine protocol ids
- validate gossipsub configuration before binding sockets and seed deterministic peer selection from facade entropy
- keep explicit floodsub selection covered by real-QUIC regression tests
- update chat, rustdoc, README guidance, and the pre-1.0 release note

## Tests

- cargo test --workspace
- minip2p feature matrix: base, nat, pubsub, nat+pubsub, discovery
- workspace and feature-specific clippy with warnings denied
- fuzz workspace clippy
- thumbv7em-none-eabi no_std check
- workspace and full-feature docs
- Rust 1.88 workspace check
- multiaddr benchmark compile
- process-level chat star, relay-only, and host-death tests

## Review notes

- default gossipsub and explicit floodsub advertise disjoint protocol sets by design
- chat forwarding assertions wait one heartbeat after subscription exchange for mesh admission
- live go-libp2p and rust-libp2p gossipsub interoperability remains a manual pre-merge validation step

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make gossipsub the default pubsub engine in `minip2p` and switch the facade to a unified `PubsubAgent`. Gossipsub now grafts new subscriptions immediately so rooms route before the first heartbeat, tightens protocol ads, validates configs early, diversifies entropy, and keeps floodsub opt-in; `examples/chat` and docs updated, with tests for reconnect/supersede backoff and v1.0 PRUNE re-encoding.

- New Features
  - `EndpointBuilder::pubsub()` now enables gossipsub by default.
  - `EndpointBuilder::pubsub_config(...)` accepts `GossipsubConfig` or `FloodsubConfig` via `PubsubConfig`.
  - Advertises only the selected engine’s protocol ids (`/meshsub/1.1.0`, `/meshsub/1.0.0`, or `/floodsub/1.0.0`).
  - Validates gossipsub config before binding; clear errors on invalid relationships or zero bounds.
  - Diversifies gossipsub peer-selection entropy with the local `PeerId`; keeps message-id seed stable per run.
  - Eagerly grafts new remote subscriptions so messages relay before the first heartbeat; discovery beacons and chat joins route immediately.
  - Keeps floodsub behind explicit selection; real-QUIC tests cover both engines, enforce pubsub-stream invisibility, and now cover reconnect/supersede backoff and v1.0 PRUNE re-encoding; docs and `examples/chat` updated.

- Migration
  - Apps relying on floodsub must call `.pubsub_config(FloodsubConfig::default())`.
  - Mixed gossipsub/floodsub peers do not exchange pubsub traffic by design (disjoint protocol sets).
  - `.discovery()` now implies default gossipsub; no code changes needed unless floodsub is required.

<sup>Written for commit 5ebc25309c15765fba4298981c83503ad98af6e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

