### PR TITLE
Fix listener memory retention when dialers drop without disconnect

### DIFF
--- a/crates/minip2p/README.md
+++ b/crates/minip2p/README.md
@@ -154,6 +154,14 @@ bind is refused rather than built empty.
 `dial` resolves a `/dns*` target and dials one address per family, so a
 dual-stack peer is tried both ways; `dial_ip4` and `dial_ip6` force one.
 
+Dropping a std `Endpoint` (or calling `Endpoint::close`) disconnects
+established peers so a long-lived listener is not left waiting on the QUIC
+idle timeout (30s by default). That covers the common "dial, talk, drop the
+dialer" pattern. It does **not** replace `kill -9` or a hard network
+partition — those still wait for idle timeout. Portable endpoints keep
+explicit `shutdown(now)` because they cannot poll without a caller-supplied
+`Now`.
+
 `minip2p::Error` preserves transport failures, Sans-I/O state rejections, and
 driver-invariant failures as separate variants. Resource limits are
 configurable through `EndpointBuilder::quic_limits` and

--- a/crates/minip2p/README.md
+++ b/crates/minip2p/README.md
@@ -154,13 +154,9 @@ bind is refused rather than built empty.
 `dial` resolves a `/dns*` target and dials one address per family, so a
 dual-stack peer is tried both ways; `dial_ip4` and `dial_ip6` force one.
 
-Dropping a std `Endpoint` (or calling `Endpoint::close`) disconnects
-established peers so a long-lived listener is not left waiting on the QUIC
-idle timeout (30s by default). That covers the common "dial, talk, drop the
-dialer" pattern. It does **not** replace `kill -9` or a hard network
-partition — those still wait for idle timeout. Portable endpoints keep
-explicit `shutdown(now)` because they cannot poll without a caller-supplied
-`Now`.
+Dropping a std `Endpoint` (or `Endpoint::close`) disconnects established
+peers. That does not cover `kill -9` or a hard partition; those still wait
+for the QUIC idle timeout. Portable endpoints use explicit `shutdown(now)`.
 
 `minip2p::Error` preserves transport failures, Sans-I/O state rejections, and
 driver-invariant failures as separate variants. Resource limits are

--- a/crates/minip2p/src/portable/mod.rs
+++ b/crates/minip2p/src/portable/mod.rs
@@ -65,12 +65,8 @@ impl Endpoint {
 /// It performs no blocking and never reads a system clock. Callers drive it
 /// with [`poll`](Self::poll) and may inspect
 /// [`next_deadline`](Self::next_deadline) to decide how long their platform
-/// loop can idle.
-///
-/// Call [`shutdown`](Self::shutdown) to notify established peers before the
-/// endpoint is dropped. There is no `Drop` disconnect: this type offers
-/// [`into_runtime`](Self::into_runtime), and `Drop` cannot `poll` without a
-/// caller [`Now`]. Transport destructors still close leftover sockets.
+/// loop can idle. Call [`shutdown`](Self::shutdown) to notify peers; there
+/// is no `Drop` disconnect (`into_runtime` moves the runtime out).
 pub struct PortableEndpoint<T: Transport, E: EntropySource> {
     runtime: SwarmRuntime<T, E>,
 }
@@ -239,14 +235,6 @@ impl<T: Transport, E: EntropySource> PortableEndpoint<T, E> {
     /// transport releases listeners and in-progress connections as well as
     /// established ones. Every established peer is attempted even if an
     /// earlier close fails. The first close error wins over a later poll error.
-    ///
-    /// Portable endpoints do not implement `Drop` close: [`Self::into_runtime`]
-    /// moves the runtime out, and `Drop` cannot `poll` without a caller
-    /// `Now`. Call `shutdown` before dropping when peers should be notified.
-    /// Transport `Drop` still closes leftover TCP sockets. QUIC is std-only;
-    /// the std `Endpoint` `close`/`Drop` path covers that case.
-    /// Neither this nor std `Drop` can notify a peer after `kill -9` or a
-    /// hard partition — those wait for the transport idle timeout.
     pub fn shutdown(mut self, now: Now) -> Result<Vec<SwarmEvent>, DriverError> {
         let mut first_error = None;
         for peer_id in self.runtime.connected_peers() {

--- a/crates/minip2p/src/portable/mod.rs
+++ b/crates/minip2p/src/portable/mod.rs
@@ -66,6 +66,11 @@ impl Endpoint {
 /// with [`poll`](Self::poll) and may inspect
 /// [`next_deadline`](Self::next_deadline) to decide how long their platform
 /// loop can idle.
+///
+/// Call [`shutdown`](Self::shutdown) to notify established peers before the
+/// endpoint is dropped. There is no `Drop` disconnect: this type offers
+/// [`into_runtime`](Self::into_runtime), and `Drop` cannot `poll` without a
+/// caller [`Now`]. Transport destructors still close leftover sockets.
 pub struct PortableEndpoint<T: Transport, E: EntropySource> {
     runtime: SwarmRuntime<T, E>,
 }
@@ -234,6 +239,14 @@ impl<T: Transport, E: EntropySource> PortableEndpoint<T, E> {
     /// transport releases listeners and in-progress connections as well as
     /// established ones. Every established peer is attempted even if an
     /// earlier close fails. The first close error wins over a later poll error.
+    ///
+    /// Portable endpoints do not implement `Drop` close: [`Self::into_runtime`]
+    /// moves the runtime out, and `Drop` cannot `poll` without a caller
+    /// `Now`. Call `shutdown` before dropping when peers should be notified.
+    /// Transport `Drop` still closes leftover TCP sockets. QUIC is std-only;
+    /// the std `Endpoint` `close`/`Drop` path covers that case.
+    /// Neither this nor std `Drop` can notify a peer after `kill -9` or a
+    /// hard partition — those wait for the transport idle timeout.
     pub fn shutdown(mut self, now: Now) -> Result<Vec<SwarmEvent>, DriverError> {
         let mut first_error = None;
         for peer_id in self.runtime.connected_peers() {

--- a/crates/minip2p/src/std/mod.rs
+++ b/crates/minip2p/src/std/mod.rs
@@ -128,6 +128,15 @@ pub type EndpointSwarm = Swarm<EndpointTransport>;
 /// additionally runs the `minip2p_nat::NatAgent` traversal orchestrator:
 /// see `Endpoint::connect`, `Endpoint::wait_path`, and
 /// `Endpoint::take_nat_events`.
+///
+/// # Closing
+///
+/// [`Endpoint::close`] disconnects established peers, flushes close frames,
+/// and consumes the endpoint. Dropping without `close` still disconnects
+/// established peers as a best-effort (errors ignored, no event loop).
+/// Either path notifies a live peer promptly; neither can help after
+/// `kill -9` or a hard network partition — those wait for the transport idle
+/// timeout (30s by default on QUIC).
 pub struct Endpoint {
     swarm: EndpointSwarm,
     #[cfg(feature = "nat")]
@@ -1169,6 +1178,9 @@ impl Endpoint {
     /// mDNS becomes permanently inactive, while QUIC and the rest of the
     /// endpoint remain usable. Every interface send and every cancellation is
     /// attempted; the first mDNS socket error is returned afterwards.
+    ///
+    /// This does **not** close QUIC/TCP peers. Use [`Endpoint::close`] to
+    /// tear the endpoint down, or drop it for a best-effort disconnect.
     #[cfg(feature = "mdns")]
     pub fn shutdown(&mut self) -> Result<(), Error> {
         let result = self
@@ -1184,29 +1196,65 @@ impl Endpoint {
         result
     }
 
-    /// Gracefully closes every established peer and drives the swarm long
-    /// enough to flush transport close frames.
+    /// Gracefully closes established peers, drives close actions once, and
+    /// consumes the endpoint.
     ///
-    /// Called from [`Drop`] so abrupt endpoint teardown notifies long-lived
-    /// listeners instead of leaving their QUIC idle timers to expire.
-    fn graceful_teardown(&mut self) {
-        let peers = self.swarm.connected_peers();
-        for peer in peers {
-            let _ = self.swarm.disconnect(&peer);
+    /// This is the std counterpart of [`crate::PortableEndpoint::shutdown`].
+    /// The method is named `close` because, with the `mdns` feature,
+    /// `shutdown` already sends mDNS goodbyes without tearing down transports.
+    ///
+    /// `disconnect` on each established peer flushes `CONNECTION_CLOSE` /
+    /// TCP FIN through the transport. One non-blocking [`Swarm::poll`] then
+    /// surfaces locally queued close events. After this returns, `self` is
+    /// dropped: [`Drop`] repeats disconnect as a no-op for peers already
+    /// closing. QUIC transport `Drop` then closes any handshake still in
+    /// the connection table (idempotent if already `Closing`). TCP has no
+    /// `Drop` close loop — `Transport::close` already removed established
+    /// connections, and leftover sockets die with the provider.
+    ///
+    /// Does not wait for the remote to acknowledge. A `kill -9` or a hard
+    /// partition still falls through to the transport idle timeout.
+    pub fn close(mut self) -> Result<Vec<Event>, Error> {
+        let mut first_error = None;
+        #[cfg(feature = "mdns")]
+        if let Err(error) = self.shutdown() {
+            first_error = Some(error);
         }
-        for _ in 0..16 {
-            match self.swarm.poll() {
-                Ok(events) if events.is_empty() => break,
-                Err(_) => break,
-                Ok(_) => {}
+        if let Some(error) = self.disconnect_established()
+            && first_error.is_none()
+        {
+            first_error = Some(error);
+        }
+        let events = self.swarm.poll();
+        match first_error {
+            Some(error) => Err(error),
+            None => events,
+        }
+    }
+
+    /// Best-effort close of every peer the swarm has surfaced as connected.
+    ///
+    /// Each [`Swarm::disconnect`] already executes `CloseConnection` against
+    /// the transport, so this is enough to emit QUIC `CONNECTION_CLOSE` /
+    /// TCP FIN. It does not poll, and therefore cannot hang in [`Drop`].
+    fn disconnect_established(&mut self) -> Option<Error> {
+        let mut first_error = None;
+        for peer in self.swarm.connected_peers() {
+            if let Err(error) = self.swarm.disconnect(&peer)
+                && first_error.is_none()
+            {
+                first_error = Some(error);
             }
         }
+        first_error
     }
 }
 
 impl Drop for Endpoint {
     fn drop(&mut self) {
-        self.graceful_teardown();
+        // Errors are ignored: destructors must not panic, and a peer that
+        // is already gone is the common case after [`Endpoint::close`].
+        let _ = self.disconnect_established();
     }
 }
 

--- a/crates/minip2p/src/std/mod.rs
+++ b/crates/minip2p/src/std/mod.rs
@@ -1202,19 +1202,33 @@ impl Endpoint {
         if let Err(error) = self.shutdown() {
             first_error = Some(error);
         }
-        let expected = self.swarm.connected_peers();
+        let expected: Vec<(PeerId, ConnectionId)> = self
+            .swarm
+            .connected_peers()
+            .into_iter()
+            .filter_map(|peer| {
+                self.swarm
+                    .core()
+                    .conn_for(&peer)
+                    .map(|conn_id| (peer, conn_id))
+            })
+            .collect();
         if let Some(error) = self.disconnect_established()
             && first_error.is_none()
         {
             first_error = Some(error);
         }
-        // QUIC may still be draining; wait for ConnectionClosed.
+        // Wait for this connection's Closed, not a superseded one for the same peer.
         let drain_by = std::time::Instant::now() + std::time::Duration::from_millis(500);
         let mut events = Vec::new();
         while std::time::Instant::now() < drain_by {
-            let closed_all = expected.iter().all(|peer| {
+            let closed_all = expected.iter().all(|(peer, conn)| {
                 events.iter().any(|event| {
-                    matches!(event, Event::ConnectionClosed { peer_id, .. } if peer_id == peer)
+                    matches!(
+                        event,
+                        Event::ConnectionClosed { peer_id, conn_id }
+                            if peer_id == peer && conn_id == conn
+                    )
                 })
             });
             if closed_all {

--- a/crates/minip2p/src/std/mod.rs
+++ b/crates/minip2p/src/std/mod.rs
@@ -129,14 +129,9 @@ pub type EndpointSwarm = Swarm<EndpointTransport>;
 /// see `Endpoint::connect`, `Endpoint::wait_path`, and
 /// `Endpoint::take_nat_events`.
 ///
-/// # Closing
-///
-/// [`Endpoint::close`] disconnects established peers, flushes close frames,
-/// and consumes the endpoint. Dropping without `close` still disconnects
-/// established peers as a best-effort (errors ignored, no event loop).
-/// Either path notifies a live peer promptly; neither can help after
-/// `kill -9` or a hard network partition — those wait for the transport idle
-/// timeout (30s by default on QUIC).
+/// [`close`](Self::close) or drop disconnects established peers so a listener
+/// is not left on the QUIC idle timeout. Neither path helps after `kill -9`
+/// or a hard partition.
 pub struct Endpoint {
     swarm: EndpointSwarm,
     #[cfg(feature = "nat")]
@@ -1179,8 +1174,7 @@ impl Endpoint {
     /// endpoint remain usable. Every interface send and every cancellation is
     /// attempted; the first mDNS socket error is returned afterwards.
     ///
-    /// This does **not** close QUIC/TCP peers. Use [`Endpoint::close`] to
-    /// tear the endpoint down, or drop it for a best-effort disconnect.
+    /// This does not close QUIC/TCP peers; use [`close`](Self::close) or drop.
     #[cfg(feature = "mdns")]
     pub fn shutdown(&mut self) -> Result<(), Error> {
         let result = self
@@ -1196,25 +1190,12 @@ impl Endpoint {
         result
     }
 
-    /// Gracefully closes established peers, drives close actions once, and
-    /// consumes the endpoint.
+    /// Disconnects established peers, waits briefly for `ConnectionClosed`,
+    /// and consumes the endpoint.
     ///
-    /// This is the std counterpart of [`crate::PortableEndpoint::shutdown`].
-    /// The method is named `close` because, with the `mdns` feature,
-    /// `shutdown` already sends mDNS goodbyes without tearing down transports.
-    ///
-    /// `disconnect` on each established peer flushes `CONNECTION_CLOSE` /
-    /// TCP FIN through the transport. A short bounded [`Swarm::poll_next`]
-    /// then waits for `ConnectionClosed` so callers (and tests) can tell
-    /// `close` did the work rather than [`Drop`]. After this returns, `self`
-    /// is dropped: [`Drop`] repeats disconnect as a no-op for peers already
-    /// closing. QUIC transport `Drop` then closes any handshake still in
-    /// the connection table (idempotent if already `Closing`). TCP has no
-    /// `Drop` close loop — `Transport::close` already removed established
-    /// connections, and leftover sockets die with the provider.
-    ///
-    /// Does not wait for the remote to acknowledge. A `kill -9` or a hard
-    /// partition still falls through to the transport idle timeout.
+    /// Named `close` because `shutdown` is already used for mDNS goodbyes.
+    /// Dropping without `close` still disconnects (errors ignored). Neither
+    /// notifies a peer after `kill -9` or a hard partition.
     pub fn close(mut self) -> Result<Vec<Event>, Error> {
         let mut first_error = None;
         #[cfg(feature = "mdns")]
@@ -1227,8 +1208,7 @@ impl Endpoint {
         {
             first_error = Some(error);
         }
-        // QUIC may still be draining after `close()`; wait briefly so the
-        // caller can observe `ConnectionClosed` instead of relying on Drop.
+        // QUIC may still be draining; wait for ConnectionClosed.
         let drain_by = std::time::Instant::now() + std::time::Duration::from_millis(500);
         let mut events = Vec::new();
         while std::time::Instant::now() < drain_by {
@@ -1257,11 +1237,6 @@ impl Endpoint {
         }
     }
 
-    /// Best-effort close of every peer the swarm has surfaced as connected.
-    ///
-    /// Each [`Swarm::disconnect`] already executes `CloseConnection` against
-    /// the transport, so this is enough to emit QUIC `CONNECTION_CLOSE` /
-    /// TCP FIN. It does not poll, and therefore cannot hang in [`Drop`].
     fn disconnect_established(&mut self) -> Option<Error> {
         let mut first_error = None;
         for peer in self.swarm.connected_peers() {
@@ -1277,8 +1252,6 @@ impl Endpoint {
 
 impl Drop for Endpoint {
     fn drop(&mut self) {
-        // Errors are ignored: destructors must not panic, and a peer that
-        // is already gone is the common case after [`Endpoint::close`].
         let _ = self.disconnect_established();
     }
 }

--- a/crates/minip2p/src/std/mod.rs
+++ b/crates/minip2p/src/std/mod.rs
@@ -1190,48 +1190,31 @@ impl Endpoint {
         result
     }
 
-    /// Disconnects established peers, waits briefly for `ConnectionClosed`,
+    /// Disconnects established peers, waits briefly until none remain,
     /// and consumes the endpoint.
     ///
     /// Named `close` because `shutdown` is already used for mDNS goodbyes.
     /// Dropping without `close` still disconnects (errors ignored). Neither
-    /// notifies a peer after `kill -9` or a hard partition.
+    /// notifies a peer after `kill -9` or a hard partition. A replacement
+    /// that lands while draining is disconnected too.
     pub fn close(mut self) -> Result<Vec<Event>, Error> {
         let mut first_error = None;
         #[cfg(feature = "mdns")]
         if let Err(error) = self.shutdown() {
             first_error = Some(error);
         }
-        let expected: Vec<(PeerId, ConnectionId)> = self
-            .swarm
-            .connected_peers()
-            .into_iter()
-            .filter_map(|peer| {
-                self.swarm
-                    .core()
-                    .conn_for(&peer)
-                    .map(|conn_id| (peer, conn_id))
-            })
-            .collect();
-        if let Some(error) = self.disconnect_established()
-            && first_error.is_none()
-        {
-            first_error = Some(error);
-        }
-        // Wait for this connection's Closed, not a superseded one for the same peer.
         let drain_by = std::time::Instant::now() + std::time::Duration::from_millis(500);
         let mut events = Vec::new();
-        while std::time::Instant::now() < drain_by {
-            let closed_all = expected.iter().all(|(peer, conn)| {
-                events.iter().any(|event| {
-                    matches!(
-                        event,
-                        Event::ConnectionClosed { peer_id, conn_id }
-                            if peer_id == peer && conn_id == conn
-                    )
-                })
-            });
-            if closed_all {
+        loop {
+            if let Some(error) = self.disconnect_established()
+                && first_error.is_none()
+            {
+                first_error = Some(error);
+            }
+            if self.swarm.connected_peers().is_empty() {
+                break;
+            }
+            if std::time::Instant::now() >= drain_by {
                 break;
             }
             match self.swarm.poll_next(drain_by) {

--- a/crates/minip2p/src/std/mod.rs
+++ b/crates/minip2p/src/std/mod.rs
@@ -1183,6 +1183,31 @@ impl Endpoint {
         }
         result
     }
+
+    /// Gracefully closes every established peer and drives the swarm long
+    /// enough to flush transport close frames.
+    ///
+    /// Called from [`Drop`] so abrupt endpoint teardown notifies long-lived
+    /// listeners instead of leaving their QUIC idle timers to expire.
+    fn graceful_teardown(&mut self) {
+        let peers = self.swarm.connected_peers();
+        for peer in peers {
+            let _ = self.swarm.disconnect(&peer);
+        }
+        for _ in 0..16 {
+            match self.swarm.poll() {
+                Ok(events) if events.is_empty() => break,
+                Err(_) => break,
+                Ok(_) => {}
+            }
+        }
+    }
+}
+
+impl Drop for Endpoint {
+    fn drop(&mut self) {
+        self.graceful_teardown();
+    }
 }
 
 #[cfg(feature = "mdns")]

--- a/crates/minip2p/src/std/mod.rs
+++ b/crates/minip2p/src/std/mod.rs
@@ -1196,7 +1196,8 @@ impl Endpoint {
     /// Named `close` because `shutdown` is already used for mDNS goodbyes.
     /// Dropping without `close` still disconnects (errors ignored). Neither
     /// notifies a peer after `kill -9` or a hard partition. A replacement
-    /// that lands while draining is disconnected too.
+    /// that lands while draining is disconnected too, including a handshake
+    /// still pending when the superseded connection closes.
     pub fn close(mut self) -> Result<Vec<Event>, Error> {
         let mut first_error = None;
         #[cfg(feature = "mdns")]
@@ -1211,15 +1212,21 @@ impl Endpoint {
             {
                 first_error = Some(error);
             }
-            if self.swarm.connected_peers().is_empty() {
-                break;
-            }
             if std::time::Instant::now() >= drain_by {
                 break;
             }
-            match self.swarm.poll_next(drain_by) {
+            let polled = if self.close_drain_busy() {
+                self.swarm.poll_next(drain_by)
+            } else {
+                self.swarm.poll_next(std::time::Duration::ZERO)
+            };
+            match polled {
                 Ok(Some(event)) => events.push(event),
-                Ok(None) => break,
+                Ok(None) => {
+                    if !self.close_drain_busy() || std::time::Instant::now() >= drain_by {
+                        break;
+                    }
+                }
                 Err(error) => {
                     return match first_error {
                         Some(first) => Err(first),
@@ -1232,6 +1239,10 @@ impl Endpoint {
             Some(error) => Err(error),
             None => Ok(events),
         }
+    }
+
+    fn close_drain_busy(&self) -> bool {
+        !self.swarm.connected_peers().is_empty() || self.swarm.core().has_tracked_connections()
     }
 
     fn disconnect_established(&mut self) -> Option<Error> {

--- a/crates/minip2p/src/std/mod.rs
+++ b/crates/minip2p/src/std/mod.rs
@@ -1204,9 +1204,10 @@ impl Endpoint {
     /// `shutdown` already sends mDNS goodbyes without tearing down transports.
     ///
     /// `disconnect` on each established peer flushes `CONNECTION_CLOSE` /
-    /// TCP FIN through the transport. One non-blocking [`Swarm::poll`] then
-    /// surfaces locally queued close events. After this returns, `self` is
-    /// dropped: [`Drop`] repeats disconnect as a no-op for peers already
+    /// TCP FIN through the transport. A short bounded [`Swarm::poll_next`]
+    /// then waits for `ConnectionClosed` so callers (and tests) can tell
+    /// `close` did the work rather than [`Drop`]. After this returns, `self`
+    /// is dropped: [`Drop`] repeats disconnect as a no-op for peers already
     /// closing. QUIC transport `Drop` then closes any handshake still in
     /// the connection table (idempotent if already `Closing`). TCP has no
     /// `Drop` close loop — `Transport::close` already removed established
@@ -1220,15 +1221,39 @@ impl Endpoint {
         if let Err(error) = self.shutdown() {
             first_error = Some(error);
         }
+        let expected = self.swarm.connected_peers();
         if let Some(error) = self.disconnect_established()
             && first_error.is_none()
         {
             first_error = Some(error);
         }
-        let events = self.swarm.poll();
+        // QUIC may still be draining after `close()`; wait briefly so the
+        // caller can observe `ConnectionClosed` instead of relying on Drop.
+        let drain_by = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        let mut events = Vec::new();
+        while std::time::Instant::now() < drain_by {
+            let closed_all = expected.iter().all(|peer| {
+                events.iter().any(|event| {
+                    matches!(event, Event::ConnectionClosed { peer_id, .. } if peer_id == peer)
+                })
+            });
+            if closed_all {
+                break;
+            }
+            match self.swarm.poll_next(drain_by) {
+                Ok(Some(event)) => events.push(event),
+                Ok(None) => break,
+                Err(error) => {
+                    return match first_error {
+                        Some(first) => Err(first),
+                        None => Err(error),
+                    };
+                }
+            }
+        }
         match first_error {
             Some(error) => Err(error),
-            None => events,
+            None => Ok(events),
         }
     }
 

--- a/crates/minip2p/tests/reconnect_churn.rs
+++ b/crates/minip2p/tests/reconnect_churn.rs
@@ -1,0 +1,99 @@
+//! Regression coverage for listener state retention when dialers connect and
+//! drop without an explicit disconnect.
+
+use std::time::{Duration, Instant};
+
+use minip2p::{Endpoint, QuicLimits};
+
+const CHURN_ROUNDS: usize = 50;
+
+fn short_idle_limits() -> QuicLimits {
+    QuicLimits {
+        idle_timeout_ms: 500,
+        ..QuicLimits::default()
+    }
+}
+
+fn default_idle_limits() -> QuicLimits {
+    QuicLimits::default()
+}
+
+fn wait_peer_ready(
+    listener: &mut Endpoint,
+    dialer: &mut Endpoint,
+    listener_peer: &minip2p::PeerId,
+    dialer_peer: &minip2p::PeerId,
+) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !listener.is_peer_ready(dialer_peer) || !dialer.is_peer_ready(listener_peer) {
+        assert!(Instant::now() < deadline, "peer ready timed out");
+        let _ = listener.next_event(Duration::from_millis(10));
+        let _ = dialer.next_event(Duration::from_millis(10));
+    }
+}
+
+fn settle_listener(listener: &mut Endpoint, within: Duration) {
+    let deadline = Instant::now() + within;
+    while Instant::now() < deadline && !listener.connected_peers().is_empty() {
+        let _ = listener.next_event(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn listener_reclaims_state_after_dialer_drop_without_disconnect() {
+    let limits = short_idle_limits();
+    let mut listener = Endpoint::builder()
+        .quic_limits(default_idle_limits())
+        .bind_quic("127.0.0.1:0")
+        .expect("bind listener");
+    let listener_addr = listener.listen().expect("listener listens");
+    let listener_peer = listener.peer_id().clone();
+
+    for round in 0..CHURN_ROUNDS {
+        let mut dialer = Endpoint::builder()
+            .quic_limits(limits.clone())
+            .bind_quic("127.0.0.1:0")
+            .expect("bind dialer");
+        let dialer_peer = dialer.peer_id().clone();
+        dialer.dial(&listener_addr).expect("dial listener");
+
+        wait_peer_ready(
+            &mut listener,
+            &mut dialer,
+            &listener_peer,
+            &dialer_peer,
+        );
+
+        // Exercise one ping so identify/ping streams are opened before drop.
+        dialer.ping(&listener_peer).expect("queue ping");
+        let ping_deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < ping_deadline {
+            let _ = listener.next_event(Duration::from_millis(10));
+            let _ = dialer.next_event(Duration::from_millis(10));
+            if listener.peer_info(&dialer_peer).is_some()
+                && dialer.peer_info(&listener_peer).is_some()
+            {
+                break;
+            }
+        }
+
+        // Drop the dialer without an explicit disconnect, as spar does.
+        drop(dialer);
+
+        settle_listener(&mut listener, Duration::from_millis(500));
+
+        assert!(
+            listener.connected_peers().is_empty(),
+            "round {round}: listener still tracks connected peers {:?}",
+            listener.connected_peers()
+        );
+        assert!(
+            listener.peer_info(&dialer_peer).is_none(),
+            "round {round}: listener retained identify state for {dialer_peer}"
+        );
+        assert!(
+            listener.swarm().core().conn_for(&dialer_peer).is_none(),
+            "round {round}: listener retained a transport connection for {dialer_peer}"
+        );
+    }
+}

--- a/crates/minip2p/tests/reconnect_churn.rs
+++ b/crates/minip2p/tests/reconnect_churn.rs
@@ -1,13 +1,5 @@
-//! Regression coverage for listener state retention when dialers connect and
-//! drop without an explicit `disconnect`.
-//!
-//! The listener advertises the default 30s QUIC idle timeout. After each
-//! dialer is dropped (or `close`d), the listener must reclaim per-peer state
-//! in well under that timeout. That is the spar reconnect-churn-200 failure
-//! mode: missing `CONNECTION_CLOSE` left live quiche connections on the
-//! listener until idle expiry (~40 KB/peer RSS).
-//!
-//! Out of scope: `kill -9` and hard partitions still wait for idle timeout.
+//! Listener must reclaim per-peer state well under the default 30s QUIC idle
+//! timeout after a dialer is dropped or `close`d without `disconnect`.
 
 #![cfg(feature = "quic")]
 
@@ -94,7 +86,6 @@ fn listener_reclaims_state_after_dialer_drop_without_disconnect() {
         wait_peer_ready(&mut listener, &mut dialer, &listener_peer, &dialer_peer);
         ping_until_rtt(&mut listener, &mut dialer, &listener_peer);
 
-        // spar reconnect-churn: drop the dialer without `disconnect()`.
         drop(dialer);
 
         assert_listener_reclaimed(&mut listener, &dialer_peer, round);
@@ -113,8 +104,8 @@ fn listener_reclaims_state_after_dialer_close() {
     wait_peer_ready(&mut listener, &mut dialer, &listener_peer, &dialer_peer);
     ping_until_rtt(&mut listener, &mut dialer, &listener_peer);
 
-    // QUIC close completes only when the peer is driven; otherwise
-    // `close()` would return no events and Drop would do the real work.
+    // Drive the listener so QUIC close can complete; otherwise Drop would
+    // be the only path that notifies the peer.
     let (stop_remote, remote_stop) = std::sync::mpsc::channel();
     let remote = std::thread::spawn(move || {
         let deadline = Instant::now() + Duration::from_secs(2);
@@ -152,8 +143,7 @@ fn listener_reclaims_state_after_dialer_drop_during_handshake() {
     let dialer_peer = dialer.peer_id().clone();
     dialer.dial(&listener_addr).expect("dial listener");
 
-    // Exchange a few packets so the listener is likely holding a QUIC
-    // connection, but do not wait for Identify / PeerReady.
+    // Do not wait for Identify; the connection may still be handshaking.
     for _ in 0..8 {
         let _ = listener
             .next_event(Duration::from_millis(10))

--- a/crates/minip2p/tests/reconnect_churn.rs
+++ b/crates/minip2p/tests/reconnect_churn.rs
@@ -5,7 +5,7 @@
 
 use std::time::{Duration, Instant};
 
-use minip2p::{Endpoint, Event, PeerId};
+use minip2p::{Ed25519Keypair, Endpoint, Event, PeerId};
 
 const CHURN_ROUNDS: usize = 50;
 /// Must stay ≪ default `QuicLimits::idle_timeout_ms` (30s).
@@ -155,4 +155,75 @@ fn listener_reclaims_state_after_dialer_drop_during_handshake() {
 
     drop(dialer);
     assert_listener_reclaimed(&mut listener, &dialer_peer, 0);
+}
+
+#[test]
+fn close_drains_replacement_connection() {
+    let mut listener = bind_loopback();
+    let listener_addr = listener.listen().expect("listener listens");
+    let listener_peer = listener.peer_id().clone();
+
+    let dialer_key = Ed25519Keypair::generate();
+    let mut dialer = Endpoint::builder()
+        .identity(dialer_key.clone())
+        .bind_quic("127.0.0.1:0")
+        .expect("bind first dialer");
+    let dialer_peer = dialer.peer_id().clone();
+    dialer.dial(&listener_addr).expect("dial listener");
+    wait_peer_ready(&mut listener, &mut dialer, &listener_peer, &dialer_peer);
+
+    // Queue a same-peer handshake without polling the listener, so close()
+    // is the first drive that can supersede and establish the replacement.
+    let mut replacement = Endpoint::builder()
+        .identity(dialer_key)
+        .bind_quic("127.0.0.1:0")
+        .expect("bind replacement dialer");
+    replacement.dial(&listener_addr).expect("redial listener");
+    for _ in 0..8 {
+        let _ = replacement
+            .next_event(Duration::from_millis(10))
+            .expect("send replacement handshake");
+    }
+
+    let (stop_remote, remote_stop) = std::sync::mpsc::channel();
+    let remote = std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if remote_stop.try_recv().is_ok() {
+                break;
+            }
+            let _ = replacement
+                .next_event(Duration::from_millis(10))
+                .expect("drive replacement during close");
+        }
+        replacement
+    });
+
+    let events = listener.close().expect("close drains replacements");
+    let _ = stop_remote.send(());
+    let _replacement = remote.join().expect("replacement driver thread");
+
+    let established: Vec<_> = events
+        .iter()
+        .filter_map(|event| match event {
+            Event::ConnectionEstablished { peer_id, conn_id } if peer_id == &dialer_peer => {
+                Some(*conn_id)
+            }
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !established.is_empty(),
+        "close must observe the replacement ConnectionEstablished: {events:?}"
+    );
+    for conn_id in established {
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                Event::ConnectionClosed { peer_id, conn_id: closed }
+                    if peer_id == &dialer_peer && *closed == conn_id
+            )),
+            "close must drain the replacement {conn_id:?}: {events:?}"
+        );
+    }
 }

--- a/crates/minip2p/tests/reconnect_churn.rs
+++ b/crates/minip2p/tests/reconnect_churn.rs
@@ -1,28 +1,27 @@
 //! Regression coverage for listener state retention when dialers connect and
-//! drop without an explicit disconnect.
+//! drop without an explicit `disconnect`.
+//!
+//! The listener advertises the default 30s QUIC idle timeout. After each
+//! dialer is dropped (or `close`d), the listener must reclaim per-peer state
+//! in well under that timeout. That is the spar reconnect-churn-200 failure
+//! mode: missing `CONNECTION_CLOSE` left live quiche connections on the
+//! listener until idle expiry (~40 KB/peer RSS).
+//!
+//! Out of scope: `kill -9` and hard partitions still wait for idle timeout.
 
 use std::time::{Duration, Instant};
 
-use minip2p::{Endpoint, QuicLimits};
+use minip2p::{Endpoint, PeerId};
 
 const CHURN_ROUNDS: usize = 50;
-
-fn short_idle_limits() -> QuicLimits {
-    QuicLimits {
-        idle_timeout_ms: 500,
-        ..QuicLimits::default()
-    }
-}
-
-fn default_idle_limits() -> QuicLimits {
-    QuicLimits::default()
-}
+/// Must stay ≪ default `QuicLimits::idle_timeout_ms` (30s).
+const RECLAIM_WITHIN: Duration = Duration::from_millis(500);
 
 fn wait_peer_ready(
     listener: &mut Endpoint,
     dialer: &mut Endpoint,
-    listener_peer: &minip2p::PeerId,
-    dialer_peer: &minip2p::PeerId,
+    listener_peer: &PeerId,
+    dialer_peer: &PeerId,
 ) {
     let deadline = Instant::now() + Duration::from_secs(5);
     while !listener.is_peer_ready(dialer_peer) || !dialer.is_peer_ready(listener_peer) {
@@ -32,68 +31,80 @@ fn wait_peer_ready(
     }
 }
 
-fn settle_listener(listener: &mut Endpoint, within: Duration) {
-    let deadline = Instant::now() + within;
+fn ping_once(
+    listener: &mut Endpoint,
+    dialer: &mut Endpoint,
+    listener_peer: &PeerId,
+    dialer_peer: &PeerId,
+) {
+    dialer.ping(listener_peer).expect("queue ping");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        let _ = listener.next_event(Duration::from_millis(10));
+        let _ = dialer.next_event(Duration::from_millis(10));
+        if listener.peer_info(dialer_peer).is_some() && dialer.peer_info(listener_peer).is_some() {
+            return;
+        }
+    }
+    panic!("identify did not complete before ping deadline");
+}
+
+fn assert_listener_reclaimed(listener: &mut Endpoint, dialer_peer: &PeerId, round: usize) {
+    let deadline = Instant::now() + RECLAIM_WITHIN;
     while Instant::now() < deadline && !listener.connected_peers().is_empty() {
         let _ = listener.next_event(Duration::from_millis(10));
     }
+
+    assert!(
+        listener.connected_peers().is_empty(),
+        "round {round}: listener still tracks connected peers {:?} after {RECLAIM_WITHIN:?}",
+        listener.connected_peers()
+    );
+    assert!(
+        listener.peer_info(dialer_peer).is_none(),
+        "round {round}: listener retained identify state for {dialer_peer}"
+    );
+}
+
+fn bind_loopback() -> Endpoint {
+    Endpoint::builder()
+        .bind_quic("127.0.0.1:0")
+        .expect("bind loopback")
 }
 
 #[test]
 fn listener_reclaims_state_after_dialer_drop_without_disconnect() {
-    let limits = short_idle_limits();
-    let mut listener = Endpoint::builder()
-        .quic_limits(default_idle_limits())
-        .bind_quic("127.0.0.1:0")
-        .expect("bind listener");
+    let mut listener = bind_loopback();
     let listener_addr = listener.listen().expect("listener listens");
     let listener_peer = listener.peer_id().clone();
 
     for round in 0..CHURN_ROUNDS {
-        let mut dialer = Endpoint::builder()
-            .quic_limits(limits.clone())
-            .bind_quic("127.0.0.1:0")
-            .expect("bind dialer");
+        let mut dialer = bind_loopback();
         let dialer_peer = dialer.peer_id().clone();
         dialer.dial(&listener_addr).expect("dial listener");
 
-        wait_peer_ready(
-            &mut listener,
-            &mut dialer,
-            &listener_peer,
-            &dialer_peer,
-        );
+        wait_peer_ready(&mut listener, &mut dialer, &listener_peer, &dialer_peer);
+        ping_once(&mut listener, &mut dialer, &listener_peer, &dialer_peer);
 
-        // Exercise one ping so identify/ping streams are opened before drop.
-        dialer.ping(&listener_peer).expect("queue ping");
-        let ping_deadline = Instant::now() + Duration::from_secs(2);
-        while Instant::now() < ping_deadline {
-            let _ = listener.next_event(Duration::from_millis(10));
-            let _ = dialer.next_event(Duration::from_millis(10));
-            if listener.peer_info(&dialer_peer).is_some()
-                && dialer.peer_info(&listener_peer).is_some()
-            {
-                break;
-            }
-        }
-
-        // Drop the dialer without an explicit disconnect, as spar does.
+        // spar reconnect-churn: drop the dialer without `disconnect()`.
         drop(dialer);
 
-        settle_listener(&mut listener, Duration::from_millis(500));
-
-        assert!(
-            listener.connected_peers().is_empty(),
-            "round {round}: listener still tracks connected peers {:?}",
-            listener.connected_peers()
-        );
-        assert!(
-            listener.peer_info(&dialer_peer).is_none(),
-            "round {round}: listener retained identify state for {dialer_peer}"
-        );
-        assert!(
-            listener.swarm().core().conn_for(&dialer_peer).is_none(),
-            "round {round}: listener retained a transport connection for {dialer_peer}"
-        );
+        assert_listener_reclaimed(&mut listener, &dialer_peer, round);
     }
+}
+
+#[test]
+fn listener_reclaims_state_after_dialer_close() {
+    let mut listener = bind_loopback();
+    let listener_addr = listener.listen().expect("listener listens");
+    let listener_peer = listener.peer_id().clone();
+
+    let mut dialer = bind_loopback();
+    let dialer_peer = dialer.peer_id().clone();
+    dialer.dial(&listener_addr).expect("dial listener");
+    wait_peer_ready(&mut listener, &mut dialer, &listener_peer, &dialer_peer);
+    ping_once(&mut listener, &mut dialer, &listener_peer, &dialer_peer);
+
+    let _events = dialer.close().expect("close flushes disconnects");
+    assert_listener_reclaimed(&mut listener, &dialer_peer, 0);
 }

--- a/crates/minip2p/tests/reconnect_churn.rs
+++ b/crates/minip2p/tests/reconnect_churn.rs
@@ -13,7 +13,7 @@
 
 use std::time::{Duration, Instant};
 
-use minip2p::{Endpoint, PeerId};
+use minip2p::{Endpoint, Event, PeerId};
 
 const CHURN_ROUNDS: usize = 50;
 /// Must stay ≪ default `QuicLimits::idle_timeout_ms` (30s).
@@ -28,33 +28,39 @@ fn wait_peer_ready(
     let deadline = Instant::now() + Duration::from_secs(5);
     while !listener.is_peer_ready(dialer_peer) || !dialer.is_peer_ready(listener_peer) {
         assert!(Instant::now() < deadline, "peer ready timed out");
-        let _ = listener.next_event(Duration::from_millis(10));
-        let _ = dialer.next_event(Duration::from_millis(10));
+        let _ = listener
+            .next_event(Duration::from_millis(10))
+            .expect("drive listener toward ready");
+        let _ = dialer
+            .next_event(Duration::from_millis(10))
+            .expect("drive dialer toward ready");
     }
 }
 
-fn ping_once(
-    listener: &mut Endpoint,
-    dialer: &mut Endpoint,
-    listener_peer: &PeerId,
-    dialer_peer: &PeerId,
-) {
+fn ping_until_rtt(listener: &mut Endpoint, dialer: &mut Endpoint, listener_peer: &PeerId) {
     dialer.ping(listener_peer).expect("queue ping");
     let deadline = Instant::now() + Duration::from_secs(2);
-    while Instant::now() < deadline {
-        let _ = listener.next_event(Duration::from_millis(10));
-        let _ = dialer.next_event(Duration::from_millis(10));
-        if listener.peer_info(dialer_peer).is_some() && dialer.peer_info(listener_peer).is_some() {
-            return;
+    loop {
+        assert!(Instant::now() < deadline, "ping rtt timed out");
+        match dialer
+            .next_event(Duration::from_millis(10))
+            .expect("drive dialer ping")
+        {
+            Some(Event::PingRttMeasured { peer_id, .. }) if peer_id == *listener_peer => return,
+            _ => {}
         }
+        let _ = listener
+            .next_event(Duration::from_millis(10))
+            .expect("drive listener ping");
     }
-    panic!("identify did not complete before ping deadline");
 }
 
 fn assert_listener_reclaimed(listener: &mut Endpoint, dialer_peer: &PeerId, round: usize) {
     let deadline = Instant::now() + RECLAIM_WITHIN;
     while Instant::now() < deadline && !listener.connected_peers().is_empty() {
-        let _ = listener.next_event(Duration::from_millis(10));
+        let _ = listener
+            .next_event(Duration::from_millis(10))
+            .expect("drive listener reclaim");
     }
 
     assert!(
@@ -86,7 +92,7 @@ fn listener_reclaims_state_after_dialer_drop_without_disconnect() {
         dialer.dial(&listener_addr).expect("dial listener");
 
         wait_peer_ready(&mut listener, &mut dialer, &listener_peer, &dialer_peer);
-        ping_once(&mut listener, &mut dialer, &listener_peer, &dialer_peer);
+        ping_until_rtt(&mut listener, &mut dialer, &listener_peer);
 
         // spar reconnect-churn: drop the dialer without `disconnect()`.
         drop(dialer);
@@ -105,8 +111,58 @@ fn listener_reclaims_state_after_dialer_close() {
     let dialer_peer = dialer.peer_id().clone();
     dialer.dial(&listener_addr).expect("dial listener");
     wait_peer_ready(&mut listener, &mut dialer, &listener_peer, &dialer_peer);
-    ping_once(&mut listener, &mut dialer, &listener_peer, &dialer_peer);
+    ping_until_rtt(&mut listener, &mut dialer, &listener_peer);
 
-    let _events = dialer.close().expect("close flushes disconnects");
+    // QUIC close completes only when the peer is driven; otherwise
+    // `close()` would return no events and Drop would do the real work.
+    let (stop_remote, remote_stop) = std::sync::mpsc::channel();
+    let remote = std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if remote_stop.try_recv().is_ok() {
+                break;
+            }
+            let _ = listener
+                .next_event(Duration::from_millis(10))
+                .expect("drive listener during close");
+        }
+        listener
+    });
+
+    let events = dialer.close().expect("close flushes disconnects");
+    let _ = stop_remote.send(());
+    let mut listener = remote.join().expect("listener driver thread");
+
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            Event::ConnectionClosed { peer_id, .. } if peer_id == &listener_peer
+        )),
+        "close must surface ConnectionClosed rather than relying on Drop: {events:?}"
+    );
+    assert_listener_reclaimed(&mut listener, &dialer_peer, 0);
+}
+
+#[test]
+fn listener_reclaims_state_after_dialer_drop_during_handshake() {
+    let mut listener = bind_loopback();
+    let listener_addr = listener.listen().expect("listener listens");
+
+    let mut dialer = bind_loopback();
+    let dialer_peer = dialer.peer_id().clone();
+    dialer.dial(&listener_addr).expect("dial listener");
+
+    // Exchange a few packets so the listener is likely holding a QUIC
+    // connection, but do not wait for Identify / PeerReady.
+    for _ in 0..8 {
+        let _ = listener
+            .next_event(Duration::from_millis(10))
+            .expect("drive listener handshake");
+        let _ = dialer
+            .next_event(Duration::from_millis(10))
+            .expect("drive dialer handshake");
+    }
+
+    drop(dialer);
     assert_listener_reclaimed(&mut listener, &dialer_peer, 0);
 }

--- a/crates/minip2p/tests/reconnect_churn.rs
+++ b/crates/minip2p/tests/reconnect_churn.rs
@@ -9,6 +9,8 @@
 //!
 //! Out of scope: `kill -9` and hard partitions still wait for idle timeout.
 
+#![cfg(feature = "quic")]
+
 use std::time::{Duration, Instant};
 
 use minip2p::{Endpoint, PeerId};

--- a/crates/minip2p/tests/reconnect_churn.rs
+++ b/crates/minip2p/tests/reconnect_churn.rs
@@ -227,3 +227,77 @@ fn close_drains_replacement_connection() {
         );
     }
 }
+
+#[test]
+fn close_drains_pending_replacement_handshake() {
+    let mut listener = bind_loopback();
+    let listener_addr = listener.listen().expect("listener listens");
+    let listener_peer = listener.peer_id().clone();
+
+    let dialer_key = Ed25519Keypair::generate();
+    let mut dialer = Endpoint::builder()
+        .identity(dialer_key.clone())
+        .bind_quic("127.0.0.1:0")
+        .expect("bind first dialer");
+    let dialer_peer = dialer.peer_id().clone();
+    dialer.dial(&listener_addr).expect("dial listener");
+    wait_peer_ready(&mut listener, &mut dialer, &listener_peer, &dialer_peer);
+
+    let mut replacement = Endpoint::builder()
+        .identity(dialer_key)
+        .bind_quic("127.0.0.1:0")
+        .expect("bind replacement dialer");
+    replacement.dial(&listener_addr).expect("redial listener");
+    for _ in 0..4 {
+        let _ = replacement
+            .next_event(Duration::from_millis(10))
+            .expect("send replacement initial");
+    }
+    // Accept the Initial without waiting for Connected; close() must keep
+    // polling after the superseded peer leaves connected_peers.
+    let _ = listener
+        .next_event(Duration::from_millis(10))
+        .expect("accept replacement initial");
+
+    let (stop_remote, remote_stop) = std::sync::mpsc::channel();
+    let remote = std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if remote_stop.try_recv().is_ok() {
+                break;
+            }
+            let _ = replacement
+                .next_event(Duration::from_millis(10))
+                .expect("drive replacement during close");
+        }
+        replacement
+    });
+
+    let events = listener.close().expect("close drains pending replacement");
+    let _ = stop_remote.send(());
+    let _replacement = remote.join().expect("replacement driver thread");
+
+    let established: Vec<_> = events
+        .iter()
+        .filter_map(|event| match event {
+            Event::ConnectionEstablished { peer_id, conn_id } if peer_id == &dialer_peer => {
+                Some(*conn_id)
+            }
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !established.is_empty(),
+        "close must observe the pending replacement ConnectionEstablished: {events:?}"
+    );
+    for conn_id in established {
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                Event::ConnectionClosed { peer_id, conn_id: closed }
+                    if peer_id == &dialer_peer && *closed == conn_id
+            )),
+            "close must drain the pending replacement {conn_id:?}: {events:?}"
+        );
+    }
+}

--- a/crates/swarm/README.md
+++ b/crates/swarm/README.md
@@ -24,7 +24,7 @@ Orchestration layer that composes minip2p's protocol state machines into a singl
 - Emits `SwarmEvent::PeerReady` once the peer id is stable and the first Identify message has been processed.
 - `swarm.ping(peer_id)` opens / reuses a ping stream with no manual protocol negotiation.
 - `swarm.listen_on_bound_addrs()` starts listening on every bound transport address and returns the local `PeerAddr`s. `listen_on_bound_addr()` remains as a first-address convenience for single-socket transports.
-- `swarm.connected_peers()`, `swarm.peer_info(&peer_id)`, and `swarm.is_peer_ready(&peer_id)` expose read-only peer state.
+- `swarm.connected_peers()`, `swarm.peer_info(&peer_id)`, and `swarm.is_peer_ready(&peer_id)` expose read-only peer state. `SwarmCore::has_tracked_connections()` is also true for inbound handshakes that have not yet emitted `ConnectionEstablished`.
 - Every public `Swarm` method returns `DriverError`, keeping transport
   failures, Sans-I/O state rejections, and driver-invariant violations
   distinguishable; asynchronous action failures are emitted as

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -612,6 +612,12 @@ impl SwarmCore {
         self.established_peers.iter().cloned().collect()
     }
 
+    /// Returns whether a transport connection is still tracked, including
+    /// inbound handshakes that have not yet emitted [`SwarmEvent::ConnectionEstablished`].
+    pub fn has_tracked_connections(&self) -> bool {
+        !self.conn_to_remote_addr.is_empty()
+    }
+
     /// Returns the latest Identify information received for `peer_id`.
     pub fn peer_info(&self, peer_id: &PeerId) -> Option<&IdentifyMessage> {
         self.peer_info.get(peer_id)
@@ -2501,6 +2507,40 @@ mod tests {
             .position(|output| matches!(output, SwarmOutput::Action(SwarmAction::CloseConnection { conn_id }) if *conn_id == original))
             .expect("transport close action");
         assert!(closed_position < close_action_position);
+    }
+
+    #[test]
+    fn incoming_connection_is_tracked_before_it_is_established() {
+        let mut core = test_core();
+        let peer_id = PeerId::from_public_key_protobuf(b"pending-handshake-peer");
+        let incoming = ConnectionId::new(22);
+
+        feed(
+            &mut core,
+            TransportEvent::IncomingConnection {
+                id: incoming,
+                endpoint: ConnectionEndpoint::new(loopback_transport()),
+            },
+        );
+
+        assert!(core.has_tracked_connections());
+        assert!(core.connected_peers().is_empty());
+
+        feed(
+            &mut core,
+            TransportEvent::Connected {
+                id: incoming,
+                endpoint: ConnectionEndpoint::with_peer_id(loopback_transport(), peer_id.clone()),
+            },
+        );
+        let _ = drain_events(&mut core);
+        assert!(core.connected_peers().contains(&peer_id));
+        assert!(core.has_tracked_connections());
+
+        feed(&mut core, TransportEvent::Closed { id: incoming });
+        let _ = drain_events(&mut core);
+        assert!(core.connected_peers().is_empty());
+        assert!(!core.has_tracked_connections());
     }
 
     #[test]

--- a/crates/swarm/src/runtime.rs
+++ b/crates/swarm/src/runtime.rs
@@ -664,8 +664,9 @@ impl<T: Transport, E: EntropySource> SwarmRuntime<T, E> {
                     )));
                 }
             }
-            SwarmAction::CloseConnection { conn_id } => {
-                if let Err(e) = self.transport.close(conn_id) {
+            SwarmAction::CloseConnection { conn_id } => match self.transport.close(conn_id) {
+                Ok(()) | Err(TransportError::ConnectionNotFound { .. }) => {}
+                Err(e) => {
                     self.core
                         .handle_input(SwarmInput::RuntimeError(runtime_error(
                             SwarmErrorKind::Transport,
@@ -674,7 +675,7 @@ impl<T: Transport, E: EntropySource> SwarmRuntime<T, E> {
                             format!("close on connection {conn_id} failed: {e}"),
                         )));
                 }
-            }
+            },
         }
     }
 }
@@ -771,6 +772,12 @@ mod tests {
         /// Protocol frames written after negotiation completed. This is the
         /// wire as the remote peer would see it.
         sent: Vec<(StreamId, Vec<u8>)>,
+        /// How many times [`Transport::close`] was invoked.
+        close_count: usize,
+        /// When true, the second and later `close` calls return
+        /// [`TransportError::ConnectionNotFound`], matching TCP after the
+        /// connection has already been removed from the live map.
+        fail_second_close: bool,
     }
 
     impl ScriptedTransport {
@@ -862,7 +869,11 @@ mod tests {
             Ok(())
         }
 
-        fn close(&mut self, _: ConnectionId) -> Result<(), TransportError> {
+        fn close(&mut self, id: ConnectionId) -> Result<(), TransportError> {
+            self.close_count += 1;
+            if self.fail_second_close && self.close_count > 1 {
+                return Err(TransportError::ConnectionNotFound { id });
+            }
             Ok(())
         }
 
@@ -1157,6 +1168,36 @@ mod tests {
             runtime.transport().ping_frames(),
             vec![expected.as_slice()],
             "the ping payload on the wire must be exactly the drawn bytes"
+        );
+    }
+
+    #[test]
+    fn a_second_close_of_the_same_connection_is_not_a_runtime_error() {
+        let peer = Ed25519Keypair::generate().peer_id();
+        let conn = ConnectionId::new(1);
+        let address = "/ip4/198.51.100.7/udp/4001/quic-v1"
+            .parse()
+            .expect("endpoint");
+        let mut runtime = runtime_with(
+            ScriptedTransport {
+                initial: vec![TransportEvent::Connected {
+                    id: conn,
+                    endpoint: ConnectionEndpoint::with_peer_id(address, peer.clone()),
+                }],
+                fail_second_close: true,
+                ..ScriptedTransport::default()
+            },
+            SeqEntropy(1),
+        );
+        runtime.poll(Now::from_millis(0)).expect("connect");
+        runtime.disconnect(&peer, 1).expect("first close");
+        runtime.disconnect(&peer, 2).expect("second close");
+        let events = runtime.poll(Now::from_millis(3)).expect("poll");
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, SwarmEvent::Error(_))),
+            "already-gone close must not surface as Error: {events:?}"
         );
     }
 }

--- a/crates/swarm/src/runtime.rs
+++ b/crates/swarm/src/runtime.rs
@@ -772,11 +772,8 @@ mod tests {
         /// Protocol frames written after negotiation completed. This is the
         /// wire as the remote peer would see it.
         sent: Vec<(StreamId, Vec<u8>)>,
-        /// How many times [`Transport::close`] was invoked.
         close_count: usize,
-        /// When true, the second and later `close` calls return
-        /// [`TransportError::ConnectionNotFound`], matching TCP after the
-        /// connection has already been removed from the live map.
+        /// Second `close` returns `ConnectionNotFound` (TCP after map removal).
         fail_second_close: bool,
     }
 

--- a/transports/quic/src/connection.rs
+++ b/transports/quic/src/connection.rs
@@ -478,6 +478,17 @@ impl QuicConnection {
         pending_datagrams: &mut VecDeque<PendingDatagram>,
         max_pending_datagrams: usize,
     ) -> Result<(), TransportError> {
+        // Endpoint Drop disconnects established peers (this path) and then
+        // the transport Drop closes leftovers. A second close must not fail
+        // or send a duplicate CONNECTION_CLOSE; flush anything still queued.
+        if matches!(
+            self.state,
+            ConnectionState::Closing | ConnectionState::Closed
+        ) {
+            self.flush(socket, pending_datagrams, max_pending_datagrams)?;
+            return Ok(());
+        }
+
         match self.conn.close(true, 0x00, b"bye") {
             Ok(()) | Err(quiche::Error::Done) => {}
             Err(e) => {

--- a/transports/quic/src/connection.rs
+++ b/transports/quic/src/connection.rs
@@ -478,9 +478,6 @@ impl QuicConnection {
         pending_datagrams: &mut VecDeque<PendingDatagram>,
         max_pending_datagrams: usize,
     ) -> Result<(), TransportError> {
-        // Endpoint Drop disconnects established peers (this path) and then
-        // the transport Drop closes leftovers. A second close must not fail
-        // or send a duplicate CONNECTION_CLOSE; flush anything still queued.
         if matches!(
             self.state,
             ConnectionState::Closing | ConnectionState::Closed

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -1628,6 +1628,11 @@ fn deadline_for_timeout(now: Now, timeout: Duration) -> Deadline {
 
 impl Drop for QuicTransport {
     fn drop(&mut self) {
+        // Backstop for connections that never reached swarm `connected_peers`
+        // (still handshaking). Established peers are closed first by
+        // `Endpoint::close` / `Drop` via `Transport::close`; that leaves them
+        // in `Closing` here until `poll` observes `is_closed()`, so this loop
+        // is intentionally idempotent.
         let ids: Vec<ConnectionId> = self.connections.keys().copied().collect();
         for id in ids {
             let _ = self.close(id);

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -1628,11 +1628,8 @@ fn deadline_for_timeout(now: Now, timeout: Duration) -> Deadline {
 
 impl Drop for QuicTransport {
     fn drop(&mut self) {
-        // Backstop for connections that never reached swarm `connected_peers`
-        // (still handshaking). Established peers are closed first by
-        // `Endpoint::close` / `Drop` via `Transport::close`; that leaves them
-        // in `Closing` here until `poll` observes `is_closed()`, so this loop
-        // is intentionally idempotent.
+        // Handshakes never surfaced as connected_peers; established peers
+        // were already closed and this call is idempotent.
         let ids: Vec<ConnectionId> = self.connections.keys().copied().collect();
         for id in ids {
             let _ = self.close(id);

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -1626,6 +1626,16 @@ fn deadline_for_timeout(now: Now, timeout: Duration) -> Deadline {
     now.deadline_after(millis.max(1))
 }
 
+impl Drop for QuicTransport {
+    fn drop(&mut self) {
+        let ids: Vec<ConnectionId> = self.connections.keys().copied().collect();
+        for id in ids {
+            let _ = self.close(id);
+        }
+        let _ = self.flush_pending_datagrams();
+    }
+}
+
 impl BlockingTransport for QuicTransport {
     fn wait_for_input(&mut self, timeout: Duration) -> WaitOutcome {
         // Buffered events are work the host has yet to see; parking on socket

--- a/transports/tcp/src/transport.rs
+++ b/transports/tcp/src/transport.rs
@@ -656,6 +656,12 @@ impl<P: TcpProvider, E: EntropySource> Transport for TcpTransport<P, E> {
     }
 
     fn close(&mut self, id: ConnectionId) -> Result<(), TransportError> {
+        // Removes the connection from the live map, so a later close of the
+        // same id is `ConnectionNotFound` (a no-op for Endpoint `close` then
+        // `Drop`). There is no `Drop` impl on this type: Rust forbids extra
+        // trait bounds on `Drop`, and `TcpProvider` is required to flush.
+        // Handshakes that never became established peers are released when
+        // the provider (and its sockets) is dropped.
         let mut connection = self
             .connections
             .remove(&id)
@@ -825,15 +831,6 @@ impl<P: TcpProvider, E: EntropySource> Transport for TcpTransport<P, E> {
             .filter(|connection| connection.inbound)
             .map(|connection| connection.remote.clone())
             .collect()
-    }
-}
-
-impl<P, E> Drop for TcpTransport<P, E> {
-    fn drop(&mut self) {
-        let ids: Vec<ConnectionId> = self.connections.keys().copied().collect();
-        for id in ids {
-            let _ = self.close(id);
-        }
     }
 }
 

--- a/transports/tcp/src/transport.rs
+++ b/transports/tcp/src/transport.rs
@@ -656,12 +656,6 @@ impl<P: TcpProvider, E: EntropySource> Transport for TcpTransport<P, E> {
     }
 
     fn close(&mut self, id: ConnectionId) -> Result<(), TransportError> {
-        // Removes the connection from the live map, so a later close of the
-        // same id is `ConnectionNotFound` (a no-op for Endpoint `close` then
-        // `Drop`). There is no `Drop` impl on this type: Rust forbids extra
-        // trait bounds on `Drop`, and `TcpProvider` is required to flush.
-        // Handshakes that never became established peers are released when
-        // the provider (and its sockets) is dropped.
         let mut connection = self
             .connections
             .remove(&id)

--- a/transports/tcp/src/transport.rs
+++ b/transports/tcp/src/transport.rs
@@ -828,6 +828,15 @@ impl<P: TcpProvider, E: EntropySource> Transport for TcpTransport<P, E> {
     }
 }
 
+impl<P, E> Drop for TcpTransport<P, E> {
+    fn drop(&mut self) {
+        let ids: Vec<ConnectionId> = self.connections.keys().copied().collect();
+        for id in ids {
+            let _ = self.close(id);
+        }
+    }
+}
+
 /// Wraps a session failure as the stream error the transport contract expects.
 ///
 /// Identifier and state errors pass through: they describe the request rather


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Inspired by spar `reconnect-churn-200` (~40 KB/peer RSS growth on loopback): a long-lived listener stays up while short-lived dialer `Endpoint`s connect, identify/ping, and are dropped without calling `disconnect`. Process RSS climbed linearly and did not fall back after dialers were dropped.

## Root cause

Swarm cleanup on disconnect is already correct — `handle_connection_closed` removes `peer_to_conn`, `peer_info`, ping/identify state, and stream maps when the transport emits `TransportEvent::Closed`.

The retention path was **delayed transport teardown**:

1. Dropping a dialer `Endpoint` destroyed the QUIC socket without sending `CONNECTION_CLOSE`.
2. The listener's quiche connection stayed established until the **30s idle timeout** (default `QuicLimits::idle_timeout_ms`).
3. Under fast reconnect churn each unique dialer peer left a ~40 KB quiche connection (plus swarm maps) on the listener until timeout.

This is not intentional peer-book retention. Discovery still keeps addresses after disconnect by design.

## Fix

- **`Endpoint::close(self)`** — std counterpart of `PortableEndpoint::shutdown`. Named `close` because `Endpoint::shutdown` already sends mDNS goodbyes without tearing down transports. Disconnects established peers (that flush already sends `CONNECTION_CLOSE` / TCP FIN), then polls until there are no established peers **and** no tracked transport connections (inbound handshakes included), or 500 ms elapses. A frozen snapshot is not the completion condition: supersession can emit `ConnectionClosed` for the old id while a replacement is still pending in the transport, and `connected_peers()` is empty until that handshake emits `ConnectionEstablished`.
- **`SwarmCore::has_tracked_connections()`** — true from `IncomingConnection` until `Closed`, so `close()` keeps driving a pending replacement instead of returning on an empty `connected_peers()` set.
- **`Endpoint::Drop`** — best-effort `disconnect` of established peers only. No poll loop (cannot hang). Errors ignored (destructors must not panic).
- **`QuicTransport::Drop`** — backstop for handshakes that never reached `connected_peers`. `QuicConnection::close` is idempotent if already `Closing`/`Closed`, so Endpoint Drop then transport Drop is safe.
- **TCP** — no `Drop` impl (`Drop` cannot carry `TcpProvider` bounds). `Transport::close` removes established connections; leftover sockets die with the provider.

Drop order: `Endpoint::drop` runs first (disconnect → `transport.close`), then fields drop (`QuicTransport::drop` closes leftovers).

## Out of scope

`kill -9` and hard network partitions still wait for the transport idle timeout. This only helps when the local process can still send a close frame.

Portable endpoints keep explicit `shutdown(now)`: they cannot `poll` without a caller `Now`, and `into_runtime` cannot coexist with `Drop` without `unsafe` (forbidden). QUIC is std-only; TCP sockets still close when the provider is dropped.

## Regression tests

`crates/minip2p/tests/reconnect_churn.rs`:

- Listener uses the **default 30s idle timeout**.
- 50 rounds: dial → peer ready → ping → **drop** dialer without `disconnect`.
- Assert `connected_peers` and `peer_info` are empty within **500 ms**.
- `close()` surfaces `ConnectionClosed`.
- `close()` while a same-peer replacement is handshaking must return that `ConnectionEstablished` and its later `ConnectionClosed`, including when the replacement is still pending after the superseded connection leaves `connected_peers`.

## Verification

```bash
cargo test -p minip2p-rs --features quic --test reconnect_churn
cargo test -p minip2p-swarm incoming_connection_is_tracked_before_it_is_established -- --exact
cargo clippy -p minip2p-rs --features quic --all-targets -- -D warnings
cargo clippy -p minip2p-rs --no-default-features --features std,tcp --all-targets -- -D warnings
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20f7a1f5-0ab8-41bc-9254-99a0f230757c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20f7a1f5-0ab8-41bc-9254-99a0f230757c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops listener memory growth when short‑lived QUIC dialers are dropped without disconnect. Old: listeners kept connections until the 30 s idle timeout; new: endpoints send CONNECTION_CLOSE on close() and on drop, and close() drains ≤500 ms until no connected peers or tracked handshakes remain so listeners reclaim state promptly.

- `minip2p` (std): adds Endpoint::close(self) that disconnects established peers, then drains events until connected_peers() is empty and `SwarmCore::has_tracked_connections()` is false (≤500 ms). Drop best‑effort disconnects established peers only; `shutdown()` remains mDNS‑only. README documents that `kill -9`/hard partitions still rely on the idle timeout.
- `minip2p` (portable): clarifies explicit PortableEndpoint::shutdown(now); no drop‑driven disconnect.
- `minip2p-quic`: makes close idempotent; `QuicTransport::Drop` closes any live connections and flushes pending datagrams.
- `swarm`: exposes `SwarmCore::has_tracked_connections()` so close() drains pending inbound replacements; treats `TransportError::ConnectionNotFound` on close as success to avoid spurious errors.
- Tests: adds `reconnect_churn.rs` (gated behind `quic`) covering drop without disconnect, close() draining established and pending replacement handshakes, and drop during handshake; waits for PingRttMeasured; asserts listener reclaims state within 500 ms and that close() surfaces ConnectionClosed.

<sup>Written for commit 02c97f6967f38a82df724d58f37cc99dbc3f2855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

