### PR TITLE
Add the Node binding shell over QUIC

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -6,12 +6,16 @@ on:
     paths:
       - "bindings/**"
       - "crates/ffi/**"
+      - "crates/ffi-core/**"
+      - "crates/nodejs/**"
       - ".github/workflows/bindings.yml"
       - ".github/workflows/bindings-native.yml"
   pull_request:
     paths:
       - "bindings/**"
       - "crates/ffi/**"
+      - "crates/ffi-core/**"
+      - "crates/nodejs/**"
       - ".github/workflows/bindings.yml"
       - ".github/workflows/bindings-native.yml"
 
@@ -44,6 +48,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
+      - run: pnpm --filter @minip2p/node native:build
       - run: pnpm test
       - run: pnpm lint
       - run: pnpm build

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -38,10 +38,10 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: "24.12.0"
+          node-version: "24.19.0"
       - uses: pnpm/action-setup@v6
         with:
-          version: "11.18.0"
+          version: "11.24.0"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /target-linux
 .DS_Store
 /tmp
+/bindings/ts/node/*.node
+/crates/nodejs/*.node
 
 # Demo peer identity files contain raw Ed25519 secrets.
 *.key

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -1542,6 +1543,8 @@ dependencies = [
  "napi-sys",
  "nohash-hasher",
  "rustc-hash",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1995,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -132,7 +132,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -329,7 +329,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -378,6 +378,15 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cpubits"
@@ -488,6 +497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,7 +536,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -558,7 +573,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -591,7 +606,7 @@ checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -679,7 +694,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -750,7 +765,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -785,25 +800,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
-name = "futures-task"
-version = "0.3.32"
+name = "futures-executor"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -987,6 +1066,16 @@ name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
  "windows-link",
@@ -1183,6 +1272,16 @@ dependencies = [
  "minip2p-test-support",
  "minip2p-transport",
  "thiserror",
+]
+
+[[package]]
+name = "minip2p-nodejs"
+version = "0.4.6"
+dependencies = [
+ "minip2p-ffi-core",
+ "napi",
+ "napi-build",
+ "napi-derive",
 ]
 
 [[package]]
@@ -1430,6 +1529,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "napi"
+version = "3.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c5f4d5375213fdb7be2655e152386e82f026f9a5ba36a75556e11359aafe09"
+dependencies = [
+ "bitflags 2.13.0",
+ "ctor",
+ "futures",
+ "libc",
+ "napi-build",
+ "napi-sys",
+ "nohash-hasher",
+ "rustc-hash",
+]
+
+[[package]]
+name = "napi-build"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60fdf9b392c50e7c4170fa633bd909490ed7835cea4c046776d1a4dd8d2ae0ab"
+
+[[package]]
+name = "napi-derive"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa55ea69990c90b888e9e77044410e304ce7f35de599dc6d0b5c1923d2e59af"
+dependencies = [
+ "convert_case",
+ "ctor",
+ "napi-derive-backend",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "napi-derive-backend"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df4056ac7c18e4438ccf0edaed4340ca0d269278c8ec19284f7b23cb039fd0ae"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "napi-sys"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fbf1fa9f1babfe396d74bbbf52b3643770243e8f5b0b46715d4caf7f0dfc9a"
+dependencies = [
+ "libloading 0.9.0",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,7 +1637,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1773,7 +1936,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1827,7 +1990,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2000,6 +2163,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,7 +2212,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2069,7 +2243,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2122,6 +2296,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "uniffi"
@@ -2185,7 +2365,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2200,7 +2380,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.118",
  "toml",
  "uniffi_meta",
 ]
@@ -2306,7 +2486,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -2524,7 +2704,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2544,7 +2724,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "serde",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/minip2p",
     "crates/multistream-select",
     "crates/nat",
+    "crates/nodejs",
     "crates/noise",
     "crates/ping",
     "crates/platform",

--- a/bindings/ts/README.md
+++ b/bindings/ts/README.md
@@ -13,6 +13,7 @@ Platform adapters implement `@minip2p/core/backend` and re-export the public SDK
 ```sh
 pnpm install --frozen-lockfile
 pnpm typecheck
+pnpm --filter @minip2p/node native:build
 pnpm test
 pnpm lint
 pnpm build

--- a/bindings/ts/README.md
+++ b/bindings/ts/README.md
@@ -6,7 +6,7 @@ TypeScript bindings for [minip2p](https://minip2p.com).
 | --- | --- |
 | [`@minip2p/core`](./core) | Platform-neutral SDK, types, events, and backend contract |
 | [`@minip2p/react-native`](./react-native) | Published React Native adapter with Android and iOS libraries |
-| [`@minip2p/node`](./node) | Private Node.js adapter scaffold |
+| [`@minip2p/node`](./node) | Node.js adapter over the napi-rs binding shell |
 
 Platform adapters implement `@minip2p/core/backend` and re-export the public SDK types. See [FEATURES.md](./FEATURES.md) for the Rust-to-TypeScript capability map.
 

--- a/bindings/ts/node/README.md
+++ b/bindings/ts/node/README.md
@@ -1,5 +1,26 @@
 # @minip2p/node
 
-Private Node.js adapter scaffold for [minip2p](https://minip2p.com).
+Node.js bindings for [minip2p](https://minip2p.com), backed by a native [napi-rs](https://napi.rs/) addon. The package is ESM-only and requires Node.js 24 or newer.
 
-The package is not published yet; a native napi-rs backend is still required before it can construct an endpoint.
+```ts
+import { Minip2p, generateSecretKey } from "@minip2p/node";
+
+const endpoint = Minip2p.create({
+  secretKey: generateSecretKey(),
+  transports: {
+    quic: { listen: ["/ip4/127.0.0.1/udp/0/quic-v1"] },
+  },
+});
+
+console.log(endpoint.peerId(), endpoint.listenAddrs());
+endpoint.close();
+```
+
+`Minip2p.create()` binds and starts the endpoint synchronously. A started endpoint keeps the Node.js process alive until `close()` requests shutdown. Calls into the backend are synchronous; promise-returning operations such as `connectAddr()` and `openStream()` resolve from native events.
+
+The package is private until the platform-package publishing work lands. Build the local addon and run its suite with:
+
+```bash
+pnpm native:build
+pnpm test
+```

--- a/bindings/ts/node/package.json
+++ b/bindings/ts/node/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "del-cli dist && tsc -p tsconfig.build.json",
     "clean": "del-cli dist",
+    "native:build": "napi build --platform --no-js --dts ../../../target/minip2p-nodejs.d.ts --release --manifest-path ../../../crates/nodejs/Cargo.toml --output-dir . -- --locked",
     "test": "vitest run --config ../vitest.config.ts --root .",
     "test:watch": "vitest --config ../vitest.config.ts --root .",
     "typecheck": "tsc -p tsconfig.json"
@@ -35,8 +36,21 @@
   },
   "devDependencies": {
     "@minip2p/test-fixtures": "workspace:*",
+    "@napi-rs/cli": "3.8.6",
     "@types/node": "catalog:",
     "del-cli": "catalog:",
     "typescript": "catalog:"
+  },
+  "napi": {
+    "binaryName": "minip2p",
+    "targets": [
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-linux-musl",
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-linux-musl",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc"
+    ]
   }
 }

--- a/bindings/ts/node/package.json
+++ b/bindings/ts/node/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@minip2p/test-fixtures": "workspace:*",
+    "@types/node": "catalog:",
     "del-cli": "catalog:",
     "typescript": "catalog:"
   }

--- a/bindings/ts/node/package.json
+++ b/bindings/ts/node/package.json
@@ -27,7 +27,7 @@
     "build": "del-cli dist && tsc -p tsconfig.build.json",
     "clean": "del-cli dist",
     "native:build": "napi build --platform --no-js --dts ../../../target/minip2p-nodejs.d.ts --release --manifest-path ../../../crates/nodejs/Cargo.toml --output-dir . -- --locked",
-    "test": "vitest run --config ../vitest.config.ts --root .",
+    "test": "vitest run --config ../vitest.config.ts --root . --no-file-parallelism",
     "test:watch": "vitest --config ../vitest.config.ts --root .",
     "typecheck": "tsc -p tsconfig.json"
   },
@@ -52,5 +52,8 @@
       "aarch64-apple-darwin",
       "x86_64-pc-windows-msvc"
     ]
+  },
+  "engines": {
+    "node": ">=24"
   }
 }

--- a/bindings/ts/node/src/adapter.ts
+++ b/bindings/ts/node/src/adapter.ts
@@ -1,0 +1,233 @@
+import { Minip2pBase, PubsubRouter } from "@minip2p/core";
+import type {
+  Bytes,
+  IdentifyInfo,
+  KnownPeerInfo,
+  Minip2pConfig,
+  Minip2pTransportOptions,
+  Reachability,
+  RelayReservationInfo,
+} from "@minip2p/core";
+import type {
+  BackendOpenStream,
+  Minip2pBackend,
+  PathKind,
+  P2pEvent,
+} from "@minip2p/core/backend";
+
+import { nativeBinding } from "./native.js";
+import type { NativeEndpoint } from "./native.js";
+
+class NodeBackend implements Minip2pBackend {
+  readonly #endpoint: NativeEndpoint;
+
+  constructor(config: Minip2pConfig) {
+    const transports = resolveTransports(config);
+    this.#endpoint = new nativeBinding.NodeEndpoint(
+      toUint8Array(config.secretKey),
+      {
+        agentVersion: config.agentVersion,
+        allowUnsigned: config.allowUnsigned ?? false,
+        autonatServers: [...(config.autonatServers ?? [])],
+        forceRelay: config.forceRelay ?? false,
+        protocols: [...(config.protocols ?? [])],
+        pubsubRouter: config.pubsubRouter ?? PubsubRouter.Gossipsub,
+        quic: toNativeTransport(transports.quic),
+        relays: [...(config.relays ?? [])],
+        tcp: toNativeTransport(transports.tcp),
+      }
+    );
+  }
+
+  start(_listener: (event: P2pEvent) => void): void {
+    this.#endpoint.start(() => {});
+  }
+
+  close(): void {
+    this.#endpoint.close();
+  }
+
+  peerId(): string {
+    return this.#endpoint.peerId();
+  }
+
+  listenAddrs(): string[] {
+    return this.#endpoint.listenAddrs();
+  }
+
+  isRunning(): boolean {
+    return this.#endpoint.isRunning();
+  }
+
+  connectedPeers(): string[] {
+    return unsupported();
+  }
+
+  isPeerReady(_peerId: string): boolean {
+    return unsupported();
+  }
+
+  peerInfo(_peerId: string): IdentifyInfo | undefined {
+    return unsupported();
+  }
+
+  knownPeers(): KnownPeerInfo[] {
+    return unsupported();
+  }
+
+  discoveryNowMs(): number | undefined {
+    return unsupported();
+  }
+
+  activeReservation(): RelayReservationInfo | undefined {
+    return unsupported();
+  }
+
+  path(_peerId: string): PathKind | undefined {
+    return unsupported();
+  }
+
+  circuitAddress(relayAddress: string, peerId: string): string {
+    return nativeBinding.circuitAddress(relayAddress, peerId);
+  }
+
+  reachability(): Reachability {
+    return unsupported();
+  }
+
+  setActive(_active: boolean): void {
+    unsupported();
+  }
+
+  subscribe(_topic: string): boolean {
+    return unsupported();
+  }
+
+  unsubscribe(_topic: string): boolean {
+    return unsupported();
+  }
+
+  publish(_topic: string, _data: Uint8Array): void {
+    unsupported();
+  }
+
+  ping(_peerId: string): void {
+    unsupported();
+  }
+
+  addProtocol(_protocolId: string): void {
+    unsupported();
+  }
+
+  openStream(_peerId: string, _protocolId: string): BackendOpenStream {
+    return unsupported();
+  }
+
+  sendStream(_peerId: string, _streamId: number, _data: Uint8Array): void {
+    unsupported();
+  }
+
+  closeStreamWrite(_peerId: string, _streamId: number): void {
+    unsupported();
+  }
+
+  resetStream(_peerId: string, _streamId: number): void {
+    unsupported();
+  }
+
+  abandonStream(_peerId: string, _streamId: number): void {
+    unsupported();
+  }
+
+  connect(_peerId: string): number {
+    return unsupported();
+  }
+
+  connectWithAddrs(_peerId: string, _addresses: readonly string[]): number {
+    return unsupported();
+  }
+
+  connectAddr(_address: string): number {
+    return unsupported();
+  }
+
+  dial(_address: string): number[] {
+    return unsupported();
+  }
+
+  dialIp4(_address: string): number {
+    return unsupported();
+  }
+
+  dialIp6(_address: string): number {
+    return unsupported();
+  }
+
+  cancelConnect(_id: number): void {
+    unsupported();
+  }
+
+  disconnect(_peerId: string): void {
+    unsupported();
+  }
+}
+
+/** High-level Node.js owner for one native minip2p endpoint. */
+export class Minip2p extends Minip2pBase {
+  private constructor(backend: Minip2pBackend, relays: readonly string[]) {
+    super(backend, relays);
+  }
+
+  /** Constructs and starts a Node.js endpoint. */
+  static create(config: Minip2pConfig): Minip2p {
+    return new Minip2p(new NodeBackend(config), config.relays ?? []);
+  }
+}
+
+/** Generates a new 32-byte Ed25519 secret key. */
+export function generateSecretKey(): Uint8Array {
+  return nativeBinding.generateSecretKey();
+}
+
+/** Derives a peer ID from raw Ed25519 secret key material. */
+export function peerIdFromSecretKey(secretKey: Bytes): string {
+  return nativeBinding.peerIdFromSecretKey(toUint8Array(secretKey));
+}
+
+/** Builds a circuit multiaddress through a direct relay address. */
+export function circuitAddress(relayAddress: string, peerId: string): string {
+  return nativeBinding.circuitAddress(relayAddress, peerId);
+}
+
+function resolveTransports(config: Minip2pConfig) {
+  const transports = config.transports;
+  if (
+    transports === undefined ||
+    (transports.quic === undefined && transports.tcp === undefined)
+  ) {
+    return { quic: true } as const;
+  }
+  return transports;
+}
+
+function toNativeTransport(
+  transport: true | Minip2pTransportOptions | undefined
+): { readonly listenAddrs?: string[] } | undefined {
+  if (transport === undefined) {
+    return undefined;
+  }
+  if (transport === true || transport.listen === undefined) {
+    return {};
+  }
+  return { listenAddrs: [...transport.listen] };
+}
+
+function toUint8Array(value: Bytes): Uint8Array {
+  return value instanceof Uint8Array
+    ? Uint8Array.from(value)
+    : new Uint8Array(value);
+}
+
+function unsupported(): never {
+  throw new Error("The native Node backend method is not implemented");
+}

--- a/bindings/ts/node/src/adapter.ts
+++ b/bindings/ts/node/src/adapter.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable class-methods-use-this, func-style, max-classes-per-file, no-use-before-define, prefer-destructuring, unicorn/no-useless-undefined -- The adapter keeps the contract-complete native endpoint, value conversion, handle maps, and drain loop together at the binding boundary. */
+
 import { Minip2pBase, PubsubRouter } from "@minip2p/core";
 import type {
   Bytes,
@@ -37,8 +39,8 @@ class NodeBackend implements Minip2pBackend {
         agentVersion: config.agentVersion,
         allowUnsigned: config.allowUnsigned ?? false,
         autonatServers: [...(config.autonatServers ?? [])],
-        forceRelay: config.forceRelay ?? false,
         discovery,
+        forceRelay: config.forceRelay ?? false,
         mdns,
         protocols: [...(config.protocols ?? [])],
         pubsubRouter: config.pubsubRouter ?? PubsubRouter.Gossipsub,
@@ -161,10 +163,7 @@ class NodeBackend implements Minip2pBackend {
   }
 
   closeStreamWrite(peerId: string, streamId: number): void {
-    this.#endpoint.closeStreamWrite(
-      peerId,
-      this.#streamIds.toNative(streamId)
-    );
+    this.#endpoint.closeStreamWrite(peerId, this.#streamIds.toNative(streamId));
   }
 
   resetStream(peerId: string, streamId: number): void {
@@ -190,9 +189,9 @@ class NodeBackend implements Minip2pBackend {
   }
 
   dial(address: string): number[] {
-    return this.#endpoint.dial(address).map((id) =>
-      this.#connectionIds.toPublic(id)
-    );
+    return this.#endpoint
+      .dial(address)
+      .map((id) => this.#connectionIds.toPublic(id));
   }
 
   dialIp4(address: string): number {
@@ -301,7 +300,9 @@ function toUint8Array(value: Bytes): Uint8Array {
 
 function numberToBigInt(value: number): bigint {
   if (!Number.isSafeInteger(value) || value < 0) {
-    throw new RangeError("Native identifiers must be non-negative safe integers");
+    throw new RangeError(
+      "Native identifiers must be non-negative safe integers"
+    );
   }
   return BigInt(value);
 }
@@ -378,8 +379,8 @@ function normalizeEvent(
   streamIds: IdMap
 ): P2pEvent {
   const event = normalizeNativeValue(value, undefined, {
-    connectionIds,
     connectIds,
+    connectionIds,
     streamIds,
   }) as { tag?: unknown; inner?: unknown };
   if (typeof event.tag !== "string" || event.inner === undefined) {
@@ -433,10 +434,7 @@ class EventDrain {
   #scheduled = false;
   #stopped = false;
 
-  constructor(
-    drain: () => unknown[],
-    normalize: (event: unknown) => P2pEvent
-  ) {
+  constructor(drain: () => unknown[], normalize: (event: unknown) => P2pEvent) {
     this.#drain = drain;
     this.#normalize = normalize;
   }

--- a/bindings/ts/node/src/adapter.ts
+++ b/bindings/ts/node/src/adapter.ts
@@ -94,7 +94,10 @@ class NodeBackend implements Minip2pBackend {
   }
 
   peerInfo(peerId: string): IdentifyInfo | undefined {
-    return normalizeOptional<IdentifyInfo>(this.#endpoint.peerInfo(peerId));
+    const info = this.#endpoint.peerInfo(peerId);
+    return info === null || info === undefined
+      ? undefined
+      : normalizeIdentifyInfo(info);
   }
 
   knownPeers(): KnownPeerInfo[] {
@@ -325,6 +328,23 @@ function normalizeRecord<Value>(value: unknown): Value {
   return normalizeNativeValue(value) as Value;
 }
 
+function normalizeIdentifyInfo(value: unknown): IdentifyInfo {
+  const info = normalizeRecord<Record<string, unknown>>(value);
+  const publicKey = info.publicKey;
+  if (publicKey === undefined) {
+    return info as unknown as IdentifyInfo;
+  }
+  if (Array.isArray(publicKey) || publicKey instanceof Uint8Array) {
+    return {
+      ...info,
+      publicKey: Uint8Array.from(publicKey).buffer,
+    } as unknown as IdentifyInfo;
+  }
+  throw new TypeError(
+    "The native addon returned an invalid Identify public key"
+  );
+}
+
 function normalizeNativeValue(
   value: unknown,
   key?: string,
@@ -418,10 +438,7 @@ function normalizeEventBytes(tag: string, value: unknown): unknown {
   if (tag === "IdentifyReceived") {
     const info = Reflect.get(inner, "info");
     if (info !== null && typeof info === "object") {
-      const publicKey = Reflect.get(info, "publicKey");
-      if (Array.isArray(publicKey) || publicKey instanceof Uint8Array) {
-        Reflect.set(info, "publicKey", Uint8Array.from(publicKey).buffer);
-      }
+      Reflect.set(inner, "info", normalizeIdentifyInfo(info));
     }
   }
   return inner;

--- a/bindings/ts/node/src/adapter.ts
+++ b/bindings/ts/node/src/adapter.ts
@@ -209,6 +209,7 @@ class NodeBackend implements Minip2pBackend {
 
   cancelConnect(id: number): void {
     this.#endpoint.cancelConnect(this.#connectIds.toNative(id));
+    this.#connectIds.deletePublic(id);
   }
 
   disconnect(peerId: string): void {
@@ -431,13 +432,14 @@ function normalizeEvent(
   ) {
     event.inner = normalizeEventBytes(event.tag, event.inner);
   }
-  releaseTerminalIds(event, connectionIds, streamIds);
+  releaseTerminalIds(event, connectionIds, connectIds, streamIds);
   return event as P2pEvent;
 }
 
 function releaseTerminalIds(
   event: { readonly tag?: unknown; readonly inner?: unknown },
   connectionIds: IdMap,
+  connectIds: IdMap,
   streamIds: IdMap
 ): void {
   if (event.inner === null || typeof event.inner !== "object") {
@@ -446,9 +448,39 @@ function releaseTerminalIds(
   if (event.tag === "ConnectionClosed") {
     connectionIds.deletePublic(Reflect.get(event.inner, "connId"));
   }
+  if (isTerminalConnectEvent(event)) {
+    connectIds.deletePublic(Reflect.get(event.inner, "connectId"));
+  }
   if (event.tag === "StreamClosed") {
     streamIds.deletePublic(Reflect.get(event.inner, "streamId"));
   }
+}
+
+function isTerminalConnectEvent(event: {
+  readonly tag?: unknown;
+  readonly inner?: unknown;
+}): boolean {
+  if (
+    event.tag === "ConnectFailed" ||
+    event.tag === "FellBackToRelay" ||
+    event.tag === "PathUpgraded"
+  ) {
+    return true;
+  }
+  if (
+    event.tag !== "PathEstablished" ||
+    event.inner === null ||
+    typeof event.inner !== "object"
+  ) {
+    return false;
+  }
+  const path = Reflect.get(event.inner, "path");
+  return (
+    path !== null &&
+    typeof path === "object" &&
+    (Reflect.get(path, "tag") === "DirectDialed" ||
+      Reflect.get(path, "tag") === "DirectPunched")
+  );
 }
 
 function normalizeEventBytes(tag: string, value: unknown): unknown {

--- a/bindings/ts/node/src/adapter.ts
+++ b/bindings/ts/node/src/adapter.ts
@@ -4,6 +4,8 @@ import type {
   IdentifyInfo,
   KnownPeerInfo,
   Minip2pConfig,
+  Minip2pDiscoveryOptions,
+  Minip2pMdnsOptions,
   Minip2pTransportOptions,
   Reachability,
   RelayReservationInfo,
@@ -19,10 +21,16 @@ import { nativeBinding } from "./native.js";
 import type { NativeEndpoint } from "./native.js";
 
 class NodeBackend implements Minip2pBackend {
+  readonly #connectionIds = new IdMap();
+  readonly #connectIds = new IdMap();
   readonly #endpoint: NativeEndpoint;
+  readonly #events: EventDrain;
+  readonly #streamIds = new IdMap();
 
   constructor(config: Minip2pConfig) {
     const transports = resolveTransports(config);
+    const discovery = toNativeDiscovery(config.discovery);
+    const mdns = toNativeMdns(config.mdns, config.discovery);
     this.#endpoint = new nativeBinding.NodeEndpoint(
       toUint8Array(config.secretKey),
       {
@@ -30,6 +38,8 @@ class NodeBackend implements Minip2pBackend {
         allowUnsigned: config.allowUnsigned ?? false,
         autonatServers: [...(config.autonatServers ?? [])],
         forceRelay: config.forceRelay ?? false,
+        discovery,
+        mdns,
         protocols: [...(config.protocols ?? [])],
         pubsubRouter: config.pubsubRouter ?? PubsubRouter.Gossipsub,
         quic: toNativeTransport(transports.quic),
@@ -37,14 +47,28 @@ class NodeBackend implements Minip2pBackend {
         tcp: toNativeTransport(transports.tcp),
       }
     );
+    this.#events = new EventDrain(
+      () => this.#endpoint.drainEvents(256),
+      (event) =>
+        normalizeEvent(
+          event,
+          this.#connectionIds,
+          this.#connectIds,
+          this.#streamIds
+        )
+    );
   }
 
-  start(_listener: (event: P2pEvent) => void): void {
-    this.#endpoint.start(() => {});
+  start(listener: (event: P2pEvent) => void): void {
+    this.#events.start(listener);
+    this.#endpoint.start(() => {
+      this.#events.ring();
+    });
   }
 
   close(): void {
     this.#endpoint.close();
+    this.#events.stop();
   }
 
   peerId(): string {
@@ -60,31 +84,36 @@ class NodeBackend implements Minip2pBackend {
   }
 
   connectedPeers(): string[] {
-    return unsupported();
+    return this.#endpoint.connectedPeers();
   }
 
-  isPeerReady(_peerId: string): boolean {
-    return unsupported();
+  isPeerReady(peerId: string): boolean {
+    return this.#endpoint.isPeerReady(peerId);
   }
 
-  peerInfo(_peerId: string): IdentifyInfo | undefined {
-    return unsupported();
+  peerInfo(peerId: string): IdentifyInfo | undefined {
+    return normalizeOptional<IdentifyInfo>(this.#endpoint.peerInfo(peerId));
   }
 
   knownPeers(): KnownPeerInfo[] {
-    return unsupported();
+    return this.#endpoint
+      .knownPeers()
+      .map((peer) => normalizeRecord<KnownPeerInfo>(peer));
   }
 
   discoveryNowMs(): number | undefined {
-    return unsupported();
+    const value = this.#endpoint.discoveryNowMs();
+    return value === undefined ? undefined : bigintToNumber(value, "clock");
   }
 
   activeReservation(): RelayReservationInfo | undefined {
-    return unsupported();
+    return normalizeOptional<RelayReservationInfo>(
+      this.#endpoint.activeReservation()
+    );
   }
 
-  path(_peerId: string): PathKind | undefined {
-    return unsupported();
+  path(peerId: string): PathKind | undefined {
+    return normalizeOptional<PathKind>(this.#endpoint.path(peerId));
   }
 
   circuitAddress(relayAddress: string, peerId: string): string {
@@ -92,83 +121,94 @@ class NodeBackend implements Minip2pBackend {
   }
 
   reachability(): Reachability {
-    return unsupported();
+    return this.#endpoint.reachability() as Reachability;
   }
 
-  setActive(_active: boolean): void {
-    unsupported();
+  setActive(active: boolean): void {
+    this.#endpoint.setActive(active);
   }
 
-  subscribe(_topic: string): boolean {
-    return unsupported();
+  subscribe(topic: string): boolean {
+    return this.#endpoint.subscribe(topic);
   }
 
-  unsubscribe(_topic: string): boolean {
-    return unsupported();
+  unsubscribe(topic: string): boolean {
+    return this.#endpoint.unsubscribe(topic);
   }
 
-  publish(_topic: string, _data: Uint8Array): void {
-    unsupported();
+  publish(topic: string, data: Uint8Array): void {
+    this.#endpoint.publish(topic, data);
   }
 
-  ping(_peerId: string): void {
-    unsupported();
+  ping(peerId: string): void {
+    this.#endpoint.ping(peerId);
   }
 
-  addProtocol(_protocolId: string): void {
-    unsupported();
+  addProtocol(protocolId: string): void {
+    this.#endpoint.addProtocol(protocolId);
   }
 
-  openStream(_peerId: string, _protocolId: string): BackendOpenStream {
-    return unsupported();
+  openStream(peerId: string, protocolId: string): BackendOpenStream {
+    const stream = this.#endpoint.openStream(peerId, protocolId);
+    return {
+      connId: this.#connectionIds.toPublic(stream.connId),
+      streamId: this.#streamIds.toPublic(stream.streamId),
+    };
   }
 
-  sendStream(_peerId: string, _streamId: number, _data: Uint8Array): void {
-    unsupported();
+  sendStream(peerId: string, streamId: number, data: Uint8Array): void {
+    this.#endpoint.sendStream(peerId, this.#streamIds.toNative(streamId), data);
   }
 
-  closeStreamWrite(_peerId: string, _streamId: number): void {
-    unsupported();
+  closeStreamWrite(peerId: string, streamId: number): void {
+    this.#endpoint.closeStreamWrite(
+      peerId,
+      this.#streamIds.toNative(streamId)
+    );
   }
 
-  resetStream(_peerId: string, _streamId: number): void {
-    unsupported();
+  resetStream(peerId: string, streamId: number): void {
+    this.#endpoint.resetStream(peerId, this.#streamIds.toNative(streamId));
   }
 
-  abandonStream(_peerId: string, _streamId: number): void {
-    unsupported();
+  abandonStream(peerId: string, streamId: number): void {
+    this.#endpoint.abandonStream(peerId, this.#streamIds.toNative(streamId));
   }
 
-  connect(_peerId: string): number {
-    return unsupported();
+  connect(peerId: string): number {
+    return this.#connectIds.toPublic(this.#endpoint.connect(peerId));
   }
 
-  connectWithAddrs(_peerId: string, _addresses: readonly string[]): number {
-    return unsupported();
+  connectWithAddrs(peerId: string, addresses: readonly string[]): number {
+    return this.#connectIds.toPublic(
+      this.#endpoint.connectWithAddrs(peerId, [...addresses])
+    );
   }
 
-  connectAddr(_address: string): number {
-    return unsupported();
+  connectAddr(address: string): number {
+    return this.#connectIds.toPublic(this.#endpoint.connectAddr(address));
   }
 
-  dial(_address: string): number[] {
-    return unsupported();
+  dial(address: string): number[] {
+    return this.#endpoint.dial(address).map((id) =>
+      this.#connectionIds.toPublic(id)
+    );
   }
 
-  dialIp4(_address: string): number {
-    return unsupported();
+  dialIp4(address: string): number {
+    return this.#connectionIds.toPublic(this.#endpoint.dialIp4(address));
   }
 
-  dialIp6(_address: string): number {
-    return unsupported();
+  dialIp6(address: string): number {
+    return this.#connectionIds.toPublic(this.#endpoint.dialIp6(address));
   }
 
-  cancelConnect(_id: number): void {
-    unsupported();
+  cancelConnect(id: number): void {
+    this.#endpoint.cancelConnect(this.#connectIds.toNative(id));
   }
 
-  disconnect(_peerId: string): void {
-    unsupported();
+  disconnect(peerId: string): void {
+    this.#endpoint.disconnect(peerId);
   }
 }
 
@@ -222,12 +262,247 @@ function toNativeTransport(
   return { listenAddrs: [...transport.listen] };
 }
 
+function toNativeDiscovery(discovery: Minip2pDiscoveryOptions | undefined) {
+  return discovery === undefined
+    ? undefined
+    : {
+        autoDial: discovery.autoDial ?? true,
+        beaconIntervalMs: numberToBigInt(discovery.beaconIntervalMs ?? 10_000),
+        peerTtlMs: numberToBigInt(discovery.peerTtlMs ?? 35_000),
+        topic: discovery.topic,
+      };
+}
+
+function toNativeMdns(
+  mdns: boolean | Minip2pMdnsOptions | undefined,
+  discovery: Minip2pDiscoveryOptions | undefined
+) {
+  const options = mdns === true ? {} : mdns;
+  if (options === undefined || options === false) {
+    return undefined;
+  }
+  return {
+    autoDial: options.autoDial ?? discovery?.autoDial ?? true,
+    enableIpv6: options.enableIpv6 ?? false,
+    interfaceRefreshMs: numberToBigInt(options.interfaceRefreshMs ?? 10_000),
+    maxAnnouncedAddrs: options.maxAnnouncedAddrs ?? 16,
+    maxPacketBytes: options.maxPacketBytes ?? 1400,
+    queryIntervalMs: numberToBigInt(options.queryIntervalMs ?? 300_000),
+    socketPollIntervalMs: numberToBigInt(options.socketPollIntervalMs ?? 100),
+    ttlMs: numberToBigInt(options.ttlMs ?? 120_000),
+  };
+}
+
 function toUint8Array(value: Bytes): Uint8Array {
   return value instanceof Uint8Array
     ? Uint8Array.from(value)
     : new Uint8Array(value);
 }
 
-function unsupported(): never {
-  throw new Error("The native Node backend method is not implemented");
+function numberToBigInt(value: number): bigint {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError("Native identifiers must be non-negative safe integers");
+  }
+  return BigInt(value);
+}
+
+function bigintToNumber(value: bigint, name: string): number {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 0) {
+    throw new RangeError(`${name} exceeds JavaScript's safe integer range`);
+  }
+  return number;
+}
+
+function normalizeOptional<Value>(value: unknown): Value | undefined {
+  return value === null || value === undefined
+    ? undefined
+    : normalizeRecord<Value>(value);
+}
+
+function normalizeRecord<Value>(value: unknown): Value {
+  return normalizeNativeValue(value) as Value;
+}
+
+function normalizeNativeValue(
+  value: unknown,
+  key?: string,
+  maps?: NativeIdMaps
+): unknown {
+  if (typeof value === "number" && maps !== undefined) {
+    if (key === "connId") {
+      return maps.connectionIds.toPublic(BigInt(value));
+    }
+    if (key === "connectId") {
+      return maps.connectIds.toPublic(BigInt(value));
+    }
+    if (key === "streamId") {
+      return maps.streamIds.toPublic(BigInt(value));
+    }
+  }
+  if (typeof value === "bigint") {
+    if (key === "connId" && maps !== undefined) {
+      return maps.connectionIds.toPublic(value);
+    }
+    if (key === "connectId" && maps !== undefined) {
+      return maps.connectIds.toPublic(value);
+    }
+    if (key === "streamId" && maps !== undefined) {
+      return maps.streamIds.toPublic(value);
+    }
+    return bigintToNumber(value, "native value");
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeNativeValue(item, undefined, maps));
+  }
+  if (value instanceof Uint8Array) {
+    return value;
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, item]) => item !== null)
+        .map(([itemKey, item]) => [
+          itemKey,
+          normalizeNativeValue(item, itemKey, maps),
+        ])
+    );
+  }
+  return value;
+}
+
+function normalizeEvent(
+  value: unknown,
+  connectionIds: IdMap,
+  connectIds: IdMap,
+  streamIds: IdMap
+): P2pEvent {
+  const event = normalizeNativeValue(value, undefined, {
+    connectionIds,
+    connectIds,
+    streamIds,
+  }) as { tag?: unknown; inner?: unknown };
+  if (typeof event.tag !== "string" || event.inner === undefined) {
+    throw new TypeError("The native addon returned an invalid event");
+  }
+  if (
+    event.tag === "StreamData" ||
+    event.tag === "Message" ||
+    event.tag === "IdentifyReceived"
+  ) {
+    event.inner = normalizeEventBytes(event.tag, event.inner);
+  }
+  return event as P2pEvent;
+}
+
+function normalizeEventBytes(tag: string, value: unknown): unknown {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  const inner = { ...value };
+  if (tag === "StreamData") {
+    const data = Reflect.get(inner, "data");
+    if (Array.isArray(data) || data instanceof Uint8Array) {
+      Reflect.set(inner, "data", Uint8Array.from(data).buffer);
+    }
+  }
+  if (tag === "Message") {
+    for (const key of ["data", "seqno"] as const) {
+      const bytes = Reflect.get(inner, key);
+      if (Array.isArray(bytes) || bytes instanceof Uint8Array) {
+        Reflect.set(inner, key, Uint8Array.from(bytes).buffer);
+      }
+    }
+  }
+  if (tag === "IdentifyReceived") {
+    const info = Reflect.get(inner, "info");
+    if (info !== null && typeof info === "object") {
+      const publicKey = Reflect.get(info, "publicKey");
+      if (Array.isArray(publicKey) || publicKey instanceof Uint8Array) {
+        Reflect.set(info, "publicKey", Uint8Array.from(publicKey).buffer);
+      }
+    }
+  }
+  return inner;
+}
+
+class EventDrain {
+  readonly #drain: () => unknown[];
+  readonly #normalize: (event: unknown) => P2pEvent;
+  #listener: ((event: P2pEvent) => void) | undefined;
+  #scheduled = false;
+  #stopped = false;
+
+  constructor(
+    drain: () => unknown[],
+    normalize: (event: unknown) => P2pEvent
+  ) {
+    this.#drain = drain;
+    this.#normalize = normalize;
+  }
+
+  start(listener: (event: P2pEvent) => void): void {
+    this.#listener = listener;
+  }
+
+  ring(): void {
+    if (this.#scheduled || this.#stopped) {
+      return;
+    }
+    this.#scheduled = true;
+    setImmediate(() => {
+      this.#run();
+    });
+  }
+
+  stop(): void {
+    this.#stopped = true;
+    this.#listener = undefined;
+  }
+
+  #run(): void {
+    this.#scheduled = false;
+    if (this.#stopped) {
+      return;
+    }
+    const events = this.#drain();
+    for (const event of events) {
+      this.#listener?.(this.#normalize(event));
+    }
+    if (events.length > 0) {
+      this.ring();
+    }
+  }
+}
+
+interface NativeIdMaps {
+  readonly connectionIds: IdMap;
+  readonly connectIds: IdMap;
+  readonly streamIds: IdMap;
+}
+
+class IdMap {
+  readonly #nativeByPublic = new Map<number, bigint>();
+  readonly #publicByNative = new Map<bigint, number>();
+  #next = 1;
+
+  toPublic(native: bigint): number {
+    const existing = this.#publicByNative.get(native);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const publicId = this.#next;
+    this.#next += 1;
+    this.#publicByNative.set(native, publicId);
+    this.#nativeByPublic.set(publicId, native);
+    return publicId;
+  }
+
+  toNative(publicId: number): bigint {
+    const native = this.#nativeByPublic.get(publicId);
+    if (native === undefined) {
+      throw new RangeError(`Unknown native identifier ${publicId}`);
+    }
+    return native;
+  }
 }

--- a/bindings/ts/node/src/adapter.ts
+++ b/bindings/ts/node/src/adapter.ts
@@ -1,4 +1,4 @@
-/* oxlint-disable class-methods-use-this, func-style, max-classes-per-file, no-use-before-define, prefer-destructuring, unicorn/no-useless-undefined -- The adapter keeps the contract-complete native endpoint, value conversion, handle maps, and drain loop together at the binding boundary. */
+/* oxlint-disable class-methods-use-this, func-style, max-classes-per-file, no-await-in-loop, no-use-before-define, prefer-destructuring, promise/avoid-new, unicorn/no-useless-undefined -- The adapter keeps the contract-complete native endpoint, value conversion, handle maps, and drain loop together at the binding boundary. */
 
 import { Minip2pBase, PubsubRouter } from "@minip2p/core";
 import type {
@@ -108,7 +108,9 @@ class NodeBackend implements Minip2pBackend {
 
   discoveryNowMs(): number | undefined {
     const value = this.#endpoint.discoveryNowMs();
-    return value === undefined ? undefined : bigintToNumber(value, "clock");
+    return value === null || value === undefined
+      ? undefined
+      : bigintToNumber(value, "clock");
   }
 
   activeReservation(): RelayReservationInfo | undefined {
@@ -287,8 +289,14 @@ function toNativeMdns(
     autoDial: options.autoDial ?? discovery?.autoDial ?? true,
     enableIpv6: options.enableIpv6 ?? false,
     interfaceRefreshMs: numberToBigInt(options.interfaceRefreshMs ?? 10_000),
-    maxAnnouncedAddrs: options.maxAnnouncedAddrs ?? 16,
-    maxPacketBytes: options.maxPacketBytes ?? 1400,
+    maxAnnouncedAddrs: numberToU32(
+      options.maxAnnouncedAddrs ?? 16,
+      "maxAnnouncedAddrs"
+    ),
+    maxPacketBytes: numberToU32(
+      options.maxPacketBytes ?? 1400,
+      "maxPacketBytes"
+    ),
     queryIntervalMs: numberToBigInt(options.queryIntervalMs ?? 300_000),
     socketPollIntervalMs: numberToBigInt(options.socketPollIntervalMs ?? 100),
     ttlMs: numberToBigInt(options.ttlMs ?? 120_000),
@@ -308,6 +316,16 @@ function numberToBigInt(value: number): bigint {
     );
   }
   return BigInt(value);
+}
+
+function numberToU32(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`);
+  }
+  if (value > 0xff_ff_ff_ff) {
+    throw new RangeError(`${name} exceeds the unsigned 32-bit range`);
+  }
+  return value;
 }
 
 function bigintToNumber(value: bigint, name: string): number {
@@ -413,7 +431,24 @@ function normalizeEvent(
   ) {
     event.inner = normalizeEventBytes(event.tag, event.inner);
   }
+  releaseTerminalIds(event, connectionIds, streamIds);
   return event as P2pEvent;
+}
+
+function releaseTerminalIds(
+  event: { readonly tag?: unknown; readonly inner?: unknown },
+  connectionIds: IdMap,
+  streamIds: IdMap
+): void {
+  if (event.inner === null || typeof event.inner !== "object") {
+    return;
+  }
+  if (event.tag === "ConnectionClosed") {
+    connectionIds.deletePublic(Reflect.get(event.inner, "connId"));
+  }
+  if (event.tag === "StreamClosed") {
+    streamIds.deletePublic(Reflect.get(event.inner, "streamId"));
+  }
 }
 
 function normalizeEventBytes(tag: string, value: unknown): unknown {
@@ -448,7 +483,8 @@ class EventDrain {
   readonly #drain: () => unknown[];
   readonly #normalize: (event: unknown) => P2pEvent;
   #listener: ((event: P2pEvent) => void) | undefined;
-  #scheduled = false;
+  #pending = false;
+  #running = false;
   #stopped = false;
 
   constructor(drain: () => unknown[], normalize: (event: unknown) => P2pEvent) {
@@ -461,31 +497,51 @@ class EventDrain {
   }
 
   ring(): void {
-    if (this.#scheduled || this.#stopped) {
+    if (this.#stopped) {
       return;
     }
-    this.#scheduled = true;
-    setImmediate(() => {
-      this.#run();
-    });
+    this.#pending = true;
+    if (!this.#running) {
+      this.#running = true;
+      setTimeout(() => {
+        void this.#run();
+      }, 0);
+    }
   }
 
   stop(): void {
     this.#stopped = true;
+    this.#pending = false;
     this.#listener = undefined;
   }
 
-  #run(): void {
-    this.#scheduled = false;
-    if (this.#stopped) {
-      return;
-    }
-    const events = this.#drain();
-    for (const event of events) {
-      this.#listener?.(this.#normalize(event));
-    }
-    if (events.length > 0) {
-      this.ring();
+  async #run(): Promise<void> {
+    try {
+      while (!this.#stopped && this.#pending) {
+        this.#pending = false;
+        let events = this.#drain();
+        while (!this.#stopped && events.length > 0) {
+          for (const event of events) {
+            try {
+              this.#listener?.(this.#normalize(event));
+            } catch {
+              // Application callbacks and malformed events cannot stop draining.
+            }
+          }
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 0);
+          });
+          if (this.#stopped) {
+            break;
+          }
+          events = this.#drain();
+        }
+      }
+    } finally {
+      this.#running = false;
+      if (this.#pending && !this.#stopped) {
+        this.ring();
+      }
     }
   }
 }
@@ -519,5 +575,16 @@ class IdMap {
       throw new RangeError(`Unknown native identifier ${publicId}`);
     }
     return native;
+  }
+
+  deletePublic(value: unknown): void {
+    if (typeof value !== "number") {
+      return;
+    }
+    const native = this.#nativeByPublic.get(value);
+    if (native !== undefined) {
+      this.#nativeByPublic.delete(value);
+      this.#publicByNative.delete(native);
+    }
   }
 }

--- a/bindings/ts/node/src/index.ts
+++ b/bindings/ts/node/src/index.ts
@@ -1,6 +1,7 @@
-/**
- * The Node package is reserved for the napi-rs adapter. Public SDK types are
- * re-exported now so the adapter can be implemented against the same contract
- * as React Native without creating a second API.
- */
 export * from "@minip2p/core";
+export {
+  Minip2p,
+  circuitAddress,
+  generateSecretKey,
+  peerIdFromSecretKey,
+} from "./adapter.js";

--- a/bindings/ts/node/src/native.ts
+++ b/bindings/ts/node/src/native.ts
@@ -42,6 +42,22 @@ interface NativeEndpointConfig {
   readonly allowUnsigned: boolean;
   readonly autonatServers: string[];
   readonly forceRelay: boolean;
+  readonly discovery?: {
+    readonly autoDial: boolean;
+    readonly beaconIntervalMs: bigint;
+    readonly peerTtlMs: bigint;
+    readonly topic: string;
+  };
+  readonly mdns?: {
+    readonly autoDial: boolean;
+    readonly enableIpv6: boolean;
+    readonly interfaceRefreshMs: bigint;
+    readonly maxAnnouncedAddrs: number;
+    readonly maxPacketBytes: number;
+    readonly queryIntervalMs: bigint;
+    readonly socketPollIntervalMs: bigint;
+    readonly ttlMs: bigint;
+  };
   readonly protocols: string[];
   readonly pubsubRouter: number;
   readonly quic?: { readonly listenAddrs?: string[] };
@@ -50,11 +66,42 @@ interface NativeEndpointConfig {
 }
 
 export interface NativeEndpoint {
+  abandonStream: (peerId: string, streamId: bigint) => void;
+  activeReservation: () => unknown;
+  addProtocol: (protocolId: string) => void;
+  cancelConnect: (id: bigint) => void;
   close: () => void;
+  closeStreamWrite: (peerId: string, streamId: bigint) => void;
+  connect: (peerId: string) => bigint;
+  connectAddr: (address: string) => bigint;
+  connectedPeers: () => string[];
+  connectWithAddrs: (peerId: string, addresses: string[]) => bigint;
+  dial: (address: string) => bigint[];
+  dialIp4: (address: string) => bigint;
+  dialIp6: (address: string) => bigint;
+  disconnect: (peerId: string) => void;
+  discoveryNowMs: () => bigint | undefined;
+  drainEvents: (limit: number) => unknown[];
   isRunning: () => boolean;
+  isPeerReady: (peerId: string) => boolean;
+  knownPeers: () => unknown[];
   listenAddrs: () => string[];
+  openStream: (
+    peerId: string,
+    protocolId: string
+  ) => { readonly connId: bigint; readonly streamId: bigint };
+  path: (peerId: string) => unknown;
   peerId: () => string;
+  peerInfo: (peerId: string) => unknown;
+  ping: (peerId: string) => void;
+  publish: (topic: string, data: Uint8Array) => void;
+  reachability: () => number;
+  resetStream: (peerId: string, streamId: bigint) => void;
+  sendStream: (peerId: string, streamId: bigint, data: Uint8Array) => void;
+  setActive: (active: boolean) => void;
   start: (doorbell: () => void) => void;
+  subscribe: (topic: string) => boolean;
+  unsubscribe: (topic: string) => boolean;
 }
 
 interface NativeBinding {

--- a/bindings/ts/node/src/native.ts
+++ b/bindings/ts/node/src/native.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable func-style, no-use-before-define -- Hoisted loader helpers keep module initialization readable. */
+
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
@@ -16,7 +18,8 @@ type SupportedTarget = (typeof supportedTargets)[number];
 
 function linuxLibc(): "gnu" | "musl" {
   const report = process.report?.getReport();
-  const header = report === undefined ? undefined : Reflect.get(report, "header");
+  const header =
+    report === undefined ? undefined : Reflect.get(report, "header");
   return header === undefined ||
     Reflect.get(header, "glibcVersionRuntime") === undefined
     ? "musl"

--- a/bindings/ts/node/src/native.ts
+++ b/bindings/ts/node/src/native.ts
@@ -21,7 +21,8 @@ function linuxLibc(): "gnu" | "musl" {
   const header =
     report === undefined ? undefined : Reflect.get(report, "header");
   return header === undefined ||
-    Reflect.get(header, "glibcVersionRuntime") === undefined
+    (Reflect.get(header, "glibcVersionRuntime") === undefined &&
+      Reflect.get(header, "glibcVersionCompiler") === undefined)
     ? "musl"
     : "gnu";
 }
@@ -35,7 +36,7 @@ function currentTarget(): string {
 
 function unsupportedTarget(target: string, cause?: unknown): Error {
   return new Error(
-    `Unsupported minip2p Node target ${target}. Supported targets: ${supportedTargets.join(", ")}. Reinstall @minip2p/node without omitting optional dependencies.`,
+    `Unsupported minip2p Node target ${target}. Supported targets: ${supportedTargets.join(", ")}.`,
     cause === undefined ? undefined : { cause }
   );
 }
@@ -83,7 +84,7 @@ export interface NativeEndpoint {
   dialIp4: (address: string) => bigint;
   dialIp6: (address: string) => bigint;
   disconnect: (peerId: string) => void;
-  discoveryNowMs: () => bigint | undefined;
+  discoveryNowMs: () => bigint | null | undefined;
   drainEvents: (limit: number) => unknown[];
   isRunning: () => boolean;
   isPeerReady: (peerId: string) => boolean;

--- a/bindings/ts/node/src/native.ts
+++ b/bindings/ts/node/src/native.ts
@@ -1,0 +1,52 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+const supportedTargets = [
+  "linux-x64-gnu",
+  "linux-x64-musl",
+  "linux-arm64-gnu",
+  "linux-arm64-musl",
+  "darwin-x64",
+  "darwin-arm64",
+  "win32-x64",
+] as const;
+
+type SupportedTarget = (typeof supportedTargets)[number];
+
+function linuxLibc(): "gnu" | "musl" {
+  const report = process.report?.getReport();
+  const header = report === undefined ? undefined : Reflect.get(report, "header");
+  return header === undefined ||
+    Reflect.get(header, "glibcVersionRuntime") === undefined
+    ? "musl"
+    : "gnu";
+}
+
+function currentTarget(): string {
+  if (process.platform === "linux") {
+    return `${process.platform}-${process.arch}-${linuxLibc()}`;
+  }
+  return `${process.platform}-${process.arch}`;
+}
+
+function unsupportedTarget(target: string, cause?: unknown): Error {
+  return new Error(
+    `Unsupported minip2p Node target ${target}. Supported targets: ${supportedTargets.join(", ")}. Reinstall @minip2p/node without omitting optional dependencies.`,
+    cause === undefined ? undefined : { cause }
+  );
+}
+
+function loadNativeBinding(target: string): unknown {
+  if (!supportedTargets.includes(target as SupportedTarget)) {
+    throw unsupportedTarget(target);
+  }
+
+  try {
+    return require(`../minip2p.${target}.node`);
+  } catch (error) {
+    throw unsupportedTarget(target, error);
+  }
+}
+
+export const nativeBinding = loadNativeBinding(currentTarget());

--- a/bindings/ts/node/src/native.ts
+++ b/bindings/ts/node/src/native.ts
@@ -37,15 +37,58 @@ function unsupportedTarget(target: string, cause?: unknown): Error {
   );
 }
 
-function loadNativeBinding(target: string): unknown {
+interface NativeEndpointConfig {
+  readonly agentVersion?: string;
+  readonly allowUnsigned: boolean;
+  readonly autonatServers: string[];
+  readonly forceRelay: boolean;
+  readonly protocols: string[];
+  readonly pubsubRouter: number;
+  readonly quic?: { readonly listenAddrs?: string[] };
+  readonly relays: string[];
+  readonly tcp?: { readonly listenAddrs?: string[] };
+}
+
+export interface NativeEndpoint {
+  close: () => void;
+  isRunning: () => boolean;
+  listenAddrs: () => string[];
+  peerId: () => string;
+  start: (doorbell: () => void) => void;
+}
+
+interface NativeBinding {
+  readonly NodeEndpoint: new (
+    secretKey: Uint8Array,
+    config: NativeEndpointConfig
+  ) => NativeEndpoint;
+  circuitAddress: (relayAddress: string, peerId: string) => string;
+  generateSecretKey: () => Uint8Array;
+  peerIdFromSecretKey: (secretKey: Uint8Array) => string;
+}
+
+function loadNativeBinding(target: string): NativeBinding {
   if (!supportedTargets.includes(target as SupportedTarget)) {
     throw unsupportedTarget(target);
   }
 
   try {
-    return require(`../minip2p.${target}.node`);
+    const binding: unknown = require(`../minip2p.${target}.node`);
+    assertNativeBinding(binding);
+    return binding;
   } catch (error) {
     throw unsupportedTarget(target, error);
+  }
+}
+
+function assertNativeBinding(value: unknown): asserts value is NativeBinding {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    typeof Reflect.get(value, "NodeEndpoint") !== "function" ||
+    typeof Reflect.get(value, "generateSecretKey") !== "function"
+  ) {
+    throw new Error("The minip2p native addon has an invalid export shape");
   }
 }
 

--- a/bindings/ts/node/tests/adapter.test.ts
+++ b/bindings/ts/node/tests/adapter.test.ts
@@ -271,6 +271,118 @@ describe("Node adapter", () => {
     endpoint.close();
   });
 
+  test("forgets connect identifiers after ConnectFailed", async () => {
+    vi.useFakeTimers();
+    const endpoint = createEndpoint();
+    const fake = fakeEndpoint();
+    const first = endpoint.startConnect("remote");
+    fake.enqueue(
+      [
+        {
+          inner: {
+            connectId: 30n,
+            detail: "no route",
+            kind: 0,
+            peerId: "remote",
+          },
+          tag: "ConnectFailed",
+        },
+      ],
+      []
+    );
+
+    fake.ring();
+    await settle();
+    const second = endpoint.startConnect("remote");
+
+    expect([first, second]).toEqual([1, 2]);
+    endpoint.close();
+  });
+
+  test("forgets connect identifiers after cancellation", () => {
+    const endpoint = createEndpoint();
+    const first = endpoint.startConnect("remote");
+
+    endpoint.cancelConnect(first);
+    const second = endpoint.startConnect("remote");
+
+    expect([first, second]).toEqual([1, 2]);
+    endpoint.close();
+  });
+
+  test("forgets connect identifiers after a direct PathEstablished", async () => {
+    vi.useFakeTimers();
+    const endpoint = createEndpoint();
+    const fake = fakeEndpoint();
+    const first = endpoint.startConnect("remote");
+    fake.enqueue(
+      [
+        {
+          inner: {
+            connectId: 30n,
+            path: { tag: "DirectDialed" },
+            peerId: "remote",
+          },
+          tag: "PathEstablished",
+        },
+      ],
+      []
+    );
+
+    fake.ring();
+    await settle();
+    const second = endpoint.startConnect("remote");
+
+    expect([first, second]).toEqual([1, 2]);
+    endpoint.close();
+  });
+
+  test("keeps a relayed connect identifier through PathUpgraded", async () => {
+    vi.useFakeTimers();
+    const endpoint = createEndpoint();
+    const fake = fakeEndpoint();
+    const ids: number[] = [];
+    endpoint.on("pathEstablished", ({ connectId }) => ids.push(connectId));
+    endpoint.on("pathUpgraded", ({ connectId }) => ids.push(connectId));
+    const first = endpoint.startConnect("remote");
+    fake.enqueue(
+      [
+        {
+          inner: {
+            connectId: 30n,
+            path: {
+              inner: { relayPeerId: "relay" },
+              tag: "Relayed",
+            },
+            peerId: "remote",
+          },
+          tag: "PathEstablished",
+        },
+        {
+          inner: {
+            connectId: 30n,
+            from: {
+              inner: { relayPeerId: "relay" },
+              tag: "Relayed",
+            },
+            peerId: "remote",
+            to: { tag: "DirectPunched" },
+          },
+          tag: "PathUpgraded",
+        },
+      ],
+      []
+    );
+
+    fake.ring();
+    await settle();
+    const second = endpoint.startConnect("remote");
+
+    expect(ids).toEqual([first, first]);
+    expect(second).toBe(2);
+    endpoint.close();
+  });
+
   test("forgets stream identifiers after StreamClosed", async () => {
     vi.useFakeTimers();
     const endpoint = createEndpoint();

--- a/bindings/ts/node/tests/adapter.test.ts
+++ b/bindings/ts/node/tests/adapter.test.ts
@@ -1,0 +1,346 @@
+/* oxlint-disable class-methods-use-this, max-classes-per-file, promise/avoid-new -- The fake implements the native endpoint boundary used by the adapter, including one deferred drain observation. */
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { Minip2p } from "../src/adapter";
+
+const native = vi.hoisted(() => {
+  interface Event {
+    readonly inner?: Readonly<Record<string, unknown>>;
+    readonly tag?: string;
+  }
+
+  class FakeNativeEndpoint {
+    static latest: FakeNativeEndpoint | undefined;
+
+    readonly drainLimits: number[] = [];
+    readonly #batches: Event[][] = [];
+    #doorbell: (() => void) | undefined;
+    #drainCalls = 0;
+    discoveryClock: bigint | null = null;
+    onDrain: ((call: number) => void) | undefined;
+
+    constructor() {
+      FakeNativeEndpoint.latest = this;
+    }
+
+    enqueue(...batches: Event[][]): void {
+      this.#batches.push(...batches);
+    }
+
+    ring(): void {
+      this.#doorbell?.();
+    }
+
+    start(doorbell: () => void): void {
+      this.#doorbell = doorbell;
+    }
+
+    drainEvents(limit: number): Event[] {
+      this.drainLimits.push(limit);
+      this.#drainCalls += 1;
+      this.onDrain?.(this.#drainCalls);
+      return this.#batches.shift() ?? [];
+    }
+
+    close(): void {
+      this.#doorbell = undefined;
+      this.#batches.length = 0;
+    }
+
+    discoveryNowMs(): bigint | null {
+      return this.discoveryClock;
+    }
+
+    activeReservation(): null {
+      return null;
+    }
+
+    addProtocol(): void {}
+
+    abandonStream(): void {}
+
+    cancelConnect(): void {}
+
+    circuitAddress(): string {
+      return "";
+    }
+
+    closeStreamWrite(): void {}
+
+    connect(): bigint {
+      return 30n;
+    }
+
+    connectAddr(): bigint {
+      return 30n;
+    }
+
+    connectedPeers(): string[] {
+      return [];
+    }
+
+    connectWithAddrs(): bigint {
+      return 30n;
+    }
+
+    dial(): bigint[] {
+      return [];
+    }
+
+    dialIp4(): bigint {
+      return 10n;
+    }
+
+    dialIp6(): bigint {
+      return 10n;
+    }
+
+    disconnect(): void {}
+
+    isPeerReady(): boolean {
+      return false;
+    }
+
+    isRunning(): boolean {
+      return true;
+    }
+
+    knownPeers(): unknown[] {
+      return [];
+    }
+
+    listenAddrs(): string[] {
+      return [];
+    }
+
+    openStream(): { readonly connId: bigint; readonly streamId: bigint } {
+      return { connId: 10n, streamId: 20n };
+    }
+
+    path(): null {
+      return null;
+    }
+
+    peerId(): string {
+      return "local";
+    }
+
+    peerInfo(): null {
+      return null;
+    }
+
+    ping(): void {}
+
+    publish(): void {}
+
+    reachability(): number {
+      return 0;
+    }
+
+    resetStream(): void {}
+
+    sendStream(): void {}
+
+    setActive(): void {}
+
+    subscribe(): boolean {
+      return true;
+    }
+
+    unsubscribe(): boolean {
+      return true;
+    }
+  }
+
+  return { FakeNativeEndpoint };
+});
+
+vi.mock("../src/native", () => ({
+  nativeBinding: {
+    NodeEndpoint: native.FakeNativeEndpoint,
+    circuitAddress: vi.fn(),
+    generateSecretKey: vi.fn(() => new Uint8Array(32)),
+    peerIdFromSecretKey: vi.fn(),
+  },
+}));
+
+const createEndpoint = () => Minip2p.create({ secretKey: new Uint8Array(32) });
+
+const fakeEndpoint = (): InstanceType<typeof native.FakeNativeEndpoint> => {
+  const fake = native.FakeNativeEndpoint.latest;
+  if (fake === undefined) {
+    throw new Error("native endpoint was not constructed");
+  }
+  return fake;
+};
+
+const settle = async (): Promise<void> => {
+  await vi.runAllTimersAsync();
+  await Promise.resolve();
+};
+
+describe("Node adapter", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    native.FakeNativeEndpoint.latest = undefined;
+  });
+
+  test("continues draining after a malformed native event", async () => {
+    vi.useFakeTimers();
+    const endpoint = createEndpoint();
+    const fake = fakeEndpoint();
+    const peers: string[] = [];
+    endpoint.on("peerReady", ({ peerId }) => peers.push(peerId));
+    fake.enqueue(
+      [{}],
+      [{ inner: { peerId: "remote", protocols: [] }, tag: "PeerReady" }],
+      []
+    );
+
+    fake.ring();
+    await settle();
+
+    expect(peers).toEqual(["remote"]);
+    expect(fake.drainLimits).toEqual([256, 256, 256]);
+    endpoint.close();
+  });
+
+  test("gives timers a turn between non-empty native batches", async () => {
+    const endpoint = createEndpoint();
+    const fake = fakeEndpoint();
+    let timerRan = false;
+    let timerRanBeforeSecondDrain = false;
+    const secondDrain = new Promise<void>((resolve) => {
+      fake.onDrain = (call) => {
+        if (call === 1) {
+          setTimeout(() => {
+            timerRan = true;
+          }, 0);
+        }
+        if (call === 2) {
+          timerRanBeforeSecondDrain = timerRan;
+          resolve();
+        }
+      };
+    });
+    fake.enqueue(
+      [{ inner: { peerId: "remote", protocols: [] }, tag: "PeerReady" }],
+      []
+    );
+
+    fake.ring();
+    await secondDrain;
+
+    expect(timerRanBeforeSecondDrain).toBe(true);
+    endpoint.close();
+  });
+
+  test("returns no discovery clock when the native option is null", () => {
+    const endpoint = createEndpoint();
+
+    expect(endpoint.discoveryNowMs()).toBeUndefined();
+    endpoint.close();
+  });
+
+  test("forgets connection identifiers after ConnectionClosed", async () => {
+    vi.useFakeTimers();
+    const endpoint = createEndpoint();
+    const fake = fakeEndpoint();
+    const ids: number[] = [];
+    endpoint.on("connectionEstablished", ({ connId }) => ids.push(connId));
+    fake.enqueue(
+      [
+        {
+          inner: { connId: 10n, peerId: "remote" },
+          tag: "ConnectionEstablished",
+        },
+        { inner: { connId: 10n, peerId: "remote" }, tag: "ConnectionClosed" },
+        {
+          inner: { connId: 10n, peerId: "remote" },
+          tag: "ConnectionEstablished",
+        },
+      ],
+      []
+    );
+
+    fake.ring();
+    await settle();
+
+    expect(ids).toEqual([1, 2]);
+    endpoint.close();
+  });
+
+  test("forgets stream identifiers after StreamClosed", async () => {
+    vi.useFakeTimers();
+    const endpoint = createEndpoint();
+    const fake = fakeEndpoint();
+
+    const firstPending = endpoint.openStream("remote", "/test/1");
+    fake.enqueue(
+      [
+        {
+          inner: {
+            connId: 10n,
+            initiatedLocally: true,
+            peerId: "remote",
+            protocolId: "/test/1",
+            streamId: 20n,
+          },
+          tag: "StreamReady",
+        },
+      ],
+      []
+    );
+    fake.ring();
+    await settle();
+    const first = await firstPending;
+
+    fake.enqueue(
+      [
+        {
+          inner: { connId: 10n, peerId: "remote", streamId: 20n },
+          tag: "StreamClosed",
+        },
+      ],
+      []
+    );
+    fake.ring();
+    await settle();
+
+    const secondPending = endpoint.openStream("remote", "/test/1");
+    fake.enqueue(
+      [
+        {
+          inner: {
+            connId: 10n,
+            initiatedLocally: true,
+            peerId: "remote",
+            protocolId: "/test/1",
+            streamId: 20n,
+          },
+          tag: "StreamReady",
+        },
+      ],
+      []
+    );
+    fake.ring();
+    await settle();
+    const second = await secondPending;
+
+    expect([first.streamId, second.streamId]).toEqual([1, 2]);
+    endpoint.close();
+  });
+
+  test.each([
+    ["maxPacketBytes", 0x1_00_00_00_00],
+    ["maxAnnouncedAddrs", -1],
+  ] as const)("rejects an invalid mDNS %s", (name, value) => {
+    expect(() =>
+      Minip2p.create({
+        mdns: { [name]: value },
+        secretKey: new Uint8Array(32),
+      })
+    ).toThrow(RangeError);
+  });
+});

--- a/bindings/ts/node/tests/fixtures/lifecycle.mjs
+++ b/bindings/ts/node/tests/fixtures/lifecycle.mjs
@@ -2,7 +2,18 @@ import { createRequire } from "node:module";
 import { performance } from "node:perf_hooks";
 
 const require = createRequire(import.meta.url);
-const binding = require("../../minip2p.linux-x64-gnu.node");
+const report = process.report?.getReport();
+const header = report === undefined ? undefined : Reflect.get(report, "header");
+const libc =
+  header === undefined ||
+  Reflect.get(header, "glibcVersionRuntime") === undefined
+    ? "musl"
+    : "gnu";
+const target =
+  process.platform === "linux"
+    ? `${process.platform}-${process.arch}-${libc}`
+    : `${process.platform}-${process.arch}`;
+const binding = require(`../../minip2p.${target}.node`);
 const endpoint = new binding.NodeEndpoint(binding.generateSecretKey(), {
   allowUnsigned: false,
   autonatServers: [],

--- a/bindings/ts/node/tests/fixtures/lifecycle.mjs
+++ b/bindings/ts/node/tests/fixtures/lifecycle.mjs
@@ -1,0 +1,30 @@
+import { createRequire } from "node:module";
+import { performance } from "node:perf_hooks";
+
+const require = createRequire(import.meta.url);
+const binding = require("../../minip2p.linux-x64-gnu.node");
+const endpoint = new binding.NodeEndpoint(binding.generateSecretKey(), {
+  allowUnsigned: false,
+  autonatServers: [],
+  forceRelay: false,
+  protocols: [],
+  pubsubRouter: 0,
+  quic: { listenAddrs: ["/ip4/127.0.0.1/udp/0/quic-v1"] },
+  relays: [],
+});
+
+endpoint.start(() => {});
+process.stdout.write("started\n");
+
+if (process.argv[2] === "close") {
+  const calls = 500;
+  const callStarted = performance.now();
+  for (let index = 0; index < calls; index += 1) {
+    endpoint.connectedPeers();
+  }
+  const averageCallMs = (performance.now() - callStarted) / calls;
+  const closeStarted = performance.now();
+  endpoint.close();
+  const closeMs = performance.now() - closeStarted;
+  process.stdout.write(`averageCallMs=${averageCallMs}\ncloseMs=${closeMs}\n`);
+}

--- a/bindings/ts/node/tests/fixtures/lifecycle.mjs
+++ b/bindings/ts/node/tests/fixtures/lifecycle.mjs
@@ -13,7 +13,9 @@ const endpoint = new binding.NodeEndpoint(binding.generateSecretKey(), {
   relays: [],
 });
 
-endpoint.start(() => {});
+endpoint.start(() => {
+  // This test measures the strong doorbell's event-loop reference.
+});
 process.stdout.write("started\n");
 
 if (process.argv[2] === "close") {

--- a/bindings/ts/node/tests/index.test.ts
+++ b/bindings/ts/node/tests/index.test.ts
@@ -49,6 +49,8 @@ describe("@minip2p/node", () => {
         b.waitPeerReady(a.peerId(), { timeoutMs: 10_000 }),
       ]);
 
+      expect(a.peerInfo(b.peerId())?.publicKey).toBeInstanceOf(ArrayBuffer);
+
       const inboundPromise = b.once("stream", { timeoutMs: 10_000 });
       const outbound = await a.openStream(b.peerId(), protocol, {
         timeoutMs: 10_000,

--- a/bindings/ts/node/tests/index.test.ts
+++ b/bindings/ts/node/tests/index.test.ts
@@ -21,7 +21,7 @@ describe("@minip2p/node", () => {
       },
     });
 
-    expect(endpoint.peerId()).toMatch(/^12D3Koo/);
+    expect(endpoint.peerId()).toMatch(/^12D3Koo/u);
     expect(endpoint.listenAddrs()).toHaveLength(1);
     expect(endpoint.isRunning()).toBe(true);
 
@@ -29,48 +29,44 @@ describe("@minip2p/node", () => {
     expect(endpoint.isRunning()).toBe(false);
   });
 
-  test(
-    "two endpoints exchange stream data over QUIC loopback",
-    async () => {
-      const protocol = "/minip2p/node-loopback/1";
-      const createEndpoint = () =>
-        nodeSdk.Minip2p.create({
-          protocols: [protocol],
-          secretKey: nodeSdk.generateSecretKey(),
-          transports: {
-            quic: { listen: ["/ip4/127.0.0.1/udp/0/quic-v1"] },
-          },
-        });
-      const a = createEndpoint();
-      const b = createEndpoint();
+  test("two endpoints exchange stream data over QUIC loopback", async () => {
+    const protocol = "/minip2p/node-loopback/1";
+    const createEndpoint = () =>
+      nodeSdk.Minip2p.create({
+        protocols: [protocol],
+        secretKey: nodeSdk.generateSecretKey(),
+        transports: {
+          quic: { listen: ["/ip4/127.0.0.1/udp/0/quic-v1"] },
+        },
+      });
+    const a = createEndpoint();
+    const b = createEndpoint();
 
-      try {
-        await a.connectAddr(b.listenAddrs()[0], { timeoutMs: 10_000 });
-        await Promise.all([
-          a.waitPeerReady(b.peerId(), { timeoutMs: 10_000 }),
-          b.waitPeerReady(a.peerId(), { timeoutMs: 10_000 }),
-        ]);
+    try {
+      await a.connectAddr(b.listenAddrs()[0], { timeoutMs: 10_000 });
+      await Promise.all([
+        a.waitPeerReady(b.peerId(), { timeoutMs: 10_000 }),
+        b.waitPeerReady(a.peerId(), { timeoutMs: 10_000 }),
+      ]);
 
-        const inboundPromise = b.once("stream", { timeoutMs: 10_000 });
-        const outbound = await a.openStream(b.peerId(), protocol, {
-          timeoutMs: 10_000,
-        });
-        const inbound = await inboundPromise;
+      const inboundPromise = b.once("stream", { timeoutMs: 10_000 });
+      const outbound = await a.openStream(b.peerId(), protocol, {
+        timeoutMs: 10_000,
+      });
+      const inbound = await inboundPromise;
 
-        outbound.write("hello from a");
-        expect(new TextDecoder().decode(await inbound.read())).toBe(
-          "hello from a"
-        );
+      outbound.write("hello from a");
+      expect(new TextDecoder().decode(await inbound.read())).toBe(
+        "hello from a"
+      );
 
-        inbound.write("hello from b");
-        expect(new TextDecoder().decode(await outbound.read())).toBe(
-          "hello from b"
-        );
-      } finally {
-        a.close();
-        b.close();
-      }
-    },
-    15_000
-  );
+      inbound.write("hello from b");
+      expect(new TextDecoder().decode(await outbound.read())).toBe(
+        "hello from b"
+      );
+    } finally {
+      a.close();
+      b.close();
+    }
+  }, 15_000);
 });

--- a/bindings/ts/node/tests/index.test.ts
+++ b/bindings/ts/node/tests/index.test.ts
@@ -49,7 +49,17 @@ describe("@minip2p/node", () => {
         b.waitPeerReady(a.peerId(), { timeoutMs: 10_000 }),
       ]);
 
-      expect(a.peerInfo(b.peerId())?.publicKey).toBeInstanceOf(ArrayBuffer);
+      const publicKey = a.peerInfo(b.peerId())?.publicKey;
+      expect(publicKey).toBeInstanceOf(ArrayBuffer);
+      if (!(publicKey instanceof ArrayBuffer)) {
+        throw new TypeError(
+          "Identify did not return an ArrayBuffer public key"
+        );
+      }
+      expect(publicKey.byteLength).toBe(36);
+      expect([...new Uint8Array(publicKey).subarray(0, 4)]).toEqual([
+        0x08, 0x01, 0x12, 0x20,
+      ]);
 
       const inboundPromise = b.once("stream", { timeoutMs: 10_000 });
       const outbound = await a.openStream(b.peerId(), protocol, {

--- a/bindings/ts/node/tests/index.test.ts
+++ b/bindings/ts/node/tests/index.test.ts
@@ -28,4 +28,49 @@ describe("@minip2p/node", () => {
     endpoint.close();
     expect(endpoint.isRunning()).toBe(false);
   });
+
+  test(
+    "two endpoints exchange stream data over QUIC loopback",
+    async () => {
+      const protocol = "/minip2p/node-loopback/1";
+      const createEndpoint = () =>
+        nodeSdk.Minip2p.create({
+          protocols: [protocol],
+          secretKey: nodeSdk.generateSecretKey(),
+          transports: {
+            quic: { listen: ["/ip4/127.0.0.1/udp/0/quic-v1"] },
+          },
+        });
+      const a = createEndpoint();
+      const b = createEndpoint();
+
+      try {
+        await a.connectAddr(b.listenAddrs()[0], { timeoutMs: 10_000 });
+        await Promise.all([
+          a.waitPeerReady(b.peerId(), { timeoutMs: 10_000 }),
+          b.waitPeerReady(a.peerId(), { timeoutMs: 10_000 }),
+        ]);
+
+        const inboundPromise = b.once("stream", { timeoutMs: 10_000 });
+        const outbound = await a.openStream(b.peerId(), protocol, {
+          timeoutMs: 10_000,
+        });
+        const inbound = await inboundPromise;
+
+        outbound.write("hello from a");
+        expect(new TextDecoder().decode(await inbound.read())).toBe(
+          "hello from a"
+        );
+
+        inbound.write("hello from b");
+        expect(new TextDecoder().decode(await outbound.read())).toBe(
+          "hello from b"
+        );
+      } finally {
+        a.close();
+        b.close();
+      }
+    },
+    15_000
+  );
 });

--- a/bindings/ts/node/tests/index.test.ts
+++ b/bindings/ts/node/tests/index.test.ts
@@ -12,4 +12,20 @@ describe("@minip2p/node", () => {
       expect(Reflect.get(nodeSdk, name)).toBe(value);
     }
   });
+
+  test("creates, starts, and closes a QUIC endpoint", () => {
+    const endpoint = nodeSdk.Minip2p.create({
+      secretKey: nodeSdk.generateSecretKey(),
+      transports: {
+        quic: { listen: ["/ip4/127.0.0.1/udp/0/quic-v1"] },
+      },
+    });
+
+    expect(endpoint.peerId()).toMatch(/^12D3Koo/);
+    expect(endpoint.listenAddrs()).toHaveLength(1);
+    expect(endpoint.isRunning()).toBe(true);
+
+    endpoint.close();
+    expect(endpoint.isRunning()).toBe(false);
+  });
 });

--- a/bindings/ts/node/tests/lifecycle.test.ts
+++ b/bindings/ts/node/tests/lifecycle.test.ts
@@ -58,9 +58,9 @@ function waitForOutput(
     });
     child.once("error", reject);
     child.once("exit", (code) => {
-      if (code !== null && code !== 0) {
-        reject(new Error(`Child exited with ${code}`));
-      }
+      reject(
+        new Error(`Child exited with ${code} before printing ${expected}`)
+      );
     });
   });
 }
@@ -82,14 +82,17 @@ async function collectOutput(child: ReturnType<typeof spawn>): Promise<string> {
   child.stderr.on("data", (chunk: Buffer) => {
     output += chunk.toString();
   });
-  await Promise.race([
-    waitForExit(child),
-    new Promise<never>((_resolve, reject) => {
-      setTimeout(() => {
-        child.kill();
-        reject(new Error(`Child did not exit. Output:\n${output}`));
-      }, 5000);
-    }),
-  ]);
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`Child did not exit. Output:\n${output}`));
+    }, 5000);
+  });
+  try {
+    await Promise.race([waitForExit(child), timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
   return output;
 }

--- a/bindings/ts/node/tests/lifecycle.test.ts
+++ b/bindings/ts/node/tests/lifecycle.test.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable func-style, no-use-before-define, promise/avoid-new -- Child-process readiness and timeout helpers are callback-backed promises. */
+
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
@@ -25,8 +27,13 @@ describe("@minip2p/node process lifecycle", () => {
   test("close is non-blocking and releases the event loop", async () => {
     const child = spawn(process.execPath, [fixture, "close"]);
     const output = await collectOutput(child);
-    const closeMs = Number(/closeMs=([\d.]+)/.exec(output)?.[1]);
-    const averageCallMs = Number(/averageCallMs=([\d.]+)/.exec(output)?.[1]);
+    const closeMs = Number(
+      /closeMs=(?<milliseconds>[\d.]+)/u.exec(output)?.groups?.milliseconds
+    );
+    const averageCallMs = Number(
+      /averageCallMs=(?<milliseconds>[\d.]+)/u.exec(output)?.groups
+        ?.milliseconds
+    );
 
     expect(output).toContain("started");
     expect(closeMs).toBeLessThan(50);
@@ -67,9 +74,7 @@ function waitForExit(child: ReturnType<typeof spawn>): Promise<void> {
   });
 }
 
-async function collectOutput(
-  child: ReturnType<typeof spawn>
-): Promise<string> {
+async function collectOutput(child: ReturnType<typeof spawn>): Promise<string> {
   let output = "";
   child.stdout.on("data", (chunk: Buffer) => {
     output += chunk.toString();

--- a/bindings/ts/node/tests/lifecycle.test.ts
+++ b/bindings/ts/node/tests/lifecycle.test.ts
@@ -1,0 +1,90 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, test } from "vitest";
+
+const fixture = fileURLToPath(
+  new URL("fixtures/lifecycle.mjs", import.meta.url)
+);
+
+describe("@minip2p/node process lifecycle", () => {
+  test("a started endpoint keeps Node alive", async () => {
+    const child = spawn(process.execPath, [fixture, "hold"]);
+    try {
+      await waitForOutput(child, "started");
+      await new Promise((resolve) => {
+        setTimeout(resolve, 200);
+      });
+      expect(child.exitCode).toBeNull();
+    } finally {
+      child.kill();
+      await waitForExit(child);
+    }
+  });
+
+  test("close is non-blocking and releases the event loop", async () => {
+    const child = spawn(process.execPath, [fixture, "close"]);
+    const output = await collectOutput(child);
+    const closeMs = Number(/closeMs=([\d.]+)/.exec(output)?.[1]);
+    const averageCallMs = Number(/averageCallMs=([\d.]+)/.exec(output)?.[1]);
+
+    expect(output).toContain("started");
+    expect(closeMs).toBeLessThan(50);
+    expect(averageCallMs).toBeLessThan(1);
+    expect(child.exitCode).toBe(0);
+  });
+});
+
+function waitForOutput(
+  child: ReturnType<typeof spawn>,
+  expected: string
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Child did not print ${expected}`));
+    }, 5000);
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes(expected)) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code !== null && code !== 0) {
+        reject(new Error(`Child exited with ${code}`));
+      }
+    });
+  });
+}
+
+function waitForExit(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    child.once("exit", () => resolve());
+  });
+}
+
+async function collectOutput(
+  child: ReturnType<typeof spawn>
+): Promise<string> {
+  let output = "";
+  child.stdout.on("data", (chunk: Buffer) => {
+    output += chunk.toString();
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    output += chunk.toString();
+  });
+  await Promise.race([
+    waitForExit(child),
+    new Promise<never>((_resolve, reject) => {
+      setTimeout(() => {
+        child.kill();
+        reject(new Error(`Child did not exit. Output:\n${output}`));
+      }, 5000);
+    }),
+  ]);
+  return output;
+}

--- a/bindings/ts/node/tests/native-events.test.ts
+++ b/bindings/ts/node/tests/native-events.test.ts
@@ -1,0 +1,123 @@
+/* oxlint-disable func-style, no-await-in-loop, no-use-before-define, unicorn/no-useless-undefined -- The native integration test keeps its polling helpers below the behavioral cases. */
+
+import { setTimeout as delay } from "node:timers/promises";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { nativeBinding } from "../src/native.js";
+import type { NativeEndpoint } from "../src/native.js";
+
+const endpoints: NativeEndpoint[] = [];
+
+afterEach(() => {
+  for (const endpoint of endpoints.splice(0)) {
+    endpoint.close();
+  }
+});
+
+describe("native event payloads", () => {
+  test("delivers stream bytes as a Uint8Array", async () => {
+    const protocol = "/minip2p/node-native-events/1";
+    const a = createEndpoint(protocol);
+    const b = createEndpoint(protocol);
+    a.connectAddr(b.listenAddrs()[0]);
+
+    await Promise.all([
+      waitPeerReady(a, b.peerId()),
+      waitPeerReady(b, a.peerId()),
+    ]);
+
+    const stream = a.openStream(b.peerId(), protocol);
+    await waitForEvent(b, "StreamReady");
+    a.sendStream(b.peerId(), stream.streamId, Uint8Array.of(0, 127, 255));
+
+    const event = await waitForEvent(b, "StreamData");
+    const data = Reflect.get(event.inner, "data");
+    expect(data).toBeInstanceOf(Uint8Array);
+    expect([...data]).toEqual([0, 127, 255]);
+  }, 15_000);
+
+  test("delivers pubsub bytes as Uint8Arrays", async () => {
+    const a = createEndpoint();
+    const b = createEndpoint();
+    a.subscribe("native-events");
+    b.subscribe("native-events");
+    a.connectAddr(b.listenAddrs()[0]);
+
+    await Promise.all([
+      waitPeerReady(a, b.peerId()),
+      waitPeerReady(b, a.peerId()),
+    ]);
+    await delay(100);
+    a.publish("native-events", Uint8Array.of(1, 128, 254));
+
+    const event = await waitForEvent(b, "Message");
+    const data = Reflect.get(event.inner, "data");
+    const seqno = Reflect.get(event.inner, "seqno");
+    expect(data).toBeInstanceOf(Uint8Array);
+    expect([...data]).toEqual([1, 128, 254]);
+    expect(seqno).toBeInstanceOf(Uint8Array);
+    expect(seqno.byteLength).toBeGreaterThan(0);
+  }, 15_000);
+});
+
+function createEndpoint(protocol?: string): NativeEndpoint {
+  const endpoint = new nativeBinding.NodeEndpoint(
+    nativeBinding.generateSecretKey(),
+    {
+      allowUnsigned: false,
+      autonatServers: [],
+      forceRelay: false,
+      protocols: protocol === undefined ? [] : [protocol],
+      pubsubRouter: 1,
+      quic: { listenAddrs: ["/ip4/127.0.0.1/udp/0/quic-v1"] },
+      relays: [],
+    }
+  );
+  endpoint.start(() => undefined);
+  endpoints.push(endpoint);
+  return endpoint;
+}
+
+async function waitPeerReady(
+  endpoint: NativeEndpoint,
+  peerId: string
+): Promise<void> {
+  await waitForEvent(
+    endpoint,
+    "PeerReady",
+    (event) => Reflect.get(event.inner, "peerId") === peerId
+  );
+}
+
+interface NativeEvent {
+  readonly inner: object;
+  readonly tag: string;
+}
+
+async function waitForEvent(
+  endpoint: NativeEndpoint,
+  tag: string,
+  matches: (event: NativeEvent) => boolean = () => true
+): Promise<NativeEvent> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    for (const value of endpoint.drainEvents(256)) {
+      if (isNativeEvent(value) && value.tag === tag && matches(value)) {
+        return value;
+      }
+    }
+    await delay(5);
+  }
+  throw new Error(`Timed out waiting for native ${tag} event`);
+}
+
+function isNativeEvent(value: unknown): value is NativeEvent {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof Reflect.get(value, "tag") === "string" &&
+    Reflect.get(value, "inner") !== null &&
+    typeof Reflect.get(value, "inner") === "object"
+  );
+}

--- a/bindings/ts/node/tests/unsupported-platform.test.ts
+++ b/bindings/ts/node/tests/unsupported-platform.test.ts
@@ -11,7 +11,7 @@ describe("@minip2p/node native loader", () => {
     Object.defineProperty(process, "platform", { value: "plan9" });
 
     await expect(import("../src/native.js")).rejects.toThrow(
-      /Unsupported minip2p Node target plan9-x64.*linux-x64-gnu.*darwin-arm64.*win32-x64/s
+      /Unsupported minip2p Node target plan9-x64.*linux-x64-gnu.*darwin-arm64.*win32-x64/su
     );
   });
 });

--- a/bindings/ts/node/tests/unsupported-platform.test.ts
+++ b/bindings/ts/node/tests/unsupported-platform.test.ts
@@ -1,17 +1,35 @@
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 const originalPlatform = process.platform;
+const originalGetReport = process.report.getReport;
 
 afterEach(() => {
   Object.defineProperty(process, "platform", { value: originalPlatform });
+  Object.defineProperty(process.report, "getReport", {
+    value: originalGetReport,
+  });
+  vi.resetModules();
 });
 
 describe("@minip2p/node native loader", () => {
   test("reports the requested and supported targets at import time", async () => {
     Object.defineProperty(process, "platform", { value: "plan9" });
 
-    await expect(import("../src/native.js")).rejects.toThrow(
+    const loading = import("../src/native.js");
+    await expect(loading).rejects.toThrow(
       /Unsupported minip2p Node target plan9-x64.*linux-x64-gnu.*darwin-arm64.*win32-x64/su
+    );
+    await expect(loading).rejects.not.toThrow(/optional dependencies/u);
+  });
+
+  test("recognizes glibc from the compiler version", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    Object.defineProperty(process.report, "getReport", {
+      value: () => ({ header: { glibcVersionCompiler: "2.28" } }),
+    });
+
+    await expect(import("../src/native.js")).resolves.toHaveProperty(
+      "nativeBinding"
     );
   });
 });

--- a/bindings/ts/node/tests/unsupported-platform.test.ts
+++ b/bindings/ts/node/tests/unsupported-platform.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+const originalPlatform = process.platform;
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform });
+});
+
+describe("@minip2p/node native loader", () => {
+  test("reports the requested and supported targets at import time", async () => {
+    Object.defineProperty(process, "platform", { value: "plan9" });
+
+    await expect(import("../src/native.js")).rejects.toThrow(
+      /Unsupported minip2p Node target plan9-x64.*linux-x64-gnu.*darwin-arm64.*win32-x64/s
+    );
+  });
+});

--- a/bindings/ts/node/tsconfig.json
+++ b/bindings/ts/node/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../core/tsconfig.json",
   "compilerOptions": {
     "customConditions": ["minip2p-source"],
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/bindings/ts/package.json
+++ b/bindings/ts/package.json
@@ -17,10 +17,10 @@
   "devDependencies": {
     "oxfmt": "0.65.0",
     "oxlint": "1.80.0",
-    "turbo": "2.10.11",
+    "turbo": "2.10.12",
     "typescript": "catalog:",
     "ultracite": "7.10.6",
     "vitest": "4.1.11"
   },
-  "packageManager": "pnpm@11.18.0+sha512.33d83c77da82f49fba836925c6f1b841181ec3132b670639bd012f7075f5c7cf634c5f870147c19aae7478fac01df09d8892e880454896edd23ee9b33757563c"
+  "packageManager": "pnpm@11.24.0+sha512.bd27e345e976dcb0be0b7a1228217b049a817e21b1f355c90dbe7dc46671895a8bc1e6d06c24554505ea93ea0b45f489a27ec1bfbc8de6a9659fca0f16fa0000"
 }

--- a/bindings/ts/pnpm-lock.yaml
+++ b/bindings/ts/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@types/node':
+      specifier: 26.2.0
+      version: 26.2.0
     '@types/react':
       specifier: 19.2.18
       version: 19.2.18
@@ -69,6 +72,9 @@ importers:
       '@minip2p/test-fixtures':
         specifier: workspace:*
         version: link:../test-fixtures
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.2.0
       del-cli:
         specifier: 'catalog:'
         version: 7.0.0

--- a/bindings/ts/pnpm-lock.yaml
+++ b/bindings/ts/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@types/node':
-      specifier: 26.2.0
-      version: 26.2.0
+      specifier: 26.3.0
+      version: 26.3.0
     '@types/react':
       specifier: 19.2.18
       version: 19.2.18
@@ -39,8 +39,8 @@ importers:
         specifier: 1.80.0
         version: 1.80.0
       turbo:
-        specifier: 2.10.11
-        version: 2.10.11
+        specifier: 2.10.12
+        version: 2.10.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -49,7 +49,7 @@ importers:
         version: 7.10.6(oxfmt@0.65.0)(oxlint@1.80.0)
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0))
+        version: 4.1.11(@types/node@26.2.0)(vite@7.3.6(@types/node@26.3.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0))
 
   core:
     devDependencies:
@@ -74,10 +74,10 @@ importers:
         version: link:../test-fixtures
       '@napi-rs/cli':
         specifier: 3.8.6
-        version: 3.8.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.2.0)(supports-color@8.1.1)
+        version: 3.8.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.3.0)(supports-color@8.1.1)
       '@types/node':
         specifier: 'catalog:'
-        version: 26.2.0
+        version: 26.3.0
       del-cli:
         specifier: 'catalog:'
         version: 7.0.0
@@ -2278,33 +2278,33 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@turbo/darwin-64@2.10.11':
-    resolution: {integrity: sha512-v3R+1R/Ysozyo+p7Ri8MCIbndOvYt3DgPFrGLhrhQHfvyvbxyH3WyJj+A/2JTNmNleuAlh3JUyCV0iSVHIONTA==}
+  '@turbo/darwin-64@2.10.12':
+    resolution: {integrity: sha512-9nKgKoF6ZOUsM+or0OtNf+TTJSfGvDNP7ZFv/ZGWVwOSCkumyctQiTeHwB4UNljHTnC41AqylgbunLDHoccNrA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.10.11':
-    resolution: {integrity: sha512-R0a0CvGAeYYsBgPIgFNB3agGXh6qukjduNhFlwVVX1Ss2IdBJLXmgjytNGmo084bLKS0B6UdLRwKhXMHKKaObQ==}
+  '@turbo/darwin-arm64@2.10.12':
+    resolution: {integrity: sha512-H4Elb1jqTZVeIC9bbcNwjSzemZ6RegoTOVHeuV5Osirt2Z8UguTyisMEkvZjPVZgMeN9J4ERZBFad40tFnkb7w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.10.11':
-    resolution: {integrity: sha512-dGlY2vg7jpsLjGS1bf9sD/cw1sGMAYbeHGQKGRFxd5Zaj+Ufbj8cNXl/vIit8ueCU97zhL/znn60ZV5iSfZAxw==}
+  '@turbo/linux-64@2.10.12':
+    resolution: {integrity: sha512-lr7KIotukvjZwEXiFSYAeOH3BWzjFVBbSzTbv0fuGFsNukYyH0+g1hB5ecqnJkgkYU+KHEMG1edOhnjiKON1wQ==}
     cpu: [x64]
     os: [android, linux]
 
-  '@turbo/linux-arm64@2.10.11':
-    resolution: {integrity: sha512-eSP9+jjsSCBs2x0QpJZlp49dSD1EIMwXH7PsMIhdWk7w6IThhuKJ+jL95JQ2IW7tRjRmdh8gKcKQtrHLD5R5lA==}
+  '@turbo/linux-arm64@2.10.12':
+    resolution: {integrity: sha512-f0pZDTtvzB5SuNwuXBaKbZHUCMCukgc8nMlHEuvLmj91Fzec+MEbr3cAvGNor5htEDqZnO6Lxt9N/GPI/77oGA==}
     cpu: [arm64]
     os: [android, linux]
 
-  '@turbo/windows-64@2.10.11':
-    resolution: {integrity: sha512-4aD7edogJ8arK8DOyvjTI2KKwmchD5M/WM4BZgidrtFf7aSgn8Ce2rJnDwmriw980c2cKlHnhXtlGy38VtKB8g==}
+  '@turbo/windows-64@2.10.12':
+    resolution: {integrity: sha512-SDOueJRjS/QcykWf2KCRtTLmIl5YMKsLbXkXQGhDwcTXvKXZiS5ih5lBl/gkwZIpYFjqA/rAlfMzlAFcVHNe0g==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.10.11':
-    resolution: {integrity: sha512-m8tJkIrTrbQ9O1uHxV0GUq623Zg1678xGna8eMsy4KbygUX/wVFgdZDYV/AxyoyaW/U7nyKoBvaDVwm22p9xqA==}
+  '@turbo/windows-arm64@2.10.12':
+    resolution: {integrity: sha512-0i0mVUa4kKk+/B3RwEwPMf9CB+T7ul56hn5FFHNA4VUNTOoLBEd6aNf3FaKfCatDNZ6cicCEf6if9QUTVyzzcA==}
     cpu: [arm64]
     os: [win32]
 
@@ -2331,6 +2331,9 @@ packages:
 
   '@types/node@26.2.0':
     resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+
+  '@types/node@26.3.0':
+    resolution: {integrity: sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==}
 
   '@types/react@19.2.18':
     resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
@@ -4599,8 +4602,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turbo@2.10.11:
-    resolution: {integrity: sha512-yQfwQVoRXwOuyX1LxiJFBFNg6VfuYh+/RyZLd82+isgyLkBXw3S5XRRzvcck1FAjSCG5sVyLd+O1eDMvYa3J7g==}
+  turbo@2.10.12:
+    resolution: {integrity: sha512-AswgMPnpOoaVZHrrSBejETzEbuIA69OVGwfkHwfrY0A23VjWXBANzgq9+OymWOHAIArB7D1+1z498WY8fGg1Jw==}
     hasBin: true
 
   typanion@3.14.0:
@@ -6252,122 +6255,122 @@ snapshots:
 
   '@inquirer/ansi@2.0.7': {}
 
-  '@inquirer/checkbox@5.2.2(@types/node@26.2.0)':
+  '@inquirer/checkbox@5.2.2(@types/node@26.3.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 12.0.0(@types/node@26.2.0)
+      '@inquirer/core': 12.0.0(@types/node@26.3.0)
       '@inquirer/figures': 2.0.8
-      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+      '@inquirer/type': 4.0.7(@types/node@26.3.0)
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.3.0
 
-  '@inquirer/confirm@6.2.0(@types/node@26.2.0)':
+  '@inquirer/confirm@6.2.0(@types/node@26.3.0)':
     dependencies:
-      '@inquirer/core': 12.0.0(@types/node@26.2.0)
-      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+      '@inquirer/core': 12.0.0(@types/node@26.3.0)
+      '@inquirer/type': 4.0.7(@types/node@26.3.0)
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.3.0
 
-  '@inquirer/core@12.0.0(@types/node@26.2.0)':
+  '@inquirer/core@12.0.0(@types/node@26.3.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
       '@inquirer/figures': 2.0.8
-      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+      '@inquirer/type': 4.0.7(@types/node@26.3.0)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.2
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.3.0
 
-  '@inquirer/editor@5.3.0(@types/node@26.2.0)':
+  '@inquirer/editor@5.3.0(@types/node@26.3.0)':
     dependencies:
-      '@inquirer/core': 12.0.0(@types/node@26.2.0)
-      '@inquirer/external-editor': 3.0.4(@types/node@26.2.0)
-      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+      '@inquirer/core': 12.0.0(@types/node@26.3.0)
+      '@inquirer/external-editor': 3.0.4(@types/node@26.3.0)
+      '@inquirer/type': 4.0.7(@types/node@26.3.0)
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.3.0
 
-  '@inquirer/expand@5.1.2(@types/node@26.2.0)':
+  '@inquirer/expand@5.1.2(@types/node@26.3.0)':
     dependencies:
-      '@inquirer/core': 12.0.0(@types/node@26.2.0)
-      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+      '@inquirer/core': 12.0.0(@types/node@26.3.0)
+      '@inquirer/type': 4.0.7(@types/node@26.3.0)
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.3.0
 
-  '@inquirer/external-editor@3.0.4(@types/node@26.2.0)':
+  '@inquirer/external-editor@3.0.4(@types/node@26.3.0)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.3
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.3.0
 
   '@inquirer/figures@2.0.8': {}
 
-  '@inquirer/input@5.1.3(@types/node@26.2.0)':
+  '@inquirer/input@5.1.3(@types/node@26.3.0)':
     dependencies:
-      '@inquirer/core': 12.0.0(@types/node@26.2.0)
-      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+      '@inquirer/core': 12.0.0(@types/node@26.3.0)
+      '@inquirer/type': 4.0.7(@types/node@26.3.0)
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.3.0
 
-  '@inquirer/number@4.2.0(@types/node@26.2.0)':
+  '@inquirer/number@4.2.0(@types/node@26.3.0)':
     dependencies:
-      '@inquirer/core': 12.0.0(@types/node@26.2.0)
-      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+      '@inquirer/core': 12.0.0(@types/node@26.3.0)
+      '@inquirer/type': 4.0.7(@types/node@26.3.0)
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.3.0
 
-  '@inquirer/password@5.1.2(@types/node@26.2.0)':
-    dependencies:
-      '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 12.0.0(@types/node@26.2.0)
-      '@inquirer/type': 4.0.7(@types/node@26.2.0)
-    optionalDependencies:
-      '@types/node': 26.2.0
-
-  '@inquirer/prompts@8.6.0(@types/node@26.2.0)':
-    dependencies:
-      '@inquirer/checkbox': 5.2.2(@types/node@26.2.0)
-      '@inquirer/confirm': 6.2.0(@types/node@26.2.0)
-      '@inquirer/editor': 5.3.0(@types/node@26.2.0)
-      '@inquirer/expand': 5.1.2(@types/node@26.2.0)
-      '@inquirer/input': 5.1.3(@types/node@26.2.0)
-      '@inquirer/number': 4.2.0(@types/node@26.2.0)
-      '@inquirer/password': 5.1.2(@types/node@26.2.0)
-      '@inquirer/rawlist': 5.3.2(@types/node@26.2.0)
-      '@inquirer/search': 4.3.0(@types/node@26.2.0)
-      '@inquirer/select': 5.2.2(@types/node@26.2.0)
-    optionalDependencies:
-      '@types/node': 26.2.0
-
-  '@inquirer/rawlist@5.3.2(@types/node@26.2.0)':
-    dependencies:
-      '@inquirer/core': 12.0.0(@types/node@26.2.0)
-      '@inquirer/type': 4.0.7(@types/node@26.2.0)
-    optionalDependencies:
-      '@types/node': 26.2.0
-
-  '@inquirer/search@4.3.0(@types/node@26.2.0)':
-    dependencies:
-      '@inquirer/core': 12.0.0(@types/node@26.2.0)
-      '@inquirer/figures': 2.0.8
-      '@inquirer/type': 4.0.7(@types/node@26.2.0)
-    optionalDependencies:
-      '@types/node': 26.2.0
-
-  '@inquirer/select@5.2.2(@types/node@26.2.0)':
+  '@inquirer/password@5.1.2(@types/node@26.3.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 12.0.0(@types/node@26.2.0)
-      '@inquirer/figures': 2.0.8
-      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+      '@inquirer/core': 12.0.0(@types/node@26.3.0)
+      '@inquirer/type': 4.0.7(@types/node@26.3.0)
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.3.0
 
-  '@inquirer/type@4.0.7(@types/node@26.2.0)':
+  '@inquirer/prompts@8.6.0(@types/node@26.3.0)':
+    dependencies:
+      '@inquirer/checkbox': 5.2.2(@types/node@26.3.0)
+      '@inquirer/confirm': 6.2.0(@types/node@26.3.0)
+      '@inquirer/editor': 5.3.0(@types/node@26.3.0)
+      '@inquirer/expand': 5.1.2(@types/node@26.3.0)
+      '@inquirer/input': 5.1.3(@types/node@26.3.0)
+      '@inquirer/number': 4.2.0(@types/node@26.3.0)
+      '@inquirer/password': 5.1.2(@types/node@26.3.0)
+      '@inquirer/rawlist': 5.3.2(@types/node@26.3.0)
+      '@inquirer/search': 4.3.0(@types/node@26.3.0)
+      '@inquirer/select': 5.2.2(@types/node@26.3.0)
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.3.0
+
+  '@inquirer/rawlist@5.3.2(@types/node@26.3.0)':
+    dependencies:
+      '@inquirer/core': 12.0.0(@types/node@26.3.0)
+      '@inquirer/type': 4.0.7(@types/node@26.3.0)
+    optionalDependencies:
+      '@types/node': 26.3.0
+
+  '@inquirer/search@4.3.0(@types/node@26.3.0)':
+    dependencies:
+      '@inquirer/core': 12.0.0(@types/node@26.3.0)
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7(@types/node@26.3.0)
+    optionalDependencies:
+      '@types/node': 26.3.0
+
+  '@inquirer/select@5.2.2(@types/node@26.3.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 12.0.0(@types/node@26.3.0)
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7(@types/node@26.3.0)
+    optionalDependencies:
+      '@types/node': 26.3.0
+
+  '@inquirer/type@4.0.7(@types/node@26.3.0)':
+    optionalDependencies:
+      '@types/node': 26.3.0
 
   '@isaacs/ttlcache@1.4.1': {}
 
@@ -6408,9 +6411,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@napi-rs/cli@3.8.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.2.0)(supports-color@8.1.1)':
+  '@napi-rs/cli@3.8.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.3.0)(supports-color@8.1.1)':
     dependencies:
-      '@inquirer/prompts': 8.6.0(@types/node@26.2.0)
+      '@inquirer/prompts': 8.6.0(@types/node@26.3.0)
       '@napi-rs/cross-toolchain': 1.0.3(supports-color@8.1.1)
       '@napi-rs/wasm-tools': 1.1.0
       '@octokit/rest': 22.0.1
@@ -7251,22 +7254,22 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@turbo/darwin-64@2.10.11':
+  '@turbo/darwin-64@2.10.12':
     optional: true
 
-  '@turbo/darwin-arm64@2.10.11':
+  '@turbo/darwin-arm64@2.10.12':
     optional: true
 
-  '@turbo/linux-64@2.10.11':
+  '@turbo/linux-64@2.10.12':
     optional: true
 
-  '@turbo/linux-arm64@2.10.11':
+  '@turbo/linux-arm64@2.10.12':
     optional: true
 
-  '@turbo/windows-64@2.10.11':
+  '@turbo/windows-64@2.10.12':
     optional: true
 
-  '@turbo/windows-arm64@2.10.11':
+  '@turbo/windows-arm64@2.10.12':
     optional: true
 
   '@tybys/wasm-util@0.10.3':
@@ -7294,6 +7297,10 @@ snapshots:
       '@types/istanbul-lib-report': 3.0.3
 
   '@types/node@26.2.0':
+    dependencies:
+      undici-types: 8.3.0
+
+  '@types/node@26.3.0':
     dependencies:
       undici-types: 8.3.0
 
@@ -7380,13 +7387,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.11(vite@7.3.6(@types/node@26.2.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.11(vite@7.3.6(@types/node@26.3.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@26.2.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.3.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
@@ -9799,14 +9806,14 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  turbo@2.10.11:
+  turbo@2.10.12:
     optionalDependencies:
-      '@turbo/darwin-64': 2.10.11
-      '@turbo/darwin-arm64': 2.10.11
-      '@turbo/linux-64': 2.10.11
-      '@turbo/linux-arm64': 2.10.11
-      '@turbo/windows-64': 2.10.11
-      '@turbo/windows-arm64': 2.10.11
+      '@turbo/darwin-64': 2.10.12
+      '@turbo/darwin-arm64': 2.10.12
+      '@turbo/linux-64': 2.10.12
+      '@turbo/linux-arm64': 2.10.12
+      '@turbo/windows-64': 2.10.12
+      '@turbo/windows-arm64': 2.10.12
 
   typanion@3.14.0: {}
 
@@ -9910,7 +9917,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.6(@types/node@26.2.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0):
+  vite@7.3.6(@types/node@26.3.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.2
       fdir: 6.5.0(picomatch@4.0.7)
@@ -9919,16 +9926,16 @@ snapshots:
       rollup: 4.62.5
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.3.0
       fsevents: 2.3.3
       lightningcss: 1.33.0
       terser: 5.50.0
       yaml: 2.9.0
 
-  vitest@4.1.11(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0)):
+  vitest@4.1.11(@types/node@26.2.0)(vite@7.3.6(@types/node@26.3.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@7.3.6(@types/node@26.2.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.11(vite@7.3.6(@types/node@26.3.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -9945,7 +9952,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 7.3.6(@types/node@26.2.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.3.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.2.0

--- a/bindings/ts/pnpm-lock.yaml
+++ b/bindings/ts/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@minip2p/test-fixtures':
         specifier: workspace:*
         version: link:../test-fixtures
+      '@napi-rs/cli':
+        specifier: 3.8.6
+        version: 3.8.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.2.0)(supports-color@8.1.1)
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
@@ -805,6 +808,24 @@ packages:
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
@@ -1123,6 +1144,140 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/checkbox@5.2.2':
+    resolution: {integrity: sha512-Y5/bAScMy5Y+9isCx0SKbyJebMCaXXX5em0kxkj115eZNscgV9srOHrgyfS0e5xAVymIfOh9piYBKDILktsMMg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.2.0':
+    resolution: {integrity: sha512-SKXarWrYhtpqOEctf9XGCGy29QjsvJAM0Aq9ZR9z4Ns94OmpqudOly+aSEfNqUf9SwsQaUgY9+Z8hyzG0xX8fw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@12.0.0':
+    resolution: {integrity: sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.3.0':
+    resolution: {integrity: sha512-nnsP/IdJ8s83q7ZuObmgn12QM+uLCkab9E0Oordojbn62WUg1c+v9Ou/F/057pgh0ppX0W+Hj5bO/Dp5hsxQtA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.1.2':
+    resolution: {integrity: sha512-OWIH1IyyWqEKIyqC9Xy+Bnga7NkGMovFdo4atYZMUOTRqf6rO2WCv9E/1MyzvOErDBCxs+9UFliRUDc50xs/jw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.4':
+    resolution: {integrity: sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.8':
+    resolution: {integrity: sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/input@5.1.3':
+    resolution: {integrity: sha512-F/BZHtyEzP+HO+IGVd4AjBRgvX/ywm42bx8S0+dENk2YclzE9tJ3X/15THwtT6ehApmKvdYDMsVTuyyDod0gOQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.2.0':
+    resolution: {integrity: sha512-ew+fSDijsQ/WhD4TV3XLb+if400cDuzTzHfGR8sTNBXkK9CYDWoGE8fhaO8GbT312pNv1AJEOsDxy/z/HVettA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.1.2':
+    resolution: {integrity: sha512-nSdufycW8xynEVssFkNQEYIzTySilog0UlfOVRwh3pXzPSk4frXUT2jZWjHnKae6RU9PaoF9wfy1pGwewQuqGw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.6.0':
+    resolution: {integrity: sha512-WgBVDRy3IQ4v9XMCpQ1YDGpso2PcMUxYJzZdH4Nt4t0eoXhEPmOCh5iZbXbR4GTbdUB9VPWBbJB12rkjbaGDCw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.3.2':
+    resolution: {integrity: sha512-oPSKrYK1X1bMkjXDzIKHUkJp195LFSfgbnVtXnjSKGFjrCbS6I+wyvfAZTwKE9BSt3HwWgfD7JfsXALBgCogzQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.3.0':
+    resolution: {integrity: sha512-HFxXE5w727ctSUcAwrDquftJGjMgu36OeV5SHEXMlr2j/ahzmRX9xSEeVolV8tzYnTf45cg6vGkdMMRdm3RPhQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.2.2':
+    resolution: {integrity: sha512-RkI8dRHWt+bh04oLixvF1kFzKC7e5rqJoHKkzcqSHATebBXFC6GmrT8ddbVkgSzLV0HnHs2cPFuBINr8otij8Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/ttlcache@1.4.1':
     resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
     engines: {node: '>=12'}
@@ -1154,12 +1309,365 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/cli@3.8.6':
+    resolution: {integrity: sha512-FnJ9fghsV9Q4zh2aJGPSvQiUlJRC27B6KhzAXcIW2rlSD8keak3mhXw4tJYa3KJkP9whETfsPwqp/DJRnQg5ng==}
+    engines: {node: ^20.17.0 || ^22.13.0 || >= 23.5.0}
+    hasBin: true
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
+      emnapi: ^1.7.1 || ^2.0.0-alpha.4
+    peerDependenciesMeta:
+      '@emnapi/core':
+        optional: true
+      '@emnapi/runtime':
+        optional: true
+      emnapi:
+        optional: true
+
+  '@napi-rs/cross-toolchain@1.0.3':
+    resolution: {integrity: sha512-ENPfLe4937bsKVTDA6zdABx4pq9w0tHqRrJHyaGxgaPq03a2Bd1unD5XSKjXJjebsABJ+MjAv1A2OvCgK9yehg==}
+    peerDependencies:
+      '@napi-rs/cross-toolchain-arm64-target-aarch64': ^1.0.3
+      '@napi-rs/cross-toolchain-arm64-target-armv7': ^1.0.3
+      '@napi-rs/cross-toolchain-arm64-target-ppc64le': ^1.0.3
+      '@napi-rs/cross-toolchain-arm64-target-s390x': ^1.0.3
+      '@napi-rs/cross-toolchain-arm64-target-x86_64': ^1.0.3
+      '@napi-rs/cross-toolchain-x64-target-aarch64': ^1.0.3
+      '@napi-rs/cross-toolchain-x64-target-armv7': ^1.0.3
+      '@napi-rs/cross-toolchain-x64-target-ppc64le': ^1.0.3
+      '@napi-rs/cross-toolchain-x64-target-s390x': ^1.0.3
+      '@napi-rs/cross-toolchain-x64-target-x86_64': ^1.0.3
+    peerDependenciesMeta:
+      '@napi-rs/cross-toolchain-arm64-target-aarch64':
+        optional: true
+      '@napi-rs/cross-toolchain-arm64-target-armv7':
+        optional: true
+      '@napi-rs/cross-toolchain-arm64-target-ppc64le':
+        optional: true
+      '@napi-rs/cross-toolchain-arm64-target-s390x':
+        optional: true
+      '@napi-rs/cross-toolchain-arm64-target-x86_64':
+        optional: true
+      '@napi-rs/cross-toolchain-x64-target-aarch64':
+        optional: true
+      '@napi-rs/cross-toolchain-x64-target-armv7':
+        optional: true
+      '@napi-rs/cross-toolchain-x64-target-ppc64le':
+        optional: true
+      '@napi-rs/cross-toolchain-x64-target-s390x':
+        optional: true
+      '@napi-rs/cross-toolchain-x64-target-x86_64':
+        optional: true
+
+  '@napi-rs/lzma-android-arm-eabi@1.5.1':
+    resolution: {integrity: sha512-sahBe4ko2Z69NPTddaX6ZgbQZu9SDoITxw1S3dWl1gAGynZG34qHHCT8UaUMFxf3h3zMhCJjEzz4basaBxiTuQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [arm]
+    os: [android]
+
+  '@napi-rs/lzma-android-arm64@1.5.1':
+    resolution: {integrity: sha512-7tkQAJJuBHxAxiEBNFgSTpvrtGpbwZYYJUSOmGEK3OfbdbNeoT2rdBxpM/gY1s+itEVbtOSlpaRPPG19MnwOzA==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/lzma-darwin-arm64@1.5.1':
+    resolution: {integrity: sha512-XWX8gtF+GHGk3nH3Wm3QUZNcxw9QHsFVZz3MzVLhWWHhceede1J4/vD+3dj3E1iKB9G6mualaZxOoD08R3E+7g==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/lzma-darwin-x64@1.5.1':
+    resolution: {integrity: sha512-CfsqUpMTI1z8enrA/b+GcHM6YDI8D0kqCiqPYEnst4rbOABQ9KZ92ybTTNnlnZ7A017WoMZKUEWc36KXDwi0xg==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/lzma-freebsd-x64@1.5.1':
+    resolution: {integrity: sha512-bTyNfg90FXIgE61U7l14aMmVOqRQ6AyP5JMT3jmCStaZI18apLNPdzZ8i7yqxZfKvRMVfPjE2brXIw27c+RRgA==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/lzma-linux-arm-gnueabihf@1.5.1':
+    resolution: {integrity: sha512-vNE+D8nrw+eOkBsdKCsmDhowDV3pIMKXEhedvXfbgrWbrO7GlZJH+RXL+X+RYLxGwi8Ym61ZMt15sIOnNmh9Sw==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/lzma-linux-arm64-gnu@1.5.1':
+    resolution: {integrity: sha512-csUem4WgoKGTprv/pOPm9UIWbb+hrfUwYXefpTHPAEGVFLl5behEFabisJ7FtihCa3yG2Efcl+yw25rlhhrIYw==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/lzma-linux-arm64-musl@1.5.1':
+    resolution: {integrity: sha512-kB/xhlVN1eLvVmDJSKZEjp5Gg2xDYexNrB5jwpSMbOkeGS6N9AasByPBg5VqCpMYC+zZi7DM458DRhtWYhqXTQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/lzma-linux-ppc64-gnu@1.5.1':
+    resolution: {integrity: sha512-s28RW0W1yBWQc1nbPdF7tp14koqslY3ZWLVI8uaanX292Dc6ezd4NPVwxEoCNBVON/oD7BmUbWGtyFvmm7dQ5A==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/lzma-linux-riscv64-gnu@1.5.1':
+    resolution: {integrity: sha512-+lGNwYlIN14YPMTNvYtIJJqHFevDTd6Juw/1NmXbWx/iRd/LLrjhlM/yluMX6pxs6NkOGsuuEXJJrbbEUS59OQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/lzma-linux-s390x-gnu@1.5.1':
+    resolution: {integrity: sha512-PB44FFWWFrLeQowhcep1hPD1YcLqKlnnY60RMU74qrxTlr4YGEyzeMItJqh2uivBfv9kQScOF/B0J9+Vab/oyw==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@napi-rs/lzma-linux-x64-musl@1.5.1':
+    resolution: {integrity: sha512-I3nsYrWtrW9JpeCr+mkJIVDt0HY3m6qVUBs5vTtoIvJQxwqf1PBXSy5IS7T53ksQFH2kd2UX8rLxJ7B4WISpZg==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/lzma-wasm32-wasi@1.5.1':
+    resolution: {integrity: sha512-gy3wwPBa6+XEyA4fUzq6CClrXA1ajXjuVf5zbnHytJRgoHznj+mvpU3+co2fxXwqTCmIpn6KrzqH5bRDztBPhA==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [wasm32]
+
+  '@napi-rs/lzma-win32-arm64-msvc@1.5.1':
+    resolution: {integrity: sha512-dK+huOsHiyH6oJjij+cnjqFCakk2HgWmpI12Xm4pLUyPphe4ebYoJBgehaNAxprmjFqBQ7nL95YPVz9BHyqmPg==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/lzma-win32-ia32-msvc@1.5.1':
+    resolution: {integrity: sha512-dGE8L+0EQ+GyU9ap9InqB/t/PmPG/bLj918q7OsJ29FuTdn8fK4OX3U4IQZhylHIA+/dQ/SXJk5n4yfah2XVvA==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/lzma-win32-x64-msvc@1.5.1':
+    resolution: {integrity: sha512-EKW4t/iqdCT/xnd5t9oXLvVER/PMNAWXKqUAl3fgvUcOILeZIIht77/dVnfFcc9htA/DCBXC/6YQWdW+LusjFA==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/lzma@1.5.1':
+    resolution: {integrity: sha512-sgOZ89+y8cDbY+3WbzR8CtIhCuFRWotZ9/2PjPVDJHz6np5KFTAev0DrwiyTJTgFsCRDhfGlbmhMgyhHbWdZ6g==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+
+  '@napi-rs/tar-android-arm-eabi@1.1.1':
+    resolution: {integrity: sha512-cAhnA10cSusAUbcE9HtjQY/tZ9BH/0w2sKtRcQc94TzIlnm7QSr1htJSd/PPrbWNPtrv1orXb2CkrHlVlbnlHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@napi-rs/tar-android-arm64@1.1.1':
+    resolution: {integrity: sha512-EslUWHCDBY/g5abTPBiHLsMaML4GagV0TXLm5WL9hAjx/DDtlxz9fegMb77RJ+f7nFLOIsUxF/3QWFvgOT0sMQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/tar-darwin-arm64@1.1.1':
+    resolution: {integrity: sha512-+A42/6ES5G9CQ35BOwzwA+WBjLID28r2jNPgc0dteD2hhClIhng0mva7D2ujUlXBNmgNOsr1LHn3stA4uTf4NQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/tar-darwin-x64@1.1.1':
+    resolution: {integrity: sha512-RYtE8w1dkEvj8hSJCDV5Jw0Rz2i13fsM7u893zv5O9n/4Ad5GNsw/f4RQ7/0YGSFaenkVxqPFrjmEvUHlKzsrg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/tar-freebsd-x64@1.1.1':
+    resolution: {integrity: sha512-rEepBvCJUwcuvUYkY83e8aot8RsR5Jcnal4PsG3tbWGKW1yAvcXhyMXf0fN6ZGpVRZFnB+FJqDyBxvsCPEXKhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/tar-linux-arm-gnueabihf@1.1.1':
+    resolution: {integrity: sha512-an1bJdfyhI5FpZYyTQ20mrqwR+a676i8GkaYc4Uy12dH/a7TJIfrK6Qa2Gm46arZvxUvx56qxoRKXbpOjUPvwA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/tar-linux-arm64-gnu@1.1.1':
+    resolution: {integrity: sha512-w++Vtx36T2yHTKws7GVnmHHcUT1ybB59xLWSh9A8bwEpJVG4dG7Qub9mFe5cpcbfrJ+XP2mKKxC3oUJSunK3iQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/tar-linux-arm64-musl@1.1.1':
+    resolution: {integrity: sha512-Rh6UFhNtj3i4deJHOBINFIeRL0072mgbeyuK5rl1HokKnNoMKx8qKIZNEzBTTqpogMfDHWGvzyTQdnVxes5dpA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/tar-linux-ppc64-gnu@1.1.1':
+    resolution: {integrity: sha512-Cp+AxFbv9zcyAXtnzQi0OzmgDnQgy2w9D4Ubr+iwzMtVgJcztzcEoCcCrN1k2ATdEB01LX2Vb49IaocGOZhC9Q==}
+    engines: {node: '>= 10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/tar-linux-s390x-gnu@1.1.1':
+    resolution: {integrity: sha512-ZyscC3SYKTBWyDRYjLOKAd5TyJ7q0KACRdQ8bWrb3rgrra1CCIJD66CsGTH6Dh0AVSdfLwZ8MfIIXU6+14BMjQ==}
+    engines: {node: '>= 10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/tar-linux-x64-gnu@1.1.1':
+    resolution: {integrity: sha512-LlIv+zg4fiOQge9LQX/ieBdRWE2fhVDjCTHxnunZkbugNmdhdelxWf1RpZb/6ZujWpNF4LPu4N/MW7ygg2oYAQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/tar-linux-x64-musl@1.1.1':
+    resolution: {integrity: sha512-gZBeoKLjanOVj55qk4EMu13P2i9M0SuINmlGQkOxm1niIJofexzddHUYtqO5o/5QqtyL8lADmAcZplLILMLhHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/tar-wasm32-wasi@1.1.1':
+    resolution: {integrity: sha512-rwtQ1Mdt/ft6g6I54fJzbUeLspl4yTwj6I3UJ6mitKnrN42soJkcDrdh3Y/FGvlpqZTad2YMQ96fGJl3EtAm2Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@napi-rs/tar-win32-arm64-msvc@1.1.1':
+    resolution: {integrity: sha512-30PVp1AehRpfwxmv5wI4cg0yj3WmWBsZ+1QnLGnvEELu7Eu/+dhNU0nrmhI7VfPgLwSRK2eg9DQTB3tP7Wv9bA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/tar-win32-ia32-msvc@1.1.1':
+    resolution: {integrity: sha512-aI3/rmz+izUChiSeaPxcasAOxhf3FpJNuIHMXlxS/vpW+HIxUsSDR5+XV61PEG5DL4L/75iENVUxmSGM5l2yaw==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/tar-win32-x64-msvc@1.1.1':
+    resolution: {integrity: sha512-yJsB2IsrODQVLKbm2Fg1nHiVRbEj49mSPbj4x7JPZWJI0jGVPjohE2Sif0FBbx8OxsVoUODvS0BwksZZ8jl/OA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/tar@1.1.1':
+    resolution: {integrity: sha512-p6q2HhUc5vwH1CNwfOcrhLoxfgn8ust8Sqlfx+sA4VzAcp1cMbvbkl99tZZlDqOjCHgQNSiTfk/yWPjl/D42qA==}
+    engines: {node: '>= 10'}
+
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
+
+  '@napi-rs/wasm-tools-android-arm-eabi@1.1.0':
+    resolution: {integrity: sha512-p6J8PB59I8d/XItXB/go5JH6nKW+xIbpzaL43EBTV0hi7mrS/Z4gs+MsB04ZrlqZN29BdZV8fChRyasuXLhRaA==}
+    engines: {node: '>= 12.22.0'}
+    cpu: [arm]
+    os: [android]
+
+  '@napi-rs/wasm-tools-android-arm64@1.1.0':
+    resolution: {integrity: sha512-lWoKN3suypeBSCIRPIw+++sH9V2K6nQkhtdt1opu7XY3v9JwLs6Gw063HWRqkNjphlYpkd/Qy8XcfSPGbJj7nQ==}
+    engines: {node: '>= 12.22.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/wasm-tools-darwin-arm64@1.1.0':
+    resolution: {integrity: sha512-jfw5vyNDUf6oe0kP8lMveFN9U7cLk1cUosS7uMIfw/xmqmopYfKQ198DAx2g/6aEF7Tm+CqER2gpMpYKui30LA==}
+    engines: {node: '>= 12.22.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/wasm-tools-darwin-x64@1.1.0':
+    resolution: {integrity: sha512-R+pjeudAB7BYdH1vKkOJM61Tfv5jB6uXkxmFscYd+KKpdUpWBlNG+s4hr0w4i1rMBM91VhIAETZn2pz+MDHK9A==}
+    engines: {node: '>= 12.22.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/wasm-tools-freebsd-x64@1.1.0':
+    resolution: {integrity: sha512-hQJTe+aazrT++Vgm6I4lUd9099ItUCFYdd+aKg6Ys6nax6d/cZ1barDLTwA2lwOoVDsXMekJI/FOL6ZvVlIYBg==}
+    engines: {node: '>= 12.22.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/wasm-tools-linux-arm64-gnu@1.1.0':
+    resolution: {integrity: sha512-1TAXJxUHsWGar90k3W/MknavvBMwOWzjh7Q6Spxo8twRcWJbBD5Kow/Q2KhhDq5hxh2sKGDXn3uLc1tdtz4WUg==}
+    engines: {node: '>= 12.22.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/wasm-tools-linux-arm64-musl@1.1.0':
+    resolution: {integrity: sha512-7rw3nlubTjNAVRH2LwphCxHy1b/N2/TerXocQ6XRn4Q+buaY1Z7P/hbdALy1i1ex2yfOU2Xcij7ib7ZLi/lKfw==}
+    engines: {node: '>= 12.22.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/wasm-tools-linux-x64-gnu@1.1.0':
+    resolution: {integrity: sha512-1sel0t9MRjI/tdT89M8Dd6gPfANeeFP24Xa46R11WeHNwhjsXXZh+xUk50uWCRTSGcaCy3ugm3AMK/lmHYQJkg==}
+    engines: {node: '>= 12.22.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/wasm-tools-linux-x64-musl@1.1.0':
+    resolution: {integrity: sha512-o2jH5AMfor4EKF2HII1LBnMQxoWu7+usPifTEY8Zk6e9OiSi4EJkAXf9v3ANlX7TI2V/cUEV34OEW7r10GiVIA==}
+    engines: {node: '>= 12.22.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/wasm-tools-wasm32-wasi@1.1.0':
+    resolution: {integrity: sha512-s6YDtDR1UWrsqJPtaxf+JLYLceWVyn3l8OpQYElHkDhf3Qfz9R6Ba3S0OgznTBv38L5/TIHysQ9Q4yO73Z0csg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@napi-rs/wasm-tools-win32-arm64-msvc@1.1.0':
+    resolution: {integrity: sha512-x+NuxbG84VxU68tU8w7Rf5lSyq0l584M6dVlke5DTweHYFZoMyeqkpbwEq+qsyAX6ivfipK8xRsmFwamb5uDnA==}
+    engines: {node: '>= 12.22.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/wasm-tools-win32-ia32-msvc@1.1.0':
+    resolution: {integrity: sha512-mdD96QDEp70SX67rXFTY6c725nVYeqEEjyDqzzbNh6u1APj7CI7IMNpMmvE75XbCRl4C2MHZVU4U6AWdAzvyQQ==}
+    engines: {node: '>= 12.22.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/wasm-tools-win32-x64-msvc@1.1.0':
+    resolution: {integrity: sha512-bVVjuvhlyVX++3eJXfDR63cXdw1ay5QYac6iq0MKQw8wZARInTM+bXCtByDT4fzVFI3+7ZthYb/ERWRdBNIqgQ==}
+    engines: {node: '>= 12.22.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/wasm-tools@1.1.0':
+    resolution: {integrity: sha512-VjHyKEqXAwYZK+HY7iJctYvRm3TFEbaQxeZwvAG1QRkoo1a39phMY8J6x9tUEqJI03W6MysB8F2jacI6wvcx+w==}
+    engines: {node: '>= 12.22.0'}
 
   '@nodable/entities@3.0.0':
     resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
@@ -1175,6 +1683,64 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.7':
+    resolution: {integrity: sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.4':
+    resolution: {integrity: sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.4':
+    resolution: {integrity: sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/openapi-types@28.0.0':
+    resolution: {integrity: sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.1':
+    resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.15':
+    resolution: {integrity: sha512-3CBg9aJ0hO9Pjyij8LbK/xYtEaPws9SW7xKz67daPNxQB1q5Y9OMA7DDOG0A6Hwf9ygGu3tvzusg0LXQ8/wAjA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@octokit/types@17.0.0':
+    resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
 
   '@oxfmt/binding-android-arm-eabi@0.65.0':
     resolution: {integrity: sha512-M10Gs1SSpTNI6ahGx3M/OlIdUF4hkaP6OgUb+MS79t/Pgflk3r1nW5gPFqsZGUAXg0H1AfANT9AvLdBSTIhZKg==}
@@ -1742,6 +2308,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -2096,6 +2665,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
@@ -2179,6 +2751,9 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
   chrome-launcher@0.15.2:
     resolution: {integrity: sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==}
     engines: {node: '>=12.13.0'}
@@ -2217,6 +2792,15 @@ packages:
     resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
     engines: {node: '>=22'}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  clipanion@4.0.0-rc.4:
+    resolution: {integrity: sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==}
+    peerDependencies:
+      typanion: '*'
+
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -2247,6 +2831,9 @@ packages:
 
   colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
   command-exists@1.2.9:
     resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
@@ -2288,6 +2875,10 @@ packages:
   content-type@2.1.0:
     resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
     engines: {node: '>=18'}
+
+  content-type@3.0.0:
+    resolution: {integrity: sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw==}
+    engines: {node: '>=22'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2448,6 +3039,9 @@ packages:
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.51.0:
+    resolution: {integrity: sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==}
 
   esbuild@0.28.2:
     resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
@@ -2981,6 +3575,9 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-with-bigint@3.5.12:
+    resolution: {integrity: sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -3354,6 +3951,10 @@ packages:
 
   multitars@1.0.2:
     resolution: {integrity: sha512-6GwVw5eLi9sThdtlS4PKwC7yRLaf45pYhIEzKBHdKxi+YOXGKFX8acIniH+Uh/+k9mS2lQOupTccjoe5r0/1IQ==}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
@@ -3995,9 +4596,15 @@ packages:
   toqr@0.1.1:
     resolution: {integrity: sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   turbo@2.10.11:
     resolution: {integrity: sha512-yQfwQVoRXwOuyX1LxiJFBFNg6VfuYh+/RyZLd82+isgyLkBXw3S5XRRzvcck1FAjSCG5sVyLd+O1eDMvYa3J7g==}
     hasBin: true
+
+  typanion@3.14.0:
+    resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -4062,6 +4669,9 @@ packages:
   uniffi-bindgen-react-native@0.31.0-5:
     resolution: {integrity: sha512-YtL3gTe+RVXAQx/2P2Iuypic/CunRZC65Cs47v//YRfwWNYU4Ufd1jT3rqxSrH5b5QFCYblP89Nf/9ssZRvNgg==}
     hasBin: true
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -5177,6 +5787,38 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
@@ -5608,6 +6250,125 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
+  '@inquirer/ansi@2.0.7': {}
+
+  '@inquirer/checkbox@5.2.2(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 12.0.0(@types/node@26.2.0)
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/confirm@6.2.0(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 12.0.0(@types/node@26.2.0)
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/core@12.0.0(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/editor@5.3.0(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 12.0.0(@types/node@26.2.0)
+      '@inquirer/external-editor': 3.0.4(@types/node@26.2.0)
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/expand@5.1.2(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 12.0.0(@types/node@26.2.0)
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/external-editor@3.0.4(@types/node@26.2.0)':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/figures@2.0.8': {}
+
+  '@inquirer/input@5.1.3(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 12.0.0(@types/node@26.2.0)
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/number@4.2.0(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 12.0.0(@types/node@26.2.0)
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/password@5.1.2(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 12.0.0(@types/node@26.2.0)
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/prompts@8.6.0(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/checkbox': 5.2.2(@types/node@26.2.0)
+      '@inquirer/confirm': 6.2.0(@types/node@26.2.0)
+      '@inquirer/editor': 5.3.0(@types/node@26.2.0)
+      '@inquirer/expand': 5.1.2(@types/node@26.2.0)
+      '@inquirer/input': 5.1.3(@types/node@26.2.0)
+      '@inquirer/number': 4.2.0(@types/node@26.2.0)
+      '@inquirer/password': 5.1.2(@types/node@26.2.0)
+      '@inquirer/rawlist': 5.3.2(@types/node@26.2.0)
+      '@inquirer/search': 4.3.0(@types/node@26.2.0)
+      '@inquirer/select': 5.2.2(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/rawlist@5.3.2(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 12.0.0(@types/node@26.2.0)
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/search@4.3.0(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 12.0.0(@types/node@26.2.0)
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/select@5.2.2(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 12.0.0(@types/node@26.2.0)
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/type@4.0.7(@types/node@26.2.0)':
+    optionalDependencies:
+      '@types/node': 26.2.0
+
   '@isaacs/ttlcache@1.4.1': {}
 
   '@jest/schemas@29.6.3':
@@ -5647,8 +6408,263 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/cli@3.8.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.2.0)(supports-color@8.1.1)':
+    dependencies:
+      '@inquirer/prompts': 8.6.0(@types/node@26.2.0)
+      '@napi-rs/cross-toolchain': 1.0.3(supports-color@8.1.1)
+      '@napi-rs/wasm-tools': 1.1.0
+      '@octokit/rest': 22.0.1
+      clipanion: 4.0.0-rc.4(typanion@3.14.0)
+      colorette: 2.0.20
+      es-toolkit: 1.51.0
+      js-yaml: 4.3.1
+      obug: 2.1.4
+      semver: 7.8.5
+      typanion: 3.14.0
+      typescript: 6.0.3
+    optionalDependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+    transitivePeerDependencies:
+      - '@napi-rs/cross-toolchain-arm64-target-aarch64'
+      - '@napi-rs/cross-toolchain-arm64-target-armv7'
+      - '@napi-rs/cross-toolchain-arm64-target-ppc64le'
+      - '@napi-rs/cross-toolchain-arm64-target-s390x'
+      - '@napi-rs/cross-toolchain-arm64-target-x86_64'
+      - '@napi-rs/cross-toolchain-x64-target-aarch64'
+      - '@napi-rs/cross-toolchain-x64-target-armv7'
+      - '@napi-rs/cross-toolchain-x64-target-ppc64le'
+      - '@napi-rs/cross-toolchain-x64-target-s390x'
+      - '@napi-rs/cross-toolchain-x64-target-x86_64'
+      - '@types/node'
+      - supports-color
+
+  '@napi-rs/cross-toolchain@1.0.3(supports-color@8.1.1)':
+    dependencies:
+      '@napi-rs/lzma': 1.5.1
+      '@napi-rs/tar': 1.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@napi-rs/lzma-android-arm-eabi@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-android-arm64@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-darwin-arm64@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-darwin-x64@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-freebsd-x64@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-linux-arm-gnueabihf@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-linux-arm64-gnu@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-linux-arm64-musl@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-linux-ppc64-gnu@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-linux-riscv64-gnu@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-linux-s390x-gnu@1.5.1':
+    optional: true
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
+
+  '@napi-rs/lzma-linux-x64-musl@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-wasm32-wasi@1.5.1':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@napi-rs/lzma-win32-arm64-msvc@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-win32-ia32-msvc@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma-win32-x64-msvc@1.5.1':
+    optional: true
+
+  '@napi-rs/lzma@1.5.1':
+    optionalDependencies:
+      '@napi-rs/lzma-android-arm-eabi': 1.5.1
+      '@napi-rs/lzma-android-arm64': 1.5.1
+      '@napi-rs/lzma-darwin-arm64': 1.5.1
+      '@napi-rs/lzma-darwin-x64': 1.5.1
+      '@napi-rs/lzma-freebsd-x64': 1.5.1
+      '@napi-rs/lzma-linux-arm-gnueabihf': 1.5.1
+      '@napi-rs/lzma-linux-arm64-gnu': 1.5.1
+      '@napi-rs/lzma-linux-arm64-musl': 1.5.1
+      '@napi-rs/lzma-linux-ppc64-gnu': 1.5.1
+      '@napi-rs/lzma-linux-riscv64-gnu': 1.5.1
+      '@napi-rs/lzma-linux-s390x-gnu': 1.5.1
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@napi-rs/lzma-linux-x64-musl': 1.5.1
+      '@napi-rs/lzma-wasm32-wasi': 1.5.1
+      '@napi-rs/lzma-win32-arm64-msvc': 1.5.1
+      '@napi-rs/lzma-win32-ia32-msvc': 1.5.1
+      '@napi-rs/lzma-win32-x64-msvc': 1.5.1
+
+  '@napi-rs/tar-android-arm-eabi@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-android-arm64@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-darwin-arm64@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-darwin-x64@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-freebsd-x64@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-linux-arm-gnueabihf@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-linux-arm64-gnu@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-linux-arm64-musl@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-linux-ppc64-gnu@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-linux-s390x-gnu@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-linux-x64-gnu@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-linux-x64-musl@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-wasm32-wasi@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@napi-rs/tar-win32-arm64-msvc@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-win32-ia32-msvc@1.1.1':
+    optional: true
+
+  '@napi-rs/tar-win32-x64-msvc@1.1.1':
+    optional: true
+
+  '@napi-rs/tar@1.1.1':
+    optionalDependencies:
+      '@napi-rs/tar-android-arm-eabi': 1.1.1
+      '@napi-rs/tar-android-arm64': 1.1.1
+      '@napi-rs/tar-darwin-arm64': 1.1.1
+      '@napi-rs/tar-darwin-x64': 1.1.1
+      '@napi-rs/tar-freebsd-x64': 1.1.1
+      '@napi-rs/tar-linux-arm-gnueabihf': 1.1.1
+      '@napi-rs/tar-linux-arm64-gnu': 1.1.1
+      '@napi-rs/tar-linux-arm64-musl': 1.1.1
+      '@napi-rs/tar-linux-ppc64-gnu': 1.1.1
+      '@napi-rs/tar-linux-s390x-gnu': 1.1.1
+      '@napi-rs/tar-linux-x64-gnu': 1.1.1
+      '@napi-rs/tar-linux-x64-musl': 1.1.1
+      '@napi-rs/tar-wasm32-wasi': 1.1.1
+      '@napi-rs/tar-win32-arm64-msvc': 1.1.1
+      '@napi-rs/tar-win32-ia32-msvc': 1.1.1
+      '@napi-rs/tar-win32-x64-msvc': 1.1.1
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-tools-android-arm-eabi@1.1.0':
+    optional: true
+
+  '@napi-rs/wasm-tools-android-arm64@1.1.0':
+    optional: true
+
+  '@napi-rs/wasm-tools-darwin-arm64@1.1.0':
+    optional: true
+
+  '@napi-rs/wasm-tools-darwin-x64@1.1.0':
+    optional: true
+
+  '@napi-rs/wasm-tools-freebsd-x64@1.1.0':
+    optional: true
+
+  '@napi-rs/wasm-tools-linux-arm64-gnu@1.1.0':
+    optional: true
+
+  '@napi-rs/wasm-tools-linux-arm64-musl@1.1.0':
+    optional: true
+
+  '@napi-rs/wasm-tools-linux-x64-gnu@1.1.0':
+    optional: true
+
+  '@napi-rs/wasm-tools-linux-x64-musl@1.1.0':
+    optional: true
+
+  '@napi-rs/wasm-tools-wasm32-wasi@1.1.0':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@napi-rs/wasm-tools-win32-arm64-msvc@1.1.0':
+    optional: true
+
+  '@napi-rs/wasm-tools-win32-ia32-msvc@1.1.0':
+    optional: true
+
+  '@napi-rs/wasm-tools-win32-x64-msvc@1.1.0':
+    optional: true
+
+  '@napi-rs/wasm-tools@1.1.0':
+    optionalDependencies:
+      '@napi-rs/wasm-tools-android-arm-eabi': 1.1.0
+      '@napi-rs/wasm-tools-android-arm64': 1.1.0
+      '@napi-rs/wasm-tools-darwin-arm64': 1.1.0
+      '@napi-rs/wasm-tools-darwin-x64': 1.1.0
+      '@napi-rs/wasm-tools-freebsd-x64': 1.1.0
+      '@napi-rs/wasm-tools-linux-arm64-gnu': 1.1.0
+      '@napi-rs/wasm-tools-linux-arm64-musl': 1.1.0
+      '@napi-rs/wasm-tools-linux-x64-gnu': 1.1.0
+      '@napi-rs/wasm-tools-linux-x64-musl': 1.1.0
+      '@napi-rs/wasm-tools-wasm32-wasi': 1.1.0
+      '@napi-rs/wasm-tools-win32-arm64-msvc': 1.1.0
+      '@napi-rs/wasm-tools-win32-ia32-msvc': 1.1.0
+      '@napi-rs/wasm-tools-win32-x64-msvc': 1.1.0
 
   '@nodable/entities@3.0.0': {}
 
@@ -5663,6 +6679,75 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.7':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.4
+      '@octokit/request': 10.0.15
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.4':
+    dependencies:
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.4':
+    dependencies:
+      '@octokit/request': 10.0.15
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/openapi-types@28.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.1':
+    dependencies:
+      '@octokit/types': 17.0.0
+
+  '@octokit/request@10.0.15':
+    dependencies:
+      '@octokit/endpoint': 11.0.4
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      content-type: 3.0.0
+      json-with-bigint: 3.5.12
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.7)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  '@octokit/types@17.0.0':
+    dependencies:
+      '@octokit/openapi-types': 28.0.0
 
   '@oxfmt/binding-android-arm-eabi@0.65.0':
     optional: true
@@ -6184,6 +7269,11 @@ snapshots:
   '@turbo/windows-arm64@2.10.11':
     optional: true
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -6514,6 +7604,8 @@ snapshots:
 
   baseline-browser-mapping@2.11.19: {}
 
+  before-after-hook@4.0.0: {}
+
   big-integer@1.6.52: {}
 
   bl@4.1.0:
@@ -6608,6 +7700,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chardet@2.2.0: {}
+
   chrome-launcher@0.15.2(supports-color@8.1.1):
     dependencies:
       '@types/node': 26.2.0
@@ -6652,6 +7746,12 @@ snapshots:
       slice-ansi: 9.0.0
       string-width: 8.2.2
 
+  cli-width@4.1.0: {}
+
+  clipanion@4.0.0-rc.4(typanion@3.14.0):
+    dependencies:
+      typanion: 3.14.0
+
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
@@ -6685,6 +7785,8 @@ snapshots:
   color-name@1.1.4: {}
 
   colorette@1.4.0: {}
+
+  colorette@2.0.20: {}
 
   command-exists@1.2.9: {}
 
@@ -6726,6 +7828,8 @@ snapshots:
       - supports-color
 
   content-type@2.1.0: {}
+
+  content-type@3.0.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -6852,6 +7956,8 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
+
+  es-toolkit@1.51.0: {}
 
   esbuild@0.28.2:
     optionalDependencies:
@@ -7424,6 +8530,8 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-with-bigint@3.5.12: {}
+
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
@@ -7978,6 +9086,8 @@ snapshots:
   ms@2.1.3: {}
 
   multitars@1.0.2: {}
+
+  mute-stream@3.0.0: {}
 
   nanoid@3.3.18: {}
 
@@ -8686,6 +9796,9 @@ snapshots:
 
   toqr@0.1.1: {}
 
+  tslib@2.8.1:
+    optional: true
+
   turbo@2.10.11:
     optionalDependencies:
       '@turbo/darwin-64': 2.10.11
@@ -8694,6 +9807,8 @@ snapshots:
       '@turbo/linux-arm64': 2.10.11
       '@turbo/windows-64': 2.10.11
       '@turbo/windows-arm64': 2.10.11
+
+  typanion@3.14.0: {}
 
   type-fest@0.21.3: {}
 
@@ -8770,6 +9885,8 @@ snapshots:
   unicorn-magic@0.3.0: {}
 
   uniffi-bindgen-react-native@0.31.0-5(patch_hash=3d3826cb29db1530c60a1092dde51421bfa266d3c2add5512d462f7c0adac050): {}
+
+  universal-user-agent@7.0.3: {}
 
   universalify@0.1.2: {}
 

--- a/bindings/ts/pnpm-workspace.yaml
+++ b/bindings/ts/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ allowBuilds:
   esbuild: true
 
 catalog:
+  "@types/node": 26.2.0
   "@types/react": 19.2.18
   del-cli: 7.0.0
   react: 19.2.8

--- a/bindings/ts/pnpm-workspace.yaml
+++ b/bindings/ts/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ allowBuilds:
   esbuild: true
 
 catalog:
-  "@types/node": 26.2.0
+  "@types/node": 26.3.0
   "@types/react": 19.2.18
   del-cli: 7.0.0
   react: 19.2.8
@@ -21,6 +21,13 @@ minimumReleaseAgeExclude:
   - "@expo/inline-modules@0.0.15"
   - "@expo/local-build-cache-provider@56.0.11"
   - expo@56.0.18
+  - "@turbo/darwin-64@2.10.12"
+  - "@turbo/darwin-arm64@2.10.12"
+  - "@turbo/linux-64@2.10.12"
+  - "@turbo/linux-arm64@2.10.12"
+  - "@turbo/windows-64@2.10.12"
+  - "@turbo/windows-arm64@2.10.12"
+  - turbo@2.10.12
 
 nodeLinker: hoisted
 

--- a/crates/ffi-core/src/endpoint.rs
+++ b/crates/ffi-core/src/endpoint.rs
@@ -773,6 +773,7 @@ impl P2pEndpoint {
                         }
                     }
                 }
+                drop(doorbell);
                 thread_shared.lock_state().doorbell_thread_id = None;
                 thread_shared
                     .doorbell_running

--- a/crates/ffi-core/src/endpoint.rs
+++ b/crates/ffi-core/src/endpoint.rs
@@ -364,11 +364,12 @@ impl P2pEndpoint {
     /// Starts the detached background endpoint driver.
     pub fn start(&self, doorbell: Arc<dyn EventDoorbell>) -> Result<(), FfiError> {
         self.start_with(doorbell, |shared, doorbell| {
-            let doorbell = Self::spawn_doorbell(Arc::clone(&shared), doorbell)?;
+            let (doorbell, doorbell_thread_id) =
+                Self::spawn_doorbell(Arc::clone(&shared), doorbell)?;
             std::thread::Builder::new()
                 .name("minip2p-driver".into())
                 .spawn(move || crate::driver::run(shared, doorbell))
-                .map(drop)
+                .map(|_| doorbell_thread_id)
         })
     }
 
@@ -758,14 +759,13 @@ impl P2pEndpoint {
     fn spawn_doorbell(
         shared: Arc<Shared>,
         doorbell: Arc<dyn EventDoorbell>,
-    ) -> std::io::Result<Arc<dyn EventDoorbell>> {
+    ) -> std::io::Result<(Arc<dyn EventDoorbell>, std::thread::ThreadId)> {
         let (sender, receiver) = sync_channel(1);
         shared.doorbell_running.store(true, Ordering::Release);
         let thread_shared = Arc::clone(&shared);
-        std::thread::Builder::new()
+        let thread = std::thread::Builder::new()
             .name("minip2p-doorbell".into())
             .spawn(move || {
-                thread_shared.lock_state().doorbell_thread_id = Some(std::thread::current().id());
                 while receiver.recv().is_ok() {
                     for _ in 0..2 {
                         if catch_unwind(AssertUnwindSafe(|| doorbell.on_events_ready())).is_ok() {
@@ -779,17 +779,21 @@ impl P2pEndpoint {
                     .store(false, Ordering::Release);
                 thread_shared.stopped_cv.notify_all();
             })
-            .map(drop)
             .inspect_err(|_| {
                 shared.doorbell_running.store(false, Ordering::Release);
             })?;
-        Ok(Arc::new(DoorbellSender(sender)))
+        let thread_id = thread.thread().id();
+        drop(thread);
+        Ok((Arc::new(DoorbellSender(sender)), thread_id))
     }
 
     fn start_with(
         &self,
         doorbell: Arc<dyn EventDoorbell>,
-        spawn: impl FnOnce(Arc<Shared>, Arc<dyn EventDoorbell>) -> std::io::Result<()>,
+        spawn: impl FnOnce(
+            Arc<Shared>,
+            Arc<dyn EventDoorbell>,
+        ) -> std::io::Result<std::thread::ThreadId>,
     ) -> Result<(), FfiError> {
         let mut state = self.shared.lock_state();
         match state.lifecycle {
@@ -801,7 +805,7 @@ impl P2pEndpoint {
         let shared = Arc::clone(&self.shared);
         state.lifecycle = Lifecycle::Running;
         self.shared.driver_running.store(true, Ordering::Release);
-        spawn(shared, doorbell).map_err(|error| {
+        let doorbell_thread_id = spawn(shared, doorbell).map_err(|error| {
             state.lifecycle = Lifecycle::Stopped;
             state.endpoint.take();
             self.shared.driver_running.store(false, Ordering::Release);
@@ -810,6 +814,7 @@ impl P2pEndpoint {
                 detail: format!("failed to spawn endpoint driver: {error}"),
             }
         })?;
+        state.doorbell_thread_id = Some(doorbell_thread_id);
         Ok(())
     }
     /// Returns Rust-side background-driver diagnostics.

--- a/crates/nodejs/Cargo.toml
+++ b/crates/nodejs/Cargo.toml
@@ -21,8 +21,9 @@ unsafe_code = "deny"
 
 [dependencies]
 minip2p-ffi-core = { path = "../ffi-core" }
-napi = { version = "=3.12.2", default-features = false, features = ["napi8"] }
+napi = { version = "=3.12.2", default-features = false, features = ["napi8", "serde-json"] }
 napi-derive = "=3.6.3"
+serde_json = "1.0.149"
 
 [build-dependencies]
 napi-build = "=2.4.1"

--- a/crates/nodejs/Cargo.toml
+++ b/crates/nodejs/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "minip2p-nodejs"
+description = "napi-rs binding shell for minip2p"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[lints.rust]
+# napi-rs's generated module-registration code contains its own scoped
+# `allow(unsafe_code)`. `deny` still rejects unsafe in this crate's source while
+# allowing that generated scope; the workspace's `forbid` cannot be lowered by
+# a procedural macro.
+unsafe_code = "deny"
+
+[dependencies]
+minip2p-ffi-core = { path = "../ffi-core" }
+napi = { version = "=3.12.2", default-features = false, features = ["napi8"] }
+napi-derive = "=3.6.3"
+
+[build-dependencies]
+napi-build = "=2.4.1"

--- a/crates/nodejs/Cargo.toml
+++ b/crates/nodejs/Cargo.toml
@@ -23,6 +23,7 @@ unsafe_code = "deny"
 minip2p-ffi-core = { path = "../ffi-core" }
 napi = { version = "=3.12.2", default-features = false, features = ["napi8", "serde-json"] }
 napi-derive = "=3.6.3"
+serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 
 [build-dependencies]

--- a/crates/nodejs/README.md
+++ b/crates/nodejs/README.md
@@ -1,0 +1,5 @@
+# minip2p-nodejs
+
+Thin [napi-rs](https://napi.rs/) binding shell over `minip2p-ffi-core`.
+The `@minip2p/node` package owns the TypeScript adapter and builds this crate
+into its native addon.

--- a/crates/nodejs/README.md
+++ b/crates/nodejs/README.md
@@ -3,3 +3,15 @@
 Thin [napi-rs](https://napi.rs/) binding shell over `minip2p-ffi-core`.
 The `@minip2p/node` package owns the TypeScript adapter and builds this crate
 into its native addon.
+
+The shell translates napi values and forwards synchronous commands to
+`minip2p-ffi-core`. A strong `ThreadsafeFunction` acts as the event doorbell;
+the TypeScript adapter drains the core's bounded carry on the Node.js thread.
+The shell does not own sockets, driver lifecycle policy, or another event
+queue.
+
+Build the linux addon from `bindings/ts/node` with:
+
+```bash
+pnpm native:build
+```

--- a/crates/nodejs/build.rs
+++ b/crates/nodejs/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/crates/nodejs/src/lib.rs
+++ b/crates/nodejs/src/lib.rs
@@ -11,9 +11,11 @@ use minip2p_ffi_core::{
 };
 use napi::bindgen_prelude::{BigInt, Uint8Array};
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
-use napi::{Error, Result, Status};
+use napi::{Env, Error, Result, Status, Unknown};
 use napi_derive::napi;
 
+// napi-rs's default MaxQueueSize of 0 is intentionally unbounded. The FFI core
+// coalesces doorbells, so this wakeup must never block the network driver.
 type DoorbellFunction = ThreadsafeFunction<(), (), (), Status, false>;
 
 struct NodeDoorbell(Arc<DoorbellFunction>);
@@ -208,11 +210,11 @@ impl NodeEndpoint {
 
     /// Pulls a bounded batch of native events.
     #[napi]
-    pub fn drain_events(&self, limit: u32) -> Vec<serde_json::Value> {
+    pub fn drain_events(&self, env: Env, limit: u32) -> Result<Vec<Unknown<'static>>> {
         self.0
             .drain_events(limit)
             .into_iter()
-            .map(event_value)
+            .map(|event| event_js_value(&env, event))
             .collect()
     }
 
@@ -479,6 +481,78 @@ pub fn circuit_address(relay_address: String, peer_id: String) -> Result<String>
 
 fn native_error(error: minip2p_ffi_core::FfiError) -> Error {
     Error::from_reason(error.to_string())
+}
+
+fn event_js_value(env: &Env, event: P2pEvent) -> Result<Unknown<'static>> {
+    match event {
+        P2pEvent::StreamData {
+            peer_id,
+            conn_id,
+            stream_id,
+            data,
+        } => env.to_js_value(&EventEnvelope {
+            tag: "StreamData",
+            inner: StreamDataValue {
+                peer_id,
+                conn_id,
+                stream_id,
+                data: NodeBytes(data),
+            },
+        }),
+        P2pEvent::Message {
+            from_peer_id,
+            topics,
+            data,
+            seqno,
+            signed,
+        } => env.to_js_value(&EventEnvelope {
+            tag: "Message",
+            inner: MessageValue {
+                from_peer_id,
+                topics,
+                data: NodeBytes(data),
+                seqno: NodeBytes(seqno),
+                signed,
+            },
+        }),
+        event => env.to_js_value(&event_value(event)),
+    }
+}
+
+#[derive(serde::Serialize)]
+struct EventEnvelope<T> {
+    tag: &'static str,
+    inner: T,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StreamDataValue {
+    peer_id: String,
+    conn_id: u64,
+    stream_id: u64,
+    data: NodeBytes,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MessageValue {
+    from_peer_id: String,
+    topics: Vec<String>,
+    data: NodeBytes,
+    seqno: NodeBytes,
+    signed: bool,
+}
+
+struct NodeBytes(Vec<u8>);
+
+impl serde::Serialize for NodeBytes {
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_bytes(&self.0)
+    }
 }
 
 fn event_value(event: P2pEvent) -> serde_json::Value {

--- a/crates/nodejs/src/lib.rs
+++ b/crates/nodejs/src/lib.rs
@@ -1,0 +1,162 @@
+//! Thin napi-rs shell over the binding-agnostic FFI core.
+
+#![warn(missing_docs)]
+
+use std::sync::Arc;
+
+use minip2p_ffi_core::{
+    EndpointConfig, EventDoorbell, P2pEndpoint, PubsubRouter, TransportOptions,
+};
+use napi::bindgen_prelude::Uint8Array;
+use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
+use napi::{Error, Result, Status};
+use napi_derive::napi;
+
+type DoorbellFunction = ThreadsafeFunction<(), (), (), Status, false>;
+
+struct NodeDoorbell(Arc<DoorbellFunction>);
+
+impl EventDoorbell for NodeDoorbell {
+    fn on_events_ready(&self) {
+        self.0.call((), ThreadsafeFunctionCallMode::NonBlocking);
+    }
+}
+
+/// QUIC listen configuration accepted from Node.js.
+#[napi(object)]
+pub struct NodeTransportOptions {
+    /// Exact listen addresses, or native defaults when absent.
+    pub listen_addrs: Option<Vec<String>>,
+}
+
+/// Endpoint configuration accepted from Node.js.
+#[napi(object)]
+pub struct NodeEndpointConfig {
+    /// Identify agent version.
+    pub agent_version: Option<String>,
+    /// Relay peer addresses.
+    pub relays: Vec<String>,
+    /// AutoNAT server peer addresses.
+    pub autonat_servers: Vec<String>,
+    /// QUIC transport configuration.
+    pub quic: Option<NodeTransportOptions>,
+    /// TCP transport configuration.
+    pub tcp: Option<NodeTransportOptions>,
+    /// Whether all outbound paths must remain relayed.
+    pub force_relay: bool,
+    /// Whether unsigned pubsub messages are accepted.
+    pub allow_unsigned: bool,
+    /// Pubsub router discriminant.
+    pub pubsub_router: u32,
+    /// Application protocol identifiers.
+    pub protocols: Vec<String>,
+}
+
+impl TryFrom<NodeEndpointConfig> for EndpointConfig {
+    type Error = Error;
+
+    fn try_from(config: NodeEndpointConfig) -> Result<Self> {
+        let pubsub_router = match config.pubsub_router {
+            0 => PubsubRouter::Gossipsub,
+            1 => PubsubRouter::Floodsub,
+            value => return Err(Error::from_reason(format!("unknown pubsub router {value}"))),
+        };
+        Ok(Self {
+            agent_version: config.agent_version,
+            relays: config.relays,
+            autonat_servers: config.autonat_servers,
+            quic: config.quic.map(convert_transport),
+            tcp: config.tcp.map(convert_transport),
+            force_relay: config.force_relay,
+            allow_unsigned: config.allow_unsigned,
+            pubsub_router,
+            protocols: config.protocols,
+            discovery: None,
+            mdns: None,
+        })
+    }
+}
+
+fn convert_transport(options: NodeTransportOptions) -> TransportOptions {
+    TransportOptions {
+        listen_addrs: options.listen_addrs,
+    }
+}
+
+/// A native minip2p endpoint owned by Node.js.
+#[napi]
+pub struct NodeEndpoint(Arc<P2pEndpoint>);
+
+#[napi]
+impl NodeEndpoint {
+    /// Binds a native endpoint without starting its driver.
+    #[napi(constructor)]
+    pub fn new(secret_key: Uint8Array, mut config: NodeEndpointConfig) -> Result<Self> {
+        if config.agent_version.is_none() {
+            config.agent_version = Some(format!("minip2p-node/{}", env!("CARGO_PKG_VERSION")));
+        }
+        P2pEndpoint::new(secret_key.to_vec(), config.try_into()?)
+            .map(Self)
+            .map_err(native_error)
+    }
+
+    /// Starts the detached driver with a strong event-loop doorbell.
+    #[napi]
+    pub fn start(&self, doorbell: Arc<DoorbellFunction>) -> Result<()> {
+        self.0
+            .start(Arc::new(NodeDoorbell(doorbell)))
+            .map_err(native_error)
+    }
+
+    /// Requests shutdown without waiting for the driver thread.
+    #[napi]
+    pub fn close(&self) {
+        self.0.stop();
+    }
+
+    /// Returns the local peer ID.
+    #[napi]
+    pub fn peer_id(&self) -> String {
+        self.0.peer_id()
+    }
+
+    /// Returns bound peer addresses.
+    #[napi]
+    pub fn listen_addrs(&self) -> Vec<String> {
+        self.0.listen_addrs()
+    }
+
+    /// Returns whether the driver accepts commands.
+    #[napi]
+    pub fn is_running(&self) -> bool {
+        self.0.is_running()
+    }
+}
+
+impl Drop for NodeEndpoint {
+    fn drop(&mut self) {
+        self.0.stop();
+    }
+}
+
+/// Generates a 32-byte Ed25519 secret key.
+#[napi]
+pub fn generate_secret_key() -> Uint8Array {
+    minip2p_ffi_core::generate_secret_key().into()
+}
+
+/// Derives a peer ID from raw Ed25519 secret key material.
+#[napi]
+pub fn peer_id_from_secret_key(secret_key: Uint8Array) -> Result<String> {
+    minip2p_ffi_core::peer_id_from_secret_key(secret_key.to_vec()).map_err(native_error)
+}
+
+/// Builds a circuit address through a direct relay address.
+#[napi]
+pub fn circuit_address(relay_address: String, peer_id: String) -> Result<String> {
+    minip2p_ffi_core::circuit_address(relay_address, peer_id).map_err(native_error)
+}
+
+fn native_error(error: minip2p_ffi_core::FfiError) -> Error {
+    Error::from_reason(error.to_string())
+}

--- a/crates/nodejs/src/lib.rs
+++ b/crates/nodejs/src/lib.rs
@@ -5,9 +5,11 @@
 use std::sync::Arc;
 
 use minip2p_ffi_core::{
-    EndpointConfig, EventDoorbell, P2pEndpoint, PubsubRouter, TransportOptions,
+    DiscoveryOptions, DiscoverySource, DriverFailureKind, EndpointConfig, EndpointErrorKind,
+    EventDoorbell, IdentifyInfo, MdnsOptions, NatErrorKind, P2pEndpoint, P2pEvent, PathKind,
+    PubsubRouter, Reachability, TransportOptions,
 };
-use napi::bindgen_prelude::Uint8Array;
+use napi::bindgen_prelude::{BigInt, Uint8Array};
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi::{Error, Result, Status};
 use napi_derive::napi;
@@ -27,6 +29,40 @@ impl EventDoorbell for NodeDoorbell {
 pub struct NodeTransportOptions {
     /// Exact listen addresses, or native defaults when absent.
     pub listen_addrs: Option<Vec<String>>,
+}
+
+/// Signed-discovery configuration accepted from Node.js.
+#[napi(object)]
+pub struct NodeDiscoveryOptions {
+    /// Pubsub topic carrying signed beacons.
+    pub topic: String,
+    /// Beacon interval in milliseconds.
+    pub beacon_interval_ms: BigInt,
+    /// Peer expiry interval in milliseconds.
+    pub peer_ttl_ms: BigInt,
+    /// Whether observations may trigger dials.
+    pub auto_dial: bool,
+}
+
+/// mDNS configuration accepted from Node.js.
+#[napi(object)]
+pub struct NodeMdnsOptions {
+    /// Whether IPv6 multicast is enabled.
+    pub enable_ipv6: bool,
+    /// Advertised record lifetime in milliseconds.
+    pub ttl_ms: BigInt,
+    /// Query interval in milliseconds.
+    pub query_interval_ms: BigInt,
+    /// Maximum encoded packet size.
+    pub max_packet_bytes: u32,
+    /// Maximum addresses per response.
+    pub max_announced_addrs: u32,
+    /// Interface refresh interval in milliseconds.
+    pub interface_refresh_ms: BigInt,
+    /// Socket polling interval in milliseconds.
+    pub socket_poll_interval_ms: BigInt,
+    /// Whether observations may trigger dials.
+    pub auto_dial: bool,
 }
 
 /// Endpoint configuration accepted from Node.js.
@@ -50,6 +86,10 @@ pub struct NodeEndpointConfig {
     pub pubsub_router: u32,
     /// Application protocol identifiers.
     pub protocols: Vec<String>,
+    /// Signed discovery configuration.
+    pub discovery: Option<NodeDiscoveryOptions>,
+    /// mDNS configuration.
+    pub mdns: Option<NodeMdnsOptions>,
 }
 
 impl TryFrom<NodeEndpointConfig> for EndpointConfig {
@@ -71,10 +111,44 @@ impl TryFrom<NodeEndpointConfig> for EndpointConfig {
             allow_unsigned: config.allow_unsigned,
             pubsub_router,
             protocols: config.protocols,
-            discovery: None,
-            mdns: None,
+            discovery: config.discovery.map(convert_discovery).transpose()?,
+            mdns: config.mdns.map(convert_mdns).transpose()?,
         })
     }
+}
+
+fn convert_discovery(options: NodeDiscoveryOptions) -> Result<DiscoveryOptions> {
+    Ok(DiscoveryOptions {
+        topic: options.topic,
+        beacon_interval_ms: bigint_u64(options.beacon_interval_ms, "beaconIntervalMs")?,
+        peer_ttl_ms: bigint_u64(options.peer_ttl_ms, "peerTtlMs")?,
+        auto_dial: options.auto_dial,
+    })
+}
+
+fn convert_mdns(options: NodeMdnsOptions) -> Result<MdnsOptions> {
+    Ok(MdnsOptions {
+        enable_ipv6: options.enable_ipv6,
+        ttl_ms: bigint_u64(options.ttl_ms, "ttlMs")?,
+        query_interval_ms: bigint_u64(options.query_interval_ms, "queryIntervalMs")?,
+        max_packet_bytes: options.max_packet_bytes,
+        max_announced_addrs: options.max_announced_addrs,
+        interface_refresh_ms: bigint_u64(options.interface_refresh_ms, "interfaceRefreshMs")?,
+        socket_poll_interval_ms: bigint_u64(
+            options.socket_poll_interval_ms,
+            "socketPollIntervalMs",
+        )?,
+        auto_dial: options.auto_dial,
+    })
+}
+
+/// Native stream identity returned to Node.js.
+#[napi(object)]
+pub struct NodeOpenStream {
+    /// Transport connection carrying the stream.
+    pub conn_id: BigInt,
+    /// Opaque transport stream identifier.
+    pub stream_id: BigInt,
 }
 
 fn convert_transport(options: NodeTransportOptions) -> TransportOptions {
@@ -131,6 +205,252 @@ impl NodeEndpoint {
     pub fn is_running(&self) -> bool {
         self.0.is_running()
     }
+
+    /// Pulls a bounded batch of native events.
+    #[napi]
+    pub fn drain_events(&self, limit: u32) -> Vec<serde_json::Value> {
+        self.0
+            .drain_events(limit)
+            .into_iter()
+            .map(event_value)
+            .collect()
+    }
+
+    /// Returns connected peer IDs.
+    #[napi]
+    pub fn connected_peers(&self) -> Result<Vec<String>> {
+        self.0.connected_peers().map_err(native_error)
+    }
+
+    /// Returns whether Identify completed for a peer.
+    #[napi]
+    pub fn is_peer_ready(&self, peer_id: String) -> Result<bool> {
+        self.0.is_peer_ready(peer_id).map_err(native_error)
+    }
+
+    /// Returns the latest Identify snapshot.
+    #[napi]
+    pub fn peer_info(&self, peer_id: String) -> Result<Option<serde_json::Value>> {
+        self.0
+            .peer_info(peer_id)
+            .map(|info| info.map(identify_value))
+            .map_err(native_error)
+    }
+
+    /// Selects foreground or idle polling.
+    #[napi]
+    pub fn set_active(&self, active: bool) {
+        self.0.set_active(active);
+    }
+
+    /// Subscribes to a pubsub topic.
+    #[napi]
+    pub fn subscribe(&self, topic: String) -> Result<bool> {
+        self.0.subscribe(topic).map_err(native_error)
+    }
+
+    /// Unsubscribes from a pubsub topic.
+    #[napi]
+    pub fn unsubscribe(&self, topic: String) -> Result<bool> {
+        self.0.unsubscribe(topic).map_err(native_error)
+    }
+
+    /// Publishes one pubsub payload.
+    #[napi]
+    pub fn publish(&self, topic: String, data: Uint8Array) -> Result<()> {
+        self.0.publish(topic, data.to_vec()).map_err(native_error)
+    }
+
+    /// Starts one ping operation.
+    #[napi]
+    pub fn ping(&self, peer_id: String) -> Result<()> {
+        self.0.ping(peer_id).map_err(native_error)
+    }
+
+    /// Registers an application protocol.
+    #[napi]
+    pub fn add_protocol(&self, protocol_id: String) -> Result<()> {
+        self.0.add_protocol(protocol_id).map_err(native_error)
+    }
+
+    /// Starts opening an application stream.
+    #[napi]
+    pub fn open_stream(&self, peer_id: String, protocol_id: String) -> Result<NodeOpenStream> {
+        self.0
+            .open_stream(peer_id, protocol_id)
+            .map(|stream| NodeOpenStream {
+                conn_id: stream.conn_id.into(),
+                stream_id: stream.stream_id.into(),
+            })
+            .map_err(native_error)
+    }
+
+    /// Sends bytes on an application stream.
+    #[napi]
+    pub fn send_stream(&self, peer_id: String, stream_id: BigInt, data: Uint8Array) -> Result<()> {
+        self.0
+            .send_stream(peer_id, bigint_u64(stream_id, "streamId")?, data.to_vec())
+            .map_err(native_error)
+    }
+
+    /// Half-closes the local stream write side.
+    #[napi]
+    pub fn close_stream_write(&self, peer_id: String, stream_id: BigInt) -> Result<()> {
+        self.0
+            .close_stream_write(peer_id, bigint_u64(stream_id, "streamId")?)
+            .map_err(native_error)
+    }
+
+    /// Resets an application stream.
+    #[napi]
+    pub fn reset_stream(&self, peer_id: String, stream_id: BigInt) -> Result<()> {
+        self.0
+            .reset_stream(peer_id, bigint_u64(stream_id, "streamId")?)
+            .map_err(native_error)
+    }
+
+    /// Resets and relinquishes an application stream.
+    #[napi]
+    pub fn abandon_stream(&self, peer_id: String, stream_id: BigInt) -> Result<()> {
+        self.0
+            .abandon_stream(peer_id, bigint_u64(stream_id, "streamId")?)
+            .map_err(native_error)
+    }
+
+    /// Starts a NAT-orchestrated connection attempt.
+    #[napi]
+    pub fn connect(&self, peer_id: String) -> Result<BigInt> {
+        self.0
+            .connect(peer_id)
+            .map(BigInt::from)
+            .map_err(native_error)
+    }
+
+    /// Starts a connection attempt with explicit addresses.
+    #[napi]
+    pub fn connect_with_addrs(&self, peer_id: String, addresses: Vec<String>) -> Result<BigInt> {
+        self.0
+            .connect_with_addrs(peer_id, addresses)
+            .map(BigInt::from)
+            .map_err(native_error)
+    }
+
+    /// Starts a direct-address connection attempt.
+    #[napi]
+    pub fn connect_addr(&self, address: String) -> Result<BigInt> {
+        self.0
+            .connect_addr(address)
+            .map(BigInt::from)
+            .map_err(native_error)
+    }
+
+    /// Starts direct dials for every applicable address family.
+    #[napi]
+    pub fn dial(&self, address: String) -> Result<Vec<BigInt>> {
+        self.0
+            .dial(address)
+            .map(|ids| ids.into_iter().map(BigInt::from).collect())
+            .map_err(native_error)
+    }
+
+    /// Starts one IPv4 dial.
+    #[napi]
+    pub fn dial_ip4(&self, address: String) -> Result<BigInt> {
+        self.0
+            .dial_ip4(address)
+            .map(BigInt::from)
+            .map_err(native_error)
+    }
+
+    /// Starts one IPv6 dial.
+    #[napi]
+    pub fn dial_ip6(&self, address: String) -> Result<BigInt> {
+        self.0
+            .dial_ip6(address)
+            .map(BigInt::from)
+            .map_err(native_error)
+    }
+
+    /// Cancels a connection attempt.
+    #[napi]
+    pub fn cancel_connect(&self, id: BigInt) -> Result<()> {
+        self.0
+            .cancel_connect(bigint_u64(id, "connectId")?)
+            .map_err(native_error)
+    }
+
+    /// Disconnects one peer.
+    #[napi]
+    pub fn disconnect(&self, peer_id: String) -> Result<()> {
+        self.0.disconnect(peer_id).map_err(native_error)
+    }
+
+    /// Returns the current path to a peer.
+    #[napi]
+    pub fn path(&self, peer_id: String) -> Result<Option<serde_json::Value>> {
+        self.0
+            .path(peer_id)
+            .map(|path| path.map(path_value))
+            .map_err(native_error)
+    }
+
+    /// Returns the discovery address book.
+    #[napi]
+    pub fn known_peers(&self) -> Result<Vec<serde_json::Value>> {
+        self.0
+            .known_peers()
+            .map(|peers| {
+                peers
+                    .into_iter()
+                    .map(|peer| {
+                        serde_json::json!({
+                            "peerId": peer.peer_id,
+                            "addrs": peer.addrs,
+                            "beaconAddrs": peer.beacon_addrs,
+                            "mdnsAddrs": peer.mdns_addrs,
+                            "beaconLastSeenAgeMs": peer.beacon_last_seen_age_ms,
+                            "mdnsLastSeenAgeMs": peer.mdns_last_seen_age_ms,
+                            "connected": peer.connected,
+                        })
+                    })
+                    .collect()
+            })
+            .map_err(native_error)
+    }
+
+    /// Returns the discovery clock.
+    #[napi]
+    pub fn discovery_now_ms(&self) -> Result<Option<BigInt>> {
+        self.0
+            .discovery_now_ms()
+            .map(|value| value.map(BigInt::from))
+            .map_err(native_error)
+    }
+
+    /// Returns the current reachability verdict.
+    #[napi]
+    pub fn reachability(&self) -> Result<u32> {
+        self.0
+            .reachability()
+            .map(reachability_value)
+            .map_err(native_error)
+    }
+
+    /// Returns the active relay reservation.
+    #[napi]
+    pub fn active_reservation(&self) -> Result<Option<serde_json::Value>> {
+        self.0
+            .active_reservation()
+            .map(|reservation| {
+                reservation.map(|reservation| {
+                    serde_json::json!({
+                        "relayPeerId": reservation.relay_peer_id,
+                        "expiresUnixSecs": reservation.expires_unix_secs,
+                    })
+                })
+            })
+            .map_err(native_error)
+    }
 }
 
 impl Drop for NodeEndpoint {
@@ -159,4 +479,368 @@ pub fn circuit_address(relay_address: String, peer_id: String) -> Result<String>
 
 fn native_error(error: minip2p_ffi_core::FfiError) -> Error {
     Error::from_reason(error.to_string())
+}
+
+fn event_value(event: P2pEvent) -> serde_json::Value {
+    let (tag, inner) = match event {
+        P2pEvent::EventsDropped {
+            dropped,
+            total_dropped,
+        } => (
+            "EventsDropped",
+            serde_json::json!({ "dropped": dropped, "totalDropped": total_dropped }),
+        ),
+        P2pEvent::DriverFailed { kind, detail } => (
+            "DriverFailed",
+            serde_json::json!({ "kind": driver_failure_value(kind), "detail": detail }),
+        ),
+        P2pEvent::ConnectionEstablished { peer_id, conn_id } => (
+            "ConnectionEstablished",
+            serde_json::json!({ "peerId": peer_id, "connId": conn_id }),
+        ),
+        P2pEvent::ConnectionClosed { peer_id, conn_id } => (
+            "ConnectionClosed",
+            serde_json::json!({ "peerId": peer_id, "connId": conn_id }),
+        ),
+        P2pEvent::PeerReady { peer_id, protocols } => (
+            "PeerReady",
+            serde_json::json!({ "peerId": peer_id, "protocols": protocols }),
+        ),
+        P2pEvent::IdentifyReceived { peer_id, info } => (
+            "IdentifyReceived",
+            serde_json::json!({ "peerId": peer_id, "info": identify_value(info) }),
+        ),
+        P2pEvent::PingRttMeasured { peer_id, rtt_ms } => (
+            "PingRttMeasured",
+            serde_json::json!({ "peerId": peer_id, "rttMs": rtt_ms }),
+        ),
+        P2pEvent::PingTimeout { peer_id } => {
+            ("PingTimeout", serde_json::json!({ "peerId": peer_id }))
+        }
+        P2pEvent::StreamReady {
+            peer_id,
+            conn_id,
+            stream_id,
+            protocol_id,
+            initiated_locally,
+        } => (
+            "StreamReady",
+            serde_json::json!({
+                "peerId": peer_id,
+                "connId": conn_id,
+                "streamId": stream_id,
+                "protocolId": protocol_id,
+                "initiatedLocally": initiated_locally,
+            }),
+        ),
+        P2pEvent::StreamData {
+            peer_id,
+            conn_id,
+            stream_id,
+            data,
+        } => (
+            "StreamData",
+            serde_json::json!({
+                "peerId": peer_id,
+                "connId": conn_id,
+                "streamId": stream_id,
+                "data": data,
+            }),
+        ),
+        P2pEvent::StreamRemoteWriteClosed {
+            peer_id,
+            conn_id,
+            stream_id,
+        } => (
+            "StreamRemoteWriteClosed",
+            serde_json::json!({
+                "peerId": peer_id,
+                "connId": conn_id,
+                "streamId": stream_id,
+            }),
+        ),
+        P2pEvent::StreamClosed {
+            peer_id,
+            conn_id,
+            stream_id,
+        } => (
+            "StreamClosed",
+            serde_json::json!({
+                "peerId": peer_id,
+                "connId": conn_id,
+                "streamId": stream_id,
+            }),
+        ),
+        P2pEvent::EndpointError {
+            kind,
+            peer_id,
+            conn_id,
+            stream_id,
+            detail,
+        } => (
+            "EndpointError",
+            serde_json::json!({
+                "kind": endpoint_error_value(kind),
+                "peerId": peer_id,
+                "connId": conn_id,
+                "streamId": stream_id,
+                "detail": detail,
+            }),
+        ),
+        P2pEvent::ReachabilityChanged {
+            previous,
+            current,
+            confirmed_addrs,
+        } => (
+            "ReachabilityChanged",
+            serde_json::json!({
+                "previous": reachability_value(previous),
+                "current": reachability_value(current),
+                "confirmedAddrs": confirmed_addrs,
+            }),
+        ),
+        P2pEvent::PublicAddressesChanged { addrs } => (
+            "PublicAddressesChanged",
+            serde_json::json!({ "addrs": addrs }),
+        ),
+        P2pEvent::RelayReserved {
+            relay_peer_id,
+            expires_unix_secs,
+        } => (
+            "RelayReserved",
+            serde_json::json!({
+                "relayPeerId": relay_peer_id,
+                "expiresUnixSecs": expires_unix_secs,
+            }),
+        ),
+        P2pEvent::RelayReservationLost { relay_peer_id } => (
+            "RelayReservationLost",
+            serde_json::json!({ "relayPeerId": relay_peer_id }),
+        ),
+        P2pEvent::PathEstablished {
+            connect_id,
+            peer_id,
+            path,
+        } => (
+            "PathEstablished",
+            serde_json::json!({
+                "connectId": connect_id,
+                "peerId": peer_id,
+                "path": path_value(path),
+            }),
+        ),
+        P2pEvent::InboundPathEstablished { peer_id, path } => (
+            "InboundPathEstablished",
+            serde_json::json!({ "peerId": peer_id, "path": path_value(path) }),
+        ),
+        P2pEvent::PathUpgraded {
+            connect_id,
+            peer_id,
+            from,
+            to,
+        } => (
+            "PathUpgraded",
+            serde_json::json!({
+                "connectId": connect_id,
+                "peerId": peer_id,
+                "from": path_value(from),
+                "to": path_value(to),
+            }),
+        ),
+        P2pEvent::HolePunchFailed {
+            connect_id,
+            attempt,
+            reason,
+        } => (
+            "HolePunchFailed",
+            serde_json::json!({
+                "connectId": connect_id,
+                "attempt": attempt,
+                "reason": reason,
+            }),
+        ),
+        P2pEvent::FellBackToRelay {
+            connect_id,
+            peer_id,
+        } => (
+            "FellBackToRelay",
+            serde_json::json!({ "connectId": connect_id, "peerId": peer_id }),
+        ),
+        P2pEvent::ConnectFailed {
+            connect_id,
+            peer_id,
+            kind,
+            detail,
+        } => (
+            "ConnectFailed",
+            serde_json::json!({
+                "connectId": connect_id,
+                "peerId": peer_id,
+                "kind": nat_error_value(kind),
+                "detail": detail,
+            }),
+        ),
+        P2pEvent::InboundDirectUpgrade { peer_id } => (
+            "InboundDirectUpgrade",
+            serde_json::json!({ "peerId": peer_id }),
+        ),
+        P2pEvent::Message {
+            from_peer_id,
+            topics,
+            data,
+            seqno,
+            signed,
+        } => (
+            "Message",
+            serde_json::json!({
+                "fromPeerId": from_peer_id,
+                "topics": topics,
+                "data": data,
+                "seqno": seqno,
+                "signed": signed,
+            }),
+        ),
+        P2pEvent::PeerSubscribed { peer_id, topic } => (
+            "PeerSubscribed",
+            serde_json::json!({ "peerId": peer_id, "topic": topic }),
+        ),
+        P2pEvent::PeerUnsubscribed { peer_id, topic } => (
+            "PeerUnsubscribed",
+            serde_json::json!({ "peerId": peer_id, "topic": topic }),
+        ),
+        P2pEvent::PubsubOutboundFailure { peer_id, reason } => (
+            "PubsubOutboundFailure",
+            serde_json::json!({ "peerId": peer_id, "reason": reason }),
+        ),
+        P2pEvent::PubsubProtocolViolation { peer_id, reason } => (
+            "PubsubProtocolViolation",
+            serde_json::json!({ "peerId": peer_id, "reason": reason }),
+        ),
+        P2pEvent::PeerDiscovered {
+            peer_id,
+            addrs,
+            source,
+        } => (
+            "PeerDiscovered",
+            serde_json::json!({
+                "peerId": peer_id,
+                "addrs": addrs,
+                "source": discovery_source_value(source),
+            }),
+        ),
+        P2pEvent::PeerUpdated {
+            peer_id,
+            addrs,
+            source,
+        } => (
+            "PeerUpdated",
+            serde_json::json!({
+                "peerId": peer_id,
+                "addrs": addrs,
+                "source": discovery_source_value(source),
+            }),
+        ),
+        P2pEvent::PeerExpired { peer_id } => {
+            ("PeerExpired", serde_json::json!({ "peerId": peer_id }))
+        }
+        P2pEvent::DiscoveryDialFailed { peer_id, reason } => (
+            "DiscoveryDialFailed",
+            serde_json::json!({ "peerId": peer_id, "reason": reason }),
+        ),
+        P2pEvent::DiscoveryProtocolViolation {
+            peer_id,
+            source,
+            reason,
+            suppressed,
+        } => (
+            "DiscoveryProtocolViolation",
+            serde_json::json!({
+                "peerId": peer_id,
+                "source": discovery_source_value(source),
+                "reason": reason,
+                "suppressed": suppressed,
+            }),
+        ),
+    };
+    serde_json::json!({ "tag": tag, "inner": inner })
+}
+
+fn identify_value(info: IdentifyInfo) -> serde_json::Value {
+    serde_json::json!({
+        "publicKey": info.public_key,
+        "listenAddrs": info.listen_addrs,
+        "protocols": info.protocols,
+        "observedAddr": info.observed_addr,
+        "protocolVersion": info.protocol_version,
+        "agentVersion": info.agent_version,
+    })
+}
+
+fn path_value(path: PathKind) -> serde_json::Value {
+    match path {
+        PathKind::DirectDialed => serde_json::json!({ "tag": "DirectDialed" }),
+        PathKind::DirectPunched => serde_json::json!({ "tag": "DirectPunched" }),
+        PathKind::Relayed { relay_peer_id } => serde_json::json!({
+            "tag": "Relayed",
+            "inner": { "relayPeerId": relay_peer_id },
+        }),
+    }
+}
+
+const fn reachability_value(value: Reachability) -> u32 {
+    match value {
+        Reachability::Unknown => 0,
+        Reachability::Public => 1,
+        Reachability::Private => 2,
+    }
+}
+
+const fn discovery_source_value(value: DiscoverySource) -> u32 {
+    match value {
+        DiscoverySource::SignedBeacon => 0,
+        DiscoverySource::Mdns => 1,
+    }
+}
+
+const fn endpoint_error_value(value: EndpointErrorKind) -> u32 {
+    match value {
+        EndpointErrorKind::Transport => 0,
+        EndpointErrorKind::Multistream => 1,
+        EndpointErrorKind::Identify => 2,
+        EndpointErrorKind::Ping => 3,
+        EndpointErrorKind::IdentifyStreamRejected => 4,
+        EndpointErrorKind::OpenStreamFailed => 5,
+        EndpointErrorKind::UnsupportedProtocol => 6,
+        EndpointErrorKind::Driver => 7,
+    }
+}
+
+const fn nat_error_value(value: NatErrorKind) -> u32 {
+    match value {
+        NatErrorKind::NoPathAvailable => 0,
+        NatErrorKind::Timeout => 1,
+        NatErrorKind::DialFailed => 2,
+        NatErrorKind::Protocol => 3,
+        NatErrorKind::RelayRefused => 4,
+    }
+}
+
+const fn driver_failure_value(value: DriverFailureKind) -> u32 {
+    match value {
+        DriverFailureKind::Transport => 0,
+        DriverFailureKind::Swarm => 1,
+        DriverFailureKind::Invariant => 2,
+        DriverFailureKind::Panic => 3,
+    }
+}
+
+fn bigint_u64(value: BigInt, name: &str) -> Result<u64> {
+    let (_, value, lossless) = value.get_u64();
+    if lossless {
+        Ok(value)
+    } else {
+        Err(Error::from_reason(format!(
+            "{name} must be an unsigned 64-bit integer"
+        )))
+    }
 }

--- a/justfile
+++ b/justfile
@@ -118,6 +118,7 @@ docs-site:
 
 bindings-check:
     cd bindings/ts && pnpm typecheck
+    cd bindings/ts && pnpm --filter @minip2p/node native:build
     cd bindings/ts && pnpm test
     cd bindings/ts && pnpm lint
     cd bindings/ts && pnpm build


### PR DESCRIPTION
Closes #100

## What changed

- add the `minip2p-nodejs` napi-rs shell over `ffi-core` and wire `@minip2p/node` into the shared TypeScript SDK
- bridge native events through a strong doorbell/drain callback and translate native identifiers into JavaScript-safe handles
- add target-loader, QUIC loopback stream exchange, and process-lifecycle coverage
- build the native addon before running the Node suite in binding CI

## Test plan

- `just fmt`
- `just clippy`
- `just test`
- `cd bindings/ts && pnpm typecheck && pnpm test && pnpm lint && pnpm build`
- `cd bindings/ts && pnpm --filter @minip2p/react-native test:built && pnpm rn:generate`

Not run: `just check-nostd` could not download `thumbv7em-none-eabi` because rustup's host failed DNS resolution on both attempts. The new native crate is std-only.
