### PR TITLE
Integrate Circuit Relay v2 server into Endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,6 +1280,7 @@ dependencies = [
  "minip2p-pubsub",
  "minip2p-quic",
  "minip2p-relay",
+ "minip2p-relay-server",
  "minip2p-swarm",
  "minip2p-tcp",
  "minip2p-test-support",

--- a/crates/minip2p/Cargo.toml
+++ b/crates/minip2p/Cargo.toml
@@ -28,6 +28,7 @@ std = [
     "minip2p-nat?/std",
     "minip2p-platform/std",
     "minip2p-pubsub?/std",
+    "minip2p-relay-server?/std",
     "minip2p-swarm/std",
     "minip2p-transport/std",
     "minip2p-tcp?/std",
@@ -39,6 +40,7 @@ portable-mdns = ["dep:minip2p-mdns", "dep:minip2p-discovery"]
 portable-autonat = ["smoltcp", "dep:minip2p-nat"]
 portable-relay = ["portable-autonat", "dep:minip2p-circuit"]
 nat = ["std", "dep:minip2p-circuit", "dep:minip2p-nat", "dep:getrandom"]
+relay-server = ["std", "dep:minip2p-relay-server"]
 pubsub = ["dep:minip2p-pubsub", "dep:thiserror"]
 discovery = ["nat", "pubsub", "dep:minip2p-discovery"]
 mdns = ["nat", "dep:minip2p-mdns", "dep:minip2p-discovery", "dep:thiserror"]
@@ -53,6 +55,7 @@ minip2p-mdns = { path = "../mdns", version = "0.4.1", default-features = false, 
 minip2p-nat = { path = "../nat", version = "0.4.1", default-features = false, optional = true }
 minip2p-platform = { path = "../platform", version = "0.4.1", default-features = false }
 minip2p-pubsub = { path = "../pubsub", version = "0.4.1", default-features = false, optional = true }
+minip2p-relay-server = { path = "../relay-server", version = "0.4.1", default-features = false, optional = true }
 minip2p-quic = { path = "../../transports/quic", version = "0.4.1", optional = true }
 minip2p-tcp = { path = "../../transports/tcp", version = "0.4.1", default-features = false, optional = true }
 minip2p-swarm = { path = "../swarm", version = "0.4.1", default-features = false }

--- a/crates/minip2p/README.md
+++ b/crates/minip2p/README.md
@@ -179,6 +179,38 @@ Background drivers can clone `Endpoint::wait_handle()` — a transport-neutral `
 `EndpointWake::Interrupted`; legacy event-specific waits consume interruptions
 and continue waiting until their event or deadline.
 
+## Hosting a relay server
+
+The std-only `relay-server` feature is independent of `nat`. The default
+hosting path is three lines:
+
+```rust,no_run
+let mut endpoint = minip2p::Endpoint::builder()
+    .relay_server()
+    .bind_quic("0.0.0.0:4001")?;
+# Ok::<(), minip2p::Error>(())
+```
+
+Use `relay_server_config` for validated capacity, duration, byte, control, and
+rate limits. `relay_server_announce_addrs` supplies explicit public TCP/QUIC
+addresses; it does not enable the service, and invalid shapes fail before
+binding. Runtime replacement is atomic, with an empty list returning to
+AutoNAT-confirmed addresses and then concrete listeners. Raw Identify-observed
+addresses are never promoted.
+
+`set_relay_server_accepting(false)` pauses only new reservations and circuits;
+HOP stays advertised and existing lifecycles remain active. Drain typed output
+with `take_relay_server_events`, or use `next_relay_server_event(deadline)` to
+drive the whole Endpoint while preserving unrelated application events.
+Synchronous controls return `RelayServerControlError`; failed asynchronous
+open/send/close/reset operations arrive as `RelayServerEvent::Error`.
+
+Relay-only endpoints accept and advertise inbound HOP and can open outbound
+STOP. NAT-only endpoints open outbound HOP and accept/advertise trusted STOP,
+without advertising HOP. Combined endpoints install both role sets. The Swarm
+keeps one live connection per peer; exact connection targeting by the relay
+driver relies on that invariant.
+
 When an application permanently relinquishes a stream, `Endpoint::abandon_stream`
 resets it, purges already-buffered events, and suppresses later stream events.
 Use `Endpoint::reset_stream` when those terminal events should remain visible.

--- a/crates/minip2p/src/std/mod.rs
+++ b/crates/minip2p/src/std/mod.rs
@@ -28,6 +28,11 @@
 //! both discovery sources to feed one shared peer book and automatic-dial
 //! state. Cargo features expose these APIs; the corresponding builder methods
 //! activate their drivers.
+//!
+//! The independent std-only `relay-server` feature enables the three-line
+//! `Endpoint::builder().relay_server().bind_*()` hosting path. Relay-only
+//! endpoints advertise inbound HOP and open outbound STOP; NAT-only endpoints
+//! install the trusted client roles, and combined endpoints compose both.
 
 mod dial;
 #[cfg(any(feature = "discovery", feature = "mdns"))]
@@ -38,12 +43,14 @@ mod mdns;
 mod nat;
 #[cfg(feature = "pubsub")]
 mod pubsub;
+#[cfg(feature = "relay-server")]
+mod relay_server;
 
 #[cfg(any(feature = "discovery", feature = "mdns"))]
 pub use discovery::DiscoveryError;
 #[allow(unused_imports)] // Only transport-less `std` builds leave this unused.
 use minip2p_core::Multiaddr;
-#[cfg(feature = "tcp")]
+#[cfg(any(feature = "tcp", feature = "relay-server"))]
 use minip2p_core::Protocol;
 #[cfg(any(feature = "quic", feature = "tcp"))]
 use minip2p_core::TransportKind;
@@ -75,6 +82,15 @@ pub use minip2p_pubsub::{
 pub use minip2p_quic::QuicLimits;
 #[cfg(feature = "quic")]
 use minip2p_quic::{QuicEndpoint, QuicNodeConfig};
+#[cfg(feature = "relay-server")]
+pub use minip2p_relay_server::{
+    CircuitByteCounts, CircuitCloseReason, CircuitDirection, CircuitLeg, RateLimit,
+    RelayServerAddressError, RelayServerAddressErrorKind, RelayServerConfig,
+    RelayServerConfigError, RelayServerConfigErrorKind, RelayServerEvent, RelayServerRuntimeError,
+    RelayServerRuntimeErrorKind, ReservationCloseReason, Status,
+};
+#[cfg(feature = "relay-server")]
+pub use minip2p_swarm::ConnectionCloseCause;
 use minip2p_swarm::SwarmBuilder;
 pub use minip2p_swarm::{
     Deadline, DriverError as Error, PollNext, RESERVED_PROTOCOL_IDS, RUN_UNTIL_SKIP_LIMIT, Swarm,
@@ -84,13 +100,49 @@ pub use minip2p_swarm::{
 use minip2p_tcp::{StdTcpProvider, TcpConfig, TcpTransport};
 #[cfg(any(feature = "quic", feature = "tcp"))]
 use minip2p_transport::ConnectionNamespace;
-#[cfg(feature = "tcp")]
+#[cfg(any(feature = "tcp", feature = "relay-server"))]
 use minip2p_transport::Transport;
 pub use minip2p_transport::{ConnectionId, StreamId, TransportError, TransportSet, WaitHandle};
 #[cfg(feature = "pubsub")]
 pub use pubsub::PubsubError;
 
 const DEFAULT_AGENT_VERSION: &str = "minip2p/0.1.0";
+#[cfg(feature = "relay-server")]
+const RELAY_HOP_PROTOCOL_ID: &str = "/libp2p/circuit/relay/0.2.0/hop";
+#[cfg(feature = "relay-server")]
+const RELAY_STOP_PROTOCOL_ID: &str = "/libp2p/circuit/relay/0.2.0/stop";
+
+/// Synchronous relay-server runtime control failure.
+#[cfg(feature = "relay-server")]
+#[derive(Debug)]
+pub enum RelayServerControlError {
+    /// This endpoint was not built with relay-server enablement.
+    NotConfigured,
+    /// The complete replacement contained an invalid address and was not applied.
+    InvalidAddress(RelayServerAddressError),
+}
+
+#[cfg(feature = "relay-server")]
+impl core::fmt::Display for RelayServerControlError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NotConfigured => formatter.write_str("relay server is not configured"),
+            Self::InvalidAddress(error) => {
+                write!(formatter, "invalid relay-server address: {error}")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "relay-server")]
+impl std::error::Error for RelayServerControlError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidAddress(error) => Some(error),
+            Self::NotConfigured => None,
+        }
+    }
+}
 
 /// Transport used by [`Endpoint`]. With NAT enabled, relay bridges are
 /// promoted into ordinary Noise/Yamux connections by `CircuitTransport`.
@@ -134,6 +186,8 @@ pub type EndpointSwarm = Swarm<EndpointTransport>;
 /// or a hard partition.
 pub struct Endpoint {
     swarm: EndpointSwarm,
+    #[cfg(feature = "relay-server")]
+    relay_server: Option<relay_server::RelayServerDriver>,
     #[cfg(feature = "nat")]
     nat: Option<nat::NatDriver>,
     #[cfg(feature = "pubsub")]
@@ -144,7 +198,7 @@ pub struct Endpoint {
     mdns: Option<mdns::MdnsDriver>,
     /// Application events set aside while a driver-focused wait was driving
     /// the endpoint; drained first by [`Endpoint::next_event`].
-    #[cfg(any(feature = "nat", feature = "pubsub"))]
+    #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
     pending_events: std::collections::VecDeque<Event>,
 }
 
@@ -174,7 +228,7 @@ pub enum EndpointWake {
 }
 
 /// Why one driver-aware swarm-driving step returned.
-#[cfg(any(feature = "nat", feature = "pubsub"))]
+#[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
 enum DriverPollKind {
     /// An event not owned by any agent is ready for the application.
     Application,
@@ -187,13 +241,13 @@ enum DriverPollKind {
     Deadline,
 }
 
-#[cfg(any(feature = "nat", feature = "pubsub"))]
+#[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
 struct DriverPoll {
     kind: DriverPollKind,
     event: Option<Event>,
 }
 
-#[cfg(any(feature = "nat", feature = "pubsub"))]
+#[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
 impl DriverPoll {
     fn application(event: Event) -> Self {
         Self {
@@ -438,7 +492,7 @@ impl Endpoint {
     /// close events for the stream. Repeated calls are idempotent.
     pub fn abandon_stream(&mut self, peer_id: &PeerId, stream_id: StreamId) -> Result<(), Error> {
         let result = self.swarm.abandon_stream(peer_id, stream_id);
-        #[cfg(any(feature = "nat", feature = "pubsub"))]
+        #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
         self.pending_events
             .retain(|event| !event.matches_stream(peer_id, stream_id));
         result
@@ -450,7 +504,7 @@ impl Endpoint {
     /// consumed here (never surfaced to the application); the agent's own
     /// events accumulate for `Endpoint::take_nat_events`.
     pub fn poll(&mut self) -> Result<Vec<Event>, Error> {
-        #[cfg(any(feature = "nat", feature = "pubsub"))]
+        #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
         {
             let polled = self.swarm.poll()?;
             let mut events: Vec<Event> = self.pending_events.drain(..).collect();
@@ -462,7 +516,7 @@ impl Endpoint {
             self.tick_drivers()?;
             Ok(events)
         }
-        #[cfg(not(any(feature = "nat", feature = "pubsub")))]
+        #[cfg(not(any(feature = "nat", feature = "pubsub", feature = "relay-server")))]
         {
             self.swarm.poll()
         }
@@ -474,7 +528,7 @@ impl Endpoint {
     /// [`std::time::Duration`], or [`Deadline::NEVER`] to wait indefinitely.
     pub fn next_event(&mut self, deadline: impl Into<Deadline>) -> Result<Option<Event>, Error> {
         let deadline = deadline.into();
-        #[cfg(any(feature = "nat", feature = "pubsub"))]
+        #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
         if self.has_drivers() {
             return self.next_event_driven(deadline);
         }
@@ -504,7 +558,7 @@ impl Endpoint {
     /// busy-spin a caller that expected the supplied deadline to block.
     pub fn next_wake(&mut self, deadline: impl Into<Deadline>) -> Result<EndpointWake, Error> {
         let deadline = deadline.into();
-        #[cfg(any(feature = "nat", feature = "pubsub"))]
+        #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
         if self.has_drivers() {
             if let Some(event) = self.pending_events.pop_front() {
                 return Ok(EndpointWake::Event(event));
@@ -533,8 +587,12 @@ impl Endpoint {
     }
 
     /// Whether any agent driver is active on this endpoint.
-    #[cfg(any(feature = "nat", feature = "pubsub"))]
+    #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
     fn has_drivers(&self) -> bool {
+        #[cfg(feature = "relay-server")]
+        if self.relay_server.is_some() {
+            return true;
+        }
         #[cfg(any(feature = "discovery", feature = "mdns"))]
         if self.discovery.is_some() {
             return true;
@@ -554,33 +612,44 @@ impl Endpoint {
         false
     }
 
-    /// Feeds one swarm event through the active drivers, NAT first (its
-    /// control-plane streams are never pubsub-relevant; neither agent
-    /// claims connection-lifecycle or PeerReady events, so ordering only
-    /// decides who sees its own streams).
+    /// Feeds one swarm event through relay-server, NAT, then pubsub.
+    ///
+    /// Relay service owns inbound HOP before NAT considers its client-side
+    /// streams. Neither service claims connection lifecycle or `PeerReady`,
+    /// so both still observe the shared connection state.
     ///
     /// Returns `true` when a driver claimed the event.
-    #[cfg(any(feature = "nat", feature = "pubsub"))]
+    #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
     fn ingest_into_drivers(&mut self, event: &Event) -> bool {
         #[cfg(any(feature = "discovery", feature = "mdns"))]
         if let Some(discovery) = self.discovery.as_mut() {
             discovery.observe(event, &self.swarm);
         }
         let mut claimed = false;
+        #[cfg(feature = "relay-server")]
+        if let Some(relay_server) = self.relay_server.as_mut() {
+            claimed = relay_server.ingest(event, &mut self.swarm);
+        }
         #[cfg(feature = "nat")]
-        if let Some(nat) = self.nat.as_mut() {
+        if !claimed && let Some(nat) = self.nat.as_mut() {
             claimed = nat.ingest(event, &mut self.swarm);
         }
         #[cfg(feature = "pubsub")]
         if !claimed && let Some(pubsub) = self.pubsub.as_mut() {
             claimed = pubsub.ingest(event, &mut self.swarm);
         }
+        #[cfg(any(feature = "nat", feature = "relay-server"))]
+        self.refresh_external_address_contributions();
         claimed
     }
 
     /// Ticks every active driver.
-    #[cfg(any(feature = "nat", feature = "pubsub"))]
+    #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
     fn tick_drivers(&mut self) -> Result<(), Error> {
+        #[cfg(feature = "relay-server")]
+        if let Some(relay_server) = self.relay_server.as_mut() {
+            relay_server.tick(&mut self.swarm);
+        }
         #[cfg(feature = "nat")]
         if let Some(nat) = self.nat.as_mut() {
             nat.tick(&mut self.swarm);
@@ -605,14 +674,20 @@ impl Endpoint {
                 &mut self.swarm,
             );
         }
+        #[cfg(any(feature = "nat", feature = "relay-server"))]
+        self.refresh_external_address_contributions();
         Ok(())
     }
 
     /// Application-visible events queued across every active driver; growth
     /// is the focused waits' progress signal.
-    #[cfg(any(feature = "nat", feature = "pubsub"))]
+    #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
     fn driver_events_len(&self) -> usize {
         let mut len = 0;
+        #[cfg(feature = "relay-server")]
+        if let Some(relay_server) = self.relay_server.as_ref() {
+            len += relay_server.events.len();
+        }
         #[cfg(feature = "nat")]
         if let Some(nat) = self.nat.as_ref() {
             len += nat.events.len();
@@ -630,9 +705,15 @@ impl Endpoint {
 
     /// One wait step's deadline: the caller's, shortened by whichever agent
     /// timer is due first.
-    #[cfg(any(feature = "nat", feature = "pubsub"))]
+    #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
     fn driver_step_deadline(&self, deadline: Deadline) -> Deadline {
         let mut step = deadline;
+        #[cfg(feature = "relay-server")]
+        if let Some(relay_server) = self.relay_server.as_ref()
+            && let Some(ms) = relay_server.agent.next_timeout(relay_server.now())
+        {
+            step = step.earliest(Deadline::from(std::time::Duration::from_millis(ms.max(1))));
+        }
         #[cfg(feature = "nat")]
         if let Some(nat) = self.nat.as_ref()
             && let Some(ms) = nat.agent.next_timeout(nat.now().mono_ms)
@@ -664,7 +745,7 @@ impl Endpoint {
     /// budget never overshoots an agent's next timer, agent-owned stream
     /// events are consumed instead of surfaced, and ticks run between
     /// waits.
-    #[cfg(any(feature = "nat", feature = "pubsub"))]
+    #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
     fn next_event_driven(&mut self, deadline: Deadline) -> Result<Option<Event>, Error> {
         if let Some(event) = self.pending_events.pop_front() {
             return Ok(Some(event));
@@ -686,7 +767,7 @@ impl Endpoint {
     /// this never drains `pending_events`: focused waits must leave
     /// application events aside instead of repeatedly picking up the same
     /// one.
-    #[cfg(any(feature = "nat", feature = "pubsub"))]
+    #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
     fn poll_new_event_driven(
         &mut self,
         deadline: Deadline,
@@ -743,7 +824,7 @@ impl Endpoint {
         deadline: impl Into<Deadline>,
     ) -> Result<Option<Event>, Error> {
         let deadline = deadline.into();
-        #[cfg(any(feature = "nat", feature = "pubsub"))]
+        #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
         if self.has_drivers() {
             return self.wait_for_event_driven(deadline, |event| {
                 matches!(event, Event::PeerReady { peer_id: ready, .. } if ready == peer_id)
@@ -762,7 +843,7 @@ impl Endpoint {
         deadline: impl Into<Deadline>,
     ) -> Result<Option<u64>, Error> {
         let deadline = deadline.into();
-        #[cfg(any(feature = "nat", feature = "pubsub"))]
+        #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
         let event = if self.has_drivers() {
             self.wait_for_event_driven(deadline, |event| {
                 matches!(event, Event::PingRttMeasured { peer_id: ready, .. } if ready == peer_id)
@@ -772,7 +853,7 @@ impl Endpoint {
                 matches!(event, Event::PingRttMeasured { peer_id: ready, .. } if ready == peer_id)
             })?
         };
-        #[cfg(not(any(feature = "nat", feature = "pubsub")))]
+        #[cfg(not(any(feature = "nat", feature = "pubsub", feature = "relay-server")))]
         let event = self.swarm.run_until(deadline, |event| {
             matches!(event, Event::PingRttMeasured { peer_id: ready, .. } if ready == peer_id)
         })?;
@@ -885,6 +966,134 @@ impl Endpoint {
         }
     }
 
+    /// Pauses or resumes admission of new relay reservations and circuits.
+    ///
+    /// Existing reservations and circuits remain active, and HOP remains
+    /// advertised while admission is paused.
+    #[cfg(feature = "relay-server")]
+    #[allow(clippy::result_large_err)]
+    pub fn set_relay_server_accepting(
+        &mut self,
+        accepting: bool,
+    ) -> Result<(), RelayServerControlError> {
+        let relay_server = self
+            .relay_server
+            .as_mut()
+            .ok_or(RelayServerControlError::NotConfigured)?;
+        relay_server.agent.set_accepting(accepting);
+        Ok(())
+    }
+
+    /// Atomically replaces the relay server's explicit announce-address override.
+    ///
+    /// Each address must be a concrete direct TCP or QUIC address for this
+    /// endpoint's peer id. [`RelayServerControlError::InvalidAddress`] retains
+    /// the rejected input's index and reason; on error, the previous override
+    /// remains active. An empty replacement clears the override, restoring the
+    /// confirmed-NAT-then-concrete-listener fallback order.
+    #[cfg(feature = "relay-server")]
+    #[allow(clippy::result_large_err)]
+    pub fn set_relay_server_announce_addrs(
+        &mut self,
+        addrs: Vec<Multiaddr>,
+    ) -> Result<(), RelayServerControlError> {
+        let relay_server = self
+            .relay_server
+            .as_mut()
+            .ok_or(RelayServerControlError::NotConfigured)?;
+        relay_server
+            .agent
+            .replace_announce_addrs(addrs)
+            .map_err(RelayServerControlError::InvalidAddress)?;
+        self.refresh_external_address_contributions();
+        Ok(())
+    }
+
+    /// Drains only application-visible relay-server events.
+    ///
+    /// Returns an empty vector when relay service is not configured and leaves
+    /// ordinary endpoint events untouched.
+    #[cfg(feature = "relay-server")]
+    pub fn take_relay_server_events(&mut self) -> Vec<RelayServerEvent> {
+        self.relay_server
+            .as_mut()
+            .map(|driver| driver.events.drain(..).collect())
+            .unwrap_or_default()
+    }
+
+    /// Drives the whole endpoint until a relay-server event or caller deadline.
+    ///
+    /// Ordinary endpoint events encountered while waiting are preserved for
+    /// [`Endpoint::next_event`]. Returns `Ok(None)` when relay service is absent
+    /// or the deadline expires. It can return [`Error::EventBacklogExceeded`]
+    /// when preserving those events exhausts the bounded backlog. Transport/action
+    /// failures discovered asynchronously are returned as
+    /// [`RelayServerEvent::Error`] rather than as this method's `Err` value.
+    #[cfg(feature = "relay-server")]
+    pub fn next_relay_server_event(
+        &mut self,
+        deadline: impl Into<Deadline>,
+    ) -> Result<Option<RelayServerEvent>, Error> {
+        let deadline = deadline.into();
+        let mut expired_poll_used = false;
+        loop {
+            match self.relay_server.as_mut() {
+                Some(driver) => {
+                    if let Some(event) = driver.events.pop_front() {
+                        return Ok(Some(event));
+                    }
+                }
+                None => return Ok(None),
+            }
+            self.ensure_pending_event_capacity()?;
+            let poll = self.poll_new_event_driven(deadline, &mut expired_poll_used)?;
+            match poll.kind {
+                DriverPollKind::Application => self
+                    .pending_events
+                    .push_back(poll.event.expect("application poll carries event")),
+                DriverPollKind::Progress | DriverPollKind::Interrupted => {}
+                DriverPollKind::Deadline => return Ok(None),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "nat", feature = "relay-server"))]
+    fn refresh_external_address_contributions(&mut self) {
+        #[cfg(feature = "relay-server")]
+        {
+            let listeners = concrete_relay_listener_addrs(self.swarm.transport().local_addresses());
+            #[cfg(feature = "nat")]
+            let confirmed = self
+                .nat
+                .as_ref()
+                .map(nat::NatDriver::confirmed_public_addrs)
+                .unwrap_or_default();
+            if let Some(relay_server) = self.relay_server.as_mut() {
+                let _ = relay_server.agent.set_listener_addrs(listeners);
+                #[cfg(feature = "nat")]
+                let _ = relay_server.agent.set_confirmed_addrs(confirmed);
+            }
+        }
+        let mut addresses = Vec::new();
+        #[cfg(feature = "nat")]
+        if let Some(nat) = self.nat.as_ref() {
+            for address in nat.advertised_addrs() {
+                if !addresses.contains(&address) {
+                    addresses.push(address);
+                }
+            }
+        }
+        #[cfg(feature = "relay-server")]
+        if let Some(relay_server) = self.relay_server.as_ref() {
+            for address in relay_server.agent.selected_addrs() {
+                if !addresses.contains(address) {
+                    addresses.push(address.clone());
+                }
+            }
+        }
+        self.swarm.set_external_addresses(addresses);
+    }
+
     /// Drains all queued NAT events.
     #[cfg(feature = "nat")]
     pub fn take_nat_events(&mut self) -> Vec<NatEvent> {
@@ -929,7 +1138,7 @@ impl Endpoint {
     /// Driver-aware equivalent of `Swarm::run_until`. Every swarm event
     /// goes through the active drivers, and non-matching application events
     /// are retained for [`Endpoint::next_event`].
-    #[cfg(any(feature = "nat", feature = "pubsub"))]
+    #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
     fn wait_for_event_driven<F>(
         &mut self,
         deadline: Deadline,
@@ -960,7 +1169,7 @@ impl Endpoint {
         }
     }
 
-    #[cfg(any(feature = "nat", feature = "pubsub"))]
+    #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
     fn ensure_pending_event_capacity(&self) -> Result<(), Error> {
         if self.pending_events.len() >= RUN_UNTIL_SKIP_LIMIT {
             return Err(Error::EventBacklogExceeded {
@@ -1327,6 +1536,10 @@ pub struct EndpointBuilder {
     tcp_config: TcpConfig,
     binds: Vec<Bind>,
     protocols: Vec<String>,
+    #[cfg(feature = "relay-server")]
+    relay_server_config: Option<RelayServerConfig>,
+    #[cfg(feature = "relay-server")]
+    relay_server_announce_addrs: Vec<Multiaddr>,
     #[cfg(feature = "nat")]
     nat_config: Option<NatConfig>,
     #[cfg(feature = "nat")]
@@ -1354,6 +1567,10 @@ impl Default for EndpointBuilder {
             tcp_config: TcpConfig::default(),
             binds: Vec::new(),
             protocols: Vec::new(),
+            #[cfg(feature = "relay-server")]
+            relay_server_config: None,
+            #[cfg(feature = "relay-server")]
+            relay_server_announce_addrs: Vec::new(),
             #[cfg(feature = "nat")]
             nat_config: None,
             #[cfg(feature = "nat")]
@@ -1382,6 +1599,10 @@ struct BuilderParts {
     tcp_config: TcpConfig,
     binds: Vec<Bind>,
     protocols: Vec<String>,
+    #[cfg(feature = "relay-server")]
+    relay_server_config: Option<RelayServerConfig>,
+    #[cfg(feature = "relay-server")]
+    relay_server_announce_addrs: Vec<Multiaddr>,
     #[cfg(feature = "nat")]
     nat_config: Option<NatConfig>,
     #[cfg(feature = "pubsub")]
@@ -1483,6 +1704,71 @@ impl EndpointBuilder {
             self.protocols.push(id);
         }
         self
+    }
+
+    /// Enables Circuit Relay v2 service with production-oriented defaults.
+    ///
+    /// After binding, use [`Endpoint::set_relay_server_accepting`] to pause or
+    /// resume admission and [`Endpoint::next_relay_server_event`] to consume
+    /// reservation, circuit, accounting, and asynchronous failure events.
+    #[cfg(feature = "relay-server")]
+    pub fn relay_server(mut self) -> Self {
+        self.relay_server_config
+            .get_or_insert_with(RelayServerConfig::default);
+        self
+    }
+
+    /// Enables Circuit Relay v2 service with validated custom limits.
+    ///
+    /// Returns [`RelayServerConfigError`] with the invalid field path and reason
+    /// when a required value is zero or a duration exceeds the wire encoding.
+    /// A failed call leaves the builder unchanged.
+    #[cfg(feature = "relay-server")]
+    pub fn relay_server_config(
+        mut self,
+        config: RelayServerConfig,
+    ) -> Result<Self, RelayServerConfigError> {
+        config.validate()?;
+        self.relay_server_config = Some(config);
+        Ok(self)
+    }
+
+    /// Configures advertised direct addresses without enabling relay service.
+    ///
+    /// This method validates direct TCP/QUIC shape, rejects wildcard and circuit
+    /// addresses, and checks a trailing peer id against an already-fixed builder
+    /// identity. The indexed [`RelayServerAddressError`] identifies the rejected
+    /// input and reason. When identity is not fixed yet, the peer-id match is
+    /// checked again at bind. Announce addresses alone do not enable the service;
+    /// also call [`EndpointBuilder::relay_server`] or
+    /// [`EndpointBuilder::relay_server_config`].
+    #[cfg(feature = "relay-server")]
+    #[allow(clippy::result_large_err)]
+    pub fn relay_server_announce_addrs(
+        mut self,
+        addrs: Vec<Multiaddr>,
+    ) -> Result<Self, RelayServerAddressError> {
+        let validation_peer = self
+            .keypair
+            .as_ref()
+            .map(Ed25519Keypair::peer_id)
+            .or_else(|| {
+                addrs
+                    .iter()
+                    .find_map(|address| match address.iter().last() {
+                        Some(Protocol::P2p(peer_id)) => Some(peer_id.clone()),
+                        _ => None,
+                    })
+            })
+            .unwrap_or_else(|| Ed25519Keypair::generate().peer_id());
+        let mut validator = minip2p_relay_server::RelayServerAgent::new(
+            validation_peer,
+            RelayServerConfig::default(),
+        )
+        .expect("default relay-server configuration is valid");
+        validator.replace_announce_addrs(addrs.clone())?;
+        self.relay_server_announce_addrs = addrs;
+        Ok(self)
     }
 
     /// Adds a relay for NAT traversal (circuit legs and reservations), in
@@ -1683,6 +1969,13 @@ impl EndpointBuilder {
                 config
             })
         };
+        #[cfg(feature = "relay-server")]
+        if self.relay_server_config.is_none() && !self.relay_server_announce_addrs.is_empty() {
+            return Err(TransportError::InvalidConfig {
+                reason: "relay-server announce addresses were configured, but the relay server is not enabled; call EndpointBuilder::relay_server or relay_server_config".into(),
+            }
+            .into());
+        }
         Ok(BuilderParts {
             keypair: self.keypair.unwrap_or_else(Ed25519Keypair::generate),
             agent_version: self.agent_version,
@@ -1692,6 +1985,10 @@ impl EndpointBuilder {
             tcp_config: self.tcp_config,
             binds: self.binds,
             protocols: self.protocols,
+            #[cfg(feature = "relay-server")]
+            relay_server_config: self.relay_server_config,
+            #[cfg(feature = "relay-server")]
+            relay_server_announce_addrs: self.relay_server_announce_addrs,
             #[cfg(feature = "nat")]
             nat_config,
             #[cfg(feature = "pubsub")]
@@ -1924,6 +2221,12 @@ fn build_endpoint(parts: BuilderParts, transport: TransportSet) -> Result<Endpoi
     let transport = minip2p_circuit::CircuitTransport::new_os(transport, parts.keypair.clone());
     #[allow(unused_mut)] // Mutated only by feature-gated composed services.
     let mut swarm = builder.build(transport)?;
+    #[cfg(feature = "relay-server")]
+    if parts.relay_server_config.is_some() {
+        swarm.add_inbound_protocol(RELAY_HOP_PROTOCOL_ID)?;
+        swarm.add_advertised_protocol(RELAY_HOP_PROTOCOL_ID)?;
+        swarm.add_outbound_protocol(RELAY_STOP_PROTOCOL_ID)?;
+    }
     #[cfg(feature = "nat")]
     if parts.nat_config.is_some() {
         swarm.add_outbound_protocol(minip2p_nat::HOP_PROTOCOL_ID)?;
@@ -1940,6 +2243,30 @@ fn build_endpoint(parts: BuilderParts, transport: TransportSet) -> Result<Endpoi
         let agent = minip2p_nat::NatAgent::new(swarm.local_peer_id().clone(), config);
         nat::NatDriver::new(agent, relay_addrs)
     });
+    #[cfg(feature = "relay-server")]
+    let relay_server = parts
+        .relay_server_config
+        .map(|config| -> Result<relay_server::RelayServerDriver, Error> {
+            let mut agent =
+                minip2p_relay_server::RelayServerAgent::new(swarm.local_peer_id().clone(), config)
+                    .map_err(|error| TransportError::InvalidConfig {
+                        reason: error.to_string(),
+                    })?;
+            agent
+                .replace_announce_addrs(parts.relay_server_announce_addrs)
+                .map_err(|error| TransportError::InvalidConfig {
+                    reason: error.to_string(),
+                })?;
+            agent
+                .set_listener_addrs(concrete_relay_listener_addrs(
+                    swarm.transport().local_addresses(),
+                ))
+                .map_err(|error| TransportError::InvalidConfig {
+                    reason: error.to_string(),
+                })?;
+            Ok(relay_server::RelayServerDriver::new(agent))
+        })
+        .transpose()?;
     #[cfg(feature = "discovery")]
     let discovery_config = parts.discovery_config;
     #[cfg(feature = "mdns")]
@@ -2060,6 +2387,8 @@ fn build_endpoint(parts: BuilderParts, transport: TransportSet) -> Result<Endpoi
     };
     Ok(Endpoint {
         swarm,
+        #[cfg(feature = "relay-server")]
+        relay_server,
         #[cfg(feature = "nat")]
         nat,
         #[cfg(feature = "pubsub")]
@@ -2068,9 +2397,20 @@ fn build_endpoint(parts: BuilderParts, transport: TransportSet) -> Result<Endpoi
         discovery,
         #[cfg(feature = "mdns")]
         mdns,
-        #[cfg(any(feature = "nat", feature = "pubsub"))]
+        #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
         pending_events: std::collections::VecDeque::new(),
     })
+}
+
+#[cfg(feature = "relay-server")]
+fn concrete_relay_listener_addrs(addrs: Vec<Multiaddr>) -> Vec<Multiaddr> {
+    addrs
+        .into_iter()
+        .filter(|address| {
+            !matches!(address.iter().next(), Some(Protocol::Ip4(ip)) if *ip == [0; 4])
+                && !matches!(address.iter().next(), Some(Protocol::Ip6(ip)) if *ip == [0; 16])
+        })
+        .collect()
 }
 
 #[cfg(all(test, feature = "quic"))]
@@ -3018,5 +3358,216 @@ mod tests {
             Err(PubsubError::Driver(Error::EventBacklogExceeded { limit }))
                 if limit == RUN_UNTIL_SKIP_LIMIT
         ));
+    }
+
+    #[cfg(all(feature = "relay-server", feature = "tcp"))]
+    #[test]
+    fn relay_server_builder_is_order_independent_and_announce_does_not_enable() {
+        let announce = vec!["/ip4/127.0.0.1/tcp/4001".parse().unwrap()];
+        let endpoint = Endpoint::builder()
+            .relay_server_announce_addrs(announce.clone())
+            .expect("valid announce address")
+            .relay_server()
+            .bind_tcp("127.0.0.1:0")
+            .expect("enabled relay server binds");
+        assert!(endpoint.relay_server.is_some());
+
+        let result = Endpoint::builder()
+            .relay_server_announce_addrs(announce)
+            .expect("valid announce address")
+            .bind_tcp("127.0.0.1:0");
+        let error = match result {
+            Ok(_) => panic!("announce addresses alone must not enable the service"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("relay server is not enabled"));
+    }
+
+    #[cfg(feature = "relay-server")]
+    #[test]
+    fn relay_server_builder_rejects_structurally_invalid_addresses_immediately() {
+        let wildcard = "/ip4/0.0.0.0/tcp/4001".parse().unwrap();
+        let error = match Endpoint::builder().relay_server_announce_addrs(vec![wildcard]) {
+            Ok(_) => panic!("wildcards are not announceable"),
+            Err(error) => error,
+        };
+        assert_eq!(error.index, 0);
+        assert_eq!(error.reason, RelayServerAddressErrorKind::Wildcard);
+    }
+
+    #[cfg(feature = "relay-server")]
+    #[test]
+    fn relay_server_builder_checks_announce_peer_against_fixed_identity_immediately() {
+        let identity = Ed25519Keypair::from_secret_key_bytes([91; 32]);
+        let other = Ed25519Keypair::from_secret_key_bytes([92; 32]).peer_id();
+        let address = format!("/ip4/127.0.0.1/udp/4001/quic-v1/p2p/{other}")
+            .parse()
+            .unwrap();
+        let error = match Endpoint::builder()
+            .identity(identity.clone())
+            .relay_server_announce_addrs(vec![address])
+        {
+            Ok(_) => panic!("conflicting peer id must fail immediately"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error.reason,
+            RelayServerAddressErrorKind::ConflictingPeerId { expected, found }
+                if expected == identity.peer_id() && found == other
+        ));
+    }
+
+    #[cfg(feature = "relay-server")]
+    #[test]
+    fn relay_server_runtime_controls_are_typed_and_address_replacement_is_atomic() {
+        let mut absent = Endpoint::builder()
+            .bind_quic("127.0.0.1:0")
+            .expect("bind endpoint");
+        assert!(matches!(
+            absent.set_relay_server_accepting(false),
+            Err(RelayServerControlError::NotConfigured)
+        ));
+
+        let original: Multiaddr = "/ip4/127.0.0.1/udp/4001/quic-v1".parse().unwrap();
+        let mut endpoint = Endpoint::builder()
+            .relay_server()
+            .relay_server_announce_addrs(vec![original.clone()])
+            .expect("valid initial address")
+            .bind_quic("127.0.0.1:0")
+            .expect("bind relay server");
+        let invalid = "/ip4/0.0.0.0/udp/4002/quic-v1".parse().unwrap();
+        let error = endpoint
+            .set_relay_server_announce_addrs(vec![invalid])
+            .expect_err("invalid replacement");
+        assert!(matches!(
+            error,
+            RelayServerControlError::InvalidAddress(RelayServerAddressError {
+                index: 0,
+                reason: RelayServerAddressErrorKind::Wildcard,
+                ..
+            })
+        ));
+        assert_eq!(
+            endpoint
+                .relay_server
+                .as_ref()
+                .unwrap()
+                .agent
+                .selected_addrs(),
+            core::slice::from_ref(&original)
+        );
+        endpoint
+            .set_relay_server_announce_addrs(Vec::new())
+            .expect("empty replacement clears override");
+        let selected = endpoint
+            .relay_server
+            .as_ref()
+            .unwrap()
+            .agent
+            .selected_addrs();
+        assert!(!selected.is_empty());
+        assert_ne!(selected, [original]);
+    }
+
+    #[cfg(feature = "relay-server")]
+    #[test]
+    fn wildcard_listener_binds_without_becoming_a_relay_announce_address() {
+        let endpoint = Endpoint::builder()
+            .relay_server()
+            .bind_quic("0.0.0.0:0")
+            .expect("wildcard listener may host once a usable address source appears");
+        assert!(
+            endpoint
+                .relay_server
+                .as_ref()
+                .unwrap()
+                .agent
+                .selected_addrs()
+                .is_empty()
+        );
+    }
+
+    #[cfg(feature = "relay-server")]
+    #[test]
+    fn relay_focused_wait_preserves_unrelated_events_and_reports_queue_progress() {
+        let mut endpoint = Endpoint::builder()
+            .relay_server()
+            .bind_quic("127.0.0.1:0")
+            .expect("bind relay server");
+        let unrelated = Ed25519Keypair::generate().peer_id();
+        endpoint.pending_events.push_back(Event::ConnectionClosed {
+            peer_id: unrelated.clone(),
+            conn_id: ConnectionId::new(1),
+            cause: minip2p_swarm::ConnectionCloseCause::Transport,
+        });
+        assert!(
+            endpoint
+                .next_relay_server_event(Duration::ZERO)
+                .expect("focused wait")
+                .is_none()
+        );
+        assert!(matches!(
+            endpoint.next_event(Duration::ZERO).expect("buffered event"),
+            Some(Event::ConnectionClosed { peer_id, .. }) if peer_id == unrelated
+        ));
+
+        endpoint
+            .relay_server
+            .as_mut()
+            .unwrap()
+            .events
+            .push_back(RelayServerEvent::Error(RelayServerRuntimeError {
+                kind: RelayServerRuntimeErrorKind::InternalInvariant,
+                peer_id: None,
+                detail: "test diagnostic".into(),
+            }));
+        assert!(matches!(
+            endpoint.next_wake(Duration::ZERO).expect("queue wake"),
+            EndpointWake::DriverProgress
+        ));
+        assert_eq!(endpoint.take_relay_server_events().len(), 1);
+    }
+
+    #[cfg(all(feature = "nat", feature = "relay-server"))]
+    #[test]
+    fn nat_and_relay_address_contributions_form_a_stable_first_wins_union() {
+        let mut endpoint = Endpoint::builder()
+            .nat_config(NatConfig::default())
+            .relay_server()
+            .bind_quic("127.0.0.1:0")
+            .expect("bind combined endpoint");
+        let nat_only: Multiaddr = "/ip4/203.0.113.1/udp/4001/quic-v1".parse().unwrap();
+        let duplicate: Multiaddr = "/ip4/203.0.113.2/udp/4002/quic-v1".parse().unwrap();
+        let relay_only: Multiaddr = "/ip4/203.0.113.3/udp/4003/quic-v1".parse().unwrap();
+        endpoint
+            .nat
+            .as_mut()
+            .unwrap()
+            .set_test_public_addrs(vec![nat_only.clone(), duplicate.clone()]);
+        endpoint
+            .relay_server
+            .as_mut()
+            .unwrap()
+            .agent
+            .replace_announce_addrs(vec![duplicate.clone(), relay_only.clone()])
+            .unwrap();
+        endpoint.refresh_external_address_contributions();
+        endpoint.swarm.poll().expect("refresh identify snapshot");
+        let advertised = endpoint.swarm.core().local_addresses();
+        let nat_index = advertised
+            .iter()
+            .position(|addr| addr == &nat_only)
+            .unwrap();
+        let duplicate_indices: Vec<_> = advertised
+            .iter()
+            .enumerate()
+            .filter_map(|(index, addr)| (addr == &duplicate).then_some(index))
+            .collect();
+        let relay_index = advertised
+            .iter()
+            .position(|addr| addr == &relay_only)
+            .unwrap();
+        assert_eq!(duplicate_indices.len(), 1);
+        assert!(nat_index < duplicate_indices[0] && duplicate_indices[0] < relay_index);
     }
 }

--- a/crates/minip2p/src/std/mod.rs
+++ b/crates/minip2p/src/std/mod.rs
@@ -200,6 +200,10 @@ pub struct Endpoint {
     /// the endpoint; drained first by [`Endpoint::next_event`].
     #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
     pending_events: std::collections::VecDeque<Event>,
+    /// Addresses installed by the composed NAT and relay-server drivers on the
+    /// previous refresh, kept separate from caller-owned Swarm contributions.
+    #[cfg(any(feature = "nat", feature = "relay-server"))]
+    managed_external_addresses: Vec<Multiaddr>,
 }
 
 /// Why one [`Endpoint::next_wake`] call returned.
@@ -1074,7 +1078,14 @@ impl Endpoint {
                 let _ = relay_server.agent.set_confirmed_addrs(confirmed);
             }
         }
-        let mut addresses = Vec::new();
+        let mut addresses: Vec<_> = self
+            .swarm
+            .external_addresses()
+            .iter()
+            .filter(|address| !self.managed_external_addresses.contains(address))
+            .cloned()
+            .collect();
+        let caller_address_count = addresses.len();
         #[cfg(feature = "nat")]
         if let Some(nat) = self.nat.as_ref() {
             for address in nat.advertised_addrs() {
@@ -1091,6 +1102,7 @@ impl Endpoint {
                 }
             }
         }
+        self.managed_external_addresses = addresses[caller_address_count..].to_vec();
         self.swarm.set_external_addresses(addresses);
     }
 
@@ -2399,6 +2411,8 @@ fn build_endpoint(parts: BuilderParts, transport: TransportSet) -> Result<Endpoi
         mdns,
         #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
         pending_events: std::collections::VecDeque::new(),
+        #[cfg(any(feature = "nat", feature = "relay-server"))]
+        managed_external_addresses: Vec::new(),
     })
 }
 
@@ -3569,5 +3583,27 @@ mod tests {
             .unwrap();
         assert_eq!(duplicate_indices.len(), 1);
         assert!(nat_index < duplicate_indices[0] && duplicate_indices[0] < relay_index);
+    }
+
+    #[cfg(feature = "relay-server")]
+    #[test]
+    fn relay_refresh_preserves_caller_owned_swarm_external_addresses() {
+        let mut endpoint = Endpoint::builder()
+            .relay_server()
+            .bind_quic("127.0.0.1:0")
+            .expect("bind relay endpoint");
+        let caller_owned: Multiaddr = "/ip4/203.0.113.8/udp/4008/quic-v1".parse().unwrap();
+        let relay_owned: Multiaddr = "/ip4/203.0.113.9/udp/4009/quic-v1".parse().unwrap();
+        endpoint
+            .swarm_mut()
+            .set_external_addresses(vec![caller_owned.clone()]);
+        endpoint
+            .set_relay_server_announce_addrs(vec![relay_owned.clone()])
+            .expect("replace relay addresses");
+        endpoint.swarm.poll().expect("refresh identify snapshot");
+
+        let advertised = endpoint.swarm.core().local_addresses();
+        assert!(advertised.contains(&caller_owned));
+        assert!(advertised.contains(&relay_owned));
     }
 }

--- a/crates/minip2p/src/std/mod.rs
+++ b/crates/minip2p/src/std/mod.rs
@@ -200,10 +200,10 @@ pub struct Endpoint {
     /// the endpoint; drained first by [`Endpoint::next_event`].
     #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
     pending_events: std::collections::VecDeque<Event>,
-    /// Addresses installed by the composed NAT and relay-server drivers on the
-    /// previous refresh, kept separate from caller-owned Swarm contributions.
     #[cfg(any(feature = "nat", feature = "relay-server"))]
-    managed_external_addresses: Vec<Multiaddr>,
+    caller_external_addresses: Vec<Multiaddr>,
+    #[cfg(any(feature = "nat", feature = "relay-server"))]
+    external_addresses_revision: u64,
 }
 
 /// Why one [`Endpoint::next_wake`] call returned.
@@ -1063,6 +1063,9 @@ impl Endpoint {
 
     #[cfg(any(feature = "nat", feature = "relay-server"))]
     fn refresh_external_address_contributions(&mut self) {
+        if self.swarm.external_addresses_revision() != self.external_addresses_revision {
+            self.caller_external_addresses = self.swarm.external_addresses().to_vec();
+        }
         #[cfg(feature = "relay-server")]
         {
             let listeners = concrete_relay_listener_addrs(self.swarm.transport().local_addresses());
@@ -1078,14 +1081,7 @@ impl Endpoint {
                 let _ = relay_server.agent.set_confirmed_addrs(confirmed);
             }
         }
-        let mut addresses: Vec<_> = self
-            .swarm
-            .external_addresses()
-            .iter()
-            .filter(|address| !self.managed_external_addresses.contains(address))
-            .cloned()
-            .collect();
-        let caller_address_count = addresses.len();
+        let mut addresses = self.caller_external_addresses.clone();
         #[cfg(feature = "nat")]
         if let Some(nat) = self.nat.as_ref() {
             for address in nat.advertised_addrs() {
@@ -1102,8 +1098,8 @@ impl Endpoint {
                 }
             }
         }
-        self.managed_external_addresses = addresses[caller_address_count..].to_vec();
         self.swarm.set_external_addresses(addresses);
+        self.external_addresses_revision = self.swarm.external_addresses_revision();
     }
 
     /// Drains all queued NAT events.
@@ -2412,7 +2408,9 @@ fn build_endpoint(parts: BuilderParts, transport: TransportSet) -> Result<Endpoi
         #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
         pending_events: std::collections::VecDeque::new(),
         #[cfg(any(feature = "nat", feature = "relay-server"))]
-        managed_external_addresses: Vec::new(),
+        caller_external_addresses: Vec::new(),
+        #[cfg(any(feature = "nat", feature = "relay-server"))]
+        external_addresses_revision: 0,
     })
 }
 
@@ -3605,5 +3603,28 @@ mod tests {
         let advertised = endpoint.swarm.core().local_addresses();
         assert!(advertised.contains(&caller_owned));
         assert!(advertised.contains(&relay_owned));
+    }
+
+    #[cfg(feature = "relay-server")]
+    #[test]
+    fn caller_keeps_an_address_after_the_matching_driver_contribution_clears() {
+        let mut endpoint = Endpoint::builder()
+            .relay_server()
+            .bind_quic("127.0.0.1:0")
+            .expect("bind relay endpoint");
+        let shared: Multiaddr = "/ip4/203.0.113.10/udp/4010/quic-v1".parse().unwrap();
+        endpoint
+            .set_relay_server_announce_addrs(vec![shared.clone()])
+            .expect("set relay contribution");
+        endpoint
+            .swarm_mut()
+            .set_external_addresses(vec![shared.clone()]);
+
+        endpoint
+            .set_relay_server_announce_addrs(Vec::new())
+            .expect("clear relay contribution");
+        endpoint.swarm.poll().expect("refresh identify snapshot");
+
+        assert!(endpoint.swarm.core().local_addresses().contains(&shared));
     }
 }

--- a/crates/minip2p/src/std/nat.rs
+++ b/crates/minip2p/src/std/nat.rs
@@ -123,7 +123,7 @@ impl NatDriver {
             }
             while let Some(event) = self.agent.poll_event() {
                 progressed = true;
-                self.observe(&event, swarm);
+                self.observe(&event);
                 self.events.push_back(event);
             }
             if !progressed {
@@ -137,6 +137,26 @@ impl NatDriver {
     /// Returns the latest usable NAT-orchestrated path for `peer`.
     pub(crate) fn path(&self, peer: &PeerId) -> Option<Path> {
         self.paths.get(peer).cloned()
+    }
+
+    pub(crate) fn advertised_addrs(&self) -> Vec<Multiaddr> {
+        let mut addrs = self.public_addrs.clone();
+        for (_, addr) in &self.reserved_relays {
+            if !addrs.contains(addr) {
+                addrs.push(addr.clone());
+            }
+        }
+        addrs
+    }
+
+    #[cfg(feature = "relay-server")]
+    pub(crate) fn confirmed_public_addrs(&self) -> Vec<Multiaddr> {
+        self.public_addrs.clone()
+    }
+
+    #[cfg(all(test, feature = "relay-server"))]
+    pub(crate) fn set_test_public_addrs(&mut self, addrs: Vec<Multiaddr>) {
+        self.public_addrs = addrs;
     }
 
     fn execute(&mut self, action: NatAction, swarm: &mut EndpointSwarm) {
@@ -282,9 +302,8 @@ impl NatDriver {
         true
     }
 
-    /// Keeps Identify's advertised set in sync with reservation state: a
-    /// held reservation advertises `<relay>/p2p/<relay-id>/p2p-circuit`.
-    fn observe(&mut self, event: &NatEvent, swarm: &mut EndpointSwarm) {
+    /// Updates NAT's address contribution after a lifecycle event.
+    fn observe(&mut self, event: &NatEvent) {
         match event {
             NatEvent::PathEstablished { peer, path, .. } => {
                 self.paths.insert(peer.clone(), path.clone());
@@ -309,14 +328,9 @@ impl NatDriver {
                 circuit.push(Protocol::P2p(relay.clone()));
                 circuit.push(Protocol::P2pCircuit);
                 self.reserved_relays.push((relay.clone(), circuit));
-                self.advertise(swarm);
             }
             NatEvent::RelayReservationLost { relay } => {
-                let before = self.reserved_relays.len();
                 self.reserved_relays.retain(|(peer, _)| peer != relay);
-                if self.reserved_relays.len() != before {
-                    self.advertise(swarm);
-                }
             }
             NatEvent::ReachabilityChanged {
                 confirmed_addrs: addrs,
@@ -326,20 +340,9 @@ impl NatDriver {
                 if self.public_addrs != *addrs =>
             {
                 self.public_addrs = addrs.clone();
-                self.advertise(swarm);
             }
             _ => {}
         }
-    }
-
-    fn advertise(&self, swarm: &mut EndpointSwarm) {
-        let mut addrs = self.public_addrs.clone();
-        for (_, addr) in &self.reserved_relays {
-            if !addrs.contains(addr) {
-                addrs.push(addr.clone());
-            }
-        }
-        swarm.set_external_addresses(addrs);
     }
 }
 
@@ -559,30 +562,31 @@ mod tests {
         let public: Multiaddr = "/ip4/203.0.113.9/udp/4001/quic-v1"
             .parse()
             .expect("public addr");
-        let Endpoint { swarm, nat, .. } = &mut endpoint;
-        let driver = nat.as_mut().expect("NAT configured");
-
-        driver.observe(
-            &NatEvent::ReachabilityChanged {
+        endpoint
+            .nat
+            .as_mut()
+            .expect("NAT configured")
+            .observe(&NatEvent::ReachabilityChanged {
                 old: ReachabilityState::Unknown,
                 new: ReachabilityState::Public,
                 confirmed_addrs: vec![public.clone()],
-            },
-            swarm,
-        );
-        swarm.poll().expect("refresh identify addresses");
-        assert!(swarm.core().local_addresses().contains(&public));
+            });
+        endpoint.refresh_external_address_contributions();
+        endpoint.swarm.poll().expect("refresh identify addresses");
+        assert!(endpoint.swarm.core().local_addresses().contains(&public));
 
-        driver.observe(
-            &NatEvent::ReachabilityChanged {
+        endpoint
+            .nat
+            .as_mut()
+            .expect("NAT configured")
+            .observe(&NatEvent::ReachabilityChanged {
                 old: ReachabilityState::Public,
                 new: ReachabilityState::Private,
                 confirmed_addrs: Vec::new(),
-            },
-            swarm,
-        );
-        swarm.poll().expect("refresh identify addresses");
-        assert!(!swarm.core().local_addresses().contains(&public));
+            });
+        endpoint.refresh_external_address_contributions();
+        endpoint.swarm.poll().expect("refresh identify addresses");
+        assert!(!endpoint.swarm.core().local_addresses().contains(&public));
     }
 
     #[test]
@@ -596,21 +600,17 @@ mod tests {
         let relay = Ed25519Keypair::from_secret_key_bytes([76; 32]).peer_id();
 
         {
-            let Endpoint { swarm, nat, .. } = &mut endpoint;
-            let driver = nat.as_mut().expect("NAT configured");
+            let driver = endpoint.nat.as_mut().expect("NAT configured");
             let connect_id = driver
                 .agent
                 .connect(peer.clone(), Vec::new(), Now::from_mono(0));
-            driver.observe(
-                &NatEvent::PathEstablished {
-                    connect_id,
-                    peer: peer.clone(),
-                    path: Path::Relayed {
-                        relay: relay.clone(),
-                    },
+            driver.observe(&NatEvent::PathEstablished {
+                connect_id,
+                peer: peer.clone(),
+                path: Path::Relayed {
+                    relay: relay.clone(),
                 },
-                swarm,
-            );
+            });
         }
         assert_eq!(
             endpoint.path(&peer),
@@ -620,31 +620,24 @@ mod tests {
         );
 
         {
-            let Endpoint { swarm, nat, .. } = &mut endpoint;
-            let driver = nat.as_mut().expect("NAT configured");
+            let driver = endpoint.nat.as_mut().expect("NAT configured");
             let connect_id = driver
                 .agent
                 .connect(peer.clone(), Vec::new(), Now::from_mono(1));
-            driver.observe(
-                &NatEvent::PathUpgraded {
-                    connect_id,
-                    peer: peer.clone(),
-                    from: Path::Relayed {
-                        relay: relay.clone(),
-                    },
-                    to: Path::DirectPunched,
+            driver.observe(&NatEvent::PathUpgraded {
+                connect_id,
+                peer: peer.clone(),
+                from: Path::Relayed {
+                    relay: relay.clone(),
                 },
-                swarm,
-            );
-            driver.observe(
-                &NatEvent::InboundPathEstablished {
-                    peer: inbound.clone(),
-                    path: Path::Relayed {
-                        relay: relay.clone(),
-                    },
+                to: Path::DirectPunched,
+            });
+            driver.observe(&NatEvent::InboundPathEstablished {
+                peer: inbound.clone(),
+                path: Path::Relayed {
+                    relay: relay.clone(),
                 },
-                swarm,
-            );
+            });
         }
         assert_eq!(
             endpoint.path(&inbound),
@@ -654,14 +647,10 @@ mod tests {
         );
 
         {
-            let Endpoint { swarm, nat, .. } = &mut endpoint;
-            let driver = nat.as_mut().expect("NAT configured");
-            driver.observe(
-                &NatEvent::InboundDirectUpgrade {
-                    peer: inbound.clone(),
-                },
-                swarm,
-            );
+            let driver = endpoint.nat.as_mut().expect("NAT configured");
+            driver.observe(&NatEvent::InboundDirectUpgrade {
+                peer: inbound.clone(),
+            });
         }
         assert_eq!(endpoint.path(&peer), Some(Path::DirectPunched));
         assert_eq!(endpoint.path(&inbound), Some(Path::DirectPunched));

--- a/crates/minip2p/src/std/relay_server.rs
+++ b/crates/minip2p/src/std/relay_server.rs
@@ -8,8 +8,23 @@ use minip2p_relay_server::{
     RelayServerAction, RelayServerAgent, RelayServerEvent, RelayServerToken, StreamKey,
 };
 use minip2p_swarm::SwarmEvent;
+use minip2p_transport::ConnectionId;
 
 use crate::EndpointSwarm;
+
+fn take_pending_for_connection<T>(
+    pending: &mut BTreeMap<StreamKey, T>,
+    conn_id: ConnectionId,
+) -> Vec<T> {
+    let keys: Vec<_> = pending
+        .keys()
+        .filter(|stream| stream.conn_id == conn_id)
+        .copied()
+        .collect();
+    keys.into_iter()
+        .filter_map(|stream| pending.remove(&stream))
+        .collect()
+}
 
 pub(crate) struct RelayServerDriver {
     pub(crate) agent: RelayServerAgent,
@@ -41,6 +56,17 @@ impl RelayServerDriver {
 
     pub(crate) fn ingest(&mut self, event: &SwarmEvent, swarm: &mut EndpointSwarm) -> bool {
         let now = self.now();
+        if let SwarmEvent::ConnectionClosed { conn_id, .. } = event {
+            for token in take_pending_for_connection(&mut self.pending_opens, *conn_id) {
+                self.agent.stream_open_result(
+                    token,
+                    Err(format!(
+                        "destination connection {conn_id} closed during protocol negotiation"
+                    )),
+                    now,
+                );
+            }
+        }
         let pending_key = match event {
             SwarmEvent::StreamReady {
                 conn_id,
@@ -176,5 +202,45 @@ impl RelayServerDriver {
                 self.agent.reset_stream_result(token, result, now);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use minip2p_transport::{ConnectionId, StreamId};
+
+    #[test]
+    fn connection_cleanup_removes_only_its_pending_opens() {
+        let closed = ConnectionId::new(7);
+        let live = ConnectionId::new(8);
+        let mut pending = BTreeMap::from([
+            (
+                StreamKey {
+                    conn_id: closed,
+                    stream_id: StreamId::new(1),
+                },
+                "first",
+            ),
+            (
+                StreamKey {
+                    conn_id: live,
+                    stream_id: StreamId::new(2),
+                },
+                "live",
+            ),
+            (
+                StreamKey {
+                    conn_id: closed,
+                    stream_id: StreamId::new(3),
+                },
+                "second",
+            ),
+        ]);
+
+        let removed = take_pending_for_connection(&mut pending, closed);
+
+        assert_eq!(removed, vec!["first", "second"]);
+        assert_eq!(pending.values().copied().collect::<Vec<_>>(), vec!["live"]);
     }
 }

--- a/crates/minip2p/src/std/relay_server.rs
+++ b/crates/minip2p/src/std/relay_server.rs
@@ -1,0 +1,180 @@
+//! Std adapter for the caller-driven relay-server service.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use minip2p_platform::Now;
+use minip2p_relay_server::{
+    RelayServerAction, RelayServerAgent, RelayServerEvent, RelayServerToken, StreamKey,
+};
+use minip2p_swarm::SwarmEvent;
+
+use crate::EndpointSwarm;
+
+pub(crate) struct RelayServerDriver {
+    pub(crate) agent: RelayServerAgent,
+    pub(crate) events: VecDeque<RelayServerEvent>,
+    epoch: Instant,
+    pending_opens: BTreeMap<StreamKey, RelayServerToken>,
+}
+
+impl RelayServerDriver {
+    pub(crate) fn new(agent: RelayServerAgent) -> Self {
+        Self {
+            agent,
+            events: VecDeque::new(),
+            epoch: Instant::now(),
+            pending_opens: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn now(&self) -> Now {
+        Now::new(
+            self.epoch.elapsed().as_millis() as u64,
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .ok()
+                .map(|duration| duration.as_secs())
+                .unwrap_or(0),
+        )
+    }
+
+    pub(crate) fn ingest(&mut self, event: &SwarmEvent, swarm: &mut EndpointSwarm) -> bool {
+        let now = self.now();
+        let pending_key = match event {
+            SwarmEvent::StreamReady {
+                conn_id,
+                stream_id,
+                initiated_locally: true,
+                ..
+            }
+            | SwarmEvent::StreamClosed {
+                conn_id, stream_id, ..
+            } => Some(StreamKey {
+                conn_id: *conn_id,
+                stream_id: *stream_id,
+            }),
+            _ => None,
+        };
+        if let Some(key) = pending_key
+            && let Some(token) = self.pending_opens.remove(&key)
+        {
+            let result = if matches!(event, SwarmEvent::StreamReady { .. }) {
+                Ok(key)
+            } else {
+                Err("stream closed before protocol negotiation completed".into())
+            };
+            self.agent.stream_open_result(token, result, now);
+            self.pump(swarm);
+            return true;
+        }
+        let is_circuit = match event {
+            SwarmEvent::ConnectionEstablished { conn_id, .. }
+            | SwarmEvent::ConnectionClosed { conn_id, .. }
+            | SwarmEvent::StreamReady { conn_id, .. }
+            | SwarmEvent::StreamData { conn_id, .. }
+            | SwarmEvent::StreamRemoteWriteClosed { conn_id, .. }
+            | SwarmEvent::StreamClosed { conn_id, .. } => conn_id.is_circuit(),
+            _ => false,
+        };
+        // `handle_event` runs the agent tick with this same sample before it
+        // dispatches the event, preserving deadline-first ordering.
+        let claimed = self.agent.handle_event(event, is_circuit, now);
+        if let SwarmEvent::ConnectionEstablished { conn_id, .. } = event
+            && let Some(address) = swarm.connection_remote_addr(*conn_id).cloned()
+        {
+            self.agent.set_connection_addr(*conn_id, address);
+        }
+        self.pump(swarm);
+        claimed
+    }
+
+    pub(crate) fn tick(&mut self, swarm: &mut EndpointSwarm) {
+        let now = self.now();
+        if self.agent.next_timeout(now) == Some(0) {
+            self.agent.handle_tick(now);
+            self.pump(swarm);
+        }
+    }
+
+    pub(crate) fn pump(&mut self, swarm: &mut EndpointSwarm) {
+        loop {
+            let mut progressed = false;
+            while let Some(action) = self.agent.poll_action() {
+                progressed = true;
+                self.execute(action, swarm);
+            }
+            while let Some(event) = self.agent.poll_event() {
+                progressed = true;
+                self.events.push_back(event);
+            }
+            if !progressed {
+                break;
+            }
+        }
+    }
+
+    fn execute(&mut self, action: RelayServerAction, swarm: &mut EndpointSwarm) {
+        let now = self.now();
+        match action {
+            RelayServerAction::OpenStream {
+                token,
+                peer_id,
+                expected_conn_id,
+                protocol_id,
+            } => {
+                if swarm.connection_remote_addr(expected_conn_id).is_none() {
+                    self.agent.stream_open_result(
+                        token,
+                        Err(format!(
+                            "expected destination connection {expected_conn_id} is no longer active"
+                        )),
+                        now,
+                    );
+                    return;
+                }
+                match swarm.open_stream_with_connection(&peer_id, &protocol_id) {
+                    Ok((conn_id, stream_id)) => {
+                        self.pending_opens
+                            .insert(StreamKey { conn_id, stream_id }, token);
+                    }
+                    Err(error) => {
+                        self.agent
+                            .stream_open_result(token, Err(error.to_string()), now);
+                    }
+                }
+            }
+            RelayServerAction::SendStream {
+                token,
+                peer_id,
+                stream,
+                data,
+            } => {
+                let result = swarm
+                    .send_stream(&peer_id, stream.stream_id, data)
+                    .map_err(|error| error.to_string());
+                self.agent.send_stream_result(token, result, now);
+            }
+            RelayServerAction::CloseStreamWrite {
+                token,
+                peer_id,
+                stream,
+            } => {
+                let result = swarm
+                    .close_stream_write(&peer_id, stream.stream_id)
+                    .map_err(|error| error.to_string());
+                self.agent.close_stream_write_result(token, result, now);
+            }
+            RelayServerAction::ResetStream {
+                token,
+                peer_id,
+                stream,
+            } => {
+                let result = swarm
+                    .reset_stream(&peer_id, stream.stream_id)
+                    .map_err(|error| error.to_string());
+                self.agent.reset_stream_result(token, result, now);
+            }
+        }
+    }
+}

--- a/crates/minip2p/tests/relay_server.rs
+++ b/crates/minip2p/tests/relay_server.rs
@@ -1,0 +1,223 @@
+//! Real std Endpoint relay-server integration coverage.
+
+#![cfg(all(feature = "relay-server", feature = "nat"))]
+
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use minip2p::{
+    Endpoint, EndpointBuilder, Event, NatConfig, NatEvent, Path, PeerAddr, RelayServerEvent,
+    ReservationPolicy,
+};
+
+const ECHO_PROTOCOL: &str = "/minip2p/tests/endpoint-relay-echo/1.0.0";
+const HOP_PROTOCOL: &str = "/libp2p/circuit/relay/0.2.0/hop";
+
+fn exercise_relay(
+    mut relay: Endpoint,
+    relay_addr: PeerAddr,
+    bind_client: impl Fn(EndpointBuilder) -> Endpoint,
+) {
+    let (stop_tx, stop_rx) = mpsc::channel();
+    let relay_thread = thread::spawn(move || {
+        while stop_rx.try_recv().is_err() {
+            relay
+                .next_event(Duration::from_millis(10))
+                .expect("drive relay server");
+        }
+        relay.take_relay_server_events()
+    });
+
+    let config = NatConfig {
+        force_relay: true,
+        reservation_policy: ReservationPolicy::Always,
+        ..NatConfig::default()
+    };
+    let mut responder = bind_client(
+        Endpoint::builder()
+            .protocol(ECHO_PROTOCOL)
+            .relay(relay_addr.clone())
+            .nat_config(config),
+    );
+    responder.listen().expect("responder listens");
+    let responder_peer = responder.peer_id().clone();
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        assert!(Instant::now() < deadline, "reservation timed out");
+        let _ = responder.next_event(Duration::from_millis(20)).unwrap();
+        if responder.take_nat_events().iter().any(|event| {
+            matches!(event, NatEvent::RelayReserved { relay, .. } if relay == relay_addr.peer_id())
+        }) {
+            break;
+        }
+    }
+
+    let mut initiator = bind_client(
+        Endpoint::builder()
+            .protocol(ECHO_PROTOCOL)
+            .relay(relay_addr.clone())
+            .nat_config(NatConfig {
+                force_relay: true,
+                reservation_policy: ReservationPolicy::Never,
+                ..NatConfig::default()
+            }),
+    );
+    initiator.listen().expect("initiator listens");
+    let initiator_peer = initiator.peer_id().clone();
+    let connect_id = initiator.connect(&responder_peer).expect("connect starts");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut connected = false;
+    let mut trace = Vec::new();
+    while !connected {
+        assert!(
+            Instant::now() < deadline,
+            "relayed connect timed out: {trace:#?}"
+        );
+        if let Some(event) = initiator.next_event(Duration::from_millis(20)).unwrap() {
+            trace.push(format!("initiator swarm: {event:?}"));
+        }
+        if let Some(event) = responder.next_event(Duration::from_millis(20)).unwrap() {
+            trace.push(format!("responder swarm: {event:?}"));
+        }
+        let initiator_events = initiator.take_nat_events();
+        trace.extend(
+            initiator_events
+                .iter()
+                .map(|event| format!("initiator nat: {event:?}")),
+        );
+        connected = initiator_events.iter().any(|event| {
+            matches!(event, NatEvent::PathEstablished { connect_id: found, path: Path::Relayed { .. }, .. } if *found == connect_id)
+        });
+        trace.extend(
+            responder
+                .take_nat_events()
+                .iter()
+                .map(|event| format!("responder nat: {event:?}")),
+        );
+    }
+    let ready_deadline = Instant::now() + Duration::from_secs(5);
+    while initiator.peer_info(&responder_peer).is_none()
+        || responder.peer_info(&initiator_peer).is_none()
+    {
+        assert!(
+            Instant::now() < ready_deadline,
+            "circuit identify timed out"
+        );
+        let _ = initiator.next_event(Duration::from_millis(20)).unwrap();
+        let _ = responder.next_event(Duration::from_millis(20)).unwrap();
+    }
+    assert!(
+        responder
+            .peer_info(relay_addr.peer_id())
+            .expect("relay identify")
+            .protocols
+            .iter()
+            .any(|protocol| protocol == HOP_PROTOCOL),
+        "relay-only server must advertise HOP"
+    );
+    assert!(
+        !initiator
+            .peer_info(&responder_peer)
+            .expect("responder identify over circuit")
+            .protocols
+            .iter()
+            .any(|protocol| protocol == HOP_PROTOCOL),
+        "NAT-only client must not advertise HOP"
+    );
+
+    let stream = initiator
+        .open_stream(&responder_peer, ECHO_PROTOCOL)
+        .expect("open echo stream");
+    let payload = b"bidirectional payload through Endpoint relay server".to_vec();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut responder_stream = None;
+    let mut echoed = None;
+    while echoed.is_none() {
+        assert!(Instant::now() < deadline, "relay payload timed out");
+        if let Some(event) = initiator.next_event(Duration::from_millis(20)).unwrap() {
+            match event {
+                Event::StreamReady {
+                    peer_id,
+                    stream_id,
+                    initiated_locally: true,
+                    ..
+                } if peer_id == responder_peer && stream_id == stream => {
+                    initiator
+                        .send_stream(&responder_peer, stream, payload.clone())
+                        .unwrap();
+                }
+                Event::StreamData {
+                    peer_id,
+                    stream_id,
+                    data,
+                    ..
+                } if peer_id == responder_peer && stream_id == stream => {
+                    echoed = Some(data);
+                }
+                _ => {}
+            }
+        }
+        if let Some(event) = responder.next_event(Duration::from_millis(20)).unwrap() {
+            match event {
+                Event::StreamReady {
+                    peer_id,
+                    stream_id,
+                    initiated_locally: false,
+                    protocol_id,
+                    ..
+                } if peer_id == initiator_peer && protocol_id == ECHO_PROTOCOL => {
+                    responder_stream = Some(stream_id);
+                }
+                Event::StreamData {
+                    peer_id,
+                    stream_id,
+                    data,
+                    ..
+                } if peer_id == initiator_peer && Some(stream_id) == responder_stream => {
+                    responder
+                        .send_stream(&initiator_peer, stream_id, data)
+                        .unwrap();
+                }
+                _ => {}
+            }
+        }
+    }
+    assert_eq!(echoed, Some(payload));
+
+    drop(initiator);
+    drop(responder);
+    thread::sleep(Duration::from_millis(50));
+    stop_tx.send(()).unwrap();
+    let relay_events = relay_thread.join().expect("relay driver thread");
+    assert!(relay_events.iter().any(|event| matches!(event, RelayServerEvent::ReservationAccepted { peer_id, .. } if peer_id == &responder_peer)));
+    assert!(relay_events.iter().any(|event| matches!(event, RelayServerEvent::CircuitOpened { source_peer_id, destination_peer_id } if source_peer_id == &initiator_peer && destination_peer_id == &responder_peer)));
+}
+
+#[cfg(feature = "quic")]
+#[test]
+fn quic_clients_exchange_payload_through_quic_relay_endpoint() {
+    let mut relay = Endpoint::builder()
+        .relay_server()
+        .bind_quic("127.0.0.1:0")
+        .expect("bind relay");
+    let relay_addr = relay.listen().expect("relay listens");
+    exercise_relay(relay, relay_addr, |builder| {
+        builder.bind_quic("127.0.0.1:0").expect("bind client")
+    });
+}
+
+#[cfg(feature = "tcp")]
+#[test]
+fn tcp_clients_exchange_payload_through_tcp_relay_endpoint() {
+    let mut relay = Endpoint::builder()
+        .relay_server()
+        .bind_tcp("127.0.0.1:0")
+        .expect("bind relay");
+    let relay_addr = relay.listen().expect("relay listens");
+    exercise_relay(relay, relay_addr, |builder| {
+        builder.bind_tcp("127.0.0.1:0").expect("bind client")
+    });
+}

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -205,6 +205,11 @@ impl<T: Transport> Swarm<T> {
         self.runtime.set_external_addresses(addrs);
     }
 
+    /// See [`SwarmRuntime::external_addresses`].
+    pub fn external_addresses(&self) -> &[Multiaddr] {
+        self.runtime.external_addresses()
+    }
+
     /// See [`SwarmRuntime::transport`].
     pub fn transport(&self) -> &T {
         self.runtime.transport()

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -210,6 +210,11 @@ impl<T: Transport> Swarm<T> {
         self.runtime.external_addresses()
     }
 
+    /// See [`SwarmRuntime::external_addresses_revision`].
+    pub fn external_addresses_revision(&self) -> u64 {
+        self.runtime.external_addresses_revision()
+    }
+
     /// See [`SwarmRuntime::transport`].
     pub fn transport(&self) -> &T {
         self.runtime.transport()
@@ -974,7 +979,11 @@ mod tests {
             .parse()
             .unwrap();
 
+        assert_eq!(swarm.external_addresses_revision(), 0);
         swarm.set_external_addresses(vec![external.clone(), circuit.clone()]);
+        assert_eq!(swarm.external_addresses_revision(), 1);
+        swarm.set_external_addresses(vec![external.clone(), circuit.clone()]);
+        assert_eq!(swarm.external_addresses_revision(), 2);
         swarm.poll().unwrap();
         // IdleTransport binds nothing, so the snapshot is exactly the
         // external set.

--- a/crates/swarm/src/runtime.rs
+++ b/crates/swarm/src/runtime.rs
@@ -85,6 +85,7 @@ pub struct SwarmRuntime<T: Transport, E: EntropySource> {
     /// addition to the transport's bound set. See
     /// [`SwarmRuntime::set_external_addresses`].
     external_addresses: Vec<Multiaddr>,
+    external_addresses_revision: u64,
 
     /// Randomness for ping nonces. Injected so the pump stays deterministic
     /// and testable, and so `no_std` hosts can supply their own source.
@@ -111,6 +112,7 @@ impl<T: Transport, E: EntropySource> SwarmRuntime<T, E> {
             event_buffer: VecDeque::new(),
             after_event_actions: VecDeque::new(),
             external_addresses: Vec::new(),
+            external_addresses_revision: 0,
             entropy,
         }
     }
@@ -124,12 +126,21 @@ impl<T: Transport, E: EntropySource> SwarmRuntime<T, E> {
     /// dropped.
     pub fn set_external_addresses(&mut self, addrs: Vec<Multiaddr>) {
         self.external_addresses = addrs;
+        self.external_addresses_revision = self.external_addresses_revision.wrapping_add(1);
     }
 
     /// Returns the externally validated addresses currently contributed to
     /// Identify, excluding transport-bound addresses.
     pub fn external_addresses(&self) -> &[Multiaddr] {
         &self.external_addresses
+    }
+
+    /// Returns the wrapping revision of the external-address replacement.
+    ///
+    /// The revision advances even when a replacement contains the same values,
+    /// allowing composed hosts to distinguish address ownership changes.
+    pub fn external_addresses_revision(&self) -> u64 {
+        self.external_addresses_revision
     }
 
     /// Returns a reference to the underlying transport.

--- a/crates/swarm/src/runtime.rs
+++ b/crates/swarm/src/runtime.rs
@@ -126,6 +126,12 @@ impl<T: Transport, E: EntropySource> SwarmRuntime<T, E> {
         self.external_addresses = addrs;
     }
 
+    /// Returns the externally validated addresses currently contributed to
+    /// Identify, excluding transport-bound addresses.
+    pub fn external_addresses(&self) -> &[Multiaddr] {
+        &self.external_addresses
+    }
+
     /// Returns a reference to the underlying transport.
     pub fn transport(&self) -> &T {
         &self.transport

--- a/justfile
+++ b/justfile
@@ -11,6 +11,10 @@ check:
     cargo check -p minip2p-rs --features nat
     cargo check -p minip2p-rs --features pubsub
     cargo check -p minip2p-rs --features nat,pubsub
+    cargo check -p minip2p-rs --features relay-server
+    cargo check -p minip2p-rs --features nat,relay-server
+    cargo check -p minip2p-rs --features nat,relay-server,tcp
+    cargo check -p minip2p-rs --no-default-features --features std,tcp,relay-server
     cargo check -p minip2p-rs --features discovery
     cargo check -p minip2p-rs --features mdns
     cargo check -p minip2p-rs --features discovery,mdns
@@ -29,6 +33,10 @@ clippy:
     cargo clippy -p minip2p-rs --features discovery --all-targets -- -D warnings
     cargo clippy -p minip2p-rs --features mdns --all-targets -- -D warnings
     cargo clippy -p minip2p-rs --features discovery,mdns --all-targets -- -D warnings
+    cargo clippy -p minip2p-rs --features relay-server --all-targets -- -D warnings
+    cargo clippy -p minip2p-rs --features nat,relay-server --all-targets -- -D warnings
+    cargo clippy -p minip2p-rs --features nat,relay-server,tcp --all-targets -- -D warnings
+    cargo clippy -p minip2p-rs --no-default-features --features std,tcp,relay-server --all-targets -- -D warnings
     cargo clippy -p minip2p-rs --features tcp --all-targets -- -D warnings
     cargo clippy -p minip2p-rs --no-default-features --features std,tcp --all-targets -- -D warnings
     cargo clippy -p minip2p-rs --no-default-features --features smoltcp --all-targets -- -D warnings
@@ -49,6 +57,10 @@ test:
     cargo nextest run --profile variants -p minip2p-rs --features discovery
     cargo nextest run --profile variants -p minip2p-rs --features mdns
     cargo nextest run --profile variants -p minip2p-rs --features discovery,mdns
+    cargo nextest run --profile variants -p minip2p-rs --features relay-server
+    cargo nextest run --profile variants -p minip2p-rs --features nat,relay-server
+    cargo nextest run --profile variants -p minip2p-rs --features nat,relay-server,tcp
+    cargo nextest run --profile variants -p minip2p-rs --no-default-features --features std,tcp,relay-server
     cargo nextest run --profile variants -p minip2p-rs --features tcp
     cargo nextest run --profile variants -p minip2p-rs --no-default-features --features std,tcp
     cargo nextest run --profile variants -p minip2p-rs --features discovery,mdns,tcp
@@ -80,7 +92,7 @@ interop-go:
 
 docs:
     cargo doc --workspace --no-deps
-    cargo doc -p minip2p-rs --features nat,pubsub,discovery,mdns,tcp --no-deps
+    cargo doc -p minip2p-rs --features nat,pubsub,discovery,mdns,tcp,relay-server --no-deps
     cargo doc -p minip2p-tcp --features smoltcp --no-deps
     cargo doc -p minip2p-mdns --features smoltcp --no-deps
     cargo doc -p minip2p-rs --no-default-features --features smoltcp --no-deps


### PR DESCRIPTION
## Summary
- compose the sans-I/O relay-server agent into the std Endpoint behind an independent feature
- add builder configuration, runtime controls, stable external-address contributions, focused waits, and typed events
- add real TCP and QUIC relay-server integration coverage plus CI feature-matrix entries and documentation

## Verification
- just test (relay-server suites passed; one known reconnect-churn timing test flaked late in a variant run and passed immediately when rerun)
- just clippy
- just check-nostd
- cargo test -p minip2p-rs --features nat,relay-server,tcp --doc
- cargo clippy -p minip2p-rs --all-targets --features nat,relay-server,tcp -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p minip2p-rs --features relay-server --no-deps
- final Standards review: pass, 0 findings
- final Spec review: pass, 0 findings

Closes #71

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates a Circuit Relay v2 server into the std `Endpoint`, gated behind the `relay-server` feature. Endpoints previously only acted as clients; when enabled they now host and advertise HOP and open outbound STOP. External address advertising now composes a stable union from NAT and relay contributions and preserves caller-owned addresses; no behavior change unless enabled.

- Builder: `relay_server()`, `relay_server_config(...)` (validated limits), and `relay_server_announce_addrs(...)` (validates concrete TCP/QUIC shape and peer id). Announce addresses alone do not enable the service; providing them without enabling the server now errors.
- Runtime: `set_relay_server_accepting`, `set_relay_server_announce_addrs` (atomic replace), `take_relay_server_events`, and `next_relay_server_event` (drives the endpoint while preserving unrelated events). Controls return typed `RelayServerControlError`; async failures surface as `RelayServerEvent::Error`.
- Protocol wiring: hosting advertises inbound HOP and opens outbound STOP; NAT-only endpoints retain client roles and do not advertise HOP; combined endpoints compose both. The Swarm maintains one live connection per peer for relay driver targeting.
- External address advertising: Endpoint composes a stable first-wins union of NAT-confirmed and relay announce/listener addrs, preserves caller-owned `Swarm` external addresses, never promotes Identify-observed addrs, and ignores wildcard listeners. Tracks caller replacements via `Swarm::external_addresses_revision()`.
- Tests/docs/CI: real TCP and QUIC relay-server integration tests, ownership/union stability tests, README hosting section, and `justfile` matrix entries. Adds dependency on `minip2p-relay-server`.

- Migration: none. To host a relay, enable `relay-server` and use:
  - `Endpoint::builder().relay_server().bind_{tcp|quic}(...).listen()`

<sup>Written for commit 60a9a73838cc8513f9bfb935ebcdc8bd9092cf72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

