### PR TITLE
Publish relay container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ jobs:
       - run: cargo check --manifest-path docs/snippets/quickstart/Cargo.toml
       - run: cargo check --manifest-path docs/snippets/custom-stream/Cargo.toml
 
+  relay-container:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - run: scripts/test-relay-container.sh
+
   # Split from `test` so the two run on parallel runners. The feature matrix
   # grows with every portable backend, and a single serial job grew ~4x in a
   # month; keeping lint and test apart keeps that growth off the critical path.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -225,7 +225,6 @@ jobs:
     uses: ./.github/workflows/relay-container.yml
     with:
       version: ${{ needs.verify-release.outputs.version }}
-    secrets: inherit
 
   android-native:
     name: Build Android release artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -216,6 +216,17 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --clobber
 
+  publish-relay-container:
+    name: Publish relay container
+    needs: [verify-release, publish-relay-server-binaries]
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/relay-container.yml
+    with:
+      version: ${{ needs.verify-release.outputs.version }}
+    secrets: inherit
+
   android-native:
     name: Build Android release artifacts
     needs: verify-release

--- a/.github/workflows/relay-container.yml
+++ b/.github/workflows/relay-container.yml
@@ -1,0 +1,104 @@
+name: Publish relay container
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Release version without the v prefix
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing release version without the v prefix
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: relay-container
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish relay container
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Verify release assets and select tags
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          case "$RELEASE_VERSION" in
+            ""|*[!0-9A-Za-z.+-]*)
+              echo "::error::Invalid release version: $RELEASE_VERSION"
+              exit 1
+              ;;
+          esac
+
+          assets="$(gh release view "v$RELEASE_VERSION" --repo "$GITHUB_REPOSITORY" --json assets)"
+          for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
+            asset="minip2p-relay-server-v$RELEASE_VERSION-$target.tar.gz"
+            jq -e --arg asset "$asset" \
+              'any(.assets[]; .name == $asset and .size > 0)' \
+              <<<"$assets" >/dev/null
+          done
+          jq -e 'any(.assets[]; .name == "SHA256SUMS" and .size > 0)' \
+            <<<"$assets" >/dev/null
+
+          latest_tag="$(gh release list \
+            --repo "$GITHUB_REPOSITORY" \
+            --exclude-drafts \
+            --exclude-pre-releases \
+            --limit 1 \
+            --json tagName \
+            --jq '.[0].tagName')"
+          {
+            echo 'tags<<EOF'
+            echo "ghcr.io/deepso7/minip2p-relay:v$RELEASE_VERSION"
+            if [[ "$latest_tag" == "v$RELEASE_VERSION" ]]; then
+              echo "ghcr.io/deepso7/minip2p-relay:latest"
+            fi
+            echo EOF
+          } >>"$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: MINIP2P_VERSION=${{ inputs.version }}
+          tags: ${{ steps.release.outputs.tags }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha,scope=relay-container
+          cache-to: type=gha,mode=max,scope=relay-container
+
+      - name: Verify anonymous access
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          docker logout ghcr.io
+          if ! docker buildx imagetools inspect \
+            "ghcr.io/deepso7/minip2p-relay:v$RELEASE_VERSION"; then
+            echo "::error::The relay package is not public. Set its GHCR visibility to Public, then rerun this workflow."
+            exit 1
+          fi

--- a/.github/workflows/relay-container.yml
+++ b/.github/workflows/relay-container.yml
@@ -28,10 +28,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Verify release assets and select tags
-        id: release
+      - name: Select container source
+        id: source
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ inputs.version }}
@@ -44,6 +42,30 @@ jobs:
               ;;
           esac
 
+          release_ref="v$RELEASE_VERSION"
+          if gh api \
+            "repos/$GITHUB_REPOSITORY/contents/Dockerfile?ref=$release_ref" \
+            >/dev/null 2>&1; then
+            echo "ref=$release_ref" >>"$GITHUB_OUTPUT"
+          elif [[ "$RELEASE_VERSION" == "0.4.3" ]]; then
+            # v0.4.3 supplied the first relay binaries but predates the image.
+            echo "ref=$GITHUB_SHA" >>"$GITHUB_OUTPUT"
+          else
+            echo "::error::Release $release_ref has no container definition"
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ steps.source.outputs.ref }}
+
+      - name: Verify release assets and select tags
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
           assets="$(gh release view "v$RELEASE_VERSION" --repo "$GITHUB_REPOSITORY" --json assets)"
           for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
             asset="minip2p-relay-server-v$RELEASE_VERSION-$target.tar.gz"

--- a/.github/workflows/relay-container.yml
+++ b/.github/workflows/relay-container.yml
@@ -49,7 +49,7 @@ jobs:
             echo "ref=$release_ref" >>"$GITHUB_OUTPUT"
           elif [[ "$RELEASE_VERSION" == "0.4.3" ]]; then
             # v0.4.3 supplied the first relay binaries but predates the image.
-            echo "ref=$GITHUB_SHA" >>"$GITHUB_OUTPUT"
+            echo "ref=b0486657ef51a3feabc5837126ba4aea00324c1f" >>"$GITHUB_OUTPUT"
           else
             echo "::error::Release $release_ref has no container definition"
             exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1.7@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
+
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241 AS download
+
+ARG MINIP2P_VERSION
+ARG TARGETARCH
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*; \
+    case "$TARGETARCH" in \
+      amd64) target="x86_64-unknown-linux-gnu" ;; \
+      arm64) target="aarch64-unknown-linux-gnu" ;; \
+      *) echo "unsupported container architecture: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    archive="minip2p-relay-server-v${MINIP2P_VERSION}-${target}"; \
+    release="https://github.com/deepso7/minip2p/releases/download/v${MINIP2P_VERSION}"; \
+    mkdir /release /out; \
+    curl -fsSL -o "/release/$archive.tar.gz" "$release/$archive.tar.gz"; \
+    curl -fsSL -o /release/SHA256SUMS "$release/SHA256SUMS"; \
+    grep -F "  $archive.tar.gz" /release/SHA256SUMS > /release/CHECKSUM; \
+    cd /release; \
+    sha256sum --check CHECKSUM; \
+    tar -xzf "$archive.tar.gz"; \
+    install -m 0755 "$archive/minip2p-relay-server" /out/minip2p-relay-server
+
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
+
+ARG MINIP2P_VERSION
+
+LABEL org.opencontainers.image.title="minip2p relay server" \
+      org.opencontainers.image.description="Circuit relay server for minip2p" \
+      org.opencontainers.image.source="https://github.com/deepso7/minip2p" \
+      org.opencontainers.image.version="$MINIP2P_VERSION" \
+      org.opencontainers.image.licenses="MIT OR Apache-2.0"
+
+COPY --from=download --chown=10001:10001 /out/minip2p-relay-server /usr/local/bin/minip2p-relay-server
+
+RUN mkdir /data && chown 10001:10001 /data
+
+USER 10001:10001
+WORKDIR /data
+VOLUME ["/data"]
+EXPOSE 19876/tcp 19876/udp
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/usr/local/bin/minip2p-relay-server"]
+CMD ["--key", "/data/identity.key"]

--- a/docs/md/guides/host-a-relay.mdx
+++ b/docs/md/guides/host-a-relay.mdx
@@ -71,19 +71,19 @@ relay identity across container replacements:
 docker run -d \
   --name minip2p-relay \
   --restart unless-stopped \
-  -p 19876:19876/tcp \
-  -p 19876:19876/udp \
+  -p 19876:19876/tcp -p 19876:19876/udp \
   -v minip2p-relay-data:/data \
-  ghcr.io/deepso7/minip2p-relay:v0.4.3 \
-  --key /data/identity.key \
-  --announce /dns/relay.example.com/tcp/19876 \
-  --announce /dns/relay.example.com/udp/19876/quic-v1
+  ghcr.io/deepso7/minip2p-relay:latest
 ```
 
-Replace `relay.example.com` with your hostname. The image runs as UID and GID
-`10001`; make a bind-mounted data directory writable by that account. Publish
-both TCP and UDP ports because the relay serves TCP and QUIC on the same port.
-Host IPv6 publication follows the Docker daemon's IPv6 configuration.
+The image stores its identity in `/data/identity.key` by default. Use `v0.4.3`
+instead of `latest` to pin the release. Pass relay options such as `--announce`
+after the image name.
+
+The image runs as UID and GID `10001`; make a bind-mounted data directory
+writable by that account. Publish both TCP and UDP ports because the relay
+serves TCP and QUIC on the same port. Host IPv6 publication follows the Docker
+daemon's IPv6 configuration.
 
 ### Run it with systemd
 

--- a/docs/md/guides/host-a-relay.mdx
+++ b/docs/md/guides/host-a-relay.mdx
@@ -62,6 +62,29 @@ The key file fixes the peer ID across restarts. The relay creates it with mode
 `0600` on Unix and refuses files owned by another user or files with broader
 permissions.
 
+### Run it with Docker
+
+The container image supports Linux x86-64 and ARM64. A named volume keeps the
+relay identity across container replacements:
+
+```bash
+docker run -d \
+  --name minip2p-relay \
+  --restart unless-stopped \
+  -p 19876:19876/tcp \
+  -p 19876:19876/udp \
+  -v minip2p-relay-data:/data \
+  ghcr.io/deepso7/minip2p-relay:v0.4.3 \
+  --key /data/identity.key \
+  --announce /dns/relay.example.com/tcp/19876 \
+  --announce /dns/relay.example.com/udp/19876/quic-v1
+```
+
+Replace `relay.example.com` with your hostname. The image runs as UID and GID
+`10001`; make a bind-mounted data directory writable by that account. Publish
+both TCP and UDP ports because the relay serves TCP and QUIC on the same port.
+Host IPv6 publication follows the Docker daemon's IPv6 configuration.
+
 ### Run it with systemd
 
 Create a dedicated user and state directory:

--- a/scripts/test-relay-container.sh
+++ b/scripts/test-relay-container.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository="$(cd "$(dirname "$0")/.." && pwd)"
+version="${MINIP2P_CONTAINER_TEST_VERSION:-0.4.3}"
+suffix="$$"
+image="minip2p-relay-test:$suffix"
+container="minip2p-relay-test-$suffix"
+volume="minip2p-relay-test-$suffix"
+
+cleanup() {
+  docker container rm --force "$container" >/dev/null 2>&1 || true
+  docker volume rm "$volume" >/dev/null 2>&1 || true
+  docker image rm --force "$image" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker build \
+  --build-arg "MINIP2P_VERSION=$version" \
+  --tag "$image" \
+  "$repository"
+
+test "$(docker image inspect --format '{{.Config.User}}' "$image")" = "10001:10001"
+test "$(docker image inspect --format '{{index .Config.ExposedPorts "19876/tcp"}}' "$image")" = "{}"
+test "$(docker image inspect --format '{{index .Config.ExposedPorts "19876/udp"}}' "$image")" = "{}"
+test "$(docker image inspect --format '{{index .Config.Volumes "/data"}}' "$image")" = "{}"
+test "$(docker run --rm "$image" --version)" = "minip2p-relay-server $version"
+
+docker volume create "$volume" >/dev/null
+docker run --detach \
+  --name "$container" \
+  --volume "$volume:/data" \
+  "$image" >/dev/null
+
+wait_for_relay() {
+  for _ in {1..20}; do
+    logs="$(docker logs "$container" 2>&1)"
+    if grep -F "/tcp/19876/" <<<"$logs" >/dev/null &&
+      grep -F "/udp/19876/quic-v1/" <<<"$logs" >/dev/null; then
+      test "$(docker container inspect --format '{{.State.Running}}' "$container")" = true
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  docker logs "$container" >&2
+  return 1
+}
+
+wait_for_relay
+first_key="$(docker run --rm \
+  --entrypoint sha256sum \
+  --volume "$volume:/data" \
+  "$image" \
+  /data/identity.key)"
+
+docker container rm --force "$container" >/dev/null
+docker run --detach \
+  --name "$container" \
+  --volume "$volume:/data" \
+  "$image" >/dev/null
+
+wait_for_relay
+second_key="$(docker run --rm \
+  --entrypoint sha256sum \
+  --volume "$volume:/data" \
+  "$image" \
+  /data/identity.key)"
+
+test "$first_key" = "$second_key"

--- a/scripts/test-relay-container.sh
+++ b/scripts/test-relay-container.sh
@@ -21,9 +21,10 @@ docker build \
   "$repository"
 
 test "$(docker image inspect --format '{{.Config.User}}' "$image")" = "10001:10001"
-test "$(docker image inspect --format '{{index .Config.ExposedPorts "19876/tcp"}}' "$image")" = "{}"
-test "$(docker image inspect --format '{{index .Config.ExposedPorts "19876/udp"}}' "$image")" = "{}"
-test "$(docker image inspect --format '{{index .Config.Volumes "/data"}}' "$image")" = "{}"
+metadata="$(docker image inspect "$image")"
+jq -e '.[0].Config.ExposedPorts | has("19876/tcp")' <<<"$metadata" >/dev/null
+jq -e '.[0].Config.ExposedPorts | has("19876/udp")' <<<"$metadata" >/dev/null
+jq -e '.[0].Config.Volumes | has("/data")' <<<"$metadata" >/dev/null
 test "$(docker run --rm "$image" --version)" = "minip2p-relay-server $version"
 
 docker volume create "$volume" >/dev/null


### PR DESCRIPTION
## Summary

- add a non-root multi-architecture relay image built from verified release binaries
- publish versioned and latest GHCR tags from the release workflow
- test image metadata, startup, and identity persistence in CI
- document Docker hosting with persistent state and TCP/QUIC port mappings

## Verification

- `scripts/test-relay-container.sh`
- `docker build --check --build-arg MINIP2P_VERSION=0.4.3 .`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 ...`
- `pnpm run check` in `docs/`
- final Standards review: pass
- final Spec review: pass

## First publication

GHCR creates a new package as private. After the first post-merge workflow run creates it, set the package visibility to Public and rerun the workflow. The workflow verifies anonymous access before succeeding.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a verified, multi‑architecture relay container image to `ghcr.io/deepso7/minip2p-relay` and adds a Docker quickstart. This enables release‑driven distribution with CI validation; previously no container image was published.

- Builds from release tarballs with SHA‑256 verification for amd64/arm64; runs as non‑root UID/GID 10001; exposes TCP/UDP 19876; defaults to `/data/identity.key`.
- Release workflow calls `relay-container.yml` to select the container source from the `vX.Y.Z` tag (pins a known revision for `v0.4.3`), verify required assets, publish multi‑arch with provenance and SBOM, and tag `vX.Y.Z` and `latest` only for the newest stable release.
- CI adds a `relay-container` job that runs `scripts/test-relay-container.sh` to validate image metadata, TCP and QUIC startup, and identity persistence.
- Docs add a shortened Docker quickstart and note UID/GID 10001, supported architectures, default key path, and port mapping guidance.

**Rollout**
- First publication creates a private GHCR package. Set `ghcr.io/deepso7/minip2p-relay` visibility to Public, then rerun the workflow; it verifies anonymous access before succeeding.

<sup>Written for commit c3ac716a8a926fd91d09046b7e45f8f695bd90c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

