### PR TITLE
docs: tighten user-facing prose

### DIFF
--- a/docs/md/guides/concepts.mdx
+++ b/docs/md/guides/concepts.mdx
@@ -81,9 +81,9 @@ TCP. They do not reserve on a relay or perform DCUtR.
 With the `nat` feature and an activated NAT driver, `connect*` can race direct
 candidates against a relay leg. The first usable result is:
 
-- `Path::DirectDialed` — a supplied direct address connected;
-- `Path::DirectPunched` — DCUtR established a direct connection;
-- `Path::Relayed { relay }` — an end-to-end protected circuit is usable.
+- `Path::DirectDialed`: a supplied direct address connected;
+- `Path::DirectPunched`: DCUtR established a direct connection;
+- `Path::Relayed { relay }`: an end-to-end protected circuit is usable.
 
 A relayed path can later emit `NatEvent::PathUpgraded` when hole punching
 lands.

--- a/docs/md/guides/discover-peers.mdx
+++ b/docs/md/guides/discover-peers.mdx
@@ -3,13 +3,10 @@ title: Discover peers
 description: Activate signed presence beacons or local-link mDNS with a bounded peer book and automatic dialing.
 ---
 
-**Goal:** Turn on signed or local-link discovery, observe the known-peer book,
-and let the driver dial peers from accepted observations.
-
-**Assumes:** [Publish with pubsub](/guides/pubsub) for signed discovery. Signed
-observations can use a configured relay — see [Traverse NAT](/guides/traverse-nat).
-mDNS observations are unauthenticated and automatic dials from them are always
-direct-only.
+Signed discovery builds on [pubsub](/guides/pubsub) and can use a configured
+relay. mDNS needs no pubsub or relay, but its observations are unauthenticated
+and automatic dials from them are always direct-only. See
+[Traverse NAT](/guides/traverse-nat) before adding relayed paths.
 
 <Badge>pre-1.0</Badge> <Badge>signed: nat + pubsub</Badge> <Badge>mDNS: nat</Badge>
 

--- a/docs/md/guides/drive-events.mdx
+++ b/docs/md/guides/drive-events.mdx
@@ -3,14 +3,10 @@ title: Drive events
 description: Choose between poll, next_event, and focused waits without losing unrelated application events.
 ---
 
-**Goal:** Drive the endpoint with the right wait, handle deadlines, and shut
-streams and connections down cleanly.
-
-**Assumes:** [Concepts](/guides/concepts#where-events-go) and preferably
-[Register a protocol](/guides/register-a-protocol).
-
 minip2p remains caller-driven at every layer. The application chooses when to
-poll, how long to wait, and which event queue to consume.
+poll, how long to wait, and which event queue to consume. Read
+[where events go](/guides/concepts#where-events-go) first. If you are working
+with custom streams, also read [Register a protocol](/guides/register-a-protocol).
 
 ## Pick a driving method
 

--- a/docs/md/guides/embedded-devices.mdx
+++ b/docs/md/guides/embedded-devices.mdx
@@ -3,16 +3,15 @@ title: Embedded devices
 description: Run a no_std endpoint on your board's smoltcp stack.
 ---
 
-**Goal:** Run authenticated libp2p TCP on a `no_std + alloc` target, using the
-board's network device, monotonic timer, and hardware entropy.
-
-**Assumes:** Your board already has a working
+This guide assumes your board already has a working
 [smoltcp](https://docs.rs/smoltcp) `Device` and configured `Interface` with an
 IP address and route. minip2p does not set up the MAC, PHY, DHCP, SLAAC, or
-interrupt controller.
+interrupt controller. You supply the network device, monotonic timer, and
+hardware entropy.
 
-Same TCP, Noise XX, Yamux, Identify, Ping, and application protocols as a
-hosted TCP endpoint. Only the I/O provider and driving loop change.
+An embedded endpoint runs the same TCP, Noise XX, Yamux, Identify, Ping, and
+application protocols as a hosted TCP endpoint. Only the I/O provider and
+driving loop change.
 
 ## Add the dependency
 
@@ -37,8 +36,8 @@ Add only what you need:
 | `portable-autonat` | AutoNAT probing over the portable endpoint |
 | `portable-relay` | Relay-only circuit connections; includes portable AutoNAT |
 
-No QUIC here — the quiche adapter needs `std`. Portable relay is therefore
-relay-only; DCUtR still needs QUIC.
+The quiche adapter needs `std`, so embedded endpoints cannot use QUIC or DCUtR.
+They can still use relay circuits.
 
 ## What you supply
 

--- a/docs/md/guides/identity.mdx
+++ b/docs/md/guides/identity.mdx
@@ -3,13 +3,11 @@ title: Identity
 description: Manage Ed25519 peer identity and distinguish bind addresses, direct peer addresses, and relay circuit addresses.
 ---
 
-**Goal:** Choose ephemeral or persistent identity and pick the right address
-shape for bind, dial, and relay.
-
-**Assumes:** [Concepts](/guides/concepts#peeraddr-and-multiaddr).
-
 Every authenticated connection binds a transport address to an Ed25519
-identity.
+identity. This guide covers key persistence and the address forms used for
+binding, direct dialing, and relaying. Read
+[PeerAddr and Multiaddr](/guides/concepts#peeraddr-and-multiaddr) first if those
+types are new to you.
 
 ## Ephemeral identity
 
@@ -94,7 +92,7 @@ a supported QUIC shape.
 
 ## Wildcards are not advertisements
 
-`0.0.0.0` and `::` mean “bind all local interfaces.” They are not routable
+`0.0.0.0` and `::` mean "bind all local interfaces." They are not routable
 remote destinations. Replace a wildcard with a real interface or public
 address before sharing it, or advertise a relay circuit address when the node
 is private.

--- a/docs/md/guides/listen-and-dial.mdx
+++ b/docs/md/guides/listen-and-dial.mdx
@@ -3,15 +3,10 @@ title: Listen and dial
 description: Bind QUIC, TCP, or both; publish dialable peer addresses; and wait for PeerReady.
 ---
 
-**Goal:** Bind, publish a dialable address, dial a known peer, and wait for
-`PeerReady`.
-
-**Assumes:** [Connect two peers](/quickstart/connect-peers) and
-[Concepts](/guides/concepts) (dial versus connect).
-
 This guide covers direct QUIC and TCP with the base Endpoint API. QUIC is on
 by default; TCP needs the `tcp` Cargo feature. For relay races and hole
-punching, use [Traverse NAT](/guides/traverse-nat).
+punching, use [Traverse NAT](/guides/traverse-nat). If you have not run a local
+connection yet, start with [Connect two peers](/quickstart/connect-peers).
 
 ## Bind an endpoint
 
@@ -96,9 +91,9 @@ when policy requires one family.
 
 A successful dial still has two useful milestones:
 
-1. `Event::ConnectionEstablished` — the transport is up and the peer identity
+1. `Event::ConnectionEstablished`: the transport is up and the peer identity
    is authenticated.
-2. `Event::PeerReady` — the first Identify exchange has completed, so the
+2. `Event::PeerReady`: the first Identify exchange has completed, so the
    endpoint knows which protocols the peer supports.
 
 ```rust
@@ -145,7 +140,7 @@ as `Event::ConnectionClosed`.
 
 `dial*` does not reserve on a relay, establish a circuit, or start DCUtR. When
 the application has enabled the `nat` feature and configured its NAT driver,
-use `connect*` plus `wait_path` instead — see
+use `connect*` plus `wait_path` instead. See
 [Traverse NAT](/guides/traverse-nat).
 
 Next: [Register a protocol](/guides/register-a-protocol) or

--- a/docs/md/guides/pubsub.mdx
+++ b/docs/md/guides/pubsub.mdx
@@ -3,14 +3,10 @@ title: Publish with pubsub
 description: Enable gossipsub, subscribe and publish signed messages, consume pubsub events, or select floodsub explicitly.
 ---
 
-**Goal:** Activate gossipsub (or floodsub), subscribe to a topic, publish
-signed messages, and consume pubsub events.
-
-**Assumes:** [Drive events](/guides/drive-events). A second peer on the same
-topic is required to observe delivery.
-
 The `pubsub` feature exposes one API for gossipsub and floodsub.
-`EndpointBuilder::pubsub()` selects gossipsub by default.
+`EndpointBuilder::pubsub()` selects gossipsub by default. You need a second
+peer on the same topic to observe delivery. See [Drive events](/guides/drive-events)
+for the caller-driven event model.
 
 ## Enable gossipsub
 
@@ -96,7 +92,7 @@ return `false` when the requested state already held.
 ## Signing and unsigned compatibility
 
 Published messages are signed with the endpoint identity. By default,
-gossipsub also rejects unsigned inbound messages—StrictSign-style behavior,
+gossipsub also rejects unsigned inbound messages. This matches StrictSign behavior
 without a separate public `StrictSign` type.
 
 Only relax inbound acceptance when interoperating with a peer that

--- a/docs/md/guides/register-a-protocol.mdx
+++ b/docs/md/guides/register-a-protocol.mdx
@@ -3,15 +3,10 @@ title: Register a protocol
 description: Register an application protocol, negotiate streams, exchange bytes, and close or abandon stream state on purpose.
 ---
 
-**Goal:** Register a versioned protocol ID, open or accept streams, exchange
-bytes, and shut streams down cleanly.
-
-**Assumes:** [Connect two peers](/quickstart/connect-peers) and
-[PeerReady](/guides/concepts#connection-readiness).
-
 Application protocols use libp2p multistream-select negotiation over an
 authenticated connection. Both peers must register the same versioned
-protocol ID.
+protocol ID. Before opening a stream, connect the peers and wait for
+[`PeerReady`](/guides/concepts#connection-readiness).
 
 ```rust
 const ECHO_PROTOCOL: &str = "/my-app/echo/1.0.0";

--- a/docs/md/guides/traverse-nat.mdx
+++ b/docs/md/guides/traverse-nat.mdx
@@ -3,12 +3,10 @@ title: Traverse NAT
 description: Configure relay and AutoNAT, establish the first usable path, and observe direct upgrades or relay fallback.
 ---
 
-**Goal:** Activate the NAT driver, connect through a relay race, and observe
-path establish / upgrade / fallback events.
-
-**Assumes:** [Listen and dial](/guides/listen-and-dial) and
-[Concepts](/guides/concepts#dial-versus-connect). You need a reachable Circuit
-Relay v2 server for relayed paths; minip2p can host it.
+This guide starts where direct [listen and dial](/guides/listen-and-dial) leaves
+off. It configures the NAT driver, races direct and relayed paths, and tracks
+later upgrades or fallback. Relayed paths require a reachable Circuit Relay v2
+server, which minip2p can host.
 
 <Badge>pre-1.0</Badge>
 
@@ -105,9 +103,9 @@ match node.wait_path(connect_id, Duration::from_secs(60))? {
 `wait_path` returns `Ok(Some(path))` when it consumes the matching
 `NatEvent::PathEstablished`. It returns `Ok(None)` in two cases:
 
-- the attempt failed — `NatEvent::ConnectFailed` stays queued for
+- the attempt failed; `NatEvent::ConnectFailed` stays queued for
   `take_nat_events`;
-- the deadline expired before either outcome — no `ConnectFailed` is
+- the deadline expired before either outcome; no `ConnectFailed` is
   synthesized.
 
 ## Path selection and upgrade
@@ -125,9 +123,9 @@ flowchart TB
 
 The first usable path is explicit:
 
-- `Path::DirectDialed` — a direct candidate connected;
-- `Path::DirectPunched` — a DCUtR hole punch connected;
-- `Path::Relayed { relay }` — the protected relay circuit is usable.
+- `Path::DirectDialed`: a direct candidate connected;
+- `Path::DirectPunched`: a DCUtR hole punch connected;
+- `Path::Relayed { relay }`: the protected relay circuit is usable.
 
 When a relayed path upgrades later, the application receives
 `NatEvent::PathUpgraded`. If punch windows fail, it receives
@@ -169,7 +167,7 @@ connection events continue to progress.
 Most applications do not configure circuit entropy: `Endpoint` uses the
 operating system's random source by default. When
 embedding `minip2p-circuit` with default features disabled, provide an
-`EntropySource` that never substitutes predictable bytes on failure — see the
+`EntropySource` that never substitutes predictable bytes on failure. See the
 [`minip2p-circuit` README](https://github.com/deepso7/minip2p/blob/main/crates/circuit/README.md)
 for the trait contract and a custom-source example.
 

--- a/docs/md/index.mdx
+++ b/docs/md/index.mdx
@@ -24,8 +24,8 @@ description: A minimal, caller-driven libp2p stack with QUIC, TCP, and no_std.
 
 minip2p opens authenticated QUIC and TCP connections from Rust and React
 Native. On `no_std + alloc`, TCP runs through a pluggable provider and
-`Endpoint::portable`. The Rust `Endpoint` is synchronous and caller-driven —
-no async runtime. The React Native SDK owns the native driver and presents
+`Endpoint::portable`. The Rust `Endpoint` is synchronous and caller-driven,
+with no async runtime. The React Native SDK owns the native driver and presents
 typed events, cancellable Promises, and `Stream` handles to JavaScript.
 
 <Tabs>
@@ -74,8 +74,6 @@ discovery, and local-link mDNS.
 
 ## Get started
 
-*learn by doing*
-
 <CardGroup cols={2}>
   <Card title="Install for Rust" href="/quickstart/install#rust" icon="package-plus">
     Add `minip2p-rs` and choose the network features your endpoint needs.
@@ -90,8 +88,6 @@ discovery, and local-link mDNS.
 
 ## Understand
 
-*understand this*
-
 <CardGroup cols={2}>
   <Card title="Concepts" href="/guides/concepts" icon="waypoints">
     Endpoint, PeerId, PeerAddr, PeerReady, and dial versus connect.
@@ -102,8 +98,6 @@ discovery, and local-link mDNS.
 </CardGroup>
 
 ## Do next
-
-*do this specific thing*
 
 <CardGroup cols={2}>
   <Card
@@ -123,13 +117,11 @@ discovery, and local-link mDNS.
     Signed presence beacons or zero-configuration local-link mDNS.
   </Card>
   <Card title="Embedded devices" href="/guides/embedded-devices" icon="cpu">
-    Portable TCP over smoltcp — you own I/O, time, and entropy.
+    Portable TCP over smoltcp, with caller-supplied I/O, time, and entropy.
   </Card>
 </CardGroup>
 
 ## Look up
-
-*look this up*
 
 <CardGroup cols={3}>
   <Card

--- a/docs/md/quickstart/connect-peers.mdx
+++ b/docs/md/quickstart/connect-peers.mdx
@@ -1,16 +1,13 @@
 ---
 title: Connect two peers
-description: In about 10 minutes, print a dialable PeerAddr and measure a libp2p Ping RTT between two local processes.
+description: Print a dialable PeerAddr and measure a libp2p Ping RTT between two local processes.
 ---
-
-In about 10 minutes you will print a dialable `PeerAddr` and a Ping RTT.
 
 This quickstart creates one small Cargo project with two binaries. The
 listener prints a paste-ready peer address; the dialer connects to it and
-measures a real Ping round trip.
+measures a Ping round trip.
 
-**Assumes:** [Install](/quickstart/install) is done (Rust 1.91+ and the
-`minip2p-rs` dependency).
+Before starting, [install minip2p](/quickstart/install) with Rust 1.91 or newer.
 
 ## Create the project
 

--- a/docs/md/quickstart/install.mdx
+++ b/docs/md/quickstart/install.mdx
@@ -51,8 +51,8 @@ inside a particular endpoint.
     ```
 
     This adds the TCP transport and its `tcp`, `tcp_multiaddr`, `bind_tcp`,
-    and `tcp_config` builder methods. Skip it if you only need QUIC — you
-    will not link the TCP stack.
+    and `tcp_config` builder methods. Skip it if you only need QUIC, and the
+    TCP stack will not be linked.
 
   </Tab>
   <Tab title="Embedded / no_std">
@@ -67,8 +67,8 @@ inside a particular endpoint.
 
     This unlocks `Endpoint::portable(...)` and the smoltcp builder. You
     supply the network device, clock samples, and entropy; minip2p runs TCP,
-    Noise XX, Yamux, Identify, Ping, and any protocols you register — no OS
-    or async runtime. Add `pubsub`, `portable-autonat`, or `portable-relay`
+    Noise XX, Yamux, Identify, Ping, and any protocols you register. It needs
+    no OS or async runtime. Add `pubsub`, `portable-autonat`, or `portable-relay`
     if you need them. Continue with
     [Embedded devices](/guides/embedded-devices) for stack setup,
     driving, and memory budgeting.

--- a/docs/md/react-native/lifecycle.mdx
+++ b/docs/md/react-native/lifecycle.mdx
@@ -122,7 +122,7 @@ Use `isDriverFailure(node)` to narrow a failed hook state to
 Application code should import from `@minip2p/react-native`. That package
 re-exports the platform-neutral high-level types from `@minip2p/core`.
 
-The generated UniFFI surface at `@minip2p/react-native/native` and the adapter
+The generated UniFFI API at `@minip2p/react-native/native` and the adapter
 contract at `@minip2p/core/backend` are low-level integration APIs. They expose
 native lifecycle details and raw tagged unions; ordinary applications should
 not use them.

--- a/docs/md/react-native/networking-and-events.mdx
+++ b/docs/md/react-native/networking-and-events.mdx
@@ -181,7 +181,7 @@ peerId)` helper builds the same address explicitly.
 Watch `relayReserved`, `relayReservationLost`, `pathEstablished`,
 `pathUpgraded`, `holePunchFailed`, `fellBackToRelay`, and `connectFailed` for
 diagnostics and UI state. Keep using ordinary peer and stream APIs when a path
-upgrades—the peer identity does not change.
+upgrades. The peer identity does not change.
 
 :::note
 Discovery can connect peers directly from advertised addresses without a

--- a/docs/md/reference/feature-matrix.mdx
+++ b/docs/md/reference/feature-matrix.mdx
@@ -46,7 +46,7 @@ Compiled with `features = ["tcp"]`:
 With default features off, `Endpoint::portable(identity, entropy)` takes a
 `Transport` you supply. The `smoltcp` feature builds one shared embedded stack
 and can layer TCP with portable mDNS, pubsub, signed discovery, AutoNAT, and
-relay. Drive it with `poll(now)` and sleep until `next_deadline(now)` — minip2p
+relay. Drive it with `poll(now)` and sleep until `next_deadline(now)`. minip2p
 does not read a system clock or start a runtime.
 
 ## NAT API
@@ -100,8 +100,8 @@ but not `pubsub`:
 - Lifecycle: `shutdown`
 
 mDNS discovers peers only on multicast-capable local links. Its address claims
-remain unauthenticated until the selected transport verifies the peer identity. Automatic
-mDNS-triggered attempts are therefore direct-only and never activate a
+remain unauthenticated until the selected transport verifies the peer identity.
+Automatic mDNS-triggered attempts are direct-only and never activate a
 configured relay or HOP CONNECT.
 `Endpoint::shutdown` sends TTL-zero goodbyes and permanently stops mDNS; QUIC
 and TCP keep working. With both `discovery` and `mdns` enabled, both sources

--- a/docs/md/reference/glossary.mdx
+++ b/docs/md/reference/glossary.mdx
@@ -18,7 +18,7 @@ Definitions only. For recipes, follow the linked guides.
 | **`next_event`** | Drives until one ordinary application event or a deadline. |
 | **Focused wait** | Drives until a specific result (`wait_peer_ready`, `wait_path`, `next_pubsub_event`, …) while buffering unrelated events. |
 | **Compiled vs enabled** | A Cargo feature unlocks APIs; a builder method activates the driver. See [Install](/quickstart/install#compiled-is-not-enabled). |
-| **Circuit address** | `/…/p2p/<relay>/p2p-circuit/p2p/<target>` — reach a peer through a Circuit Relay v2 reservation. |
+| **Circuit address** | `/…/p2p/<relay>/p2p-circuit/p2p/<target>` reaches a peer through a Circuit Relay v2 reservation. |
 
 For symptom-driven fixes, see [Troubleshooting](/reference/troubleshooting).
-For API surface by feature, see the [feature matrix](/reference/feature-matrix).
+For APIs grouped by feature, see the [feature matrix](/reference/feature-matrix).

--- a/docs/md/reference/troubleshooting.mdx
+++ b/docs/md/reference/troubleshooting.mdx
@@ -17,7 +17,7 @@ directly and reports later runtime or protocol failures through events.
 | `ProtocolNotRegistered` | The local endpoint never registered the ID | Add `.protocol("/app/name/1.0.0")` on the builder or call `add_protocol`. |
 | `ReservedProtocol` | The app tried to register Identify or Ping | Choose an application-owned, versioned protocol ID. |
 | `RemoteDoesNotSupport` | Identify completed and the remote did not advertise the protocol | Register the same protocol version on both peers. |
-| NAT, pubsub, discovery, or mDNS reports “not enabled” | Cargo compiled the API but the builder did not activate the driver | Add the corresponding builder activation from the feature matrix. |
+| NAT, pubsub, discovery, or mDNS reports "not enabled" | Cargo compiled the API but the builder did not activate the driver | Add the corresponding builder activation from the feature matrix. |
 | AutoNAT reports reachability but `connect` has no relay path | Only `.autonat_server(...)` was configured | Add a Circuit Relay v2 server with `.relay(...)` or `NatConfig::relays`. |
 | No relay reservation appears | Relay unreachable, incompatible, or policy does not currently reserve | Check the relay address, connection events, reachability state, and `ReservationPolicy`. |
 | Hole punching fails | UDP paths or observed addresses are unusable | Keep the relay path, inspect `HolePunchFailed`, and verify both sides keep driving. |


### PR DESCRIPTION
## Summary

- replace repeated Goal and Assumes blocks with direct introductions
- remove slogan-like captions, redundant claims, and dash-heavy sentences
- clarify wording without changing API behavior or examples

## Validation

- `cd docs && pnpm check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens user-facing docs for clarity and consistency by replacing “Goal/Assumes” blocks with brief contextual intros and removing slogan-like copy. No API or example changes.

- Clarifies terminology and formatting across guides: consistent colon-delimited lists for path results, clearer `wait_path` outcomes, and explicit references to related guides.
- Embedded devices: states that QUIC/DCUtR require `std`; embedded endpoints use relay circuits only and must supply I/O, timer, and entropy.
- Quickstarts and install: simplifies instructions, avoids implying TCP links when not enabled, and reiterates that embedded mode needs no OS or async runtime.
- React Native: clarifies import guidance (`@minip2p/react-native`), names the UniFFI API surface, and keeps low-level modules (`@minip2p/react-native/native`, `@minip2p/core/backend`) documented as integration-only.
- Index, feature matrix, glossary, and troubleshooting: removes captions, tightens wording, and standardizes quotes and link references.

<sup>Written for commit 078e329677366e13ebc136be6c6b7b12aae7891c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

