### PR TITLE
fix(multistream): allow protocol fallback after na

### DIFF
--- a/crates/multistream-select/src/lib.rs
+++ b/crates/multistream-select/src/lib.rs
@@ -28,7 +28,8 @@ pub enum MultistreamOutput {
     OutboundData(Vec<u8>),
     /// Protocol negotiation succeeded.
     Negotiated { protocol: String },
-    /// The remote peer does not support the requested protocol.
+    /// A protocol proposal was unavailable: either the listener rejected the
+    /// dialer's proposal or the dialer received `na` from the listener.
     NotAvailable,
     /// A protocol-level error occurred; negotiation is terminated.
     ProtocolError { reason: String },
@@ -254,7 +255,11 @@ fn handle_message(
                 )
             } else {
                 (
-                    State::Done,
+                    // A dialer may propose another protocol on the same
+                    // stream after `na` (for example rust-libp2p tries
+                    // meshsub 1.2 before falling back to 1.1). Keep the
+                    // listener alive for that next proposal.
+                    State::WaitingForProtocolRequest,
                     vec![
                         MultistreamOutput::OutboundData(encode_message(NOT_AVAILABLE)),
                         MultistreamOutput::NotAvailable,
@@ -438,6 +443,33 @@ mod tests {
                 MultistreamOutput::NotAvailable
             ]
         );
+        assert!(!listener.is_done());
+    }
+
+    #[test]
+    fn listener_accepts_fallback_after_unsupported_proposal() {
+        const MESHSUB_V1_2: &str = "/meshsub/1.2.0";
+        const MESHSUB_V1_1: &str = "/meshsub/1.1.0";
+
+        let mut listener = MultistreamSelect::listener([MESHSUB_V1_1.to_string()]);
+        let _ = listener.start();
+
+        let mut pipelined = encode_message(MULTISTREAM_PROTOCOL_ID);
+        pipelined.extend_from_slice(&encode_message(MESHSUB_V1_2));
+        pipelined.extend_from_slice(&encode_message(MESHSUB_V1_1));
+
+        assert_eq!(
+            listener.receive(&pipelined),
+            vec![
+                MultistreamOutput::OutboundData(encode_message("na")),
+                MultistreamOutput::NotAvailable,
+                MultistreamOutput::OutboundData(encode_message(MESHSUB_V1_1)),
+                MultistreamOutput::Negotiated {
+                    protocol: MESHSUB_V1_1.to_string()
+                }
+            ]
+        );
+        assert!(listener.is_done());
     }
 
     #[test]

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -1524,7 +1524,11 @@ impl SwarmCore {
                 *negotiated_protocol = Some(protocol);
                 false
             }
-            MultistreamOutput::NotAvailable => true,
+            // Inbound listeners remain open after replying `na` so dialers
+            // can offer their next protocol on the same stream. Outbound
+            // dialers handle `NotAvailable` as terminal in
+            // `feed_outbound_negotiator` above.
+            MultistreamOutput::NotAvailable => false,
             MultistreamOutput::ProtocolError { reason } => {
                 self.emit_error(
                     SwarmErrorKind::Multistream,
@@ -1859,6 +1863,7 @@ mod tests {
     use core::str::FromStr;
 
     use minip2p_identify::IdentifyConfig;
+    use minip2p_multistream_select::MULTISTREAM_PROTOCOL_ID;
     use minip2p_ping::PingConfig;
     use minip2p_transport::{ConnectionEndpoint, ConnectionId, StreamId, TransportEvent};
 
@@ -1906,6 +1911,18 @@ mod tests {
         events
     }
 
+    fn multistream_frame(protocol: &str) -> Vec<u8> {
+        let payload_len = protocol.len() + 1;
+        assert!(
+            payload_len < 128,
+            "test helper only encodes one-byte lengths"
+        );
+        let mut frame = vec![payload_len as u8];
+        frame.extend_from_slice(protocol.as_bytes());
+        frame.push(b'\n');
+        frame
+    }
+
     #[test]
     fn swarm_core_implements_common_sans_io_protocol_trait() {
         fn drive_idle<S: SansIoProtocol<Input = SwarmInput, Output = SwarmOutput>>(engine: &mut S) {
@@ -1935,6 +1952,93 @@ mod tests {
         core.add_protocol("/myapp/1.0.0")
             .expect("application ids must be accepted");
         assert!(core.user_protocols.iter().any(|p| p == "/myapp/1.0.0"));
+    }
+
+    #[test]
+    fn inbound_multistream_accepts_fallback_after_na_on_same_stream() {
+        const MESHSUB_V1_2: &str = "/meshsub/1.2.0";
+        const MESHSUB_V1_1: &str = "/meshsub/1.1.0";
+
+        let mut core = test_core();
+        core.add_protocol(MESHSUB_V1_1)
+            .expect("register meshsub 1.1");
+        let peer_id = PeerId::from_public_key_protobuf(b"fallback-peer");
+        let conn_id = ConnectionId::new(7);
+        let stream_id = StreamId::new(3);
+        core.conn_to_peer.insert(conn_id, peer_id.clone());
+        core.peer_to_conn.insert(peer_id.clone(), conn_id);
+
+        feed(
+            &mut core,
+            TransportEvent::IncomingStream {
+                id: conn_id,
+                stream_id,
+            },
+        );
+        core.actions.clear(); // listener's multistream header
+
+        let mut first_offer = multistream_frame(MULTISTREAM_PROTOCOL_ID);
+        first_offer.extend_from_slice(&multistream_frame(MESHSUB_V1_2));
+        feed(
+            &mut core,
+            TransportEvent::StreamData {
+                id: conn_id,
+                stream_id,
+                data: first_offer,
+            },
+        );
+
+        assert!(core.inbound_negotiators.contains_key(&(conn_id, stream_id)));
+        assert!(matches!(
+            core.actions.pop_front(),
+            Some(SwarmAction::SendStream {
+                conn_id: action_conn,
+                stream_id: action_stream,
+                data,
+            }) if action_conn == conn_id
+                && action_stream == stream_id
+                && data == multistream_frame("na")
+        ));
+        assert!(core.actions.is_empty(), "unsupported offer must not reset");
+
+        feed(
+            &mut core,
+            TransportEvent::StreamData {
+                id: conn_id,
+                stream_id,
+                data: multistream_frame(MESHSUB_V1_1),
+            },
+        );
+
+        assert!(!core.inbound_negotiators.contains_key(&(conn_id, stream_id)));
+        assert_eq!(
+            core.stream_owner.get(&(conn_id, stream_id)),
+            Some(&ProtocolKind::User(MESHSUB_V1_1.to_string()))
+        );
+        assert!(matches!(
+            core.actions.pop_front(),
+            Some(SwarmAction::SendStream {
+                conn_id: action_conn,
+                stream_id: action_stream,
+                data,
+            }) if action_conn == conn_id
+                && action_stream == stream_id
+                && data == multistream_frame(MESHSUB_V1_1)
+        ));
+        assert!(core.actions.is_empty());
+        assert!(matches!(
+            core.events.pop_front(),
+            Some(SwarmEvent::StreamReady {
+                peer_id: ready_peer,
+                conn_id: ready_conn,
+                stream_id: ready_stream,
+                protocol_id,
+                initiated_locally: false,
+            }) if ready_peer == peer_id
+                && ready_conn == conn_id
+                && ready_stream == stream_id
+                && protocol_id == MESHSUB_V1_1
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep inbound multistream-select negotiation open after rejecting an unsupported proposal with `na`
- let the same stream accept a later supported proposal instead of resetting it
- cover both the state machine and swarm routing path with v1.2-to-v1.1 meshsub fallback regressions

## Root cause

Live issue #28 validation against rust-libp2p 0.56 showed one-way traffic. rust-libp2p offers `/meshsub/1.2.0` first; minip2p replied `na` but then treated that listener-side result as terminal and reset the stream before rust-libp2p could offer `/meshsub/1.1.0`. After four reset attempts rust-libp2p disabled its gossipsub handler and dropped outbound subscription/message work.

With this change, rust-libp2p default gossipsub negotiated v1.1 and passed signed traffic in both directions, including a publish after 30 seconds on the same connection.

## Validation

- `just test`
- `just clippy`
- `just fmt` + `git diff --check`
- `just check-nostd`
- `just fuzz 30` (19,289 executions)
- live rust-libp2p 0.56: QUIC + Identify + ping + `MessageAuthenticity::Signed` + `ValidationMode::Strict`; two-way delivery and >30s liveness

Refs #28

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix multistream-select negotiation to allow protocol fallback after `na`, keeping inbound listeners open so dialers can offer the next protocol on the same stream. Restores gossipsub compatibility with rust-libp2p by negotiating `/meshsub/1.1.0` after rejecting `/meshsub/1.2.0`.

- **Bug Fixes**
  - `minip2p_multistream_select`: listener remains active after `na` and can accept a later supported proposal on the same stream; supports pipelined offers; tests added for fallback.
  - `minip2p_swarm`: inbound `NotAvailable` is no longer terminal; stream isn’t reset, negotiation proceeds to a fallback protocol and emits `StreamReady` when done.

<sup>Written for commit 2f46585b4f6f802b8539e9f19d465d81ba998fee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

