### PR TITLE
Fix dual-stack TCP wildcard binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,7 @@ dependencies = [
  "minip2p-smoltcp",
  "minip2p-transport",
  "mio",
+ "socket2",
  "thiserror",
 ]
 

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 default = ["std"]
 std = [
     "dep:mio",
+    "dep:socket2",
     "minip2p-core/std",
     "minip2p-identity/std",
     "minip2p-platform/std",
@@ -35,6 +36,7 @@ minip2p-platform = { path = "../../crates/platform", version = "0.4.3", default-
 minip2p-secure-mux = { path = "../../crates/secure-mux", version = "0.4.3", default-features = false }
 minip2p-transport = { path = "../../crates/transport", version = "0.4.3", default-features = false }
 mio = { version = "1.0", features = ["net", "os-poll"], optional = true }
+socket2 = { version = "0.6.5", optional = true }
 minip2p-smoltcp = { path = "../../crates/smoltcp", version = "0.4.3", optional = true }
 thiserror = { version = "2.0.18", default-features = false }
 

--- a/transports/tcp/src/std_provider.rs
+++ b/transports/tcp/src/std_provider.rs
@@ -13,6 +13,7 @@ use minip2p_core::{Multiaddr, Protocol};
 use minip2p_platform::Now;
 use minip2p_transport::{WaitHandle, WaitOutcome};
 use mio::{Events, Interest, Poll, Token, Waker};
+use socket2::{Domain, Protocol as SocketProtocol, Socket as Socket2, Type};
 
 use crate::blocking::BlockingTcpProvider;
 use crate::provider::{SocketHandle, TcpError, TcpEvent, TcpProvider, host_and_port};
@@ -67,6 +68,30 @@ fn listen_addr(addr: &Multiaddr) -> Result<SocketAddr, TcpError> {
             reason: "listen needs an /ip4 or /ip6 host; names are dial-only".to_string(),
         }),
     }
+}
+
+fn bind_listener(requested: SocketAddr) -> std::io::Result<mio::net::TcpListener> {
+    let socket = Socket2::new(
+        Domain::for_address(requested),
+        Type::STREAM,
+        Some(SocketProtocol::TCP),
+    )?;
+    if requested.is_ipv6() {
+        socket.set_only_v6(true)?;
+    }
+    #[cfg(not(windows))]
+    socket.set_reuse_address(true)?;
+    socket.set_nonblocking(true)?;
+    socket.bind(&requested.into())?;
+    let backlog = if cfg!(target_os = "horizon") {
+        20
+    } else if cfg!(target_os = "haiku") {
+        32
+    } else {
+        128
+    };
+    socket.listen(backlog)?;
+    Ok(mio::net::TcpListener::from_std(socket.into()))
 }
 
 /// Resolves a dial address, performing a blocking name lookup for `/dns*`.
@@ -170,12 +195,12 @@ struct Socket {
 /// `/dns`, `/dns4`, and `/dns6` dial addresses are resolved here, with a
 /// blocking lookup. Listening requires a concrete `/ip4` or `/ip6` host.
 ///
-/// A wildcard listen host binds what the operating system takes it to mean --
-/// every interface, including ones that appear later -- and is reported back
-/// as the wildcard rather than expanded, because which of a machine's
-/// addresses are worth handing to a peer is the host's decision, not a
-/// socket's. mDNS makes that substitution from its own interface list, and
-/// address selection drops what is left.
+/// A wildcard listen host binds every interface, including ones that appear
+/// later. IPv6 listeners are IPv6-only, so explicit IPv4 and IPv6 wildcards can
+/// share a port. The bound address is reported as the wildcard rather than
+/// expanded, because which of a machine's addresses are worth handing to a
+/// peer is the host's decision, not a socket's. mDNS makes that substitution
+/// from its own interface list, and address selection drops what is left.
 pub struct StdTcpProvider {
     poll: Poll,
     events: Events,
@@ -556,8 +581,8 @@ fn event_socket(event: &TcpEvent) -> SocketHandle {
 impl TcpProvider for StdTcpProvider {
     fn listen(&mut self, addr: &Multiaddr) -> Result<Multiaddr, TcpError> {
         let requested = listen_addr(addr)?;
-        let mut listener = mio::net::TcpListener::bind(requested)
-            .map_err(|error| io_error("binding a listener", &error))?;
+        let mut listener =
+            bind_listener(requested).map_err(|error| io_error("binding a listener", &error))?;
         let bound = listener
             .local_addr()
             .map_err(|error| io_error("reading the bound address", &error))?;

--- a/transports/tcp/tests/loopback.rs
+++ b/transports/tcp/tests/loopback.rs
@@ -11,10 +11,10 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use minip2p_core::{Multiaddr, PeerAddr};
+use minip2p_core::{Multiaddr, PeerAddr, Protocol};
 use minip2p_identity::{Ed25519Keypair, PeerId};
 use minip2p_platform::{Now, StdEntropy};
-use minip2p_tcp::{StdTcpProvider, TcpTransport};
+use minip2p_tcp::{StdTcpProvider, TcpProvider, TcpTransport};
 use minip2p_transport::{
     BlockingTransport, ConnectionId, StreamId, Transport, TransportError, TransportEvent,
     WaitOutcome,
@@ -346,6 +346,26 @@ fn a_refused_connect_is_reported_and_closed() {
 
 fn is_connected_event(event: &TransportEvent) -> bool {
     matches!(event, TransportEvent::Connected { .. })
+}
+
+#[test]
+fn ipv4_and_ipv6_wildcard_listeners_can_share_a_port() {
+    let mut provider = StdTcpProvider::new().expect("a readiness registry");
+    let ipv4 = provider
+        .listen(&"/ip4/0.0.0.0/tcp/0".parse().expect("IPv4 wildcard"))
+        .expect("the IPv4 wildcard binds");
+    let port = match ipv4.protocols().get(1) {
+        Some(Protocol::Tcp(port)) => *port,
+        protocols => panic!("bound address has no TCP port: {protocols:?}"),
+    };
+    let ipv6 = format!("/ip6/::/tcp/{port}")
+        .parse()
+        .expect("IPv6 wildcard");
+
+    provider
+        .listen(&ipv6)
+        .expect("separate IPv4 and IPv6 wildcard listeners share a port");
+    assert_eq!(provider.local_addresses(), vec![ipv4, ipv6]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- make IPv6 TCP listeners IPv6-only so explicit IPv4 and IPv6 wildcards can share one port on Linux
- preserve Mio's existing non-Windows `SO_REUSEADDR` and platform backlog behavior
- document the listener contract and add a provider-level regression test

This fixes the relay server's default Linux startup falling back to IPv4 when both address families are available.

## TDD

The new wildcard same-port test failed in a Linux container before the implementation with:

```
binding a listener failed: Address already in use (os error 98)
```

It passes after setting `IPV6_V6ONLY`. A full Linux relay-server startup with default addresses then reported IPv4 and IPv6 listeners for both TCP and QUIC on port 19876.

## Verification

- `cargo test --locked -p minip2p-tcp`
- `cargo test --locked -p minip2p-tcp --features smoltcp`
- `cargo check --locked -p minip2p-tcp --no-default-features`
- `cargo test --locked -p minip2p-rs --features tcp`
- `cargo test --locked -p minip2p-relay-server-example`
- `cargo clippy --locked -p minip2p-tcp --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- Linux container regression test
- Linux container default relay-server startup
- final Standards review: 0 findings
- final Spec review: 0 findings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make IPv6 TCP listeners IPv6-only so IPv4 and IPv6 wildcard listeners can share a port on Linux. Previously, binding `/ip4/0.0.0.0` and `/ip6/::` on the same port failed (EADDRINUSE) and the relay server could fall back to IPv4; now both bind and report wildcard addresses.

- Uses `socket2` to set `IPV6_V6ONLY`, keep non-Windows `SO_REUSEADDR`, set nonblocking, and preserve platform backlog defaults; replaces direct `mio::net::TcpListener::bind`.
- Documents the listener contract and adds a regression test that asserts dual wildcard listeners share a port.
- Adds optional `socket2` under the `std` feature in `minip2p-tcp`; no API changes or migration actions required.

<sup>Written for commit 4254477ab5e120ac6fd4891df81e04aa0c38be17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

