### PR TITLE
feat: add UniFFI endpoint and background driver

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Three layers, strictly separated:
 
 1. **Sans-I/O protocol crates** (`no_std + alloc`), one per protocol: `multistream-select`, `ping`, `identify`, `relay`, `autonat`, `dcutr`, `pubsub`, `mdns`; plus `identity`, `core`, `tls`, and `transport` (trait contract only).
 2. **Sans-I/O orchestrators**: `crates/swarm` (`SwarmCore`; also a `std`-gated `Swarm<T>` driver), `crates/nat` (`NatAgent`: direct-dial vs. relay race + DCUtR hole punching), and `crates/discovery` (`BeaconAgent` + `PeerDiscoveryAgent`: signed beacons and the shared multi-source book/dial policy).
-3. **`std` adapters**: `transports/quic` (quiche-based, owns UDP/DNS, exposes deadlines), the `std`-gated mDNS socket driver, and `crates/minip2p` — the `Endpoint` facade; features layer on without changing the base API.
+3. **`std` adapters**: `transports/quic` (quiche-based, owns UDP/DNS, exposes deadlines), the `std`-gated mDNS socket driver, `crates/minip2p` — the `Endpoint` facade whose features layer on without changing the base API — and `crates/ffi`, the UniFFI endpoint/driver adapter for foreign runtimes.
 
 The default swarm composes only identify + ping + protocols registered via `SwarmBuilder::protocol`/`EndpointBuilder::protocol`; relay/AutoNAT/DCUtR policy belongs to the host. `code-ref/` is read-only reference checkouts, not part of the build.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,6 +1030,7 @@ name = "minip2p-ffi"
 version = "0.2.0"
 dependencies = [
  "minip2p-rs",
+ "minip2p-swarm",
  "thiserror",
  "uniffi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
 name = "minip2p-ffi"
 version = "0.2.0"
 dependencies = [
+ "minip2p-pubsub",
  "minip2p-rs",
  "minip2p-swarm",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,8 +1030,10 @@ name = "minip2p-ffi"
 version = "0.2.0"
 dependencies = [
  "minip2p-pubsub",
+ "minip2p-relay",
  "minip2p-rs",
  "minip2p-swarm",
+ "minip2p-test-support",
  "thiserror",
  "uniffi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +107,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bindgen"
@@ -96,8 +153,7 @@ dependencies = [
 [[package]]
 name = "boring"
 version = "4.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0e3bc837369e9e662d3845c374ac3771b054d4bc2dee5457591198d16d684c"
+source = "git+https://github.com/deepso7/boring?rev=de6ec29406df54911ea50dec47f40d6b6e4d6ef7#de6ec29406df54911ea50dec47f40d6b6e4d6ef7"
 dependencies = [
  "bitflags",
  "boring-sys",
@@ -109,8 +165,7 @@ dependencies = [
 [[package]]
 name = "boring-sys"
 version = "4.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15aad385759d3da2737772aefb391332227bef7cb71fb85c106cadd9d1e63a98"
+source = "git+https://github.com/deepso7/boring?rev=de6ec29406df54911ea50dec47f40d6b6e4d6ef7#de6ec29406df54911ea50dec47f40d6b6e4d6ef7"
 dependencies = [
  "bindgen",
  "cmake",
@@ -129,6 +184,38 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "camino"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "cast"
@@ -543,6 +630,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "ff"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +705,15 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "fs_extra"
@@ -656,6 +774,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "group"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +805,18 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac"
@@ -705,6 +846,18 @@ checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -772,6 +925,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -864,6 +1023,15 @@ name = "minip2p-example-common"
 version = "0.2.0"
 dependencies = [
  "minip2p-rs",
+]
+
+[[package]]
+name = "minip2p-ffi"
+version = "0.2.0"
+dependencies = [
+ "minip2p-rs",
+ "thiserror",
+ "uniffi",
 ]
 
 [[package]]
@@ -1171,6 +1339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1359,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -1378,6 +1558,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,6 +1583,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1411,6 +1624,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -1453,6 +1670,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1510,6 +1736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,6 +1752,12 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smawk"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
@@ -1542,6 +1780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,6 +1800,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
 ]
 
 [[package]]
@@ -1610,6 +1876,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1925,125 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "uniffi"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c6dec3fc6645f71a16a3fa9ff57991028153bd194ca97f4b55e610c73ce66a"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "uniffi_bindgen",
+ "uniffi_core",
+ "uniffi_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed0150801958d4825da56a41c71f000a457ac3a4613fa9647df78ac4b6b6881"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "indexmap",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml",
+ "uniffi_internal_macros",
+ "uniffi_meta",
+ "uniffi_pipeline",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0ef62e69762fbb9386dcb6c87cd3dd05d525fa8a3a579a290892e60ddbda47e"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9d12529f1223d014fd501e5f29ca0884d15d6ed5ddddd9f506e55350327dc3"
+dependencies = [
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df6d413db2827c68588f8149d30d49b71d540d46539e435b23a7f7dbd4d4f86"
+dependencies = [
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "tempfile",
+ "uniffi_internal_macros",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d1a7339539bf6f6fa3e9b534dece13f778bda2d54b1a6d4e40b4d6090ac26e7"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "weedle2",
+]
 
 [[package]]
 name = "universal-hash"
@@ -1706,6 +2130,15 @@ checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1826,6 +2259,21 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wnaf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/core",
     "crates/dcutr",
     "crates/discovery",
+    "crates/ffi",
     "crates/identify",
     "crates/identity",
     "crates/mdns",
@@ -39,3 +40,9 @@ keywords = ["libp2p", "peer-to-peer", "p2p", "networking", "sans-io"]
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
+
+# Temporary Android allocator-hook fix. Remove when cloudflare/boring#518 is
+# released on crates.io.
+[patch.crates-io]
+boring = { git = "https://github.com/deepso7/boring", rev = "de6ec29406df54911ea50dec47f40d6b6e4d6ef7" }
+boring-sys = { git = "https://github.com/deepso7/boring", rev = "de6ec29406df54911ea50dec47f40d6b6e4d6ef7" }

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 minip2p = { package = "minip2p-rs", path = "../minip2p", features = ["discovery"] }
+minip2p-swarm = { path = "../swarm" }
 thiserror = "2.0.18"
 # Must remain paired with ubrn and @ubjs/core 0.31.0-3.
 uniffi = "=0.31.0"

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "minip2p-ffi"
+description = "UniFFI bindings for embedding minip2p in mobile applications"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+crate-type = ["lib", "staticlib", "cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+minip2p = { package = "minip2p-rs", path = "../minip2p", features = ["discovery"] }
+thiserror = "2.0.18"
+# Must remain paired with ubrn and @ubjs/core 0.31.0-3.
+uniffi = "=0.31.0"

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -22,3 +22,7 @@ minip2p-pubsub = { path = "../pubsub" }
 thiserror = "2.0.18"
 # Must remain paired with ubrn and @ubjs/core 0.31.0-3.
 uniffi = "=0.31.0"
+
+[dev-dependencies]
+minip2p-relay = { path = "../relay" }
+minip2p-test-support = { path = "../test-support" }

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [dependencies]
 minip2p = { package = "minip2p-rs", path = "../minip2p", features = ["discovery"] }
 minip2p-swarm = { path = "../swarm" }
+minip2p-pubsub = { path = "../pubsub" }
 thiserror = "2.0.18"
 # Must remain paired with ubrn and @ubjs/core 0.31.0-3.
 uniffi = "=0.31.0"

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -11,8 +11,9 @@ so the host-visible configuration record cannot stringify them. The lifecycle
 surface includes detached background driving, listener callbacks, activity
 hints, running-state inspection, flag-only stop, and bounded stopped-state
 waits. Swarm, NAT, pubsub, and signed-discovery events are converted to the
-flattened `P2pEvent` model. Network commands and state snapshot queries remain
-to be added.
+flattened `P2pEvent` model. The command surface covers pubsub and NAT connection
+attempts; live queries cover connected and discovered peers, reachability, and
+the active relay reservation.
 
 `IdentifyReceived` is represented by the later `PeerReady` event, so the raw
 Identify event is not delivered. User-stream events are omitted because the v1
@@ -20,6 +21,11 @@ FFI exposes neither user-protocol registration nor stream commands. Listener
 callbacks run on the native driver thread and must not block waiting for that
 same driver to stop; `wait_stopped` called from a listener returns `false`
 immediately.
+
+Connection-attempt IDs are retained in an endpoint-lifetime map so cancellation
+remains valid after an initial path event. This assumes chat-scale connection
+volume; a long-lived service issuing unbounded attempts should periodically
+recreate its endpoint until a bounded retirement policy is added.
 
 Android currently pins `boring` and `boring-sys` to the immutable fix proposed
 in [cloudflare/boring#518](https://github.com/cloudflare/boring/pull/518).

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -7,8 +7,10 @@ change between releases.
 The current surface contains identity and relay-address helpers plus validated
 endpoint construction, immutable identity/listen-address queries, and a live
 connected-peer query. Secret key bytes are passed separately to the constructor
-so the host-visible configuration record cannot stringify them. Driver lifecycle,
-commands, and events will be added in the next implementation slice.
+so the host-visible configuration record cannot stringify them. The initial
+lifecycle surface includes activity hints, running-state inspection, synchronous
+stop, and bounded stopped-state waits. Background driving, listener callbacks,
+network commands, and events will be added in the next implementation slice.
 
 Android currently pins `boring` and `boring-sys` to the immutable fix proposed
 in [cloudflare/boring#518](https://github.com/cloudflare/boring/pull/518).

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -15,6 +15,31 @@ flattened `P2pEvent` model. The command surface covers pubsub and NAT connection
 attempts; live queries cover connected and discovered peers, reachability, and
 the active relay reservation.
 
+## Lifecycle and ownership
+
+`P2pEndpoint::new` validates configuration, binds sockets, and returns an
+endpoint in the created state. Call `start` once before issuing application
+work. The detached native driver owns all network progress and invokes the
+listener synchronously on its own thread.
+
+`stop` only requests shutdown. It never joins the driver and callbacks already
+in progress may finish after `stop` returns. `wait_stopped` is the native
+quietness barrier: after it returns `true`, the endpoint has released its
+listener and no later callback can begin. It returns `false` for a created
+endpoint until that endpoint is explicitly stopped, and returns immediately
+with `false` when called from the driver callback itself.
+
+Dropping the final native `P2pEndpoint` reference requests the same shutdown as
+`stop`; it does not synchronously join the detached thread. UniFFI object
+destruction therefore does not replace `stop` plus `wait_stopped` when the host
+needs an observable native shutdown barrier. The future TypeScript wrapper owns
+its separate handler-suppression and close semantics.
+
+The endpoint and its driver share one mutex. Synchronous commands interrupt an
+in-flight transport wait before acquiring it, and the driver yields ownership
+while commands are pending. Listener callbacks never run while that mutex is
+held.
+
 `IdentifyReceived` is represented by the later `PeerReady` event, so the raw
 Identify event is not delivered. User-stream events are omitted because the v1
 FFI exposes neither user-protocol registration nor stream commands. Listener
@@ -39,11 +64,56 @@ draining a backlog. One listener callback that blocks for roughly the entire
 QUIC idle window can still cause connection loss, so callbacks must return
 promptly and hand expensive work to the host runtime.
 
+## Addresses, discovery, and event ordering
+
+`listen_addrs` returns locally bound addresses. Wildcard, loopback, and private
+addresses are not automatically remotely dialable. Public observations arrive
+through `PublicAddressesChanged`; a relay circuit address is composed from
+`active_reservation` and `circuit_address`.
+
+The v1 crate enables signed-beacon discovery but not mDNS. Consequently mDNS
+address fields are empty today, while their explicit provenance remains in the
+API for a future opt-in implementation. Mobile mDNS permissions, background
+socket operation, and iOS background networking are outside the v1 contract.
+
+Events preserve FIFO order within each upstream source. There is no total order
+across swarm, NAT, pubsub, and discovery queues because their original
+cross-source production order is not observable. Hosts must track readiness,
+subscriptions, and paths independently.
+
+## Queue and memory policy
+
 Native callback carry is capped at 4096 source events and delivered in batches
 of at most 512. Overflow discards oldest message events first, then oldest
 remaining events, and reports the loss through a dedicated `EventsDropped`
 diagnostic. Rust-side tests can inspect exact accounting through
 `P2pEndpoint::driver_stats`; this diagnostic method is not exported by UniFFI.
+
+The upstream audit is:
+
+- QUIC accepts at most 128 UDP datagrams per transport poll and separately
+  bounds connections, streams, pending datagrams, and pending stream bytes.
+- Swarm, NAT, and pubsub events are drained after every endpoint pump. While
+  native callback carry is being delivered, the endpoint is not pumped, so
+  those source queues do not cumulatively grow behind a slow listener.
+- Pubsub bounds each encoded RPC to 65,536 bytes and bounds pending outbound
+  work per peer.
+- Signed discovery defaults to 128 known peers, 16 addresses per source and
+  four pending protocol-violation slots; peer state changes are coalesced.
+- NAT event/state volume can still scale with endpoint-lifetime connection
+  attempts. The v1 operational assumption is chat-scale connect volume, as
+  described above. The 4096-event carry cap bounds retained converted events,
+  not every transient allocation inside an upstream poll.
+- Any out-of-repository host wrapper queue must define its own hard cap and
+  overflow notification; the native carry limit does not bound host queues.
+
+## Stability and exclusions
+
+The entire FFI ABI and generated binding shape are unstable before 1.0.
+Regenerate downstream bindings after every change to this crate. v1 deliberately
+does not expose arbitrary user protocols/streams, `connect_with_addrs`, mDNS,
+standalone Swift/Kotlin packages, authoritative per-peer path queries, or
+background-networking guarantees.
 
 Android currently pins `boring` and `boring-sys` to the immutable fix proposed
 in [cloudflare/boring#518](https://github.com/cloudflare/boring/pull/518).

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -1,0 +1,15 @@
+# minip2p-ffi
+
+UniFFI bindings for embedding minip2p in React Native and other mobile hosts.
+The ABI, generated bindings, event enums, and error enums are pre-1.0 and may
+change between releases.
+
+The current surface contains identity and relay-address helpers. Endpoint
+construction, lifecycle, events, and signed discovery will be added in the next
+implementation slice; they are intentionally not exported before an endpoint
+object consumes them.
+
+Android currently pins `boring` and `boring-sys` to the immutable fix proposed
+in [cloudflare/boring#518](https://github.com/cloudflare/boring/pull/518).
+Remove the workspace patch when an upstream crates.io release contains that
+fix.

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -47,17 +47,21 @@ callbacks run on the native driver thread and must not block waiting for that
 same driver to stop; `wait_stopped` called from a listener returns `false`
 immediately.
 
-Connection-attempt IDs are retained in an endpoint-lifetime map so cancellation
-remains valid after an initial path event. This assumes chat-scale connection
-volume; a long-lived service issuing unbounded attempts should periodically
-recreate its endpoint until a bounded retirement policy is added. Cancellation
-suppresses queued connection-attempt events on a best-effort basis; an event
-whose callback already won the dispatch race may still be observed after
-`cancel_connect` returns.
+Connection-attempt IDs are retained in an endpoint-lifetime map. This assumes
+chat-scale connection volume; a long-lived service issuing unbounded attempts
+should periodically recreate its endpoint until a bounded retirement policy is
+added. Cancellation suppresses queued connection-attempt events on a
+best-effort basis; an event whose callback already won the dispatch race may
+still be observed after `cancel_connect` returns. Cancellation cannot retract a
+transport connection that completed concurrently. A host that wants cancel to
+also mean "close any resulting session" must call `disconnect` for the target
+peer.
 
 The native driver owns connection keepalive. Every 10 seconds it pings every
 currently connected peer, keeping quiet connections inside QUIC's default
-30-second idle timeout. Successful replies and timeouts surface normally as
+30-second idle timeout. The driver releases its shared endpoint mutex between
+peer pings so commands can interleave with a large keepalive pass. Successful
+replies and timeouts surface normally as
 `PingRttMeasured` and `PingTimeout` events; hosts should not run a second
 keepalive loop. Keepalive is serviced between callback deliveries while
 draining a backlog. One listener callback that blocks for roughly the entire

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -7,10 +7,19 @@ change between releases.
 The current surface contains identity and relay-address helpers plus validated
 endpoint construction, immutable identity/listen-address queries, and a live
 connected-peer query. Secret key bytes are passed separately to the constructor
-so the host-visible configuration record cannot stringify them. The initial
-lifecycle surface includes activity hints, running-state inspection, synchronous
-stop, and bounded stopped-state waits. Background driving, listener callbacks,
-network commands, and events will be added in the next implementation slice.
+so the host-visible configuration record cannot stringify them. The lifecycle
+surface includes detached background driving, listener callbacks, activity
+hints, running-state inspection, flag-only stop, and bounded stopped-state
+waits. Swarm, NAT, pubsub, and signed-discovery events are converted to the
+flattened `P2pEvent` model. Network commands and state snapshot queries remain
+to be added.
+
+`IdentifyReceived` is represented by the later `PeerReady` event, so the raw
+Identify event is not delivered. User-stream events are omitted because the v1
+FFI exposes neither user-protocol registration nor stream commands. Listener
+callbacks run on the native driver thread and must not block waiting for that
+same driver to stop; `wait_stopped` called from a listener returns `false`
+immediately.
 
 Android currently pins `boring` and `boring-sys` to the immutable fix proposed
 in [cloudflare/boring#518](https://github.com/cloudflare/boring/pull/518).

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -25,7 +25,16 @@ immediately.
 Connection-attempt IDs are retained in an endpoint-lifetime map so cancellation
 remains valid after an initial path event. This assumes chat-scale connection
 volume; a long-lived service issuing unbounded attempts should periodically
-recreate its endpoint until a bounded retirement policy is added.
+recreate its endpoint until a bounded retirement policy is added. Cancellation
+suppresses queued connection-attempt events on a best-effort basis; an event
+whose callback already won the dispatch race may still be observed after
+`cancel_connect` returns.
+
+The native driver owns connection keepalive. Every 10 seconds it pings every
+currently connected peer, keeping quiet connections inside QUIC's default
+30-second idle timeout. Successful replies and timeouts surface normally as
+`PingRttMeasured` and `PingTimeout` events; hosts should not run a second
+keepalive loop.
 
 Native callback carry is capped at 4096 source events and delivered in batches
 of at most 512. Overflow discards oldest message events first, then oldest

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -27,6 +27,12 @@ remains valid after an initial path event. This assumes chat-scale connection
 volume; a long-lived service issuing unbounded attempts should periodically
 recreate its endpoint until a bounded retirement policy is added.
 
+Native callback carry is capped at 4096 source events and delivered in batches
+of at most 512. Overflow discards oldest message events first, then oldest
+remaining events, and reports the loss through a dedicated `EventsDropped`
+diagnostic. Rust-side tests can inspect exact accounting through
+`P2pEndpoint::driver_stats`; this diagnostic method is not exported by UniFFI.
+
 Android currently pins `boring` and `boring-sys` to the immutable fix proposed
 in [cloudflare/boring#518](https://github.com/cloudflare/boring/pull/518).
 Remove the workspace patch when an upstream crates.io release contains that

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -34,7 +34,10 @@ The native driver owns connection keepalive. Every 10 seconds it pings every
 currently connected peer, keeping quiet connections inside QUIC's default
 30-second idle timeout. Successful replies and timeouts surface normally as
 `PingRttMeasured` and `PingTimeout` events; hosts should not run a second
-keepalive loop.
+keepalive loop. Keepalive is serviced between callback deliveries while
+draining a backlog. One listener callback that blocks for roughly the entire
+QUIC idle window can still cause connection loss, so callbacks must return
+promptly and hand expensive work to the host runtime.
 
 Native callback carry is capped at 4096 source events and delivered in batches
 of at most 512. Overflow discards oldest message events first, then oldest

--- a/crates/ffi/README.md
+++ b/crates/ffi/README.md
@@ -4,10 +4,11 @@ UniFFI bindings for embedding minip2p in React Native and other mobile hosts.
 The ABI, generated bindings, event enums, and error enums are pre-1.0 and may
 change between releases.
 
-The current surface contains identity and relay-address helpers. Endpoint
-construction, lifecycle, events, and signed discovery will be added in the next
-implementation slice; they are intentionally not exported before an endpoint
-object consumes them.
+The current surface contains identity and relay-address helpers plus validated
+endpoint construction, immutable identity/listen-address queries, and a live
+connected-peer query. Secret key bytes are passed separately to the constructor
+so the host-visible configuration record cannot stringify them. Driver lifecycle,
+commands, and events will be added in the next implementation slice.
 
 Android currently pins `boring` and `boring-sys` to the immutable fix proposed
 in [cloudflare/boring#518](https://github.com/cloudflare/boring/pull/518).

--- a/crates/ffi/src/config.rs
+++ b/crates/ffi/src/config.rs
@@ -44,6 +44,34 @@ pub struct EndpointConfig {
     pub discovery: Option<DiscoveryOptions>,
 }
 
+/// One peer in the shared discovery address book.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct KnownPeerInfo {
+    /// Discovered peer.
+    pub peer_id: String,
+    /// Merged dial-order addresses.
+    pub addrs: Vec<String>,
+    /// Addresses authenticated by signed beacons.
+    pub beacon_addrs: Vec<String>,
+    /// Addresses learned from unauthenticated mDNS.
+    pub mdns_addrs: Vec<String>,
+    /// Age of the most recent signed beacon.
+    pub beacon_last_seen_age_ms: Option<u64>,
+    /// Age of the most recent mDNS observation.
+    pub mdns_last_seen_age_ms: Option<u64>,
+    /// Whether the endpoint currently has a connection to this peer.
+    pub connected: bool,
+}
+
+/// Snapshot of the active inbound relay reservation.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct RelayReservationInfo {
+    /// Relay holding the reservation.
+    pub relay_peer_id: String,
+    /// Absolute relay-reported expiry, when present.
+    pub expires_unix_secs: Option<u64>,
+}
+
 impl fmt::Debug for EndpointConfig {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter

--- a/crates/ffi/src/config.rs
+++ b/crates/ffi/src/config.rs
@@ -1,0 +1,59 @@
+//! Foreign-facing endpoint configuration.
+
+use std::fmt;
+
+/// Signed-discovery configuration.
+#[derive(Clone, uniffi::Record)]
+pub struct DiscoveryOptions {
+    /// Pubsub topic carrying signed discovery beacons.
+    pub topic: String,
+    /// Milliseconds between local beacon announcements.
+    pub beacon_interval_ms: u64,
+    /// Milliseconds before a signed peer observation expires.
+    pub peer_ttl_ms: u64,
+    /// Whether accepted observations may trigger automatic dials.
+    pub auto_dial: bool,
+}
+
+impl fmt::Debug for DiscoveryOptions {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DiscoveryOptions")
+            .field("topic", &self.topic)
+            .field("beacon_interval_ms", &self.beacon_interval_ms)
+            .field("peer_ttl_ms", &self.peer_ttl_ms)
+            .field("auto_dial", &self.auto_dial)
+            .finish()
+    }
+}
+
+/// Configuration used to construct an FFI endpoint.
+#[derive(Clone, uniffi::Record)]
+pub struct EndpointConfig {
+    /// Identify agent version, or the crate-derived default when absent.
+    pub agent_version: Option<String>,
+    /// Relay peer addresses.
+    pub relays: Vec<String>,
+    /// QUIC listen multiaddress, or dual-stack wildcard binding when absent.
+    pub listen_addr: Option<String>,
+    /// Whether connection attempts must remain relayed.
+    pub force_relay: bool,
+    /// Whether unsigned pubsub messages are accepted.
+    pub allow_unsigned: bool,
+    /// Signed-discovery settings, or no discovery when absent.
+    pub discovery: Option<DiscoveryOptions>,
+}
+
+impl fmt::Debug for EndpointConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EndpointConfig")
+            .field("agent_version", &self.agent_version)
+            .field("relays", &self.relays)
+            .field("listen_addr", &self.listen_addr)
+            .field("force_relay", &self.force_relay)
+            .field("allow_unsigned", &self.allow_unsigned)
+            .field("discovery", &self.discovery)
+            .finish()
+    }
+}

--- a/crates/ffi/src/driver.rs
+++ b/crates/ffi/src/driver.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use minip2p::{EndpointWake, Error, NatEvent};
 
-use crate::endpoint::{Lifecycle, Shared};
+use crate::endpoint::{EndpointState, Lifecycle, Shared};
 use crate::events::{convert_discovery, convert_nat, convert_pubsub, convert_swarm};
 use crate::{DriverFailureKind, P2pEvent, P2pEventListener};
 
@@ -174,6 +174,7 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
             state.stats.dropped = state.stats.dropped.saturating_add(carry.len() as u64);
             return Ok(());
         }
+        service_keepalive(&mut state, &mut next_keepalive_at);
         if !carry.is_empty() || overflow.pending != 0 {
             let cancelled = carry.suppress_cancelled(&state.cancelled_connect_ids);
             state.stats.dropped = state.stats.dropped.saturating_add(cancelled as u64);
@@ -187,6 +188,7 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
             for event in delivery.batch {
                 let should_dispatch = {
                     let mut state = guard.shared.lock_state();
+                    service_keepalive(&mut state, &mut next_keepalive_at);
                     let cancelled = p2p_connect_id(&event)
                         .is_some_and(|id| state.cancelled_connect_ids.contains(&id));
                     record_source_dispatch(cancelled, &mut state.stats)
@@ -209,15 +211,6 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
             ..
         } = &mut *state;
         let endpoint = endpoint.as_mut().expect("running endpoint exists");
-        if Instant::now() >= next_keepalive_at {
-            advance_keepalive_deadline(&mut next_keepalive_at, Instant::now());
-            let peers = endpoint.connected_peers();
-            for peer in keepalive_targets(&peers) {
-                // A peer may disconnect between the snapshot and ping.
-                // Its close/timeout event is the authoritative signal.
-                let _ = endpoint.ping(peer);
-            }
-        }
         let wake = endpoint.next_wake(deadline)?;
         if matches!(wake, EndpointWake::Interrupted) {
             drop(state);
@@ -268,6 +261,23 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
         );
         stats.carry_high_water = stats.carry_high_water.max(carry.len());
         stats.iterations = stats.iterations.saturating_add(1);
+    }
+}
+
+fn service_keepalive(state: &mut EndpointState, next_at: &mut Instant) {
+    let now = Instant::now();
+    if now < *next_at {
+        return;
+    }
+    advance_keepalive_deadline(next_at, now);
+    let Some(endpoint) = state.endpoint.as_mut() else {
+        return;
+    };
+    let peers = endpoint.connected_peers();
+    for peer in keepalive_targets(&peers) {
+        // A peer may disconnect between the snapshot and ping. Its
+        // close/timeout event is the authoritative signal.
+        let _ = endpoint.ping(peer);
     }
 }
 

--- a/crates/ffi/src/driver.rs
+++ b/crates/ffi/src/driver.rs
@@ -1,0 +1,131 @@
+//! Detached background endpoint driver.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use minip2p::{EndpointWake, Error};
+
+use crate::endpoint::{Lifecycle, Shared};
+use crate::events::{convert_discovery, convert_nat, convert_pubsub, convert_swarm};
+use crate::{DriverFailureKind, P2pEvent, P2pEventListener};
+
+const DRIVER_POLL: Duration = Duration::from_millis(25);
+const DRIVER_IDLE_POLL: Duration = Duration::from_millis(500);
+
+struct ExitGuard {
+    shared: Arc<Shared>,
+    listener: Option<Arc<dyn P2pEventListener>>,
+}
+
+impl Drop for ExitGuard {
+    fn drop(&mut self) {
+        drop(self.listener.take());
+        let mut state = self.shared.lock_state();
+        state.endpoint.take();
+        state.lifecycle = Lifecycle::Stopped;
+        self.shared.driver_running.store(false, Ordering::Release);
+        drop(state);
+        self.shared.stopped_cv.notify_all();
+    }
+}
+
+pub(crate) fn run(shared: Arc<Shared>, listener: Arc<dyn P2pEventListener>) {
+    shared.lock_state().driver_thread_id = Some(std::thread::current().id());
+    let mut guard = ExitGuard {
+        shared,
+        listener: Some(listener),
+    };
+    let result = catch_unwind(AssertUnwindSafe(|| pump(&mut guard)));
+    let report_failure = {
+        let mut state = guard.shared.lock_state();
+        if state.lifecycle == Lifecycle::Running && matches!(&result, Err(_) | Ok(Err(_))) {
+            state.lifecycle = Lifecycle::Stopping;
+            true
+        } else {
+            false
+        }
+    };
+    if report_failure && let Some(listener) = guard.listener.as_ref() {
+        match result {
+            Ok(Err(error)) => dispatch(
+                listener,
+                P2pEvent::DriverFailed {
+                    kind: failure_kind(&error),
+                    detail: error.to_string(),
+                },
+            ),
+            Err(_) => dispatch(
+                listener,
+                P2pEvent::DriverFailed {
+                    kind: DriverFailureKind::Panic,
+                    detail: "background endpoint driver panicked".into(),
+                },
+            ),
+            Ok(Ok(())) => {}
+        }
+    }
+}
+
+fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
+    loop {
+        let mut state = guard.shared.lock_state();
+        if state.lifecycle != Lifecycle::Running {
+            return Ok(());
+        }
+        let deadline = if state.active {
+            DRIVER_POLL
+        } else {
+            DRIVER_IDLE_POLL
+        };
+        let endpoint = state.endpoint.as_mut().expect("running endpoint exists");
+        let wake = endpoint.next_wake(deadline)?;
+        if matches!(wake, EndpointWake::Interrupted) {
+            drop(state);
+            while guard.shared.pending_commands.load(Ordering::Acquire) != 0 {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            continue;
+        }
+
+        let mut events = Vec::new();
+        if let EndpointWake::Event(event) = wake {
+            events.extend(convert_swarm(event));
+        }
+        events.extend(endpoint.poll()?.into_iter().filter_map(convert_swarm));
+        events.extend(endpoint.take_nat_events().into_iter().map(convert_nat));
+        events.extend(
+            endpoint
+                .take_pubsub_events()
+                .into_iter()
+                .map(convert_pubsub),
+        );
+        events.extend(
+            endpoint
+                .take_discovery_events()
+                .into_iter()
+                .map(convert_discovery),
+        );
+        drop(state);
+
+        let listener = guard.listener.as_ref().expect("listener exists");
+        for event in events {
+            dispatch(listener, event);
+        }
+    }
+}
+
+fn dispatch(listener: &Arc<dyn P2pEventListener>, event: P2pEvent) {
+    let _ = catch_unwind(AssertUnwindSafe(|| listener.on_event(event)));
+}
+
+fn failure_kind(error: &Error) -> DriverFailureKind {
+    match error {
+        Error::Transport(_) => DriverFailureKind::Transport,
+        Error::Swarm(_) => DriverFailureKind::Swarm,
+        Error::Invariant { .. } | Error::EventBacklogExceeded { .. } | Error::Entropy => {
+            DriverFailureKind::Invariant
+        }
+    }
+}

--- a/crates/ffi/src/driver.rs
+++ b/crates/ffi/src/driver.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use minip2p::{EndpointWake, Error, NatEvent};
 
-use crate::endpoint::{EndpointState, Lifecycle, Shared};
+use crate::endpoint::{Lifecycle, Shared};
 use crate::events::{convert_discovery, convert_nat, convert_pubsub, convert_swarm};
 use crate::{DriverFailureKind, P2pEvent, P2pEventListener};
 
@@ -169,12 +169,12 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
     let mut overflow = OverflowDiagnostic::default();
     let mut next_keepalive_at = Instant::now() + KEEPALIVE_INTERVAL;
     loop {
+        service_keepalive(&guard.shared, &mut next_keepalive_at);
         let mut state = guard.shared.lock_state();
         if state.lifecycle != Lifecycle::Running {
             state.stats.dropped = state.stats.dropped.saturating_add(carry.len() as u64);
             return Ok(());
         }
-        service_keepalive(&mut state, &mut next_keepalive_at);
         if !carry.is_empty() || overflow.pending != 0 {
             let cancelled = carry.suppress_cancelled(&state.cancelled_connect_ids);
             state.stats.dropped = state.stats.dropped.saturating_add(cancelled as u64);
@@ -186,9 +186,9 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
                 dispatch(listener, event);
             }
             for event in delivery.batch {
+                service_keepalive(&guard.shared, &mut next_keepalive_at);
                 let should_dispatch = {
                     let mut state = guard.shared.lock_state();
-                    service_keepalive(&mut state, &mut next_keepalive_at);
                     let cancelled = p2p_connect_id(&event)
                         .is_some_and(|id| state.cancelled_connect_ids.contains(&id));
                     record_source_dispatch(cancelled, &mut state.stats)
@@ -264,17 +264,30 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
     }
 }
 
-fn service_keepalive(state: &mut EndpointState, next_at: &mut Instant) {
+fn service_keepalive(shared: &Shared, next_at: &mut Instant) {
     let now = Instant::now();
     if now < *next_at {
         return;
     }
     advance_keepalive_deadline(next_at, now);
-    let Some(endpoint) = state.endpoint.as_mut() else {
-        return;
+    let peers = {
+        let state = shared.lock_state();
+        if state.lifecycle != Lifecycle::Running {
+            return;
+        }
+        let Some(endpoint) = state.endpoint.as_ref() else {
+            return;
+        };
+        endpoint.connected_peers()
     };
-    let peers = endpoint.connected_peers();
     for peer in keepalive_targets(&peers) {
+        let mut state = shared.lock_state();
+        if state.lifecycle != Lifecycle::Running {
+            return;
+        }
+        let Some(endpoint) = state.endpoint.as_mut() else {
+            return;
+        };
         // A peer may disconnect between the snapshot and ping. Its
         // close/timeout event is the authoritative signal.
         let _ = endpoint.ping(peer);

--- a/crates/ffi/src/driver.rs
+++ b/crates/ffi/src/driver.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use minip2p::{EndpointWake, Error, NatEvent};
 
@@ -14,6 +14,7 @@ use crate::{DriverFailureKind, P2pEvent, P2pEventListener};
 
 const DRIVER_POLL: Duration = Duration::from_millis(25);
 const DRIVER_IDLE_POLL: Duration = Duration::from_millis(500);
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 const MAX_BATCH_PER_ITER: usize = 512;
 const MAX_CARRY_EVENTS: usize = 4096;
 
@@ -166,6 +167,7 @@ pub(crate) fn run(shared: Arc<Shared>, listener: Arc<dyn P2pEventListener>) {
 fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
     let mut carry = Carry::default();
     let mut overflow = OverflowDiagnostic::default();
+    let mut next_keepalive_at = Instant::now() + KEEPALIVE_INTERVAL;
     loop {
         let mut state = guard.shared.lock_state();
         if state.lifecycle != Lifecycle::Running {
@@ -185,8 +187,9 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
             for event in delivery.batch {
                 let should_dispatch = {
                     let mut state = guard.shared.lock_state();
-                    let cancelled = state.cancelled_connect_ids.clone();
-                    record_source_dispatch(&event, &cancelled, &mut state.stats)
+                    let cancelled = p2p_connect_id(&event)
+                        .is_some_and(|id| state.cancelled_connect_ids.contains(&id));
+                    record_source_dispatch(cancelled, &mut state.stats)
                 };
                 if should_dispatch {
                     dispatch(listener, event);
@@ -199,11 +202,22 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
         } else {
             DRIVER_IDLE_POLL
         };
-        let cancelled_connect_ids = state.cancelled_connect_ids.clone();
         let crate::endpoint::EndpointState {
-            endpoint, stats, ..
+            endpoint,
+            cancelled_connect_ids,
+            stats,
+            ..
         } = &mut *state;
         let endpoint = endpoint.as_mut().expect("running endpoint exists");
+        if Instant::now() >= next_keepalive_at {
+            advance_keepalive_deadline(&mut next_keepalive_at, Instant::now());
+            let peers = endpoint.connected_peers();
+            for peer in keepalive_targets(&peers) {
+                // A peer may disconnect between the snapshot and ping.
+                // Its close/timeout event is the authoritative signal.
+                let _ = endpoint.ping(peer);
+            }
+        }
         let wake = endpoint.next_wake(deadline)?;
         if matches!(wake, EndpointWake::Interrupted) {
             drop(state);
@@ -255,6 +269,16 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
         stats.carry_high_water = stats.carry_high_water.max(carry.len());
         stats.iterations = stats.iterations.saturating_add(1);
     }
+}
+
+fn advance_keepalive_deadline(deadline: &mut Instant, now: Instant) {
+    while *deadline <= now {
+        *deadline += KEEPALIVE_INTERVAL;
+    }
+}
+
+fn keepalive_targets<T>(peers: &[T]) -> &[T] {
+    peers
 }
 
 fn ingest(
@@ -319,12 +343,8 @@ fn p2p_connect_id(event: &P2pEvent) -> Option<u64> {
     }
 }
 
-fn record_source_dispatch(
-    event: &P2pEvent,
-    cancelled: &BTreeSet<u64>,
-    stats: &mut DriverStats,
-) -> bool {
-    if p2p_connect_id(event).is_some_and(|id| cancelled.contains(&id)) {
+fn record_source_dispatch(cancelled: bool, stats: &mut DriverStats) -> bool {
+    if cancelled {
         stats.dropped = stats.dropped.saturating_add(1);
         false
     } else {
@@ -423,16 +443,16 @@ mod tests {
             })
         );
         assert_eq!(stats.dispatch_attempted_synthetic, 1);
-        for event in &first.batch {
-            assert!(record_source_dispatch(event, &BTreeSet::new(), &mut stats));
+        for _ in &first.batch {
+            assert!(record_source_dispatch(false, &mut stats));
         }
 
         while !carry.is_empty() {
             let delivery = take_delivery(&mut carry, &mut overflow, &mut stats);
             assert!(delivery.batch.len() <= MAX_BATCH_PER_ITER);
             assert!(delivery.diagnostic.is_none());
-            for event in &delivery.batch {
-                assert!(record_source_dispatch(event, &BTreeSet::new(), &mut stats));
+            for _ in &delivery.batch {
+                assert!(record_source_dispatch(false, &mut stats));
             }
         }
 
@@ -471,12 +491,29 @@ mod tests {
             path: crate::PathKind::DirectDialed,
         };
         let mut stats = DriverStats::default();
-        assert!(!record_source_dispatch(
-            &extracted,
-            &BTreeSet::from([7]),
-            &mut stats
-        ));
+        let cancelled = p2p_connect_id(&extracted).is_some_and(|id| id == 7);
+        assert!(!record_source_dispatch(cancelled, &mut stats));
         assert_eq!(stats.dropped, 1);
         assert_eq!(stats.dispatch_attempted, 0);
+    }
+
+    #[test]
+    fn keepalive_deadline_advances_from_its_previous_schedule() {
+        let start = Instant::now();
+        let mut deadline = start + KEEPALIVE_INTERVAL;
+
+        advance_keepalive_deadline(
+            &mut deadline,
+            start + KEEPALIVE_INTERVAL + Duration::from_secs(25),
+        );
+
+        assert_eq!(deadline, start + Duration::from_secs(40));
+    }
+
+    #[test]
+    fn keepalive_targets_include_every_connected_peer() {
+        let peers: Vec<_> = (0..32).collect();
+
+        assert_eq!(keepalive_targets(&peers), peers);
     }
 }

--- a/crates/ffi/src/driver.rs
+++ b/crates/ffi/src/driver.rs
@@ -1,5 +1,6 @@
 //! Detached background endpoint driver.
 
+use std::collections::VecDeque;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -13,6 +14,36 @@ use crate::{DriverFailureKind, P2pEvent, P2pEventListener};
 
 const DRIVER_POLL: Duration = Duration::from_millis(25);
 const DRIVER_IDLE_POLL: Duration = Duration::from_millis(500);
+const MAX_BATCH_PER_ITER: usize = 512;
+const MAX_CARRY_EVENTS: usize = 4096;
+
+/// Rust-side instrumentation for the background driver.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DriverStats {
+    /// Largest bounded carry-buffer length observed.
+    pub carry_high_water: usize,
+    /// Source events for which a listener callback was attempted.
+    pub dispatch_attempted: u64,
+    /// Synthetic diagnostics for which a listener callback was attempted.
+    pub dispatch_attempted_synthetic: u64,
+    /// Source events discarded by overflow or shutdown.
+    pub dropped: u64,
+    /// Source events produced by conversion before batching.
+    pub converted: u64,
+    /// Completed driver-loop iterations.
+    pub iterations: u64,
+}
+
+#[derive(Default)]
+struct OverflowDiagnostic {
+    pending: u64,
+    total: u64,
+}
+
+struct Delivery {
+    diagnostic: Option<P2pEvent>,
+    batch: Vec<P2pEvent>,
+}
 
 struct ExitGuard {
     shared: Arc<Shared>,
@@ -48,6 +79,11 @@ pub(crate) fn run(shared: Arc<Shared>, listener: Arc<dyn P2pEventListener>) {
         }
     };
     if report_failure && let Some(listener) = guard.listener.as_ref() {
+        {
+            let mut state = guard.shared.lock_state();
+            state.stats.dispatch_attempted_synthetic =
+                state.stats.dispatch_attempted_synthetic.saturating_add(1);
+        }
         match result {
             Ok(Err(error)) => dispatch(
                 listener,
@@ -69,10 +105,26 @@ pub(crate) fn run(shared: Arc<Shared>, listener: Arc<dyn P2pEventListener>) {
 }
 
 fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
+    let mut carry = VecDeque::new();
+    let mut overflow = OverflowDiagnostic::default();
     loop {
         let mut state = guard.shared.lock_state();
         if state.lifecycle != Lifecycle::Running {
+            state.stats.dropped = state.stats.dropped.saturating_add(carry.len() as u64);
             return Ok(());
+        }
+        if !carry.is_empty() || overflow.pending != 0 {
+            let delivery = take_delivery(&mut carry, &mut overflow, &mut state.stats);
+            state.stats.iterations = state.stats.iterations.saturating_add(1);
+            drop(state);
+            let listener = guard.listener.as_ref().expect("listener exists");
+            if let Some(event) = delivery.diagnostic {
+                dispatch(listener, event);
+            }
+            for event in delivery.batch {
+                dispatch(listener, event);
+            }
+            continue;
         }
         let deadline = if state.active {
             DRIVER_POLL
@@ -80,7 +132,10 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
             DRIVER_IDLE_POLL
         };
         let cancelled_connect_ids = state.cancelled_connect_ids.clone();
-        let endpoint = state.endpoint.as_mut().expect("running endpoint exists");
+        let crate::endpoint::EndpointState {
+            endpoint, stats, ..
+        } = &mut *state;
+        let endpoint = endpoint.as_mut().expect("running endpoint exists");
         let wake = endpoint.next_wake(deadline)?;
         if matches!(wake, EndpointWake::Interrupted) {
             drop(state);
@@ -90,39 +145,110 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
             continue;
         }
 
-        let mut events = Vec::new();
         if let EndpointWake::Event(event) = wake {
-            events.extend(convert_swarm(event));
+            ingest(convert_swarm(event), &mut carry, &mut overflow, stats);
         }
-        events.extend(endpoint.poll()?.into_iter().filter_map(convert_swarm));
+        ingest(
+            endpoint.poll()?.into_iter().filter_map(convert_swarm),
+            &mut carry,
+            &mut overflow,
+            stats,
+        );
         let nat_events = endpoint.take_nat_events();
-        events.extend(
+        ingest(
             nat_events
                 .into_iter()
                 .filter(|event| {
                     nat_connect_id(event).is_none_or(|id| !cancelled_connect_ids.contains(&id))
                 })
                 .map(convert_nat),
+            &mut carry,
+            &mut overflow,
+            stats,
         );
-        events.extend(
+        ingest(
             endpoint
                 .take_pubsub_events()
                 .into_iter()
                 .map(convert_pubsub),
+            &mut carry,
+            &mut overflow,
+            stats,
         );
-        events.extend(
+        ingest(
             endpoint
                 .take_discovery_events()
                 .into_iter()
                 .map(convert_discovery),
+            &mut carry,
+            &mut overflow,
+            stats,
         );
-        drop(state);
-
-        let listener = guard.listener.as_ref().expect("listener exists");
-        for event in events {
-            dispatch(listener, event);
-        }
+        stats.carry_high_water = stats.carry_high_water.max(carry.len());
+        stats.iterations = stats.iterations.saturating_add(1);
     }
+}
+
+fn ingest(
+    events: impl IntoIterator<Item = P2pEvent>,
+    carry: &mut VecDeque<P2pEvent>,
+    overflow: &mut OverflowDiagnostic,
+    stats: &mut DriverStats,
+) {
+    let before = carry.len();
+    carry.extend(events);
+    stats.converted = stats
+        .converted
+        .saturating_add(carry.len().saturating_sub(before) as u64);
+    let dropped = trim_carry(carry) as u64;
+    stats.dropped = stats.dropped.saturating_add(dropped);
+    overflow.pending = overflow.pending.saturating_add(dropped);
+    overflow.total = overflow.total.saturating_add(dropped);
+}
+
+fn take_delivery(
+    carry: &mut VecDeque<P2pEvent>,
+    overflow: &mut OverflowDiagnostic,
+    stats: &mut DriverStats,
+) -> Delivery {
+    let diagnostic = (overflow.pending != 0).then(|| {
+        let event = P2pEvent::EventsDropped {
+            dropped: overflow.pending,
+            total_dropped: overflow.total,
+        };
+        overflow.pending = 0;
+        stats.dispatch_attempted_synthetic = stats.dispatch_attempted_synthetic.saturating_add(1);
+        event
+    });
+    let batch: Vec<_> = carry.drain(..carry.len().min(MAX_BATCH_PER_ITER)).collect();
+    stats.dispatch_attempted = stats.dispatch_attempted.saturating_add(batch.len() as u64);
+    Delivery { diagnostic, batch }
+}
+
+fn trim_carry(carry: &mut VecDeque<P2pEvent>) -> usize {
+    let excess = carry.len().saturating_sub(MAX_CARRY_EVENTS);
+    if excess == 0 {
+        return 0;
+    }
+    let messages_to_drop = excess.min(
+        carry
+            .iter()
+            .filter(|event| matches!(event, P2pEvent::Message { .. }))
+            .count(),
+    );
+    let mut dropped_messages = 0;
+    carry.retain(|event| {
+        if dropped_messages < messages_to_drop && matches!(event, P2pEvent::Message { .. }) {
+            dropped_messages += 1;
+            false
+        } else {
+            true
+        }
+    });
+    for _ in 0..excess - messages_to_drop {
+        carry.pop_front();
+    }
+    excess
 }
 
 fn nat_connect_id(event: &NatEvent) -> Option<u64> {
@@ -151,5 +277,90 @@ fn failure_kind(error: &Error) -> DriverFailureKind {
         Error::Invariant { .. } | Error::EventBacklogExceeded { .. } | Error::Entropy => {
             DriverFailureKind::Invariant
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message(byte: u8) -> P2pEvent {
+        P2pEvent::Message {
+            from_peer_id: "peer".into(),
+            topics: vec!["room".into()],
+            data: vec![byte],
+            seqno: vec![byte],
+            signed: true,
+        }
+    }
+
+    #[test]
+    fn carry_cap_drops_oldest_messages_before_lifecycle_events() {
+        let lifecycle = P2pEvent::PeerReady {
+            peer_id: "peer".into(),
+            protocols: Vec::new(),
+        };
+        let mut carry = VecDeque::from([lifecycle.clone()]);
+        carry.extend((0..=MAX_CARRY_EVENTS).map(|index| message(index as u8)));
+
+        let dropped = trim_carry(&mut carry);
+
+        assert_eq!(dropped, 2);
+        assert_eq!(carry.len(), MAX_CARRY_EVENTS);
+        assert_eq!(carry.front(), Some(&lifecycle));
+        assert_eq!(carry.get(1), Some(&message(2)));
+    }
+
+    #[test]
+    fn carry_cap_falls_back_to_oldest_event_when_no_messages_exist() {
+        let mut carry = VecDeque::new();
+        for index in 0..=MAX_CARRY_EVENTS {
+            carry.push_back(P2pEvent::PingTimeout {
+                peer_id: index.to_string(),
+            });
+        }
+
+        assert_eq!(trim_carry(&mut carry), 1);
+        assert_eq!(carry.len(), MAX_CARRY_EVENTS);
+        assert_eq!(
+            carry.front(),
+            Some(&P2pEvent::PingTimeout {
+                peer_id: "1".into()
+            })
+        );
+    }
+
+    #[test]
+    fn overflow_diagnostic_batch_limit_and_stats_accounting_close() {
+        let mut carry = VecDeque::new();
+        let mut overflow = OverflowDiagnostic::default();
+        let mut stats = DriverStats::default();
+        ingest(
+            (0..MAX_CARRY_EVENTS + 10).map(|index| message(index as u8)),
+            &mut carry,
+            &mut overflow,
+            &mut stats,
+        );
+
+        let first = take_delivery(&mut carry, &mut overflow, &mut stats);
+        assert_eq!(first.batch.len(), MAX_BATCH_PER_ITER);
+        assert_eq!(
+            first.diagnostic,
+            Some(P2pEvent::EventsDropped {
+                dropped: 10,
+                total_dropped: 10,
+            })
+        );
+        assert_eq!(stats.dispatch_attempted_synthetic, 1);
+
+        while !carry.is_empty() {
+            let delivery = take_delivery(&mut carry, &mut overflow, &mut stats);
+            assert!(delivery.batch.len() <= MAX_BATCH_PER_ITER);
+            assert!(delivery.diagnostic.is_none());
+        }
+
+        assert_eq!(stats.converted, stats.dispatch_attempted + stats.dropped);
+        assert_eq!(stats.converted, (MAX_CARRY_EVENTS + 10) as u64);
+        assert_eq!(stats.dropped, 10);
     }
 }

--- a/crates/ffi/src/driver.rs
+++ b/crates/ffi/src/driver.rs
@@ -1,6 +1,6 @@
 //! Detached background endpoint driver.
 
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -43,6 +43,65 @@ struct OverflowDiagnostic {
 struct Delivery {
     diagnostic: Option<P2pEvent>,
     batch: Vec<P2pEvent>,
+}
+
+#[derive(Default)]
+struct Carry {
+    events: BTreeMap<u64, P2pEvent>,
+    message_ids: VecDeque<u64>,
+    next_id: u64,
+}
+
+impl Carry {
+    fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    fn push(&mut self, event: P2pEvent) -> bool {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
+        if matches!(event, P2pEvent::Message { .. }) {
+            self.message_ids.push_back(id);
+        }
+        self.events.insert(id, event);
+        if self.events.len() <= MAX_CARRY_EVENTS {
+            return false;
+        }
+        if let Some(message_id) = self.message_ids.pop_front() {
+            self.events.remove(&message_id);
+        } else {
+            self.events.pop_first();
+        }
+        true
+    }
+
+    fn take(&mut self, limit: usize) -> Vec<P2pEvent> {
+        let ids: Vec<_> = self.events.keys().take(limit).copied().collect();
+        let mut batch = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(event) = self.events.remove(&id) {
+                batch.push(event);
+            }
+        }
+        self.prune_message_ids();
+        batch
+    }
+
+    fn suppress_cancelled(&mut self, cancelled: &BTreeSet<u64>) -> usize {
+        let before = self.events.len();
+        self.events
+            .retain(|_, event| p2p_connect_id(event).is_none_or(|id| !cancelled.contains(&id)));
+        self.prune_message_ids();
+        before - self.events.len()
+    }
+
+    fn prune_message_ids(&mut self) {
+        self.message_ids.retain(|id| self.events.contains_key(id));
+    }
 }
 
 struct ExitGuard {
@@ -105,7 +164,7 @@ pub(crate) fn run(shared: Arc<Shared>, listener: Arc<dyn P2pEventListener>) {
 }
 
 fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
-    let mut carry = VecDeque::new();
+    let mut carry = Carry::default();
     let mut overflow = OverflowDiagnostic::default();
     loop {
         let mut state = guard.shared.lock_state();
@@ -114,6 +173,8 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
             return Ok(());
         }
         if !carry.is_empty() || overflow.pending != 0 {
+            let cancelled = carry.suppress_cancelled(&state.cancelled_connect_ids);
+            state.stats.dropped = state.stats.dropped.saturating_add(cancelled as u64);
             let delivery = take_delivery(&mut carry, &mut overflow, &mut state.stats);
             state.stats.iterations = state.stats.iterations.saturating_add(1);
             drop(state);
@@ -122,7 +183,14 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
                 dispatch(listener, event);
             }
             for event in delivery.batch {
-                dispatch(listener, event);
+                let should_dispatch = {
+                    let mut state = guard.shared.lock_state();
+                    let cancelled = state.cancelled_connect_ids.clone();
+                    record_source_dispatch(&event, &cancelled, &mut state.stats)
+                };
+                if should_dispatch {
+                    dispatch(listener, event);
+                }
             }
             continue;
         }
@@ -191,23 +259,24 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
 
 fn ingest(
     events: impl IntoIterator<Item = P2pEvent>,
-    carry: &mut VecDeque<P2pEvent>,
+    carry: &mut Carry,
     overflow: &mut OverflowDiagnostic,
     stats: &mut DriverStats,
 ) {
-    let before = carry.len();
-    carry.extend(events);
-    stats.converted = stats
-        .converted
-        .saturating_add(carry.len().saturating_sub(before) as u64);
-    let dropped = trim_carry(carry) as u64;
+    let mut converted = 0_u64;
+    let mut dropped = 0_u64;
+    for event in events {
+        converted = converted.saturating_add(1);
+        dropped = dropped.saturating_add(u64::from(carry.push(event)));
+    }
+    stats.converted = stats.converted.saturating_add(converted);
     stats.dropped = stats.dropped.saturating_add(dropped);
     overflow.pending = overflow.pending.saturating_add(dropped);
     overflow.total = overflow.total.saturating_add(dropped);
 }
 
 fn take_delivery(
-    carry: &mut VecDeque<P2pEvent>,
+    carry: &mut Carry,
     overflow: &mut OverflowDiagnostic,
     stats: &mut DriverStats,
 ) -> Delivery {
@@ -220,35 +289,8 @@ fn take_delivery(
         stats.dispatch_attempted_synthetic = stats.dispatch_attempted_synthetic.saturating_add(1);
         event
     });
-    let batch: Vec<_> = carry.drain(..carry.len().min(MAX_BATCH_PER_ITER)).collect();
-    stats.dispatch_attempted = stats.dispatch_attempted.saturating_add(batch.len() as u64);
+    let batch = carry.take(MAX_BATCH_PER_ITER);
     Delivery { diagnostic, batch }
-}
-
-fn trim_carry(carry: &mut VecDeque<P2pEvent>) -> usize {
-    let excess = carry.len().saturating_sub(MAX_CARRY_EVENTS);
-    if excess == 0 {
-        return 0;
-    }
-    let messages_to_drop = excess.min(
-        carry
-            .iter()
-            .filter(|event| matches!(event, P2pEvent::Message { .. }))
-            .count(),
-    );
-    let mut dropped_messages = 0;
-    carry.retain(|event| {
-        if dropped_messages < messages_to_drop && matches!(event, P2pEvent::Message { .. }) {
-            dropped_messages += 1;
-            false
-        } else {
-            true
-        }
-    });
-    for _ in 0..excess - messages_to_drop {
-        carry.pop_front();
-    }
-    excess
 }
 
 fn nat_connect_id(event: &NatEvent) -> Option<u64> {
@@ -263,6 +305,31 @@ fn nat_connect_id(event: &NatEvent) -> Option<u64> {
         | NatEvent::RelayReserved { .. }
         | NatEvent::RelayReservationLost { .. }
         | NatEvent::InboundDirectUpgrade { .. } => None,
+    }
+}
+
+fn p2p_connect_id(event: &P2pEvent) -> Option<u64> {
+    match event {
+        P2pEvent::PathEstablished { connect_id, .. }
+        | P2pEvent::PathUpgraded { connect_id, .. }
+        | P2pEvent::HolePunchFailed { connect_id, .. }
+        | P2pEvent::FellBackToRelay { connect_id, .. }
+        | P2pEvent::ConnectFailed { connect_id, .. } => Some(*connect_id),
+        _ => None,
+    }
+}
+
+fn record_source_dispatch(
+    event: &P2pEvent,
+    cancelled: &BTreeSet<u64>,
+    stats: &mut DriverStats,
+) -> bool {
+    if p2p_connect_id(event).is_some_and(|id| cancelled.contains(&id)) {
+        stats.dropped = stats.dropped.saturating_add(1);
+        false
+    } else {
+        stats.dispatch_attempted = stats.dispatch_attempted.saturating_add(1);
+        true
     }
 }
 
@@ -300,30 +367,34 @@ mod tests {
             peer_id: "peer".into(),
             protocols: Vec::new(),
         };
-        let mut carry = VecDeque::from([lifecycle.clone()]);
-        carry.extend((0..=MAX_CARRY_EVENTS).map(|index| message(index as u8)));
-
-        let dropped = trim_carry(&mut carry);
+        let mut carry = Carry::default();
+        assert!(!carry.push(lifecycle.clone()));
+        let dropped = (0..=MAX_CARRY_EVENTS)
+            .filter(|index| carry.push(message(*index as u8)))
+            .count();
 
         assert_eq!(dropped, 2);
         assert_eq!(carry.len(), MAX_CARRY_EVENTS);
-        assert_eq!(carry.front(), Some(&lifecycle));
-        assert_eq!(carry.get(1), Some(&message(2)));
+        let retained = carry.take(MAX_CARRY_EVENTS);
+        assert_eq!(retained.first(), Some(&lifecycle));
+        assert_eq!(retained.get(1), Some(&message(2)));
     }
 
     #[test]
     fn carry_cap_falls_back_to_oldest_event_when_no_messages_exist() {
-        let mut carry = VecDeque::new();
+        let mut carry = Carry::default();
+        let mut dropped = 0;
         for index in 0..=MAX_CARRY_EVENTS {
-            carry.push_back(P2pEvent::PingTimeout {
+            dropped += usize::from(carry.push(P2pEvent::PingTimeout {
                 peer_id: index.to_string(),
-            });
+            }));
         }
 
-        assert_eq!(trim_carry(&mut carry), 1);
+        assert_eq!(dropped, 1);
         assert_eq!(carry.len(), MAX_CARRY_EVENTS);
+        let retained = carry.take(MAX_CARRY_EVENTS);
         assert_eq!(
-            carry.front(),
+            retained.first(),
             Some(&P2pEvent::PingTimeout {
                 peer_id: "1".into()
             })
@@ -332,7 +403,7 @@ mod tests {
 
     #[test]
     fn overflow_diagnostic_batch_limit_and_stats_accounting_close() {
-        let mut carry = VecDeque::new();
+        let mut carry = Carry::default();
         let mut overflow = OverflowDiagnostic::default();
         let mut stats = DriverStats::default();
         ingest(
@@ -352,15 +423,60 @@ mod tests {
             })
         );
         assert_eq!(stats.dispatch_attempted_synthetic, 1);
+        for event in &first.batch {
+            assert!(record_source_dispatch(event, &BTreeSet::new(), &mut stats));
+        }
 
         while !carry.is_empty() {
             let delivery = take_delivery(&mut carry, &mut overflow, &mut stats);
             assert!(delivery.batch.len() <= MAX_BATCH_PER_ITER);
             assert!(delivery.diagnostic.is_none());
+            for event in &delivery.batch {
+                assert!(record_source_dispatch(event, &BTreeSet::new(), &mut stats));
+            }
         }
 
         assert_eq!(stats.converted, stats.dispatch_attempted + stats.dropped);
         assert_eq!(stats.converted, (MAX_CARRY_EVENTS + 10) as u64);
         assert_eq!(stats.dropped, 10);
+    }
+
+    #[test]
+    fn live_cancellation_suppresses_events_already_in_carry() {
+        let mut carry = Carry::default();
+        carry.push(P2pEvent::ConnectFailed {
+            connect_id: 7,
+            peer_id: "peer".into(),
+            kind: crate::NatErrorKind::NoPathAvailable,
+            detail: "no path".into(),
+        });
+        carry.push(P2pEvent::PingTimeout {
+            peer_id: "other".into(),
+        });
+
+        let suppressed = carry.suppress_cancelled(&BTreeSet::from([7]));
+        let retained = carry.take(MAX_BATCH_PER_ITER);
+
+        assert_eq!(suppressed, 1);
+        assert_eq!(
+            retained,
+            vec![P2pEvent::PingTimeout {
+                peer_id: "other".into()
+            }]
+        );
+
+        let extracted = P2pEvent::PathEstablished {
+            connect_id: 7,
+            peer_id: "peer".into(),
+            path: crate::PathKind::DirectDialed,
+        };
+        let mut stats = DriverStats::default();
+        assert!(!record_source_dispatch(
+            &extracted,
+            &BTreeSet::from([7]),
+            &mut stats
+        ));
+        assert_eq!(stats.dropped, 1);
+        assert_eq!(stats.dispatch_attempted, 0);
     }
 }

--- a/crates/ffi/src/driver.rs
+++ b/crates/ffi/src/driver.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use minip2p::{EndpointWake, Error};
+use minip2p::{EndpointWake, Error, NatEvent};
 
 use crate::endpoint::{Lifecycle, Shared};
 use crate::events::{convert_discovery, convert_nat, convert_pubsub, convert_swarm};
@@ -79,6 +79,7 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
         } else {
             DRIVER_IDLE_POLL
         };
+        let cancelled_connect_ids = state.cancelled_connect_ids.clone();
         let endpoint = state.endpoint.as_mut().expect("running endpoint exists");
         let wake = endpoint.next_wake(deadline)?;
         if matches!(wake, EndpointWake::Interrupted) {
@@ -94,7 +95,15 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
             events.extend(convert_swarm(event));
         }
         events.extend(endpoint.poll()?.into_iter().filter_map(convert_swarm));
-        events.extend(endpoint.take_nat_events().into_iter().map(convert_nat));
+        let nat_events = endpoint.take_nat_events();
+        events.extend(
+            nat_events
+                .into_iter()
+                .filter(|event| {
+                    nat_connect_id(event).is_none_or(|id| !cancelled_connect_ids.contains(&id))
+                })
+                .map(convert_nat),
+        );
         events.extend(
             endpoint
                 .take_pubsub_events()
@@ -113,6 +122,21 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
         for event in events {
             dispatch(listener, event);
         }
+    }
+}
+
+fn nat_connect_id(event: &NatEvent) -> Option<u64> {
+    match event {
+        NatEvent::PathEstablished { connect_id, .. }
+        | NatEvent::PathUpgraded { connect_id, .. }
+        | NatEvent::HolePunchFailed { connect_id, .. }
+        | NatEvent::FellBackToRelay { connect_id, .. }
+        | NatEvent::ConnectFailed { connect_id, .. } => Some(connect_id.as_u64()),
+        NatEvent::ReachabilityChanged { .. }
+        | NatEvent::PublicAddressesChanged { .. }
+        | NatEvent::RelayReserved { .. }
+        | NatEvent::RelayReservationLost { .. }
+        | NatEvent::InboundDirectUpgrade { .. } => None,
     }
 }
 

--- a/crates/ffi/src/endpoint.rs
+++ b/crates/ffi/src/endpoint.rs
@@ -1,11 +1,13 @@
 //! Foreign-facing endpoint object and construction.
 
 use std::str::FromStr;
-use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard, PoisonError};
+use std::time::{Duration, Instant};
 
 use minip2p::{
     BeaconConfig, Endpoint, GossipsubConfig, Multiaddr, NatConfig, PeerDiscoveryConfig,
-    TransportError,
+    QuicWaitHandle, TransportError,
 };
 
 use crate::{EndpointConfig, FfiError, keypair_from_bytes, parse_direct_quic_peer_addr};
@@ -13,14 +15,37 @@ use crate::{EndpointConfig, FfiError, keypair_from_bytes, parse_direct_quic_peer
 /// A minip2p endpoint owned by a foreign runtime.
 #[derive(uniffi::Object)]
 pub struct P2pEndpoint {
-    endpoint: Mutex<Option<Endpoint>>,
+    shared: Arc<Shared>,
     peer_id: String,
     listen_addrs: Vec<String>,
 }
 
+struct Shared {
+    state: Mutex<EndpointState>,
+    stopped_cv: Condvar,
+    wait_handle: QuicWaitHandle,
+    pending_commands: AtomicUsize,
+}
+
+struct EndpointState {
+    lifecycle: Lifecycle,
+    endpoint: Option<Endpoint>,
+    active: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Lifecycle {
+    Created,
+    Running,
+    Stopped,
+}
+
 #[uniffi::export]
 impl P2pEndpoint {
-    /// Validates the secret key and `config`, binds QUIC, and creates a stopped endpoint.
+    /// Validates the secret key and `config`, binds QUIC, and creates an endpoint.
+    ///
+    /// The endpoint begins in the created state and owns its bound sockets,
+    /// but does not run a background driver until explicitly started.
     #[uniffi::constructor]
     pub fn new(secret_key: Vec<u8>, config: EndpointConfig) -> Result<Arc<Self>, FfiError> {
         let keypair = keypair_from_bytes(secret_key)?;
@@ -99,9 +124,19 @@ impl P2pEndpoint {
             .map(|address| address.to_string())
             .collect();
         let peer_id = endpoint.peer_id().to_base58();
+        let wait_handle = endpoint.wait_handle();
 
         Ok(Arc::new(Self {
-            endpoint: Mutex::new(Some(endpoint)),
+            shared: Arc::new(Shared {
+                state: Mutex::new(EndpointState {
+                    lifecycle: Lifecycle::Created,
+                    endpoint: Some(endpoint),
+                    active: false,
+                }),
+                stopped_cv: Condvar::new(),
+                wait_handle,
+                pending_commands: AtomicUsize::new(0),
+            }),
             peer_id,
             listen_addrs,
         }))
@@ -119,7 +154,9 @@ impl P2pEndpoint {
 
     /// Returns peers with an established QUIC or circuit connection.
     pub fn connected_peers(&self) -> Result<Vec<String>, FfiError> {
-        self.lock_endpoint()
+        self.shared
+            .lock_state()
+            .endpoint
             .as_ref()
             .map(|endpoint| {
                 endpoint
@@ -132,11 +169,95 @@ impl P2pEndpoint {
                 detail: "endpoint is stopped".into(),
             })
     }
+
+    /// Selects active or idle driver polling without changing delivery semantics.
+    pub fn set_active(&self, active: bool) {
+        let _pending = PendingCommand::new(&self.shared);
+        self.shared.lock_state().active = active;
+    }
+
+    /// Returns whether the background driver is currently running.
+    pub fn is_running(&self) -> bool {
+        self.shared.lock_state().lifecycle == Lifecycle::Running
+    }
+
+    /// Requests shutdown without waiting for an in-flight callback.
+    pub fn stop(&self) {
+        let _pending = PendingCommand::new(&self.shared);
+        let endpoint = {
+            let mut state = self.shared.lock_state();
+            match state.lifecycle {
+                Lifecycle::Created | Lifecycle::Running => {
+                    state.lifecycle = Lifecycle::Stopped;
+                    state.endpoint.take()
+                }
+                Lifecycle::Stopped => None,
+            }
+        };
+        drop(endpoint);
+
+        let stopped = self.shared.lock_state().lifecycle == Lifecycle::Stopped;
+        if stopped {
+            self.shared.stopped_cv.notify_all();
+        }
+    }
+
+    /// Waits up to `timeout_ms` for the endpoint to reach the stopped state.
+    ///
+    /// A newly created endpoint still owns bound sockets, so this returns
+    /// `false` until either a driver exits or [`P2pEndpoint::stop`] is called.
+    pub fn wait_stopped(&self, timeout_ms: u64) -> bool {
+        let timeout = Duration::from_millis(timeout_ms);
+        let started = Instant::now();
+        let mut state = self.shared.lock_state();
+        loop {
+            if state.lifecycle == Lifecycle::Stopped {
+                return true;
+            }
+            let remaining = timeout.saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                return false;
+            }
+            let (next, result) = self
+                .shared
+                .stopped_cv
+                .wait_timeout(state, remaining)
+                .unwrap_or_else(PoisonError::into_inner);
+            state = next;
+            if result.timed_out() && state.lifecycle != Lifecycle::Stopped {
+                return false;
+            }
+        }
+    }
 }
 
-impl P2pEndpoint {
-    fn lock_endpoint(&self) -> MutexGuard<'_, Option<Endpoint>> {
-        self.endpoint.lock().unwrap_or_else(PoisonError::into_inner)
+impl Drop for P2pEndpoint {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+impl Shared {
+    fn lock_state(&self) -> MutexGuard<'_, EndpointState> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+struct PendingCommand<'a> {
+    shared: &'a Shared,
+}
+
+impl<'a> PendingCommand<'a> {
+    fn new(shared: &'a Shared) -> Self {
+        shared.pending_commands.fetch_add(1, Ordering::AcqRel);
+        shared.wait_handle.interrupt();
+        Self { shared }
+    }
+}
+
+impl Drop for PendingCommand<'_> {
+    fn drop(&mut self) {
+        self.shared.pending_commands.fetch_sub(1, Ordering::AcqRel);
     }
 }
 
@@ -279,12 +400,12 @@ mod tests {
         let endpoint = endpoint(config()).expect("endpoint");
         let endpoint_for_panic = Arc::clone(&endpoint);
         let _ = std::thread::spawn(move || {
-            let _guard = endpoint_for_panic.endpoint.lock().expect("lock");
+            let _guard = endpoint_for_panic.shared.state.lock().expect("lock");
             panic!("poison endpoint lock");
         })
         .join();
 
-        assert!(endpoint.lock_endpoint().is_some());
+        assert!(endpoint.shared.lock_state().endpoint.is_some());
     }
 
     #[test]
@@ -330,7 +451,7 @@ mod tests {
     #[test]
     fn connected_peers_reports_a_stopped_endpoint() {
         let endpoint = endpoint(config()).expect("endpoint");
-        *endpoint.lock_endpoint() = None;
+        endpoint.stop();
 
         assert!(matches!(
             endpoint.connected_peers(),
@@ -351,5 +472,73 @@ mod tests {
                 FfiError::Internal { .. }
             ));
         }
+    }
+
+    #[test]
+    fn created_endpoint_requires_stop_before_wait_stopped() {
+        let endpoint = endpoint(config()).expect("endpoint");
+
+        assert!(!endpoint.is_running());
+        assert!(!endpoint.wait_stopped(0));
+        endpoint.stop();
+        assert!(endpoint.wait_stopped(100));
+        assert!(!endpoint.is_running());
+    }
+
+    #[test]
+    fn stop_and_set_active_are_idempotent_in_created_and_stopped_states() {
+        let endpoint = endpoint(config()).expect("endpoint");
+
+        endpoint.set_active(true);
+        assert!(endpoint.shared.lock_state().active);
+        endpoint.stop();
+        endpoint.stop();
+        endpoint.set_active(false);
+
+        let state = endpoint.shared.lock_state();
+        assert_eq!(state.lifecycle, Lifecycle::Stopped);
+        assert!(!state.active);
+        assert!(state.endpoint.is_none());
+    }
+
+    #[test]
+    fn stop_finishes_a_synthetic_running_state() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        endpoint.shared.lock_state().lifecycle = Lifecycle::Running;
+
+        endpoint.stop();
+
+        let state = endpoint.shared.lock_state();
+        assert_eq!(state.lifecycle, Lifecycle::Stopped);
+        assert!(state.endpoint.is_none());
+        drop(state);
+        assert!(endpoint.wait_stopped(0));
+    }
+
+    #[test]
+    fn pending_command_interrupts_a_waiter_and_balances_the_counter() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        let shared = Arc::clone(&endpoint.shared);
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            let mut state = shared.lock_state();
+            entered_tx.send(()).expect("signal waiter");
+            let wake = state
+                .endpoint
+                .as_mut()
+                .expect("endpoint")
+                .next_wake(Duration::from_secs(5))
+                .expect("wait");
+            assert!(matches!(wake, minip2p::EndpointWake::Interrupted));
+        });
+        entered_rx.recv().expect("waiter entered");
+        std::thread::sleep(Duration::from_millis(20));
+
+        {
+            let _pending = PendingCommand::new(&endpoint.shared);
+            assert_eq!(endpoint.shared.pending_commands.load(Ordering::Acquire), 1);
+        }
+        waiter.join().expect("waiter exits after interrupt");
+        assert_eq!(endpoint.shared.pending_commands.load(Ordering::Acquire), 0);
     }
 }

--- a/crates/ffi/src/endpoint.rs
+++ b/crates/ffi/src/endpoint.rs
@@ -1,7 +1,7 @@
 //! Foreign-facing endpoint object and construction.
 
 use std::str::FromStr;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, PoisonError};
 use std::time::{Duration, Instant};
 
@@ -10,7 +10,9 @@ use minip2p::{
     QuicWaitHandle, TransportError,
 };
 
-use crate::{EndpointConfig, FfiError, keypair_from_bytes, parse_direct_quic_peer_addr};
+use crate::{
+    EndpointConfig, FfiError, P2pEventListener, keypair_from_bytes, parse_direct_quic_peer_addr,
+};
 
 /// A minip2p endpoint owned by a foreign runtime.
 #[derive(uniffi::Object)]
@@ -20,23 +22,26 @@ pub struct P2pEndpoint {
     listen_addrs: Vec<String>,
 }
 
-struct Shared {
+pub(crate) struct Shared {
     state: Mutex<EndpointState>,
-    stopped_cv: Condvar,
+    pub(crate) stopped_cv: Condvar,
     wait_handle: QuicWaitHandle,
-    pending_commands: AtomicUsize,
+    pub(crate) pending_commands: AtomicUsize,
+    pub(crate) driver_running: AtomicBool,
 }
 
-struct EndpointState {
-    lifecycle: Lifecycle,
-    endpoint: Option<Endpoint>,
-    active: bool,
+pub(crate) struct EndpointState {
+    pub(crate) lifecycle: Lifecycle,
+    pub(crate) endpoint: Option<Endpoint>,
+    pub(crate) active: bool,
+    pub(crate) driver_thread_id: Option<std::thread::ThreadId>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum Lifecycle {
+pub(crate) enum Lifecycle {
     Created,
     Running,
+    Stopping,
     Stopped,
 }
 
@@ -132,10 +137,12 @@ impl P2pEndpoint {
                     lifecycle: Lifecycle::Created,
                     endpoint: Some(endpoint),
                     active: false,
+                    driver_thread_id: None,
                 }),
                 stopped_cv: Condvar::new(),
                 wait_handle,
                 pending_commands: AtomicUsize::new(0),
+                driver_running: AtomicBool::new(false),
             }),
             peer_id,
             listen_addrs,
@@ -154,6 +161,7 @@ impl P2pEndpoint {
 
     /// Returns peers with an established QUIC or circuit connection.
     pub fn connected_peers(&self) -> Result<Vec<String>, FfiError> {
+        let _pending = PendingCommand::new(&self.shared);
         self.shared
             .lock_state()
             .endpoint
@@ -176,9 +184,39 @@ impl P2pEndpoint {
         self.shared.lock_state().active = active;
     }
 
-    /// Returns whether the background driver is currently running.
+    /// Returns whether the background driver is accepting work.
+    ///
+    /// This becomes `false` when shutdown is requested. Use
+    /// [`P2pEndpoint::wait_stopped`] to observe complete driver exit.
     pub fn is_running(&self) -> bool {
+        let _pending = PendingCommand::new(&self.shared);
         self.shared.lock_state().lifecycle == Lifecycle::Running
+    }
+
+    /// Starts the detached background endpoint driver.
+    pub fn start(&self, listener: Arc<dyn P2pEventListener>) -> Result<(), FfiError> {
+        let mut state = self.shared.lock_state();
+        match state.lifecycle {
+            Lifecycle::Created => {}
+            Lifecycle::Running => return Err(FfiError::AlreadyStarted),
+            Lifecycle::Stopping | Lifecycle::Stopped => return Err(FfiError::Stopped),
+        }
+
+        let shared = Arc::clone(&self.shared);
+        std::thread::Builder::new()
+            .name("minip2p-driver".into())
+            .spawn(move || crate::driver::run(shared, listener))
+            .map_err(|error| {
+                state.lifecycle = Lifecycle::Stopped;
+                state.endpoint.take();
+                self.shared.stopped_cv.notify_all();
+                FfiError::Internal {
+                    detail: format!("failed to spawn endpoint driver: {error}"),
+                }
+            })?;
+        state.lifecycle = Lifecycle::Running;
+        self.shared.driver_running.store(true, Ordering::Release);
+        Ok(())
     }
 
     /// Requests shutdown without waiting for an in-flight callback.
@@ -187,11 +225,15 @@ impl P2pEndpoint {
         let endpoint = {
             let mut state = self.shared.lock_state();
             match state.lifecycle {
-                Lifecycle::Created | Lifecycle::Running => {
+                Lifecycle::Created => {
                     state.lifecycle = Lifecycle::Stopped;
                     state.endpoint.take()
                 }
-                Lifecycle::Stopped => None,
+                Lifecycle::Running => {
+                    state.lifecycle = Lifecycle::Stopping;
+                    None
+                }
+                Lifecycle::Stopping | Lifecycle::Stopped => None,
             }
         };
         drop(endpoint);
@@ -205,11 +247,21 @@ impl P2pEndpoint {
     /// Waits up to `timeout_ms` for the endpoint to reach the stopped state.
     ///
     /// A newly created endpoint still owns bound sockets, so this returns
-    /// `false` until either a driver exits or [`P2pEndpoint::stop`] is called.
+    /// `false` until `stop` releases it. For a running endpoint, `stop` only
+    /// requests shutdown and this waits for the driver exit cleanup.
+    ///
+    /// Calling this from a listener callback would wait on the callback's own
+    /// driver thread, so that case returns `false` immediately.
     pub fn wait_stopped(&self, timeout_ms: u64) -> bool {
         let timeout = Duration::from_millis(timeout_ms);
         let started = Instant::now();
         let mut state = self.shared.lock_state();
+        if state.lifecycle == Lifecycle::Stopped {
+            return true;
+        }
+        if state.driver_thread_id == Some(std::thread::current().id()) {
+            return false;
+        }
         loop {
             if state.lifecycle == Lifecycle::Stopped {
                 return true;
@@ -238,26 +290,32 @@ impl Drop for P2pEndpoint {
 }
 
 impl Shared {
-    fn lock_state(&self) -> MutexGuard<'_, EndpointState> {
+    pub(crate) fn lock_state(&self) -> MutexGuard<'_, EndpointState> {
         self.state.lock().unwrap_or_else(PoisonError::into_inner)
     }
 }
 
 struct PendingCommand<'a> {
     shared: &'a Shared,
+    engaged: bool,
 }
 
 impl<'a> PendingCommand<'a> {
     fn new(shared: &'a Shared) -> Self {
-        shared.pending_commands.fetch_add(1, Ordering::AcqRel);
-        shared.wait_handle.interrupt();
-        Self { shared }
+        let engaged = shared.driver_running.load(Ordering::Acquire);
+        if engaged {
+            shared.pending_commands.fetch_add(1, Ordering::AcqRel);
+            shared.wait_handle.interrupt();
+        }
+        Self { shared, engaged }
     }
 }
 
 impl Drop for PendingCommand<'_> {
     fn drop(&mut self) {
-        self.shared.pending_commands.fetch_sub(1, Ordering::AcqRel);
+        if self.engaged {
+            self.shared.pending_commands.fetch_sub(1, Ordering::AcqRel);
+        }
     }
 }
 
@@ -284,6 +342,42 @@ fn map_constructor_error(error: minip2p::Error) -> FfiError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct NoopListener;
+
+    impl P2pEventListener for NoopListener {
+        fn on_event(&self, _event: crate::P2pEvent) {}
+    }
+
+    #[derive(Default)]
+    struct RecordingListener {
+        events: Mutex<Vec<crate::P2pEvent>>,
+    }
+
+    impl P2pEventListener for RecordingListener {
+        fn on_event(&self, event: crate::P2pEvent) {
+            self.events
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(event);
+        }
+    }
+
+    struct WaitingListener {
+        endpoint: std::sync::Weak<P2pEndpoint>,
+        result: Mutex<Option<bool>>,
+    }
+
+    impl P2pEventListener for WaitingListener {
+        fn on_event(&self, _event: crate::P2pEvent) {
+            let result = self
+                .endpoint
+                .upgrade()
+                .expect("endpoint")
+                .wait_stopped(60_000);
+            *self.result.lock().unwrap_or_else(PoisonError::into_inner) = Some(result);
+        }
+    }
 
     fn config() -> EndpointConfig {
         EndpointConfig {
@@ -502,22 +596,108 @@ mod tests {
     }
 
     #[test]
-    fn stop_finishes_a_synthetic_running_state() {
+    fn stop_finishes_a_running_driver() {
         let endpoint = endpoint(config()).expect("endpoint");
-        endpoint.shared.lock_state().lifecycle = Lifecycle::Running;
+        endpoint.start(Arc::new(NoopListener)).expect("start");
+        assert!(endpoint.is_running());
 
         endpoint.stop();
 
-        let state = endpoint.shared.lock_state();
-        assert_eq!(state.lifecycle, Lifecycle::Stopped);
-        assert!(state.endpoint.is_none());
-        drop(state);
+        assert!(endpoint.wait_stopped(1_000));
+        assert!(!endpoint.is_running());
+        assert!(endpoint.shared.lock_state().endpoint.is_none());
+    }
+
+    #[test]
+    fn start_rejects_double_start_and_restart_after_stop() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        endpoint.start(Arc::new(NoopListener)).expect("start");
+
+        assert!(matches!(
+            endpoint.start(Arc::new(NoopListener)),
+            Err(FfiError::AlreadyStarted)
+        ));
+        endpoint.stop();
+        assert!(endpoint.wait_stopped(1_000));
+        assert!(matches!(
+            endpoint.start(Arc::new(NoopListener)),
+            Err(FfiError::Stopped)
+        ));
+    }
+
+    #[test]
+    fn fatal_driver_panic_is_reported_before_stopped() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        let listener = Arc::new(RecordingListener::default());
+        {
+            let mut state = endpoint.shared.lock_state();
+            state.lifecycle = Lifecycle::Running;
+            state.endpoint = None;
+        }
+        endpoint
+            .shared
+            .driver_running
+            .store(true, Ordering::Release);
+
+        crate::driver::run(
+            Arc::clone(&endpoint.shared),
+            Arc::clone(&listener) as Arc<dyn P2pEventListener>,
+        );
+
+        assert!(matches!(
+            listener
+                .events
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .as_slice(),
+            [crate::P2pEvent::DriverFailed {
+                kind: crate::DriverFailureKind::Panic,
+                ..
+            }]
+        ));
         assert!(endpoint.wait_stopped(0));
+    }
+
+    #[test]
+    fn wait_stopped_from_driver_callback_returns_immediately() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        let listener = Arc::new(WaitingListener {
+            endpoint: Arc::downgrade(&endpoint),
+            result: Mutex::new(None),
+        });
+        {
+            let mut state = endpoint.shared.lock_state();
+            state.lifecycle = Lifecycle::Running;
+            state.endpoint = None;
+        }
+        endpoint
+            .shared
+            .driver_running
+            .store(true, Ordering::Release);
+
+        let started = Instant::now();
+        crate::driver::run(
+            Arc::clone(&endpoint.shared),
+            Arc::clone(&listener) as Arc<dyn P2pEventListener>,
+        );
+
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert_eq!(
+            *listener
+                .result
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner),
+            Some(false)
+        );
     }
 
     #[test]
     fn pending_command_interrupts_a_waiter_and_balances_the_counter() {
         let endpoint = endpoint(config()).expect("endpoint");
+        endpoint
+            .shared
+            .driver_running
+            .store(true, Ordering::Release);
         let shared = Arc::clone(&endpoint.shared);
         let (entered_tx, entered_rx) = std::sync::mpsc::channel();
         let waiter = std::thread::spawn(move || {
@@ -540,5 +720,9 @@ mod tests {
         }
         waiter.join().expect("waiter exits after interrupt");
         assert_eq!(endpoint.shared.pending_commands.load(Ordering::Acquire), 0);
+        endpoint
+            .shared
+            .driver_running
+            .store(false, Ordering::Release);
     }
 }

--- a/crates/ffi/src/endpoint.rs
+++ b/crates/ffi/src/endpoint.rs
@@ -342,6 +342,19 @@ impl P2pEndpoint {
         Ok(())
     }
 
+    /// Closes the active connection to `peer_id`.
+    ///
+    /// Cancelling a connection attempt suppresses that attempt's progress
+    /// events, but cannot retract a transport connection that has already
+    /// completed. Call this method when cancellation must also close an
+    /// established connection.
+    pub fn disconnect(&self, peer_id: String) -> Result<(), FfiError> {
+        let peer = PeerId::from_str(&peer_id).map_err(|error| FfiError::InvalidPeerId {
+            detail: error.to_string(),
+        })?;
+        self.with_endpoint_mut(|endpoint| endpoint.disconnect(&peer).map_err(map_driver_error))
+    }
+
     /// Returns the shared discovery address-book snapshot.
     pub fn known_peers(&self) -> Result<Vec<KnownPeerInfo>, FfiError> {
         self.with_endpoint(|endpoint| {
@@ -1074,6 +1087,16 @@ mod tests {
                 .contains(&connect_id)
         );
         endpoint.cancel_connect(u64::MAX).expect("unknown cancel");
+    }
+
+    #[test]
+    fn disconnect_validates_the_peer_id() {
+        let endpoint = endpoint(config()).expect("endpoint");
+
+        assert!(matches!(
+            endpoint.disconnect("not-a-peer-id".into()),
+            Err(FfiError::InvalidPeerId { .. })
+        ));
     }
 
     #[test]

--- a/crates/ffi/src/endpoint.rs
+++ b/crates/ffi/src/endpoint.rs
@@ -12,7 +12,7 @@ use minip2p::{
 };
 
 use crate::{
-    EndpointConfig, FfiError, KnownPeerInfo, P2pEventListener, RelayReservationInfo,
+    DriverStats, EndpointConfig, FfiError, KnownPeerInfo, P2pEventListener, RelayReservationInfo,
     keypair_from_bytes, parse_direct_quic_peer_addr,
 };
 
@@ -39,6 +39,7 @@ pub(crate) struct EndpointState {
     pub(crate) driver_thread_id: Option<std::thread::ThreadId>,
     connect_ids: BTreeMap<u64, minip2p::ConnectId>,
     pub(crate) cancelled_connect_ids: BTreeSet<u64>,
+    pub(crate) stats: DriverStats,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -142,6 +143,7 @@ impl P2pEndpoint {
                     driver_thread_id: None,
                     connect_ids: BTreeMap::new(),
                     cancelled_connect_ids: BTreeSet::new(),
+                    stats: DriverStats::default(),
                 }),
                 stopped_cv: Condvar::new(),
                 wait_handle,
@@ -392,6 +394,13 @@ impl P2pEndpoint {
 }
 
 impl P2pEndpoint {
+    /// Returns Rust-side background-driver diagnostics.
+    ///
+    /// This method is intentionally outside the UniFFI export block.
+    pub fn driver_stats(&self) -> DriverStats {
+        self.shared.lock_state().stats
+    }
+
     fn with_endpoint<T>(&self, operation: impl FnOnce(&Endpoint) -> T) -> Result<T, FfiError> {
         let _pending = PendingCommand::new(&self.shared);
         let state = self.shared.lock_state();

--- a/crates/ffi/src/endpoint.rs
+++ b/crates/ffi/src/endpoint.rs
@@ -202,28 +202,12 @@ impl P2pEndpoint {
 
     /// Starts the detached background endpoint driver.
     pub fn start(&self, listener: Arc<dyn P2pEventListener>) -> Result<(), FfiError> {
-        let mut state = self.shared.lock_state();
-        match state.lifecycle {
-            Lifecycle::Created => {}
-            Lifecycle::Running => return Err(FfiError::AlreadyStarted),
-            Lifecycle::Stopping | Lifecycle::Stopped => return Err(FfiError::Stopped),
-        }
-
-        let shared = Arc::clone(&self.shared);
-        std::thread::Builder::new()
-            .name("minip2p-driver".into())
-            .spawn(move || crate::driver::run(shared, listener))
-            .map_err(|error| {
-                state.lifecycle = Lifecycle::Stopped;
-                state.endpoint.take();
-                self.shared.stopped_cv.notify_all();
-                FfiError::Internal {
-                    detail: format!("failed to spawn endpoint driver: {error}"),
-                }
-            })?;
-        state.lifecycle = Lifecycle::Running;
-        self.shared.driver_running.store(true, Ordering::Release);
-        Ok(())
+        self.start_with(listener, |shared, listener| {
+            std::thread::Builder::new()
+                .name("minip2p-driver".into())
+                .spawn(move || crate::driver::run(shared, listener))
+                .map(drop)
+        })
     }
 
     /// Requests shutdown without waiting for an in-flight callback.
@@ -397,6 +381,31 @@ impl P2pEndpoint {
 }
 
 impl P2pEndpoint {
+    fn start_with(
+        &self,
+        listener: Arc<dyn P2pEventListener>,
+        spawn: impl FnOnce(Arc<Shared>, Arc<dyn P2pEventListener>) -> std::io::Result<()>,
+    ) -> Result<(), FfiError> {
+        let mut state = self.shared.lock_state();
+        match state.lifecycle {
+            Lifecycle::Created => {}
+            Lifecycle::Running => return Err(FfiError::AlreadyStarted),
+            Lifecycle::Stopping | Lifecycle::Stopped => return Err(FfiError::Stopped),
+        }
+
+        let shared = Arc::clone(&self.shared);
+        spawn(shared, listener).map_err(|error| {
+            state.lifecycle = Lifecycle::Stopped;
+            state.endpoint.take();
+            self.shared.stopped_cv.notify_all();
+            FfiError::Internal {
+                detail: format!("failed to spawn endpoint driver: {error}"),
+            }
+        })?;
+        state.lifecycle = Lifecycle::Running;
+        self.shared.driver_running.store(true, Ordering::Release);
+        Ok(())
+    }
     /// Returns Rust-side background-driver diagnostics.
     ///
     /// This method is intentionally outside the UniFFI export block.
@@ -534,6 +543,7 @@ fn ensure_accepting_commands(state: &EndpointState) -> Result<(), FfiError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicUsize;
 
     struct NoopListener;
 
@@ -552,6 +562,23 @@ mod tests {
                 .lock()
                 .unwrap_or_else(PoisonError::into_inner)
                 .push(event);
+        }
+    }
+
+    struct DropTrackingListener {
+        callbacks: Arc<AtomicUsize>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl P2pEventListener for DropTrackingListener {
+        fn on_event(&self, _event: crate::P2pEvent) {
+            self.callbacks.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    impl Drop for DropTrackingListener {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::Release);
         }
     }
 
@@ -813,6 +840,98 @@ mod tests {
             endpoint.start(Arc::new(NoopListener)),
             Err(FfiError::Stopped)
         ));
+    }
+
+    #[test]
+    fn spawn_failure_stops_and_releases_endpoint() {
+        let endpoint = endpoint(config()).expect("endpoint");
+
+        let error = endpoint
+            .start_with(Arc::new(NoopListener), |_, _| {
+                Err(std::io::Error::other("injected spawn failure"))
+            })
+            .expect_err("spawn must fail");
+
+        assert!(matches!(error, FfiError::Internal { .. }));
+        assert!(endpoint.wait_stopped(0));
+        let state = endpoint.shared.lock_state();
+        assert_eq!(state.lifecycle, Lifecycle::Stopped);
+        assert!(state.endpoint.is_none());
+    }
+
+    #[test]
+    fn wait_stopped_releases_listener_before_returning() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        let callbacks = Arc::new(AtomicUsize::new(0));
+        let dropped = Arc::new(AtomicBool::new(false));
+        endpoint
+            .start(Arc::new(DropTrackingListener {
+                callbacks: Arc::clone(&callbacks),
+                dropped: Arc::clone(&dropped),
+            }))
+            .expect("start");
+
+        endpoint.stop();
+        assert!(endpoint.wait_stopped(1_000));
+
+        assert!(dropped.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn drop_without_explicit_stop_releases_listener() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        let callbacks = Arc::new(AtomicUsize::new(0));
+        let dropped = Arc::new(AtomicBool::new(false));
+        endpoint
+            .start(Arc::new(DropTrackingListener {
+                callbacks,
+                dropped: Arc::clone(&dropped),
+            }))
+            .expect("start");
+
+        drop(endpoint);
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !dropped.load(Ordering::Acquire) && Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        assert!(dropped.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn concurrent_commands_queries_and_stop_complete() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        endpoint.start(Arc::new(NoopListener)).expect("start");
+        let mut workers = Vec::new();
+
+        for worker in 0..4 {
+            let endpoint = Arc::clone(&endpoint);
+            workers.push(std::thread::spawn(move || {
+                for index in 0..250 {
+                    match worker {
+                        0 => {
+                            let _ = endpoint.connected_peers();
+                        }
+                        1 => endpoint.set_active(index % 2 == 0),
+                        2 => {
+                            let _ = endpoint.publish("room".into(), vec![index as u8]);
+                        }
+                        _ => {
+                            let _ = endpoint.cancel_connect(u64::MAX);
+                        }
+                    }
+                }
+            }));
+        }
+
+        std::thread::yield_now();
+        endpoint.stop();
+        for worker in workers {
+            worker.join().expect("worker must not panic");
+        }
+
+        assert!(endpoint.wait_stopped(5_000));
+        assert!(!endpoint.is_running());
     }
 
     #[test]

--- a/crates/ffi/src/endpoint.rs
+++ b/crates/ffi/src/endpoint.rs
@@ -342,6 +342,9 @@ impl P2pEndpoint {
     }
 
     /// Cancels a known connection attempt; unknown ids are an idempotent no-op.
+    ///
+    /// Queued connection events are suppressed when possible. A listener
+    /// callback that already won the dispatch race may still arrive.
     pub fn cancel_connect(&self, id: u64) -> Result<(), FfiError> {
         let _pending = PendingCommand::new(&self.shared);
         let mut state = self.shared.lock_state();

--- a/crates/ffi/src/endpoint.rs
+++ b/crates/ffi/src/endpoint.rs
@@ -1040,32 +1040,4 @@ mod tests {
             FfiError::Transport { .. }
         ));
     }
-
-    #[test]
-    fn cancelled_pre_start_terminal_event_is_not_delivered() {
-        let endpoint = endpoint(config()).expect("endpoint");
-        let remote = minip2p::Ed25519Keypair::from_secret_key_bytes([12; 32]).peer_id();
-        let id = endpoint.connect(remote.to_base58()).expect("connect");
-        endpoint.cancel_connect(id).expect("cancel");
-        let listener = Arc::new(RecordingListener::default());
-
-        endpoint
-            .start(Arc::clone(&listener) as Arc<dyn P2pEventListener>)
-            .expect("start");
-        std::thread::sleep(Duration::from_millis(50));
-        endpoint.stop();
-        assert!(endpoint.wait_stopped(1_000));
-
-        assert!(
-            !listener
-                .events
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner)
-                .iter()
-                .any(|event| matches!(
-                    event,
-                    crate::P2pEvent::ConnectFailed { connect_id, .. } if *connect_id == id
-                ))
-        );
-    }
 }

--- a/crates/ffi/src/endpoint.rs
+++ b/crates/ffi/src/endpoint.rs
@@ -1,0 +1,355 @@
+//! Foreign-facing endpoint object and construction.
+
+use std::str::FromStr;
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+
+use minip2p::{
+    BeaconConfig, Endpoint, GossipsubConfig, Multiaddr, NatConfig, PeerDiscoveryConfig,
+    TransportError,
+};
+
+use crate::{EndpointConfig, FfiError, keypair_from_bytes, parse_direct_quic_peer_addr};
+
+/// A minip2p endpoint owned by a foreign runtime.
+#[derive(uniffi::Object)]
+pub struct P2pEndpoint {
+    endpoint: Mutex<Option<Endpoint>>,
+    peer_id: String,
+    listen_addrs: Vec<String>,
+}
+
+#[uniffi::export]
+impl P2pEndpoint {
+    /// Validates the secret key and `config`, binds QUIC, and creates a stopped endpoint.
+    #[uniffi::constructor]
+    pub fn new(secret_key: Vec<u8>, config: EndpointConfig) -> Result<Arc<Self>, FfiError> {
+        let keypair = keypair_from_bytes(secret_key)?;
+        let relays = config
+            .relays
+            .iter()
+            .map(|address| parse_direct_quic_peer_addr(address))
+            .collect::<Result<Vec<_>, _>>()?;
+        if config.force_relay && relays.is_empty() {
+            return Err(FfiError::InvalidConfig {
+                detail: "force_relay requires at least one relay".into(),
+            });
+        }
+
+        let pubsub = GossipsubConfig {
+            allow_unsigned: config.allow_unsigned,
+            ..GossipsubConfig::default()
+        };
+        pubsub.validate().map_err(invalid_config)?;
+
+        let mut builder = Endpoint::builder()
+            .identity(keypair)
+            .agent_version(
+                config
+                    .agent_version
+                    .unwrap_or_else(|| format!("minip2p-rn/{}", env!("CARGO_PKG_VERSION"))),
+            )
+            .pubsub_config(pubsub);
+
+        if !relays.is_empty() || config.force_relay {
+            builder = builder.nat_config(NatConfig {
+                relays,
+                force_relay: config.force_relay,
+                ..NatConfig::default()
+            });
+        }
+
+        if let Some(discovery) = config.discovery {
+            let beacon = BeaconConfig {
+                topic: discovery.topic,
+                beacon_interval_ms: discovery.beacon_interval_ms,
+                ..BeaconConfig::default()
+            };
+            beacon.validate().map_err(invalid_config)?;
+            let peer_discovery = PeerDiscoveryConfig {
+                beacon_peer_ttl_ms: discovery.peer_ttl_ms,
+                auto_dial: discovery.auto_dial,
+                ..PeerDiscoveryConfig::default()
+            };
+            peer_discovery.validate().map_err(invalid_config)?;
+            builder = builder
+                .discovery_config(beacon)
+                .map_err(invalid_config)?
+                .peer_discovery_config(peer_discovery)
+                .map_err(invalid_config)?;
+        }
+
+        let mut endpoint = match config.listen_addr {
+            Some(address) => {
+                let address =
+                    Multiaddr::from_str(&address).map_err(|error| FfiError::InvalidAddress {
+                        detail: error.to_string(),
+                    })?;
+                builder
+                    .bind_quic_multiaddr(&address)
+                    .map_err(map_constructor_error)?
+            }
+            None => builder
+                .bind_quic_dual_stack()
+                .map_err(map_constructor_error)?,
+        };
+        let listen_addrs = endpoint
+            .listen_all()
+            .map_err(map_constructor_error)?
+            .into_iter()
+            .map(|address| address.to_string())
+            .collect();
+        let peer_id = endpoint.peer_id().to_base58();
+
+        Ok(Arc::new(Self {
+            endpoint: Mutex::new(Some(endpoint)),
+            peer_id,
+            listen_addrs,
+        }))
+    }
+
+    /// Returns the local peer ID as legacy base58 text.
+    pub fn peer_id(&self) -> String {
+        self.peer_id.clone()
+    }
+
+    /// Returns the bound QUIC peer addresses.
+    pub fn listen_addrs(&self) -> Vec<String> {
+        self.listen_addrs.clone()
+    }
+
+    /// Returns peers with an established QUIC or circuit connection.
+    pub fn connected_peers(&self) -> Result<Vec<String>, FfiError> {
+        self.lock_endpoint()
+            .as_ref()
+            .map(|endpoint| {
+                endpoint
+                    .connected_peers()
+                    .into_iter()
+                    .map(|peer| peer.to_base58())
+                    .collect()
+            })
+            .ok_or_else(|| FfiError::InvalidState {
+                detail: "endpoint is stopped".into(),
+            })
+    }
+}
+
+impl P2pEndpoint {
+    fn lock_endpoint(&self) -> MutexGuard<'_, Option<Endpoint>> {
+        self.endpoint.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+fn invalid_config(error: impl std::fmt::Display) -> FfiError {
+    FfiError::InvalidConfig {
+        detail: error.to_string(),
+    }
+}
+
+fn map_constructor_error(error: minip2p::Error) -> FfiError {
+    match error {
+        minip2p::Error::Transport(TransportError::InvalidAddress { .. }) => {
+            FfiError::InvalidAddress {
+                detail: error.to_string(),
+            }
+        }
+        minip2p::Error::Transport(TransportError::InvalidConfig { .. }) => invalid_config(error),
+        _ => FfiError::Internal {
+            detail: error.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> EndpointConfig {
+        EndpointConfig {
+            agent_version: None,
+            relays: Vec::new(),
+            listen_addr: Some("/ip4/127.0.0.1/udp/0/quic-v1".into()),
+            force_relay: false,
+            allow_unsigned: false,
+            discovery: None,
+        }
+    }
+
+    fn endpoint(config: EndpointConfig) -> Result<Arc<P2pEndpoint>, FfiError> {
+        P2pEndpoint::new(vec![9; 32], config)
+    }
+
+    #[test]
+    fn constructs_a_real_loopback_endpoint() {
+        let endpoint = endpoint(config()).expect("endpoint");
+
+        assert!(!endpoint.peer_id().is_empty());
+        assert_eq!(endpoint.listen_addrs().len(), 1);
+    }
+
+    #[test]
+    fn force_relay_requires_a_relay_before_binding() {
+        let mut config = config();
+        config.force_relay = true;
+
+        assert!(matches!(
+            endpoint(config),
+            Err(FfiError::InvalidConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn constructor_rejects_bad_key_relay_and_listen_address() {
+        let bad_key = config();
+        let mut bad_secret = vec![9; 32];
+        bad_secret.pop();
+        assert!(matches!(
+            P2pEndpoint::new(bad_secret, bad_key),
+            Err(FfiError::InvalidKey { .. })
+        ));
+
+        let mut bad_relay = config();
+        bad_relay.relays.push("not-a-peer-address".into());
+        assert!(matches!(
+            endpoint(bad_relay),
+            Err(FfiError::InvalidAddress { .. })
+        ));
+
+        let mut bad_listen = config();
+        bad_listen.listen_addr = Some("not-a-multiaddr".into());
+        assert!(matches!(
+            endpoint(bad_listen),
+            Err(FfiError::InvalidAddress { .. })
+        ));
+    }
+
+    #[test]
+    fn constructor_validates_discovery_before_binding() {
+        let mut invalid_topic = config();
+        invalid_topic.discovery = Some(crate::DiscoveryOptions {
+            topic: String::new(),
+            beacon_interval_ms: 10_000,
+            peer_ttl_ms: 35_000,
+            auto_dial: true,
+        });
+        assert!(matches!(
+            endpoint(invalid_topic),
+            Err(FfiError::InvalidConfig { .. })
+        ));
+
+        let mut invalid_ttl = config();
+        invalid_ttl.discovery = Some(crate::DiscoveryOptions {
+            topic: "room".into(),
+            beacon_interval_ms: 10_000,
+            peer_ttl_ms: 0,
+            auto_dial: true,
+        });
+        assert!(matches!(
+            endpoint(invalid_ttl),
+            Err(FfiError::InvalidConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn immutable_queries_reflect_the_constructed_endpoint() {
+        let expected_peer = minip2p::Ed25519Keypair::from_secret_key_bytes([9; 32])
+            .peer_id()
+            .to_base58();
+        let endpoint = endpoint(config()).expect("endpoint");
+
+        assert_eq!(endpoint.peer_id(), expected_peer);
+        assert!(endpoint.listen_addrs()[0].starts_with("/ip4/127.0.0.1/udp/"));
+        assert!(
+            endpoint
+                .connected_peers()
+                .expect("running endpoint")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn endpoint_config_contains_no_secret_material() {
+        let debug = format!("{:?}", config());
+
+        assert!(!debug.contains("9, 9, 9"));
+    }
+
+    #[test]
+    fn poisoned_endpoint_lock_recovers() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        let endpoint_for_panic = Arc::clone(&endpoint);
+        let _ = std::thread::spawn(move || {
+            let _guard = endpoint_for_panic.endpoint.lock().expect("lock");
+            panic!("poison endpoint lock");
+        })
+        .join();
+
+        assert!(endpoint.lock_endpoint().is_some());
+    }
+
+    #[test]
+    fn constructor_accepts_default_dual_stack_binding() {
+        let mut config = config();
+        config.listen_addr = None;
+
+        let endpoint = endpoint(config).expect("dual-stack endpoint");
+
+        assert!(!endpoint.listen_addrs().is_empty());
+    }
+
+    #[test]
+    fn constructor_accepts_valid_discovery_configuration() {
+        let mut config = config();
+        config.discovery = Some(crate::DiscoveryOptions {
+            topic: "room".into(),
+            beacon_interval_ms: 10_000,
+            peer_ttl_ms: 35_000,
+            auto_dial: true,
+        });
+
+        endpoint(config).expect("discovery endpoint");
+    }
+
+    #[test]
+    fn constructor_rejects_non_quic_and_circuit_relays() {
+        let relay = minip2p::Ed25519Keypair::from_secret_key_bytes([8; 32]).peer_id();
+
+        for address in [
+            format!("/ip4/127.0.0.1/udp/4001/p2p/{relay}"),
+            format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p-circuit/p2p/{relay}"),
+        ] {
+            let mut config = config();
+            config.relays.push(address);
+            assert!(matches!(
+                endpoint(config),
+                Err(FfiError::InvalidAddress { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn connected_peers_reports_a_stopped_endpoint() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        *endpoint.lock_endpoint() = None;
+
+        assert!(matches!(
+            endpoint.connected_peers(),
+            Err(FfiError::InvalidState { .. })
+        ));
+    }
+
+    #[test]
+    fn runtime_constructor_failures_are_internal() {
+        for error in [
+            TransportError::ListenFailed {
+                reason: "socket unavailable".into(),
+            },
+            TransportError::ResourceExhausted { resource: "socket" },
+        ] {
+            assert!(matches!(
+                map_constructor_error(error.into()),
+                FfiError::Internal { .. }
+            ));
+        }
+    }
+}

--- a/crates/ffi/src/endpoint.rs
+++ b/crates/ffi/src/endpoint.rs
@@ -1,17 +1,19 @@
 //! Foreign-facing endpoint object and construction.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, PoisonError};
 use std::time::{Duration, Instant};
 
 use minip2p::{
-    BeaconConfig, Endpoint, GossipsubConfig, Multiaddr, NatConfig, PeerDiscoveryConfig,
-    QuicWaitHandle, TransportError,
+    BeaconConfig, Endpoint, GossipsubConfig, Multiaddr, NatConfig, PeerDiscoveryConfig, PeerId,
+    PublishError, PubsubError, QuicWaitHandle, TopicError, TransportError,
 };
 
 use crate::{
-    EndpointConfig, FfiError, P2pEventListener, keypair_from_bytes, parse_direct_quic_peer_addr,
+    EndpointConfig, FfiError, KnownPeerInfo, P2pEventListener, RelayReservationInfo,
+    keypair_from_bytes, parse_direct_quic_peer_addr,
 };
 
 /// A minip2p endpoint owned by a foreign runtime.
@@ -35,6 +37,8 @@ pub(crate) struct EndpointState {
     pub(crate) endpoint: Option<Endpoint>,
     pub(crate) active: bool,
     pub(crate) driver_thread_id: Option<std::thread::ThreadId>,
+    connect_ids: BTreeMap<u64, minip2p::ConnectId>,
+    pub(crate) cancelled_connect_ids: BTreeSet<u64>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -80,13 +84,11 @@ impl P2pEndpoint {
             )
             .pubsub_config(pubsub);
 
-        if !relays.is_empty() || config.force_relay {
-            builder = builder.nat_config(NatConfig {
-                relays,
-                force_relay: config.force_relay,
-                ..NatConfig::default()
-            });
-        }
+        builder = builder.nat_config(NatConfig {
+            relays,
+            force_relay: config.force_relay,
+            ..NatConfig::default()
+        });
 
         if let Some(discovery) = config.discovery {
             let beacon = BeaconConfig {
@@ -138,6 +140,8 @@ impl P2pEndpoint {
                     endpoint: Some(endpoint),
                     active: false,
                     driver_thread_id: None,
+                    connect_ids: BTreeMap::new(),
+                    cancelled_connect_ids: BTreeSet::new(),
                 }),
                 stopped_cv: Condvar::new(),
                 wait_handle,
@@ -162,8 +166,11 @@ impl P2pEndpoint {
     /// Returns peers with an established QUIC or circuit connection.
     pub fn connected_peers(&self) -> Result<Vec<String>, FfiError> {
         let _pending = PendingCommand::new(&self.shared);
-        self.shared
-            .lock_state()
+        let state = self.shared.lock_state();
+        if matches!(state.lifecycle, Lifecycle::Stopping | Lifecycle::Stopped) {
+            return Err(FfiError::Stopped);
+        }
+        state
             .endpoint
             .as_ref()
             .map(|endpoint| {
@@ -173,9 +180,7 @@ impl P2pEndpoint {
                     .map(|peer| peer.to_base58())
                     .collect()
             })
-            .ok_or_else(|| FfiError::InvalidState {
-                detail: "endpoint is stopped".into(),
-            })
+            .ok_or(FfiError::Stopped)
     }
 
     /// Selects active or idle driver polling without changing delivery semantics.
@@ -281,6 +286,129 @@ impl P2pEndpoint {
             }
         }
     }
+
+    /// Subscribes to a pubsub topic.
+    pub fn subscribe(&self, topic: String) -> Result<bool, FfiError> {
+        self.with_endpoint_mut(|endpoint| endpoint.subscribe(&topic).map_err(map_pubsub_error))
+    }
+
+    /// Withdraws a pubsub subscription.
+    pub fn unsubscribe(&self, topic: String) -> Result<bool, FfiError> {
+        self.with_endpoint_mut(|endpoint| endpoint.unsubscribe(&topic).map_err(map_pubsub_error))
+    }
+
+    /// Publishes one application payload.
+    pub fn publish(&self, topic: String, data: Vec<u8>) -> Result<(), FfiError> {
+        if data.len() > minip2p_pubsub::MAX_RPC_SIZE {
+            return Err(FfiError::MessageTooLarge);
+        }
+        self.with_endpoint_mut(|endpoint| endpoint.publish(&topic, data).map_err(map_pubsub_error))
+    }
+
+    /// Starts a connection attempt toward a peer without known direct addresses.
+    pub fn connect(&self, peer_id: String) -> Result<u64, FfiError> {
+        let peer = PeerId::from_str(&peer_id).map_err(|error| FfiError::InvalidPeerId {
+            detail: error.to_string(),
+        })?;
+        let _pending = PendingCommand::new(&self.shared);
+        let mut state = self.shared.lock_state();
+        ensure_accepting_commands(&state)?;
+        let id = state
+            .endpoint
+            .as_mut()
+            .ok_or(FfiError::Stopped)?
+            .connect(&peer)
+            .map_err(map_driver_error)?;
+        state.connect_ids.insert(id.as_u64(), id);
+        Ok(id.as_u64())
+    }
+
+    /// Starts a connection attempt toward a direct QUIC peer address.
+    pub fn connect_addr(&self, address: String) -> Result<u64, FfiError> {
+        let address = parse_direct_quic_peer_addr(&address)?;
+        let _pending = PendingCommand::new(&self.shared);
+        let mut state = self.shared.lock_state();
+        ensure_accepting_commands(&state)?;
+        let id = state
+            .endpoint
+            .as_mut()
+            .ok_or(FfiError::Stopped)?
+            .connect_addr(&address)
+            .map_err(map_driver_error)?;
+        state.connect_ids.insert(id.as_u64(), id);
+        Ok(id.as_u64())
+    }
+
+    /// Cancels a known connection attempt; unknown ids are an idempotent no-op.
+    pub fn cancel_connect(&self, id: u64) -> Result<(), FfiError> {
+        let _pending = PendingCommand::new(&self.shared);
+        let mut state = self.shared.lock_state();
+        ensure_accepting_commands(&state)?;
+        let connect_id = state.connect_ids.get(&id).copied();
+        let endpoint = state.endpoint.as_mut().ok_or(FfiError::Stopped)?;
+        if let Some(connect_id) = connect_id {
+            endpoint.cancel_connect(connect_id);
+            state.cancelled_connect_ids.insert(id);
+        }
+        Ok(())
+    }
+
+    /// Returns the shared discovery address-book snapshot.
+    pub fn known_peers(&self) -> Result<Vec<KnownPeerInfo>, FfiError> {
+        self.with_endpoint(|endpoint| {
+            let now = endpoint.discovery_now_ms();
+            endpoint
+                .known_peers()
+                .into_iter()
+                .map(|peer| KnownPeerInfo {
+                    peer_id: peer.peer.to_base58(),
+                    addrs: display_addrs(peer.addrs),
+                    beacon_addrs: display_addrs(peer.beacon_addrs),
+                    mdns_addrs: display_addrs(peer.mdns_addrs),
+                    beacon_last_seen_age_ms: age(now, peer.beacon_last_seen_ms),
+                    mdns_last_seen_age_ms: age(now, peer.mdns_last_seen_ms),
+                    connected: peer.connected,
+                })
+                .collect()
+        })
+    }
+
+    /// Returns the current AutoNAT reachability verdict.
+    pub fn reachability(&self) -> Result<crate::Reachability, FfiError> {
+        self.with_endpoint(|endpoint| crate::events::convert_reachability(endpoint.reachability()))
+    }
+
+    /// Returns the active inbound relay reservation.
+    pub fn active_reservation(&self) -> Result<Option<RelayReservationInfo>, FfiError> {
+        self.with_endpoint(|endpoint| {
+            endpoint
+                .active_reservation()
+                .map(|reservation| RelayReservationInfo {
+                    relay_peer_id: reservation.relay.to_base58(),
+                    expires_unix_secs: reservation.expires_unix_secs,
+                })
+        })
+    }
+}
+
+impl P2pEndpoint {
+    fn with_endpoint<T>(&self, operation: impl FnOnce(&Endpoint) -> T) -> Result<T, FfiError> {
+        let _pending = PendingCommand::new(&self.shared);
+        let state = self.shared.lock_state();
+        ensure_accepting_commands(&state)?;
+        let endpoint = state.endpoint.as_ref().ok_or(FfiError::Stopped)?;
+        Ok(operation(endpoint))
+    }
+
+    fn with_endpoint_mut<T>(
+        &self,
+        operation: impl FnOnce(&mut Endpoint) -> Result<T, FfiError>,
+    ) -> Result<T, FfiError> {
+        let _pending = PendingCommand::new(&self.shared);
+        let mut state = self.shared.lock_state();
+        ensure_accepting_commands(&state)?;
+        operation(state.endpoint.as_mut().ok_or(FfiError::Stopped)?)
+    }
 }
 
 impl Drop for P2pEndpoint {
@@ -336,6 +464,58 @@ fn map_constructor_error(error: minip2p::Error) -> FfiError {
         _ => FfiError::Internal {
             detail: error.to_string(),
         },
+    }
+}
+
+fn map_pubsub_error(error: PubsubError) -> FfiError {
+    match error {
+        PubsubError::DiscoveryTopicReserved => FfiError::NotPermitted {
+            detail: error.to_string(),
+        },
+        PubsubError::Publish(PublishError::TooLarge) => FfiError::MessageTooLarge,
+        PubsubError::Publish(PublishError::Backpressure) => FfiError::Backpressure,
+        PubsubError::Publish(PublishError::Topic(error)) | PubsubError::Topic(error) => {
+            map_topic_error(error)
+        }
+        PubsubError::Driver(error) => map_driver_error(error),
+        PubsubError::NotEnabled => FfiError::Internal {
+            detail: error.to_string(),
+        },
+    }
+}
+
+fn map_topic_error(error: TopicError) -> FfiError {
+    FfiError::InvalidTopic {
+        detail: error.to_string(),
+    }
+}
+
+fn map_driver_error(error: minip2p::Error) -> FfiError {
+    match error {
+        minip2p::Error::Transport(_) => FfiError::Transport {
+            detail: error.to_string(),
+        },
+        _ => FfiError::Internal {
+            detail: error.to_string(),
+        },
+    }
+}
+
+fn display_addrs(addrs: Vec<Multiaddr>) -> Vec<String> {
+    addrs
+        .into_iter()
+        .map(|address| address.to_string())
+        .collect()
+}
+
+fn age(now: Option<u64>, last_seen: Option<u64>) -> Option<u64> {
+    Some(now?.saturating_sub(last_seen?))
+}
+
+fn ensure_accepting_commands(state: &EndpointState) -> Result<(), FfiError> {
+    match state.lifecycle {
+        Lifecycle::Created | Lifecycle::Running => Ok(()),
+        Lifecycle::Stopping | Lifecycle::Stopped => Err(FfiError::Stopped),
     }
 }
 
@@ -532,6 +712,7 @@ mod tests {
         for address in [
             format!("/ip4/127.0.0.1/udp/4001/p2p/{relay}"),
             format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p-circuit/p2p/{relay}"),
+            format!("/ip4/0.0.0.0/udp/4001/quic-v1/p2p/{relay}"),
         ] {
             let mut config = config();
             config.relays.push(address);
@@ -547,10 +728,7 @@ mod tests {
         let endpoint = endpoint(config()).expect("endpoint");
         endpoint.stop();
 
-        assert!(matches!(
-            endpoint.connected_peers(),
-            Err(FfiError::InvalidState { .. })
-        ));
+        assert!(matches!(endpoint.connected_peers(), Err(FfiError::Stopped)));
     }
 
     #[test]
@@ -724,5 +902,161 @@ mod tests {
             .shared
             .driver_running
             .store(false, Ordering::Release);
+    }
+
+    #[test]
+    fn pre_start_commands_and_queries_are_deterministic() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        let remote = minip2p::Ed25519Keypair::from_secret_key_bytes([7; 32]).peer_id();
+
+        assert!(endpoint.subscribe("room".into()).expect("subscribe"));
+        assert!(!endpoint.subscribe("room".into()).expect("idempotent"));
+        endpoint
+            .publish("room".into(), b"hello".to_vec())
+            .expect("publish");
+        assert!(endpoint.unsubscribe("room".into()).expect("unsubscribe"));
+        assert!(endpoint.connected_peers().expect("peers").is_empty());
+        assert!(endpoint.known_peers().expect("known peers").is_empty());
+        assert_eq!(
+            endpoint.reachability().expect("reachability"),
+            crate::Reachability::Unknown
+        );
+        assert!(
+            endpoint
+                .active_reservation()
+                .expect("reservation")
+                .is_none()
+        );
+        let connect_id = endpoint
+            .connect(remote.to_base58())
+            .expect("connection attempt");
+        {
+            let state = endpoint.shared.lock_state();
+            assert!(state.connect_ids.contains_key(&connect_id));
+        }
+        endpoint.cancel_connect(connect_id).expect("known cancel");
+        assert!(
+            endpoint
+                .shared
+                .lock_state()
+                .cancelled_connect_ids
+                .contains(&connect_id)
+        );
+        endpoint.cancel_connect(u64::MAX).expect("unknown cancel");
+    }
+
+    #[test]
+    fn command_inputs_and_stopped_state_are_typed() {
+        let endpoint = endpoint(config()).expect("endpoint");
+
+        assert!(matches!(
+            endpoint.subscribe(String::new()),
+            Err(FfiError::InvalidTopic { .. })
+        ));
+        assert!(matches!(
+            endpoint.connect("not-a-peer".into()),
+            Err(FfiError::InvalidPeerId { .. })
+        ));
+        assert!(matches!(
+            endpoint.connect_addr("not-an-address".into()),
+            Err(FfiError::InvalidAddress { .. })
+        ));
+
+        endpoint.stop();
+        assert!(matches!(
+            endpoint.publish("room".into(), Vec::new()),
+            Err(FfiError::Stopped)
+        ));
+        assert!(matches!(endpoint.known_peers(), Err(FfiError::Stopped)));
+    }
+
+    #[test]
+    fn source_age_uses_saturating_discovery_clock_math() {
+        assert_eq!(age(Some(100), Some(40)), Some(60));
+        assert_eq!(age(Some(40), Some(100)), Some(0));
+        assert_eq!(age(None, Some(10)), None);
+        assert_eq!(age(Some(10), None), None);
+    }
+
+    #[test]
+    fn commands_reject_stopping_and_oversized_payloads() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        assert!(matches!(
+            endpoint.publish("room".into(), vec![0; minip2p_pubsub::MAX_RPC_SIZE + 1]),
+            Err(FfiError::MessageTooLarge)
+        ));
+
+        endpoint.shared.lock_state().lifecycle = Lifecycle::Stopping;
+        assert!(matches!(
+            endpoint.subscribe("room".into()),
+            Err(FfiError::Stopped)
+        ));
+        assert!(matches!(
+            endpoint.publish("room".into(), Vec::new()),
+            Err(FfiError::Stopped)
+        ));
+        assert!(matches!(endpoint.cancel_connect(0), Err(FfiError::Stopped)));
+    }
+
+    #[test]
+    fn pubsub_and_transport_errors_map_by_context() {
+        let mut discovery = config();
+        discovery.discovery = Some(crate::DiscoveryOptions {
+            topic: "presence".into(),
+            beacon_interval_ms: 10_000,
+            peer_ttl_ms: 35_000,
+            auto_dial: false,
+        });
+        let endpoint = endpoint(discovery).expect("endpoint");
+        assert!(matches!(
+            endpoint.unsubscribe("presence".into()),
+            Err(FfiError::NotPermitted { .. })
+        ));
+
+        assert!(matches!(
+            map_pubsub_error(PubsubError::Publish(PublishError::TooLarge)),
+            FfiError::MessageTooLarge
+        ));
+        assert!(matches!(
+            map_pubsub_error(PubsubError::Publish(PublishError::Backpressure)),
+            FfiError::Backpressure
+        ));
+        assert!(matches!(
+            map_driver_error(
+                TransportError::PollError {
+                    reason: "test".into()
+                }
+                .into()
+            ),
+            FfiError::Transport { .. }
+        ));
+    }
+
+    #[test]
+    fn cancelled_pre_start_terminal_event_is_not_delivered() {
+        let endpoint = endpoint(config()).expect("endpoint");
+        let remote = minip2p::Ed25519Keypair::from_secret_key_bytes([12; 32]).peer_id();
+        let id = endpoint.connect(remote.to_base58()).expect("connect");
+        endpoint.cancel_connect(id).expect("cancel");
+        let listener = Arc::new(RecordingListener::default());
+
+        endpoint
+            .start(Arc::clone(&listener) as Arc<dyn P2pEventListener>)
+            .expect("start");
+        std::thread::sleep(Duration::from_millis(50));
+        endpoint.stop();
+        assert!(endpoint.wait_stopped(1_000));
+
+        assert!(
+            !listener
+                .events
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .iter()
+                .any(|event| matches!(
+                    event,
+                    crate::P2pEvent::ConnectFailed { connect_id, .. } if *connect_id == id
+                ))
+        );
     }
 }

--- a/crates/ffi/src/error.rs
+++ b/crates/ffi/src/error.rs
@@ -1,0 +1,30 @@
+//! Errors exposed across the foreign-function boundary.
+
+/// An error returned by a synchronous FFI operation.
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum FfiError {
+    /// Endpoint configuration was internally inconsistent.
+    #[error("invalid endpoint configuration: {detail}")]
+    InvalidConfig {
+        /// Human-readable validation detail.
+        detail: String,
+    },
+    /// Secret key material was not exactly 32 bytes.
+    #[error("invalid secret key: {detail}")]
+    InvalidKey {
+        /// Human-readable validation detail.
+        detail: String,
+    },
+    /// A peer ID could not be parsed.
+    #[error("invalid peer id: {detail}")]
+    InvalidPeerId {
+        /// Human-readable parse detail.
+        detail: String,
+    },
+    /// A multiaddress or peer address could not be parsed.
+    #[error("invalid address: {detail}")]
+    InvalidAddress {
+        /// Human-readable parse detail.
+        detail: String,
+    },
+}

--- a/crates/ffi/src/error.rs
+++ b/crates/ffi/src/error.rs
@@ -33,6 +33,30 @@ pub enum FfiError {
         /// Human-readable parse detail.
         detail: String,
     },
+    /// A pubsub topic failed validation.
+    #[error("invalid topic: {detail}")]
+    InvalidTopic {
+        /// Human-readable validation detail.
+        detail: String,
+    },
+    /// The operation is valid but reserved by another endpoint subsystem.
+    #[error("operation not permitted: {detail}")]
+    NotPermitted {
+        /// Human-readable refusal detail.
+        detail: String,
+    },
+    /// A bounded outbound queue is full.
+    #[error("outbound backpressure")]
+    Backpressure,
+    /// A pubsub message exceeds the protocol limit.
+    #[error("message too large")]
+    MessageTooLarge,
+    /// A synchronous transport operation failed.
+    #[error("transport error: {detail}")]
+    Transport {
+        /// Human-readable transport detail.
+        detail: String,
+    },
     /// The operation is unavailable in the endpoint's current lifecycle state.
     #[error("invalid endpoint state: {detail}")]
     InvalidState {

--- a/crates/ffi/src/error.rs
+++ b/crates/ffi/src/error.rs
@@ -27,4 +27,16 @@ pub enum FfiError {
         /// Human-readable parse detail.
         detail: String,
     },
+    /// The operation is unavailable in the endpoint's current lifecycle state.
+    #[error("invalid endpoint state: {detail}")]
+    InvalidState {
+        /// Human-readable state detail.
+        detail: String,
+    },
+    /// An internal invariant or unexpected construction path failed.
+    #[error("internal error: {detail}")]
+    Internal {
+        /// Human-readable failure detail.
+        detail: String,
+    },
 }

--- a/crates/ffi/src/error.rs
+++ b/crates/ffi/src/error.rs
@@ -3,6 +3,12 @@
 /// An error returned by a synchronous FFI operation.
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 pub enum FfiError {
+    /// The endpoint's background driver was already started.
+    #[error("endpoint driver already started")]
+    AlreadyStarted,
+    /// The endpoint has stopped and cannot be restarted.
+    #[error("endpoint is stopped")]
+    Stopped,
     /// Endpoint configuration was internally inconsistent.
     #[error("invalid endpoint configuration: {detail}")]
     InvalidConfig {

--- a/crates/ffi/src/events.rs
+++ b/crates/ffi/src/events.rs
@@ -225,7 +225,8 @@ pub enum P2pEvent {
     /// An accepted pubsub message arrived.
     ///
     /// When unsigned messages are enabled, `signed` can be `false`; hosts
-    /// requiring authenticated publishers must check it before using `data`.
+    /// must treat both `from_peer_id` and `data` as unauthenticated unless
+    /// `signed` is `true`.
     Message {
         /// Publisher identity.
         from_peer_id: String,
@@ -500,7 +501,7 @@ pub(crate) fn convert_discovery(event: DiscoveryEvent) -> P2pEvent {
     }
 }
 
-fn convert_reachability(state: ReachabilityState) -> Reachability {
+pub(crate) fn convert_reachability(state: ReachabilityState) -> Reachability {
     match state {
         ReachabilityState::Unknown => Reachability::Unknown,
         ReachabilityState::Public => Reachability::Public,

--- a/crates/ffi/src/events.rs
+++ b/crates/ffi/src/events.rs
@@ -643,4 +643,63 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn nat_error_categories_are_exhaustively_converted() {
+        for (error, expected) in [
+            (NatError::NoPathAvailable, NatErrorKind::NoPathAvailable),
+            (NatError::Timeout, NatErrorKind::Timeout),
+            (
+                NatError::DialFailed("dial".into()),
+                NatErrorKind::DialFailed,
+            ),
+            (
+                NatError::Protocol("protocol".into()),
+                NatErrorKind::Protocol,
+            ),
+            (
+                NatError::RelayRefused("relay".into()),
+                NatErrorKind::RelayRefused,
+            ),
+        ] {
+            assert_eq!(convert_nat_error_kind(&error), expected);
+        }
+    }
+
+    #[test]
+    fn discovery_terminal_and_failure_events_preserve_fields() {
+        let remote = peer(8);
+        assert_eq!(
+            convert_discovery(DiscoveryEvent::PeerExpired {
+                peer: remote.clone()
+            }),
+            P2pEvent::PeerExpired {
+                peer_id: remote.to_base58()
+            }
+        );
+        assert_eq!(
+            convert_discovery(DiscoveryEvent::DialFailed {
+                peer: remote.clone(),
+                reason: "offline".into(),
+            }),
+            P2pEvent::DiscoveryDialFailed {
+                peer_id: remote.to_base58(),
+                reason: "offline".into(),
+            }
+        );
+        assert_eq!(
+            convert_discovery(DiscoveryEvent::ProtocolViolation {
+                peer: Some(remote.clone()),
+                source: UpstreamDiscoverySource::Mdns,
+                reason: "bad claim".into(),
+                suppressed: 3,
+            }),
+            P2pEvent::DiscoveryProtocolViolation {
+                peer_id: Some(remote.to_base58()),
+                source: DiscoverySource::Mdns,
+                reason: "bad claim".into(),
+                suppressed: 3,
+            }
+        );
+    }
 }

--- a/crates/ffi/src/events.rs
+++ b/crates/ffi/src/events.rs
@@ -93,6 +93,13 @@ pub enum DriverFailureKind {
 #[derive(Clone, Debug, Eq, PartialEq, uniffi::Enum)]
 #[allow(clippy::large_enum_variant)]
 pub enum P2pEvent {
+    /// Native event carry overflow discarded source events.
+    EventsDropped {
+        /// Events discarded since the previous diagnostic.
+        dropped: u64,
+        /// Events discarded since this driver started.
+        total_dropped: u64,
+    },
     /// The background driver terminated after a fatal failure.
     DriverFailed {
         /// Machine-readable failure category.

--- a/crates/ffi/src/events.rs
+++ b/crates/ffi/src/events.rs
@@ -1,0 +1,638 @@
+//! Foreign-facing event model and upstream event conversion.
+
+use minip2p::{
+    DiscoveryEvent, DiscoverySource as UpstreamDiscoverySource, Event, NatError, NatEvent, Path,
+    PubsubEvent, ReachabilityState,
+};
+use minip2p_swarm::SwarmErrorKind;
+
+/// Coarse local reachability state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, uniffi::Enum)]
+pub enum Reachability {
+    /// Not enough evidence is available.
+    Unknown,
+    /// The endpoint is directly reachable.
+    Public,
+    /// The endpoint needs traversal or relay assistance.
+    Private,
+}
+
+/// Kind of usable connection path.
+#[derive(Clone, Debug, Eq, PartialEq, uniffi::Enum)]
+pub enum PathKind {
+    /// A known address was dialed directly.
+    DirectDialed,
+    /// A direct path was established by hole punching.
+    DirectPunched,
+    /// Traffic is carried through a relay.
+    Relayed {
+        /// Relay carrying the circuit.
+        relay_peer_id: String,
+    },
+}
+
+/// Source that contributed a discovery observation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, uniffi::Enum)]
+pub enum DiscoverySource {
+    /// Public-key-authenticated signed beacon.
+    SignedBeacon,
+    /// Unauthenticated local-link mDNS observation.
+    Mdns,
+}
+
+/// Category of a non-fatal endpoint runtime error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, uniffi::Enum)]
+pub enum EndpointErrorKind {
+    /// Underlying transport operation failed.
+    Transport,
+    /// Multistream negotiation failed.
+    Multistream,
+    /// Identify protocol failed.
+    Identify,
+    /// Ping protocol failed.
+    Ping,
+    /// Identify stream setup was rejected.
+    IdentifyStreamRejected,
+    /// Outbound stream opening failed.
+    OpenStreamFailed,
+    /// The remote does not support a requested protocol.
+    UnsupportedProtocol,
+    /// The swarm driver contract failed.
+    Driver,
+}
+
+/// Category of a failed NAT connection attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, uniffi::Enum)]
+pub enum NatErrorKind {
+    /// No usable direct or relayed path exists.
+    NoPathAvailable,
+    /// The connection attempt timed out.
+    Timeout,
+    /// A transport dial failed.
+    DialFailed,
+    /// A traversal protocol exchange failed.
+    Protocol,
+    /// A relay refused the circuit.
+    RelayRefused,
+}
+
+/// Category of a fatal background-driver failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, uniffi::Enum)]
+pub enum DriverFailureKind {
+    /// The transport driver failed.
+    Transport,
+    /// The swarm driver failed.
+    Swarm,
+    /// An internal driver invariant failed.
+    Invariant,
+    /// The background pump panicked.
+    Panic,
+}
+
+/// Event delivered by the native endpoint driver.
+#[derive(Clone, Debug, Eq, PartialEq, uniffi::Enum)]
+#[allow(clippy::large_enum_variant)]
+pub enum P2pEvent {
+    /// The background driver terminated after a fatal failure.
+    DriverFailed {
+        /// Machine-readable failure category.
+        kind: DriverFailureKind,
+        /// Human-readable diagnostic detail.
+        detail: String,
+    },
+    /// A verified connection was established.
+    ConnectionEstablished {
+        /// Remote peer.
+        peer_id: String,
+        /// Endpoint-local transport connection id.
+        conn_id: u64,
+    },
+    /// A connection closed.
+    ConnectionClosed {
+        /// Remote peer.
+        peer_id: String,
+        /// Endpoint-local transport connection id.
+        conn_id: u64,
+    },
+    /// A peer completed Identify and is ready for application protocols.
+    PeerReady {
+        /// Remote peer.
+        peer_id: String,
+        /// Protocols advertised by the peer.
+        protocols: Vec<String>,
+    },
+    /// A ping round-trip measurement completed.
+    PingRttMeasured {
+        /// Remote peer.
+        peer_id: String,
+        /// Round-trip duration in milliseconds.
+        rtt_ms: u64,
+    },
+    /// A ping timed out.
+    PingTimeout {
+        /// Remote peer.
+        peer_id: String,
+    },
+    /// A non-fatal endpoint error occurred.
+    EndpointError {
+        /// Machine-readable category.
+        kind: EndpointErrorKind,
+        /// Remote peer, when known.
+        peer_id: Option<String>,
+        /// Transport connection, when known.
+        conn_id: Option<u64>,
+        /// Human-readable diagnostic detail.
+        detail: String,
+    },
+    /// The local reachability verdict changed.
+    ReachabilityChanged {
+        /// Previous verdict.
+        previous: Reachability,
+        /// Current verdict.
+        current: Reachability,
+        /// AutoNAT-confirmed public addresses.
+        confirmed_addrs: Vec<String>,
+    },
+    /// AutoNAT confirmed a changed public address set.
+    PublicAddressesChanged {
+        /// Current public addresses.
+        addrs: Vec<String>,
+    },
+    /// A relay reservation was acquired or renewed.
+    RelayReserved {
+        /// Relay holding the reservation.
+        relay_peer_id: String,
+        /// Absolute relay-reported expiry, when present.
+        expires_unix_secs: Option<u64>,
+    },
+    /// A relay reservation was lost.
+    RelayReservationLost {
+        /// Relay that held the reservation.
+        relay_peer_id: String,
+    },
+    /// The first usable path for an attempt became available.
+    PathEstablished {
+        /// Endpoint-local connection-attempt id.
+        connect_id: u64,
+        /// Remote peer.
+        peer_id: String,
+        /// Established path.
+        path: PathKind,
+    },
+    /// A better path replaced an earlier path.
+    PathUpgraded {
+        /// Endpoint-local connection-attempt id.
+        connect_id: u64,
+        /// Remote peer.
+        peer_id: String,
+        /// Previous path.
+        from: PathKind,
+        /// Replacement path.
+        to: PathKind,
+    },
+    /// One hole-punch window failed.
+    HolePunchFailed {
+        /// Endpoint-local connection-attempt id.
+        connect_id: u64,
+        /// One-based attempt number.
+        attempt: u32,
+        /// Human-readable failure detail.
+        reason: String,
+    },
+    /// Direct upgrade attempts ended with the relay path retained.
+    FellBackToRelay {
+        /// Endpoint-local connection-attempt id.
+        connect_id: u64,
+        /// Remote peer.
+        peer_id: String,
+    },
+    /// A connection attempt ended without a usable path.
+    ConnectFailed {
+        /// Endpoint-local connection-attempt id.
+        connect_id: u64,
+        /// Remote peer.
+        peer_id: String,
+        /// Machine-readable failure category.
+        kind: NatErrorKind,
+        /// Human-readable failure detail.
+        detail: String,
+    },
+    /// An inbound circuit upgraded to a direct connection.
+    InboundDirectUpgrade {
+        /// Remote peer.
+        peer_id: String,
+    },
+    /// An accepted pubsub message arrived.
+    ///
+    /// When unsigned messages are enabled, `signed` can be `false`; hosts
+    /// requiring authenticated publishers must check it before using `data`.
+    Message {
+        /// Publisher identity.
+        from_peer_id: String,
+        /// Topics carried by the message.
+        topics: Vec<String>,
+        /// Application payload.
+        data: Vec<u8>,
+        /// Opaque publisher sequence number.
+        seqno: Vec<u8>,
+        /// Whether the message carried a verified signature.
+        signed: bool,
+    },
+    /// A peer announced a subscription.
+    PeerSubscribed {
+        /// Remote peer.
+        peer_id: String,
+        /// Subscribed topic.
+        topic: String,
+    },
+    /// A peer withdrew a subscription.
+    PeerUnsubscribed {
+        /// Remote peer.
+        peer_id: String,
+        /// Unsubscribed topic.
+        topic: String,
+    },
+    /// Pubsub outbound work was discarded.
+    PubsubOutboundFailure {
+        /// Destination peer.
+        peer_id: String,
+        /// Human-readable failure detail.
+        reason: String,
+    },
+    /// A peer violated the pubsub protocol.
+    PubsubProtocolViolation {
+        /// Offending peer.
+        peer_id: String,
+        /// Human-readable violation detail.
+        reason: String,
+    },
+    /// Discovery introduced a peer.
+    PeerDiscovered {
+        /// Discovered peer.
+        peer_id: String,
+        /// Current merged address snapshot.
+        addrs: Vec<String>,
+        /// Observation source.
+        source: DiscoverySource,
+    },
+    /// Discovery updated a peer.
+    PeerUpdated {
+        /// Updated peer.
+        peer_id: String,
+        /// Current merged address snapshot.
+        addrs: Vec<String>,
+        /// Observation source.
+        source: DiscoverySource,
+    },
+    /// A discovered peer expired or was evicted.
+    PeerExpired {
+        /// Removed peer.
+        peer_id: String,
+    },
+    /// An automatic discovery dial failed.
+    DiscoveryDialFailed {
+        /// Peer that could not be reached.
+        peer_id: String,
+        /// Human-readable failure detail.
+        reason: String,
+    },
+    /// A discovery source supplied an invalid claim.
+    DiscoveryProtocolViolation {
+        /// Claimed peer, when identifiable.
+        peer_id: Option<String>,
+        /// Observation source.
+        source: DiscoverySource,
+        /// Human-readable violation detail.
+        reason: String,
+        /// Additional violations folded into this event.
+        suppressed: u32,
+    },
+}
+
+/// Listener implemented by the embedding runtime.
+#[uniffi::export(with_foreign)]
+pub trait P2pEventListener: Send + Sync {
+    /// Receives one converted native event.
+    fn on_event(&self, event: P2pEvent);
+}
+
+pub(crate) fn convert_swarm(event: Event) -> Option<P2pEvent> {
+    Some(match event {
+        Event::ConnectionEstablished { peer_id, conn_id } => P2pEvent::ConnectionEstablished {
+            peer_id: peer_id.to_base58(),
+            conn_id: conn_id.as_u64(),
+        },
+        Event::ConnectionClosed { peer_id, conn_id } => P2pEvent::ConnectionClosed {
+            peer_id: peer_id.to_base58(),
+            conn_id: conn_id.as_u64(),
+        },
+        Event::IdentifyReceived { .. }
+        | Event::StreamReady { .. }
+        | Event::StreamData { .. }
+        | Event::StreamRemoteWriteClosed { .. }
+        | Event::StreamClosed { .. } => return None,
+        Event::PeerReady { peer_id, protocols } => P2pEvent::PeerReady {
+            peer_id: peer_id.to_base58(),
+            protocols,
+        },
+        Event::PingRttMeasured { peer_id, rtt_ms } => P2pEvent::PingRttMeasured {
+            peer_id: peer_id.to_base58(),
+            rtt_ms,
+        },
+        Event::PingTimeout { peer_id } => P2pEvent::PingTimeout {
+            peer_id: peer_id.to_base58(),
+        },
+        Event::Error(error) => P2pEvent::EndpointError {
+            kind: convert_swarm_error_kind(error.kind),
+            peer_id: error.peer_id.map(|peer| peer.to_base58()),
+            conn_id: error.conn_id.map(|id| id.as_u64()),
+            detail: error.detail,
+        },
+    })
+}
+
+pub(crate) fn convert_nat(event: NatEvent) -> P2pEvent {
+    match event {
+        NatEvent::ReachabilityChanged {
+            old,
+            new,
+            confirmed_addrs,
+        } => P2pEvent::ReachabilityChanged {
+            previous: convert_reachability(old),
+            current: convert_reachability(new),
+            confirmed_addrs: display_addrs(confirmed_addrs),
+        },
+        NatEvent::PublicAddressesChanged { addrs } => P2pEvent::PublicAddressesChanged {
+            addrs: display_addrs(addrs),
+        },
+        NatEvent::RelayReserved {
+            relay,
+            expires_unix_secs,
+            ..
+        } => P2pEvent::RelayReserved {
+            relay_peer_id: relay.to_base58(),
+            expires_unix_secs,
+        },
+        NatEvent::RelayReservationLost { relay } => P2pEvent::RelayReservationLost {
+            relay_peer_id: relay.to_base58(),
+        },
+        NatEvent::PathEstablished {
+            connect_id,
+            peer,
+            path,
+        } => P2pEvent::PathEstablished {
+            connect_id: connect_id.as_u64(),
+            peer_id: peer.to_base58(),
+            path: convert_path(path),
+        },
+        NatEvent::PathUpgraded {
+            connect_id,
+            peer,
+            from,
+            to,
+        } => P2pEvent::PathUpgraded {
+            connect_id: connect_id.as_u64(),
+            peer_id: peer.to_base58(),
+            from: convert_path(from),
+            to: convert_path(to),
+        },
+        NatEvent::HolePunchFailed {
+            connect_id,
+            attempt,
+            reason,
+        } => P2pEvent::HolePunchFailed {
+            connect_id: connect_id.as_u64(),
+            attempt,
+            reason,
+        },
+        NatEvent::FellBackToRelay { connect_id, peer } => P2pEvent::FellBackToRelay {
+            connect_id: connect_id.as_u64(),
+            peer_id: peer.to_base58(),
+        },
+        NatEvent::ConnectFailed {
+            connect_id,
+            peer,
+            error,
+        } => P2pEvent::ConnectFailed {
+            connect_id: connect_id.as_u64(),
+            peer_id: peer.to_base58(),
+            kind: convert_nat_error_kind(&error),
+            detail: error.to_string(),
+        },
+        NatEvent::InboundDirectUpgrade { peer } => P2pEvent::InboundDirectUpgrade {
+            peer_id: peer.to_base58(),
+        },
+    }
+}
+
+pub(crate) fn convert_pubsub(event: PubsubEvent) -> P2pEvent {
+    match event {
+        PubsubEvent::Message {
+            from,
+            topics,
+            data,
+            seqno,
+            signed,
+        } => P2pEvent::Message {
+            from_peer_id: from.to_base58(),
+            topics,
+            data,
+            seqno,
+            signed,
+        },
+        PubsubEvent::PeerSubscribed { peer, topic } => P2pEvent::PeerSubscribed {
+            peer_id: peer.to_base58(),
+            topic,
+        },
+        PubsubEvent::PeerUnsubscribed { peer, topic } => P2pEvent::PeerUnsubscribed {
+            peer_id: peer.to_base58(),
+            topic,
+        },
+        PubsubEvent::OutboundFailure { peer, reason } => P2pEvent::PubsubOutboundFailure {
+            peer_id: peer.to_base58(),
+            reason,
+        },
+        PubsubEvent::ProtocolViolation { peer, reason } => P2pEvent::PubsubProtocolViolation {
+            peer_id: peer.to_base58(),
+            reason,
+        },
+    }
+}
+
+pub(crate) fn convert_discovery(event: DiscoveryEvent) -> P2pEvent {
+    match event {
+        DiscoveryEvent::PeerDiscovered {
+            peer,
+            addrs,
+            source,
+        } => P2pEvent::PeerDiscovered {
+            peer_id: peer.to_base58(),
+            addrs: display_addrs(addrs),
+            source: convert_discovery_source(source),
+        },
+        DiscoveryEvent::PeerUpdated {
+            peer,
+            addrs,
+            source,
+        } => P2pEvent::PeerUpdated {
+            peer_id: peer.to_base58(),
+            addrs: display_addrs(addrs),
+            source: convert_discovery_source(source),
+        },
+        DiscoveryEvent::PeerExpired { peer } => P2pEvent::PeerExpired {
+            peer_id: peer.to_base58(),
+        },
+        DiscoveryEvent::DialFailed { peer, reason } => P2pEvent::DiscoveryDialFailed {
+            peer_id: peer.to_base58(),
+            reason,
+        },
+        DiscoveryEvent::ProtocolViolation {
+            peer,
+            source,
+            reason,
+            suppressed,
+        } => P2pEvent::DiscoveryProtocolViolation {
+            peer_id: peer.map(|peer| peer.to_base58()),
+            source: convert_discovery_source(source),
+            reason,
+            suppressed,
+        },
+    }
+}
+
+fn convert_reachability(state: ReachabilityState) -> Reachability {
+    match state {
+        ReachabilityState::Unknown => Reachability::Unknown,
+        ReachabilityState::Public => Reachability::Public,
+        ReachabilityState::Private => Reachability::Private,
+    }
+}
+
+fn convert_path(path: Path) -> PathKind {
+    match path {
+        Path::DirectDialed => PathKind::DirectDialed,
+        Path::DirectPunched => PathKind::DirectPunched,
+        Path::Relayed { relay } => PathKind::Relayed {
+            relay_peer_id: relay.to_base58(),
+        },
+    }
+}
+
+fn convert_discovery_source(source: UpstreamDiscoverySource) -> DiscoverySource {
+    match source {
+        UpstreamDiscoverySource::SignedBeacon => DiscoverySource::SignedBeacon,
+        UpstreamDiscoverySource::Mdns => DiscoverySource::Mdns,
+    }
+}
+
+fn convert_swarm_error_kind(kind: SwarmErrorKind) -> EndpointErrorKind {
+    match kind {
+        SwarmErrorKind::Transport => EndpointErrorKind::Transport,
+        SwarmErrorKind::Multistream => EndpointErrorKind::Multistream,
+        SwarmErrorKind::Identify => EndpointErrorKind::Identify,
+        SwarmErrorKind::Ping => EndpointErrorKind::Ping,
+        SwarmErrorKind::IdentifyStreamRejected => EndpointErrorKind::IdentifyStreamRejected,
+        SwarmErrorKind::OpenStreamFailed => EndpointErrorKind::OpenStreamFailed,
+        SwarmErrorKind::UnsupportedProtocol => EndpointErrorKind::UnsupportedProtocol,
+        SwarmErrorKind::Driver => EndpointErrorKind::Driver,
+    }
+}
+
+fn convert_nat_error_kind(error: &NatError) -> NatErrorKind {
+    match error {
+        NatError::NoPathAvailable => NatErrorKind::NoPathAvailable,
+        NatError::Timeout => NatErrorKind::Timeout,
+        NatError::DialFailed(_) => NatErrorKind::DialFailed,
+        NatError::Protocol(_) => NatErrorKind::Protocol,
+        NatError::RelayRefused(_) => NatErrorKind::RelayRefused,
+    }
+}
+
+fn display_addrs(addrs: Vec<minip2p::Multiaddr>) -> Vec<String> {
+    addrs
+        .into_iter()
+        .map(|address| address.to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use minip2p::{ConnectionId, Ed25519Keypair, PeerId};
+    use std::str::FromStr;
+
+    fn peer(seed: u8) -> PeerId {
+        Ed25519Keypair::from_secret_key_bytes([seed; 32]).peer_id()
+    }
+
+    #[test]
+    fn swarm_connection_conversion_preserves_ids() {
+        let remote = peer(3);
+
+        assert_eq!(
+            convert_swarm(Event::ConnectionEstablished {
+                peer_id: remote.clone(),
+                conn_id: ConnectionId::new(17),
+            }),
+            Some(P2pEvent::ConnectionEstablished {
+                peer_id: remote.to_base58(),
+                conn_id: 17,
+            })
+        );
+    }
+
+    #[test]
+    fn internal_swarm_events_are_deliberately_not_exported() {
+        let remote = peer(4);
+        assert!(
+            convert_swarm(Event::IdentifyReceived {
+                peer_id: remote,
+                info: minip2p::IdentifyMessage::default(),
+            })
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn pubsub_message_conversion_preserves_binary_fields() {
+        let remote = peer(5);
+        let event = convert_pubsub(PubsubEvent::Message {
+            from: remote.clone(),
+            topics: vec!["room".into()],
+            data: vec![1, 2],
+            seqno: vec![3, 4],
+            signed: true,
+        });
+
+        assert_eq!(
+            event,
+            P2pEvent::Message {
+                from_peer_id: remote.to_base58(),
+                topics: vec!["room".into()],
+                data: vec![1, 2],
+                seqno: vec![3, 4],
+                signed: true,
+            }
+        );
+    }
+
+    #[test]
+    fn discovery_conversion_preserves_source_and_addresses() {
+        let remote = peer(6);
+        let address =
+            minip2p::Multiaddr::from_str("/ip4/127.0.0.1/udp/7/quic-v1").expect("address");
+
+        assert_eq!(
+            convert_discovery(DiscoveryEvent::PeerDiscovered {
+                peer: remote.clone(),
+                addrs: vec![address.clone()],
+                source: UpstreamDiscoverySource::SignedBeacon,
+            }),
+            P2pEvent::PeerDiscovered {
+                peer_id: remote.to_base58(),
+                addrs: vec![address.to_string()],
+                source: DiscoverySource::SignedBeacon,
+            }
+        );
+    }
+}

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -3,14 +3,20 @@
 #![warn(missing_docs)]
 
 mod config;
+mod driver;
 mod endpoint;
 mod error;
+mod events;
 
 use std::str::FromStr;
 
 pub use config::{DiscoveryOptions, EndpointConfig};
 pub use endpoint::P2pEndpoint;
 pub use error::FfiError;
+pub use events::{
+    DiscoverySource, DriverFailureKind, EndpointErrorKind, NatErrorKind, P2pEvent,
+    P2pEventListener, PathKind, Reachability,
+};
 use minip2p::{Ed25519Keypair, Multiaddr, PeerAddr, PeerId, Protocol};
 
 const SECRET_KEY_LENGTH: usize = 32;

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -10,7 +10,7 @@ mod events;
 
 use std::str::FromStr;
 
-pub use config::{DiscoveryOptions, EndpointConfig};
+pub use config::{DiscoveryOptions, EndpointConfig, KnownPeerInfo, RelayReservationInfo};
 pub use endpoint::P2pEndpoint;
 pub use error::FfiError;
 pub use events::{
@@ -57,7 +57,7 @@ fn parse_direct_quic_peer_addr(address: &str) -> Result<PeerAddr, FfiError> {
     let relay = PeerAddr::from_str(address).map_err(|error| FfiError::InvalidAddress {
         detail: error.to_string(),
     })?;
-    if !relay.transport().is_quic_transport() {
+    if !relay.transport().is_quic_transport() || relay.transport().is_wildcard_host() {
         return Err(FfiError::InvalidAddress {
             detail: "relay address must be a direct QUIC-v1 peer address".into(),
         });

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -11,6 +11,7 @@ mod events;
 use std::str::FromStr;
 
 pub use config::{DiscoveryOptions, EndpointConfig, KnownPeerInfo, RelayReservationInfo};
+pub use driver::DriverStats;
 pub use endpoint::P2pEndpoint;
 pub use error::FfiError;
 pub use events::{

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -2,10 +2,14 @@
 
 #![warn(missing_docs)]
 
+mod config;
+mod endpoint;
 mod error;
 
 use std::str::FromStr;
 
+pub use config::{DiscoveryOptions, EndpointConfig};
+pub use endpoint::P2pEndpoint;
 pub use error::FfiError;
 use minip2p::{Ed25519Keypair, Multiaddr, PeerAddr, PeerId, Protocol};
 
@@ -31,7 +35,20 @@ pub fn peer_id_from_secret_key(secret_key: Vec<u8>) -> Result<String, FfiError> 
 /// Builds a circuit multiaddress for `peer_id` through `relay_addr`.
 #[uniffi::export]
 pub fn circuit_address(relay_addr: String, peer_id: String) -> Result<String, FfiError> {
-    let relay = PeerAddr::from_str(&relay_addr).map_err(|error| FfiError::InvalidAddress {
+    let relay = parse_direct_quic_peer_addr(&relay_addr)?;
+    let target = PeerId::from_str(&peer_id).map_err(|error| FfiError::InvalidPeerId {
+        detail: error.to_string(),
+    })?;
+
+    let mut protocols = relay.transport().protocols().to_vec();
+    protocols.push(Protocol::P2p(relay.peer_id().clone()));
+    protocols.push(Protocol::P2pCircuit);
+    protocols.push(Protocol::P2p(target));
+    Ok(Multiaddr::from_protocols(protocols).to_string())
+}
+
+fn parse_direct_quic_peer_addr(address: &str) -> Result<PeerAddr, FfiError> {
+    let relay = PeerAddr::from_str(address).map_err(|error| FfiError::InvalidAddress {
         detail: error.to_string(),
     })?;
     if !relay.transport().is_quic_transport()
@@ -45,15 +62,7 @@ pub fn circuit_address(relay_addr: String, peer_id: String) -> Result<String, Ff
             detail: "relay address must be a direct QUIC-v1 peer address".into(),
         });
     }
-    let target = PeerId::from_str(&peer_id).map_err(|error| FfiError::InvalidPeerId {
-        detail: error.to_string(),
-    })?;
-
-    let mut protocols = relay.transport().protocols().to_vec();
-    protocols.push(Protocol::P2p(relay.peer_id().clone()));
-    protocols.push(Protocol::P2pCircuit);
-    protocols.push(Protocol::P2p(target));
-    Ok(Multiaddr::from_protocols(protocols).to_string())
+    Ok(relay)
 }
 
 fn keypair_from_bytes(secret_key: Vec<u8>) -> Result<Ed25519Keypair, FfiError> {
@@ -153,15 +162,15 @@ mod tests {
 
         for invalid in [
             format!("/ip4/127.0.0.1/udp/4001/p2p/{relay}"),
-            format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p/{relay}/p2p-circuit/p2p/{relay}"),
+            format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p-circuit/p2p/{relay}"),
         ] {
-            assert!(
-                matches!(
-                    circuit_address(invalid, target.to_base58()),
-                    Err(FfiError::InvalidAddress { .. })
-                ),
-                "invalid relay shape must be rejected"
-            );
+            let error = circuit_address(invalid, target.to_base58())
+                .expect_err("invalid relay shape must be rejected");
+            assert!(matches!(
+                error,
+                FfiError::InvalidAddress { ref detail }
+                    if detail == "relay address must be a direct QUIC-v1 peer address"
+            ));
         }
     }
 }

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -51,13 +51,7 @@ fn parse_direct_quic_peer_addr(address: &str) -> Result<PeerAddr, FfiError> {
     let relay = PeerAddr::from_str(address).map_err(|error| FfiError::InvalidAddress {
         detail: error.to_string(),
     })?;
-    if !relay.transport().is_quic_transport()
-        || relay
-            .transport()
-            .protocols()
-            .iter()
-            .any(|protocol| matches!(protocol, Protocol::P2pCircuit))
-    {
+    if !relay.transport().is_quic_transport() {
         return Err(FfiError::InvalidAddress {
             detail: "relay address must be a direct QUIC-v1 peer address".into(),
         });

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -1,0 +1,167 @@
+//! UniFFI bindings for embedding minip2p in mobile applications.
+
+#![warn(missing_docs)]
+
+mod error;
+
+use std::str::FromStr;
+
+pub use error::FfiError;
+use minip2p::{Ed25519Keypair, Multiaddr, PeerAddr, PeerId, Protocol};
+
+const SECRET_KEY_LENGTH: usize = 32;
+
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<minip2p::Endpoint>();
+};
+
+/// Generates raw Ed25519 secret key material.
+#[uniffi::export]
+pub fn generate_secret_key() -> Vec<u8> {
+    Ed25519Keypair::generate().secret_key_bytes().to_vec()
+}
+
+/// Derives a base58 peer ID from raw Ed25519 secret key material.
+#[uniffi::export]
+pub fn peer_id_from_secret_key(secret_key: Vec<u8>) -> Result<String, FfiError> {
+    Ok(keypair_from_bytes(secret_key)?.peer_id().to_base58())
+}
+
+/// Builds a circuit multiaddress for `peer_id` through `relay_addr`.
+#[uniffi::export]
+pub fn circuit_address(relay_addr: String, peer_id: String) -> Result<String, FfiError> {
+    let relay = PeerAddr::from_str(&relay_addr).map_err(|error| FfiError::InvalidAddress {
+        detail: error.to_string(),
+    })?;
+    if !relay.transport().is_quic_transport()
+        || relay
+            .transport()
+            .protocols()
+            .iter()
+            .any(|protocol| matches!(protocol, Protocol::P2pCircuit))
+    {
+        return Err(FfiError::InvalidAddress {
+            detail: "relay address must be a direct QUIC-v1 peer address".into(),
+        });
+    }
+    let target = PeerId::from_str(&peer_id).map_err(|error| FfiError::InvalidPeerId {
+        detail: error.to_string(),
+    })?;
+
+    let mut protocols = relay.transport().protocols().to_vec();
+    protocols.push(Protocol::P2p(relay.peer_id().clone()));
+    protocols.push(Protocol::P2pCircuit);
+    protocols.push(Protocol::P2p(target));
+    Ok(Multiaddr::from_protocols(protocols).to_string())
+}
+
+fn keypair_from_bytes(secret_key: Vec<u8>) -> Result<Ed25519Keypair, FfiError> {
+    let secret_key: [u8; SECRET_KEY_LENGTH] =
+        secret_key
+            .try_into()
+            .map_err(|value: Vec<u8>| FfiError::InvalidKey {
+                detail: format!(
+                    "expected {SECRET_KEY_LENGTH} bytes, received {}",
+                    value.len()
+                ),
+            })?;
+    Ok(Ed25519Keypair::from_secret_key_bytes(secret_key))
+}
+
+uniffi::setup_scaffolding!();
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secret_key_round_trips_to_a_stable_peer_id() {
+        let secret = vec![7; SECRET_KEY_LENGTH];
+        let first = peer_id_from_secret_key(secret.clone()).expect("peer id");
+        let second = peer_id_from_secret_key(secret).expect("peer id");
+        let expected = Ed25519Keypair::from_secret_key_bytes([7; SECRET_KEY_LENGTH])
+            .peer_id()
+            .to_base58();
+
+        assert_eq!(first, second);
+        assert_eq!(first, expected);
+    }
+
+    #[test]
+    fn generated_secret_key_has_the_expected_length_and_derives_a_peer_id() {
+        let secret = generate_secret_key();
+
+        assert_eq!(secret.len(), SECRET_KEY_LENGTH);
+        let peer_id = peer_id_from_secret_key(secret).expect("generated key must round-trip");
+        assert!(PeerId::from_str(&peer_id).is_ok());
+    }
+
+    #[test]
+    fn secret_key_length_is_validated() {
+        assert!(matches!(
+            peer_id_from_secret_key(vec![1; SECRET_KEY_LENGTH - 1]),
+            Err(FfiError::InvalidKey { .. })
+        ));
+    }
+
+    #[test]
+    fn circuit_address_matches_the_libp2p_shape() {
+        let relay = Ed25519Keypair::from_secret_key_bytes([1; SECRET_KEY_LENGTH]).peer_id();
+        let target = Ed25519Keypair::from_secret_key_bytes([2; SECRET_KEY_LENGTH]).peer_id();
+        let relay_addr = format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p/{relay}");
+
+        let address =
+            circuit_address(relay_addr.clone(), target.to_base58()).expect("circuit address");
+
+        assert_eq!(address, format!("{relay_addr}/p2p-circuit/p2p/{target}"));
+    }
+
+    #[test]
+    fn circuit_address_accepts_a_cid_v1_target() {
+        let relay = Ed25519Keypair::from_secret_key_bytes([1; SECRET_KEY_LENGTH]).peer_id();
+        let target = Ed25519Keypair::from_secret_key_bytes([2; SECRET_KEY_LENGTH]).peer_id();
+        let relay_addr = format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p/{relay}");
+
+        let address = circuit_address(relay_addr, target.to_cid_base32()).expect("circuit address");
+
+        assert!(address.ends_with(&format!("/p2p/{target}")));
+    }
+
+    #[test]
+    fn circuit_address_rejects_invalid_inputs() {
+        let relay = Ed25519Keypair::from_secret_key_bytes([1; SECRET_KEY_LENGTH]).peer_id();
+        let target = Ed25519Keypair::from_secret_key_bytes([2; SECRET_KEY_LENGTH]).peer_id();
+
+        assert!(matches!(
+            circuit_address("not-an-address".into(), target.to_base58()),
+            Err(FfiError::InvalidAddress { .. })
+        ));
+        assert!(matches!(
+            circuit_address(
+                format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p/{relay}"),
+                "not-a-peer-id".into()
+            ),
+            Err(FfiError::InvalidPeerId { .. })
+        ));
+    }
+
+    #[test]
+    fn circuit_address_rejects_non_quic_and_existing_circuit_relays() {
+        let relay = Ed25519Keypair::from_secret_key_bytes([1; SECRET_KEY_LENGTH]).peer_id();
+        let target = Ed25519Keypair::from_secret_key_bytes([2; SECRET_KEY_LENGTH]).peer_id();
+
+        for invalid in [
+            format!("/ip4/127.0.0.1/udp/4001/p2p/{relay}"),
+            format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p/{relay}/p2p-circuit/p2p/{relay}"),
+        ] {
+            assert!(
+                matches!(
+                    circuit_address(invalid, target.to_base58()),
+                    Err(FfiError::InvalidAddress { .. })
+                ),
+                "invalid relay shape must be rejected"
+            );
+        }
+    }
+}

--- a/crates/ffi/tests/loopback.rs
+++ b/crates/ffi/tests/loopback.rs
@@ -1,0 +1,151 @@
+//! End-to-end FFI tests over real loopback QUIC sockets.
+
+use std::sync::{Arc, Condvar, Mutex, PoisonError};
+use std::time::{Duration, Instant};
+
+use minip2p_ffi::{EndpointConfig, FfiError, P2pEndpoint, P2pEvent, P2pEventListener, PathKind};
+
+#[derive(Default)]
+struct EventLog {
+    events: Mutex<Vec<P2pEvent>>,
+    changed: Condvar,
+}
+
+impl EventLog {
+    fn wait_for(
+        &self,
+        timeout: Duration,
+        predicate: impl Fn(&P2pEvent) -> bool,
+    ) -> Option<P2pEvent> {
+        let started = Instant::now();
+        let mut events = self.events.lock().unwrap_or_else(PoisonError::into_inner);
+        loop {
+            if let Some(event) = events.iter().find(|event| predicate(event)) {
+                return Some(event.clone());
+            }
+            let remaining = timeout.saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                return None;
+            }
+            let (next, result) = self
+                .changed
+                .wait_timeout(events, remaining)
+                .unwrap_or_else(PoisonError::into_inner);
+            events = next;
+            if result.timed_out() {
+                return events.iter().find(|event| predicate(event)).cloned();
+            }
+        }
+    }
+}
+
+impl P2pEventListener for EventLog {
+    fn on_event(&self, event: P2pEvent) {
+        self.events
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(event);
+        self.changed.notify_all();
+    }
+}
+
+fn config() -> EndpointConfig {
+    EndpointConfig {
+        agent_version: Some("minip2p-ffi-loopback-test".into()),
+        relays: Vec::new(),
+        listen_addr: Some("/ip4/127.0.0.1/udp/0/quic-v1".into()),
+        force_relay: false,
+        allow_unsigned: false,
+        discovery: None,
+    }
+}
+
+fn endpoint(seed: u8) -> Arc<P2pEndpoint> {
+    P2pEndpoint::new(vec![seed; 32], config()).expect("construct endpoint")
+}
+
+fn stop(endpoint: &P2pEndpoint) {
+    endpoint.stop();
+    assert!(endpoint.wait_stopped(5_000), "driver did not stop");
+}
+
+#[test]
+fn two_endpoints_chat_over_loopback() -> Result<(), FfiError> {
+    let a = endpoint(21);
+    let b = endpoint(22);
+    let a_log = Arc::new(EventLog::default());
+    let b_log = Arc::new(EventLog::default());
+    let a_peer = a.peer_id();
+    let b_peer = b.peer_id();
+
+    a.start(Arc::clone(&a_log) as Arc<dyn P2pEventListener>)?;
+    b.start(Arc::clone(&b_log) as Arc<dyn P2pEventListener>)?;
+    a.subscribe("room".into())?;
+    b.subscribe("room".into())?;
+
+    let connect_id = a.connect_addr(b.listen_addrs()[0].clone())?;
+    assert!(matches!(
+        a_log.wait_for(Duration::from_secs(5), |event| matches!(
+            event,
+            P2pEvent::PathEstablished {
+                connect_id: observed,
+                peer_id,
+                path: PathKind::DirectDialed,
+            } if *observed == connect_id && peer_id == &b_peer
+        )),
+        Some(P2pEvent::PathEstablished { .. })
+    ));
+    a.cancel_connect(connect_id)?;
+    assert!(
+        a_log
+            .wait_for(Duration::from_secs(5), |event| matches!(
+                event,
+            P2pEvent::PeerReady { peer_id, protocols }
+                if peer_id == &b_peer
+                    && protocols.iter().any(|protocol| protocol.contains("meshsub"))
+            ))
+            .is_some()
+    );
+    assert!(
+        b_log
+            .wait_for(Duration::from_secs(5), |event| matches!(
+                event,
+                P2pEvent::PeerReady { peer_id, .. } if peer_id == &a_peer
+            ))
+            .is_some()
+    );
+    assert!(
+        a_log
+            .wait_for(Duration::from_secs(5), |event| matches!(
+                event,
+                P2pEvent::PeerSubscribed { peer_id, topic }
+                    if peer_id == &b_peer && topic == "room"
+            ))
+            .is_some()
+    );
+
+    b.publish("room".into(), b"hello from b".to_vec())?;
+    assert!(
+        a_log
+            .wait_for(Duration::from_secs(5), |event| matches!(
+                event,
+                P2pEvent::Message {
+                    from_peer_id,
+                    topics,
+                    data,
+                    seqno,
+                    signed: true,
+                } if from_peer_id == &b_peer
+                    && topics == &["room".to_string()]
+                    && data == b"hello from b"
+                    && !seqno.is_empty()
+            ))
+            .is_some()
+    );
+
+    stop(&a);
+    stop(&b);
+    assert!(!a.is_running());
+    assert!(!b.is_running());
+    Ok(())
+}

--- a/crates/ffi/tests/loopback.rs
+++ b/crates/ffi/tests/loopback.rs
@@ -95,7 +95,6 @@ fn two_endpoints_chat_over_loopback() -> Result<(), FfiError> {
         )),
         Some(P2pEvent::PathEstablished { .. })
     ));
-    a.cancel_connect(connect_id)?;
     assert!(
         a_log
             .wait_for(Duration::from_secs(5), |event| matches!(

--- a/crates/ffi/tests/loopback.rs
+++ b/crates/ffi/tests/loopback.rs
@@ -429,7 +429,6 @@ fn bounded_load_preserves_order_and_accounting() -> Result<(), FfiError> {
     stop(&a);
     stop(&b);
     let stats = a.driver_stats();
-    assert!(stats.carry_high_water <= 4096);
     assert!(stats.converted > 0);
     assert!(stats.dispatch_attempted > 0);
     assert_eq!(stats.converted, stats.dispatch_attempted + stats.dropped);

--- a/crates/ffi/tests/loopback.rs
+++ b/crates/ffi/tests/loopback.rs
@@ -1,5 +1,6 @@
 //! End-to-end FFI tests over real loopback QUIC sockets.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
@@ -37,6 +38,40 @@ impl EventLog {
             }
         }
     }
+
+    fn wait_for_message_count(&self, timeout: Duration, count: usize) -> Vec<Vec<u8>> {
+        let started = Instant::now();
+        let mut events = self.events.lock().unwrap_or_else(PoisonError::into_inner);
+        loop {
+            let messages: Vec<_> = events
+                .iter()
+                .filter_map(|event| match event {
+                    P2pEvent::Message { data, .. } => Some(data.clone()),
+                    _ => None,
+                })
+                .collect();
+            if messages.len() >= count {
+                return messages;
+            }
+            let remaining = timeout.saturating_sub(started.elapsed());
+            assert!(!remaining.is_zero(), "message delivery timed out");
+            let (next, result) = self
+                .changed
+                .wait_timeout(events, remaining)
+                .unwrap_or_else(PoisonError::into_inner);
+            events = next;
+            if result.timed_out() {
+                let delivered = events
+                    .iter()
+                    .filter(|event| matches!(event, P2pEvent::Message { .. }))
+                    .count();
+                assert!(
+                    delivered >= count,
+                    "message delivery timed out: delivered {delivered} of {count}"
+                );
+            }
+        }
+    }
 }
 
 impl P2pEventListener for EventLog {
@@ -46,6 +81,34 @@ impl P2pEventListener for EventLog {
             .unwrap_or_else(PoisonError::into_inner)
             .push(event);
         self.changed.notify_all();
+    }
+}
+
+struct PanicOnceListener {
+    log: Arc<EventLog>,
+    panicked: AtomicBool,
+}
+
+struct SlowListener {
+    log: Arc<EventLog>,
+}
+
+impl P2pEventListener for SlowListener {
+    fn on_event(&self, event: P2pEvent) {
+        if matches!(event, P2pEvent::Message { .. }) {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        self.log.on_event(event);
+    }
+}
+
+impl P2pEventListener for PanicOnceListener {
+    fn on_event(&self, event: P2pEvent) {
+        if matches!(event, P2pEvent::Message { .. }) && !self.panicked.swap(true, Ordering::AcqRel)
+        {
+            panic!("injected listener panic");
+        }
+        self.log.on_event(event);
     }
 }
 
@@ -142,9 +205,145 @@ fn two_endpoints_chat_over_loopback() -> Result<(), FfiError> {
             .is_some()
     );
 
+    for index in 0_u8..10 {
+        b.publish("room".into(), vec![index])?;
+    }
+    let messages = a_log.wait_for_message_count(Duration::from_secs(5), 11);
+    assert_eq!(
+        &messages[1..],
+        &(0_u8..10).map(|index| vec![index]).collect::<Vec<_>>()
+    );
+
     stop(&a);
     stop(&b);
     assert!(!a.is_running());
     assert!(!b.is_running());
+    Ok(())
+}
+
+#[test]
+fn panicking_listener_does_not_kill_driver() -> Result<(), FfiError> {
+    let a = endpoint(23);
+    let b = endpoint(24);
+    let a_log = Arc::new(EventLog::default());
+    let b_log = Arc::new(EventLog::default());
+    let listener = Arc::new(PanicOnceListener {
+        log: Arc::clone(&a_log),
+        panicked: AtomicBool::new(false),
+    });
+    let a_peer = a.peer_id();
+
+    a.start(Arc::clone(&listener) as Arc<dyn P2pEventListener>)?;
+    b.start(Arc::clone(&b_log) as Arc<dyn P2pEventListener>)?;
+    a.subscribe("panic-room".into())?;
+    b.subscribe("panic-room".into())?;
+    a.connect_addr(b.listen_addrs()[0].clone())?;
+    assert!(
+        b_log
+            .wait_for(Duration::from_secs(5), |event| matches!(
+                event,
+                P2pEvent::PeerSubscribed { peer_id, topic }
+                    if peer_id == &a_peer && topic == "panic-room"
+            ))
+            .is_some()
+    );
+
+    b.publish("panic-room".into(), b"panic".to_vec())?;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !listener.panicked.load(Ordering::Acquire) && Instant::now() < deadline {
+        std::thread::yield_now();
+    }
+    assert!(listener.panicked.load(Ordering::Acquire));
+
+    b.publish("panic-room".into(), b"survived".to_vec())?;
+    assert!(
+        a_log
+            .wait_for(Duration::from_secs(5), |event| matches!(
+                event,
+                P2pEvent::Message { data, .. } if data == b"survived"
+            ))
+            .is_some()
+    );
+    assert!(a.is_running());
+
+    stop(&a);
+    stop(&b);
+    Ok(())
+}
+
+#[test]
+fn bounded_load_preserves_accounting_and_query_handoff() -> Result<(), FfiError> {
+    const MESSAGE_COUNT: usize = 600;
+
+    let a = endpoint(25);
+    let b = endpoint(26);
+    let a_log = Arc::new(EventLog::default());
+    let b_log = Arc::new(EventLog::default());
+    let a_peer = a.peer_id();
+    a.start(Arc::new(SlowListener {
+        log: Arc::clone(&a_log),
+    }))?;
+    b.start(Arc::clone(&b_log) as Arc<dyn P2pEventListener>)?;
+    a.set_active(true);
+    a.subscribe("load-room".into())?;
+    b.subscribe("load-room".into())?;
+    a.connect_addr(b.listen_addrs()[0].clone())?;
+    assert!(
+        b_log
+            .wait_for(Duration::from_secs(5), |event| matches!(
+                event,
+                P2pEvent::PeerSubscribed { peer_id, topic }
+                    if peer_id == &a_peer && topic == "load-room"
+            ))
+            .is_some()
+    );
+
+    let query_endpoint = Arc::clone(&a);
+    let keep_querying = Arc::new(AtomicBool::new(true));
+    let query_running = Arc::clone(&keep_querying);
+    let queries = std::thread::spawn(move || {
+        let mut maximum = Duration::ZERO;
+        let mut count = 0_u64;
+        while query_running.load(Ordering::Acquire) {
+            let started = Instant::now();
+            let _ = query_endpoint.connected_peers();
+            maximum = maximum.max(started.elapsed());
+            count += 1;
+            std::thread::yield_now();
+        }
+        (count, maximum)
+    });
+
+    for index in 0..MESSAGE_COUNT {
+        let payload = (index as u32).to_be_bytes().to_vec();
+        loop {
+            match b.publish("load-room".into(), payload.clone()) {
+                Ok(()) => break,
+                Err(FfiError::Backpressure) => std::thread::yield_now(),
+                Err(error) => return Err(error),
+            }
+        }
+    }
+    let messages = a_log.wait_for_message_count(Duration::from_secs(15), MESSAGE_COUNT);
+    let expected: Vec<_> = (0..MESSAGE_COUNT)
+        .map(|index| (index as u32).to_be_bytes().to_vec())
+        .collect();
+    assert_eq!(messages, expected);
+
+    keep_querying.store(false, Ordering::Release);
+    let (query_count, maximum_query) = queries.join().expect("query worker");
+    assert!(query_count > 0, "query worker did not run");
+    assert!(
+        maximum_query < Duration::from_millis(500),
+        "sync query starvation: max={maximum_query:?}"
+    );
+
+    stop(&a);
+    stop(&b);
+    let stats = a.driver_stats();
+    assert!(stats.carry_high_water <= 4096);
+    assert!(stats.converted > 0);
+    assert!(stats.dispatch_attempted > 0);
+    assert_eq!(stats.converted, stats.dispatch_attempted + stats.dropped);
     Ok(())
 }

--- a/crates/ffi/tests/loopback.rs
+++ b/crates/ffi/tests/loopback.rs
@@ -6,6 +6,8 @@ use std::time::{Duration, Instant};
 
 use minip2p_ffi::{EndpointConfig, FfiError, P2pEndpoint, P2pEvent, P2pEventListener, PathKind};
 
+static LOOPBACK_TEST_LOCK: Mutex<()> = Mutex::new(());
+
 #[derive(Default)]
 struct EventLog {
     events: Mutex<Vec<P2pEvent>>,
@@ -93,6 +95,55 @@ struct SlowListener {
     log: Arc<EventLog>,
 }
 
+#[derive(Default)]
+struct CallbackGate {
+    state: Mutex<(bool, bool)>,
+    changed: Condvar,
+}
+
+impl CallbackGate {
+    fn wait_until_entered(&self, timeout: Duration) -> bool {
+        let state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        let (state, _) = self
+            .changed
+            .wait_timeout_while(state, timeout, |(entered, _)| !*entered)
+            .unwrap_or_else(PoisonError::into_inner);
+        state.0
+    }
+
+    fn release(&self) {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner).1 = true;
+        self.changed.notify_all();
+    }
+}
+
+struct BlockingListener {
+    log: Arc<EventLog>,
+    gate: Arc<CallbackGate>,
+}
+
+impl P2pEventListener for BlockingListener {
+    fn on_event(&self, event: P2pEvent) {
+        if matches!(event, P2pEvent::Message { .. }) {
+            let mut state = self
+                .gate
+                .state
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            state.0 = true;
+            self.gate.changed.notify_all();
+            while !state.1 {
+                state = self
+                    .gate
+                    .changed
+                    .wait(state)
+                    .unwrap_or_else(PoisonError::into_inner);
+            }
+        }
+        self.log.on_event(event);
+    }
+}
+
 impl P2pEventListener for SlowListener {
     fn on_event(&self, event: P2pEvent) {
         if matches!(event, P2pEvent::Message { .. }) {
@@ -134,6 +185,9 @@ fn stop(endpoint: &P2pEndpoint) {
 
 #[test]
 fn two_endpoints_chat_over_loopback() -> Result<(), FfiError> {
+    let _serial = LOOPBACK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
     let a = endpoint(21);
     let b = endpoint(22);
     let a_log = Arc::new(EventLog::default());
@@ -223,6 +277,9 @@ fn two_endpoints_chat_over_loopback() -> Result<(), FfiError> {
 
 #[test]
 fn panicking_listener_does_not_kill_driver() -> Result<(), FfiError> {
+    let _serial = LOOPBACK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
     let a = endpoint(23);
     let b = endpoint(24);
     let a_log = Arc::new(EventLog::default());
@@ -272,9 +329,64 @@ fn panicking_listener_does_not_kill_driver() -> Result<(), FfiError> {
 }
 
 #[test]
-fn bounded_load_preserves_accounting_and_query_handoff() -> Result<(), FfiError> {
+fn query_completes_while_listener_callback_is_in_flight() -> Result<(), FfiError> {
+    let _serial = LOOPBACK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    let a = endpoint(27);
+    let b = endpoint(28);
+    let a_log = Arc::new(EventLog::default());
+    let b_log = Arc::new(EventLog::default());
+    let gate = Arc::new(CallbackGate::default());
+    let a_peer = a.peer_id();
+
+    a.start(Arc::new(BlockingListener {
+        log: a_log,
+        gate: Arc::clone(&gate),
+    }))?;
+    b.start(Arc::clone(&b_log) as Arc<dyn P2pEventListener>)?;
+    a.subscribe("handoff-room".into())?;
+    b.subscribe("handoff-room".into())?;
+    a.connect_addr(b.listen_addrs()[0].clone())?;
+    assert!(
+        b_log
+            .wait_for(Duration::from_secs(5), |event| matches!(
+                event,
+                P2pEvent::PeerSubscribed { peer_id, topic }
+                    if peer_id == &a_peer && topic == "handoff-room"
+            ))
+            .is_some()
+    );
+
+    b.publish("handoff-room".into(), b"block callback".to_vec())?;
+    assert!(
+        gate.wait_until_entered(Duration::from_secs(5)),
+        "listener callback did not start"
+    );
+
+    let query_endpoint = Arc::clone(&a);
+    let (sent, received) = std::sync::mpsc::sync_channel(1);
+    let query = std::thread::spawn(move || {
+        sent.send(query_endpoint.connected_peers().is_ok())
+            .expect("query result receiver");
+    });
+    let query_completed = received.recv_timeout(Duration::from_secs(1));
+    gate.release();
+    query.join().expect("query worker");
+    assert!(query_completed.expect("query blocked behind listener callback"));
+
+    stop(&a);
+    stop(&b);
+    Ok(())
+}
+
+#[test]
+fn bounded_load_preserves_order_and_accounting() -> Result<(), FfiError> {
     const MESSAGE_COUNT: usize = 600;
 
+    let _serial = LOOPBACK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
     let a = endpoint(25);
     let b = endpoint(26);
     let a_log = Arc::new(EventLog::default());
@@ -298,22 +410,6 @@ fn bounded_load_preserves_accounting_and_query_handoff() -> Result<(), FfiError>
             .is_some()
     );
 
-    let query_endpoint = Arc::clone(&a);
-    let keep_querying = Arc::new(AtomicBool::new(true));
-    let query_running = Arc::clone(&keep_querying);
-    let queries = std::thread::spawn(move || {
-        let mut maximum = Duration::ZERO;
-        let mut count = 0_u64;
-        while query_running.load(Ordering::Acquire) {
-            let started = Instant::now();
-            let _ = query_endpoint.connected_peers();
-            maximum = maximum.max(started.elapsed());
-            count += 1;
-            std::thread::yield_now();
-        }
-        (count, maximum)
-    });
-
     for index in 0..MESSAGE_COUNT {
         let payload = (index as u32).to_be_bytes().to_vec();
         loop {
@@ -329,14 +425,6 @@ fn bounded_load_preserves_accounting_and_query_handoff() -> Result<(), FfiError>
         .map(|index| (index as u32).to_be_bytes().to_vec())
         .collect();
     assert_eq!(messages, expected);
-
-    keep_querying.store(false, Ordering::Release);
-    let (query_count, maximum_query) = queries.join().expect("query worker");
-    assert!(query_count > 0, "query worker did not run");
-    assert!(
-        maximum_query < Duration::from_millis(500),
-        "sync query starvation: max={maximum_query:?}"
-    );
 
     stop(&a);
     stop(&b);

--- a/crates/ffi/tests/relayed.rs
+++ b/crates/ffi/tests/relayed.rs
@@ -3,9 +3,7 @@
 use std::sync::{Arc, Condvar, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
-use minip2p_ffi::{
-    EndpointConfig, P2pEndpoint, P2pEvent, P2pEventListener, PathKind, circuit_address,
-};
+use minip2p_ffi::{EndpointConfig, P2pEndpoint, P2pEvent, P2pEventListener, PathKind};
 
 #[path = "../../../tests/support/relay.rs"]
 mod relay_support;
@@ -119,10 +117,6 @@ fn relayed_chat_and_reservation_loss() {
             ..
         }
     ));
-    let expected_circuit =
-        circuit_address(relay_addr, b_peer.clone()).expect("compose circuit address");
-    assert!(expected_circuit.ends_with(&format!("/p2p-circuit/p2p/{b_peer}")));
-
     a.subscribe(TOPIC.into()).expect("subscribe initiator");
     b.subscribe(TOPIC.into()).expect("subscribe responder");
     let connect_id = a.connect(b_peer.clone()).expect("start relay connect");

--- a/crates/ffi/tests/relayed.rs
+++ b/crates/ffi/tests/relayed.rs
@@ -1,0 +1,179 @@
+//! End-to-end FFI coverage over a real loopback Circuit Relay v2 service.
+
+use std::sync::{Arc, Condvar, Mutex, PoisonError};
+use std::time::{Duration, Instant};
+
+use minip2p_ffi::{
+    EndpointConfig, P2pEndpoint, P2pEvent, P2pEventListener, PathKind, circuit_address,
+};
+
+#[path = "../../../tests/support/relay.rs"]
+mod relay_support;
+
+const TOPIC: &str = "ffi-relayed-room";
+const TIMEOUT: Duration = Duration::from_secs(15);
+const RELAY_LOSS_TIMEOUT: Duration = Duration::from_secs(75);
+
+#[derive(Default)]
+struct EventLog {
+    events: Mutex<Vec<P2pEvent>>,
+    changed: Condvar,
+}
+
+impl EventLog {
+    fn wait_for(&self, predicate: impl Fn(&P2pEvent) -> bool) -> P2pEvent {
+        self.wait_for_with_timeout(TIMEOUT, predicate)
+    }
+
+    fn wait_for_with_timeout(
+        &self,
+        timeout: Duration,
+        predicate: impl Fn(&P2pEvent) -> bool,
+    ) -> P2pEvent {
+        let deadline = Instant::now() + timeout;
+        let mut events = self.events.lock().unwrap_or_else(PoisonError::into_inner);
+        loop {
+            if let Some(event) = events.iter().find(|event| predicate(event)) {
+                return event.clone();
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for event; observed {events:#?}"
+            );
+            let (next, result) = self
+                .changed
+                .wait_timeout(events, remaining)
+                .unwrap_or_else(PoisonError::into_inner);
+            events = next;
+            assert!(
+                !result.timed_out() || events.iter().any(&predicate),
+                "timed out waiting for event; observed {events:#?}"
+            );
+        }
+    }
+}
+
+impl P2pEventListener for EventLog {
+    fn on_event(&self, event: P2pEvent) {
+        self.events
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(event);
+        self.changed.notify_all();
+    }
+}
+
+fn endpoint(seed: u8, relay: String) -> Arc<P2pEndpoint> {
+    P2pEndpoint::new(
+        vec![seed; 32],
+        EndpointConfig {
+            agent_version: Some("minip2p-ffi-relay-test".into()),
+            relays: vec![relay],
+            listen_addr: Some("/ip4/127.0.0.1/udp/0/quic-v1".into()),
+            force_relay: true,
+            allow_unsigned: false,
+            discovery: None,
+        },
+    )
+    .expect("construct relay endpoint")
+}
+
+fn stop(endpoint: &P2pEndpoint) {
+    endpoint.stop();
+    assert!(endpoint.wait_stopped(5_000), "driver did not stop");
+}
+
+#[test]
+fn relayed_chat_and_reservation_loss() {
+    let relay = relay_support::RelayServer::spawn();
+    let relay_addr = relay.addr().to_string();
+    let relay_peer = relay.addr().peer_id().to_base58();
+    let a = endpoint(31, relay_addr.clone());
+    let b = endpoint(32, relay_addr.clone());
+    let a_log = Arc::new(EventLog::default());
+    let b_log = Arc::new(EventLog::default());
+    let b_peer = b.peer_id();
+
+    a.start(Arc::clone(&a_log) as Arc<dyn P2pEventListener>)
+        .expect("start initiator");
+    b.start(Arc::clone(&b_log) as Arc<dyn P2pEventListener>)
+        .expect("start responder");
+
+    let reserved = b_log.wait_for(|event| {
+        matches!(
+            event,
+            P2pEvent::RelayReserved { relay_peer_id, .. } if relay_peer_id == &relay_peer
+        )
+    });
+    let reservation = b
+        .active_reservation()
+        .expect("reservation query")
+        .expect("active reservation");
+    assert_eq!(reservation.relay_peer_id, relay_peer);
+    assert_eq!(reservation.expires_unix_secs, Some(9_999_999_999));
+    assert!(matches!(
+        reserved,
+        P2pEvent::RelayReserved {
+            expires_unix_secs: Some(9_999_999_999),
+            ..
+        }
+    ));
+    let expected_circuit =
+        circuit_address(relay_addr, b_peer.clone()).expect("compose circuit address");
+    assert!(expected_circuit.ends_with(&format!("/p2p-circuit/p2p/{b_peer}")));
+
+    a.subscribe(TOPIC.into()).expect("subscribe initiator");
+    b.subscribe(TOPIC.into()).expect("subscribe responder");
+    let connect_id = a.connect(b_peer.clone()).expect("start relay connect");
+    a_log.wait_for(|event| {
+        matches!(
+            event,
+            P2pEvent::PathEstablished {
+                connect_id: found,
+                peer_id,
+                path: PathKind::Relayed { relay_peer_id },
+            } if *found == connect_id && peer_id == &b_peer && relay_peer_id == &relay_peer
+        )
+    });
+    b_log.wait_for(|event| {
+        matches!(
+            event,
+            P2pEvent::PeerSubscribed { peer_id, topic }
+                if peer_id == &a.peer_id() && topic == TOPIC
+        )
+    });
+
+    a.publish(TOPIC.into(), b"through relay".to_vec())
+        .expect("publish over relay");
+    b_log.wait_for(|event| {
+        matches!(
+            event,
+            P2pEvent::Message {
+                from_peer_id,
+                data,
+                signed: true,
+                ..
+            } if from_peer_id == &a.peer_id() && data == b"through relay"
+        )
+    });
+
+    drop(relay);
+    // Stopping the relay cannot signal an immediate close over UDP. The
+    // endpoint detects the dead relay through QUIC's 30-second idle timeout.
+    // The wider bound covers the keepalive/idle phase and slower CI scheduling.
+    b_log.wait_for_with_timeout(RELAY_LOSS_TIMEOUT, |event| {
+        matches!(
+            event,
+            P2pEvent::RelayReservationLost { relay_peer_id } if relay_peer_id == &relay_peer
+        )
+    });
+    assert!(
+        b.active_reservation()
+            .expect("reservation query after loss")
+            .is_none()
+    );
+
+    stop(&a);
+    stop(&b);
+}

--- a/crates/pubsub/src/agent.rs
+++ b/crates/pubsub/src/agent.rs
@@ -23,7 +23,7 @@ use crate::message::{
     FLOODSUB_PROTOCOL_ID, FrameDecode, MAX_RPC_SIZE, MAX_TOPIC_LEN, RawMessage, Rpc, SubOpts,
     decode_frame, encode_frame,
 };
-use crate::seen::{SeenCache, message_id};
+use crate::seen::{SeenCache, seen_message_id};
 
 /// Longest possible frame prefix; bounds the inbound reassembly buffers.
 const MAX_PREFIX_LEN: usize = 10;
@@ -268,7 +268,7 @@ impl FloodsubAgent {
         }
         self.next_seqno = self.next_seqno.wrapping_add(1);
 
-        let id = message_id(&self.local_peer_id.to_bytes(), &seqno.to_be_bytes());
+        let id = seen_message_id(&self.local_peer_id.to_bytes(), &seqno.to_be_bytes(), true);
         self.seen.insert(
             id,
             now_ms,
@@ -893,7 +893,7 @@ impl FloodsubAgent {
             }
         };
 
-        let id = message_id(&from.to_bytes(), &seqno);
+        let id = seen_message_id(&from.to_bytes(), &seqno, signed);
         if self.seen.contains(&id) {
             return; // duplicate: silent
         }

--- a/crates/pubsub/src/gossipsub/agent.rs
+++ b/crates/pubsub/src/gossipsub/agent.rs
@@ -18,7 +18,7 @@ use crate::message::{
     MAX_RPC_SIZE, MAX_TOPIC_LEN, MESHSUB_PROTOCOL_ID_V10, MESHSUB_PROTOCOL_ID_V11, RawMessage, Rpc,
     SubOpts, decode_frame, encode_frame,
 };
-use crate::seen::{MessageId, SeenCache, message_id};
+use crate::seen::{MessageId, SeenCache, message_id, seen_message_id, seen_message_id_from_wire};
 
 const MAX_PREFIX_LEN: usize = 10;
 
@@ -587,7 +587,7 @@ impl GossipsubAgent {
         self.next_seqno = self.next_seqno.wrapping_add(1);
         let id = message_id(&self.local_peer_id.to_bytes(), &seqno.to_be_bytes());
         self.seen.insert(
-            id.clone(),
+            seen_message_id(&self.local_peer_id.to_bytes(), &seqno.to_be_bytes(), true),
             now_ms,
             self.config.seen_ttl_ms,
             self.config.max_seen_messages,
@@ -1268,7 +1268,9 @@ impl GossipsubAgent {
                 if self.iwant_requested.len() >= self.config.max_iwant_ids_per_heartbeat {
                     break;
                 }
-                if self.seen.contains(&id) || self.iwant_requested.contains(&id) {
+                if self.seen.contains(&seen_message_id_from_wire(&id, true))
+                    || self.iwant_requested.contains(&id)
+                {
                     continue;
                 }
                 if !control_item_fits(&ControlItem::IWant(id.clone())) {
@@ -1314,8 +1316,9 @@ impl GossipsubAgent {
                 return;
             }
         };
-        let id = message_id(&dedup_from.to_bytes(), &dedup_seqno);
-        if self.seen.contains(&id) {
+        let signed_claim = message.signature.is_some();
+        let seen_id = seen_message_id(&dedup_from.to_bytes(), &dedup_seqno, signed_claim);
+        if self.seen.contains(&seen_id) {
             return;
         }
         let (from, seqno, signed) = match message.verify(self.config.allow_unsigned) {
@@ -1330,6 +1333,8 @@ impl GossipsubAgent {
         };
         debug_assert_eq!(from, dedup_from);
         debug_assert_eq!(seqno, dedup_seqno);
+        debug_assert_eq!(signed, signed_claim);
+        let id = message_id(&dedup_from.to_bytes(), &dedup_seqno);
         let interested_topics: Vec<String> = message
             .topic_ids
             .iter()
@@ -1340,7 +1345,7 @@ impl GossipsubAgent {
             return;
         }
         self.seen.insert(
-            id.clone(),
+            seen_id,
             now_ms,
             self.config.seen_ttl_ms,
             self.config.max_seen_messages,

--- a/crates/pubsub/src/seen.rs
+++ b/crates/pubsub/src/seen.rs
@@ -14,6 +14,24 @@ pub(crate) fn message_id(from: &[u8], seqno: &[u8]) -> MessageId {
     id
 }
 
+/// A cache-local message id that keeps authenticated and unauthenticated
+/// claims in separate namespaces.
+///
+/// The wire-visible gossipsub id remains [`message_id`]. This variant is only
+/// used by the seen cache so an unsigned message cannot reserve a signed
+/// publisher's `(from, seqno)` pair before the authentic publish arrives.
+pub(crate) fn seen_message_id(from: &[u8], seqno: &[u8], signed: bool) -> MessageId {
+    let id = message_id(from, seqno);
+    seen_message_id_from_wire(&id, signed)
+}
+
+pub(crate) fn seen_message_id_from_wire(id: &[u8], signed: bool) -> MessageId {
+    let mut namespaced = Vec::with_capacity(1 + id.len());
+    namespaced.push(u8::from(signed));
+    namespaced.extend_from_slice(id);
+    namespaced
+}
+
 /// Dedup cache for message ids.
 ///
 /// `order` is append-ordered by expiry because `now_ms` is monotonic, so

--- a/crates/pubsub/tests/agent.rs
+++ b/crates/pubsub/tests/agent.rs
@@ -779,6 +779,45 @@ fn unsigned_messages_require_the_allow_unsigned_config() {
 }
 
 #[test]
+fn unsigned_message_cannot_suppress_later_signed_message_with_same_id() {
+    let mut agent = agent_with(FloodsubConfig {
+        allow_unsigned: true,
+        ..FloodsubConfig::default()
+    });
+    agent.subscribe("t", 0).unwrap();
+    let arrival = peer(2);
+    connect(&mut agent, &arrival, 0);
+    assert!(inbound_open(&mut agent, &arrival, StreamId::new(3), 1));
+
+    let signer = keypair(9);
+    let signed = RawMessage::build_signed(&signer, "t", b"authentic".to_vec(), 5);
+    let mut unsigned = signed.clone();
+    unsigned.data = Some(b"forged".to_vec());
+    unsigned.signature = None;
+    unsigned.key = None;
+    unsigned.raw = Vec::new();
+    let frame = |message| {
+        encode_frame(
+            &Rpc {
+                publish: vec![message],
+                ..Rpc::default()
+            }
+            .encode(),
+        )
+    };
+
+    inbound_data(&mut agent, &arrival, StreamId::new(3), &frame(unsigned), 2);
+    assert!(drain_events(&mut agent).iter().any(
+        |event| matches!(event, PubsubEvent::Message { signed: false, data, .. } if data == b"forged")
+    ));
+
+    inbound_data(&mut agent, &arrival, StreamId::new(3), &frame(signed), 3);
+    assert!(drain_events(&mut agent).iter().any(
+        |event| matches!(event, PubsubEvent::Message { signed: true, data, .. } if data == b"authentic")
+    ));
+}
+
+#[test]
 fn subscription_overflow_is_transactional() {
     let mut a = agent_with(FloodsubConfig {
         max_topics_per_peer: 2,

--- a/crates/pubsub/tests/gossipsub.rs
+++ b/crates/pubsub/tests/gossipsub.rs
@@ -1190,6 +1190,62 @@ fn valid_message_delivers_once_and_invalid_signature_never_delivers() {
 }
 
 #[test]
+fn unsigned_message_cannot_suppress_later_signed_message_with_same_id() {
+    let mut agent = agent_with(GossipsubConfig {
+        allow_unsigned: true,
+        ..GossipsubConfig::default()
+    });
+    agent.subscribe("room", 0).unwrap();
+    let remote = peer(2);
+    connect(&mut agent, &remote, &[MESHSUB_PROTOCOL_ID_V11], 0);
+    let subscription = make_ready(
+        &mut agent,
+        &remote,
+        StreamId::new(4),
+        MESHSUB_PROTOCOL_ID_V11,
+        0,
+    );
+    ack(&mut agent, &remote, &subscription, 0);
+    drain_actions(&mut agent);
+    inbound_open(&mut agent, &remote, StreamId::new(5), 0);
+
+    let signer = keypair(9);
+    let signed = RawMessage::build_signed(&signer, "room", b"authentic".to_vec(), 1);
+    let mut unsigned = signed.clone();
+    unsigned.data = Some(b"forged".to_vec());
+    unsigned.signature = None;
+    unsigned.key = None;
+    unsigned.raw = Vec::new();
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            publish: vec![unsigned],
+            ..Rpc::default()
+        },
+        1,
+    );
+    assert!(drain_events(&mut agent).iter().any(
+        |event| matches!(event, PubsubEvent::Message { signed: false, data, .. } if data == b"forged")
+    ));
+
+    inbound_rpc(
+        &mut agent,
+        &remote,
+        StreamId::new(5),
+        Rpc {
+            publish: vec![signed],
+            ..Rpc::default()
+        },
+        2,
+    );
+    assert!(drain_events(&mut agent).iter().any(
+        |event| matches!(event, PubsubEvent::Message { signed: true, data, .. } if data == b"authentic")
+    ));
+}
+
+#[test]
 fn off_topic_message_is_not_cached_as_seen() {
     let mut agent = agent();
     let remote = peer(2);


### PR DESCRIPTION
## Summary

- add a UniFFI-facing endpoint wrapper with validated configuration, lifecycle management, commands, queries, and typed events
- add the interruptible background driver with bounded event carry, cancellation filtering, keepalive, overflow accounting, and panic isolation
- add direct-loopback and relay-backed integration coverage, including ordering, load, shutdown, listener panic, and callback/query handoff regressions
- document native ownership, lifecycle, address semantics, discovery constraints, queue bounds, and host-wrapper responsibilities
- pin the Android BoringSSL allocator-hook fix pending an upstream crates.io release

## Verification

- `just test`
- `just clippy`
- `just check-nostd`
- `just docs`
- `cargo +1.88 check --workspace --all-targets`
- `just fuzz 30`
- iOS physical-device runtime spike
- Android physical-device runtime spike
- direct loopback and relay-backed FFI integration tests

## Notes

- the FFI ABI and generated binding shape remain pre-1.0 and unstable
- host-side TypeScript/Swift/Kotlin queues must define their own bounds; the native carry limit does not bound host queues
- the temporary `boring`/`boring-sys` patch should be removed after an upstream release includes cloudflare/boring#518

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a UniFFI-based `minip2p-ffi` endpoint and an interruptible background driver to embed `minip2p` safely in mobile apps. Includes validated config, lifecycle controls, typed events, hardened pubsub deduplication, and stabilized end-to-end tests over loopback and relay.

- **New Features**
  - New crate `minip2p-ffi` exposing a UniFFI endpoint for React Native, Swift, and Kotlin, plus identity and relay-address helpers.
  - Validated construction; commands and queries; typed events for swarm, NAT, pubsub, and signed discovery.
  - Background driver with bounded event carry, cancellation filtering, keepalive, overflow accounting, and panic isolation; start/stop with bounded waits and listener callbacks.
  - Integration tests for direct loopback and relay paths, covering ordering, load, shutdown, and listener-panic cases; stabilized loopback CI timing; README on lifecycle and ownership.
  - Hardened pubsub dedup so unsigned messages cannot suppress later signed messages; added Floodsub and Gossipsub tests.

- **Dependencies**
  - Added `uniffi` pinned to `=0.31.0` to match host tooling.
  - Temporarily patched `boring` and `boring-sys` to a git revision to fix the Android allocator hook; remove after the upstream crates.io release.

<sup>Written for commit d735d96cf161e701b37942a7149d37e7f2673378. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

