### PR TITLE
Add async iteration helpers to @minip2p/core

### DIFF
--- a/bindings/ts/core/README.md
+++ b/bindings/ts/core/README.md
@@ -16,6 +16,24 @@ stream.write(new Uint8Array([1, 2, 3]));
 stream.closeWrite();
 ```
 
-Use `endpoint.on("stream", handler)` to claim inbound streams. Operations accept `{ timeoutMs, signal }`; the default timeout is 65 seconds and `timeoutMs: 0` disables it.
+Streams are async iterables. Iteration preserves chunk order and ends when the remote write side or stream closes:
+
+```ts
+for await (const chunk of stream) {
+  process(chunk);
+}
+```
+
+`endpoint.events()` returns an async iterable of endpoint events. Each iterator has a bounded, drop-oldest buffer. It reports dropped events in-band as `queueOverflow` events. The default cap is 4096; pass `bufferCap` to change it or `signal` to end iteration on abort.
+
+```ts
+for await (const event of endpoint.events({ signal })) {
+  if (event.type === "peerReady") {
+    console.log(event.peerId);
+  }
+}
+```
+
+Use `endpoint.on("stream", handler)` to claim inbound streams. Operations accept `{ timeoutMs, signal }`; the default timeout is 65 seconds and `timeoutMs: 0` disables it. Both endpoints and streams implement `Symbol.dispose`, including the fallback used by `await using`; neither implements `Symbol.asyncDispose`.
 
 Raw native unions and the `Minip2pBackend` adapter contract are available from `@minip2p/core/backend`.

--- a/bindings/ts/core/README.md
+++ b/bindings/ts/core/README.md
@@ -16,7 +16,7 @@ stream.write(new Uint8Array([1, 2, 3]));
 stream.closeWrite();
 ```
 
-Streams are async iterables. Iteration preserves chunk order and ends when the remote write side or stream closes:
+Streams are async iterables. Iteration preserves chunk order. A remote write half-close or local shutdown ends the loop quietly. A remote reset, peer disconnect, or driver failure rejects the iterator with its terminal error:
 
 ```ts
 for await (const chunk of stream) {

--- a/bindings/ts/core/README.md
+++ b/bindings/ts/core/README.md
@@ -16,7 +16,7 @@ stream.write(new Uint8Array([1, 2, 3]));
 stream.closeWrite();
 ```
 
-Streams are async iterables. Iteration preserves chunk order. A remote write half-close or local shutdown ends the loop quietly. A remote reset, peer disconnect, or driver failure rejects the iterator with its terminal error:
+Streams are async iterables. Iteration preserves chunk order. A remote write half-close or local shutdown ends the loop quietly. A reset, peer disconnect, or driver failure observed before that EOF rejects the iterator with its terminal error:
 
 ```ts
 for await (const chunk of stream) {

--- a/bindings/ts/core/src/index.ts
+++ b/bindings/ts/core/src/index.ts
@@ -24,6 +24,7 @@ export {
   type Bytes,
   type CloseReason,
   type ConnectResult,
+  type EventsOptions,
   type IdentifyInfo,
   type InboundStreamMeta,
   type KnownPeerInfo,

--- a/bindings/ts/core/src/sdk.ts
+++ b/bindings/ts/core/src/sdk.ts
@@ -177,6 +177,7 @@ export class Stream {
   #mode: "pull" | "flowing" | undefined;
   #remoteWriteClosed = false;
   #closed = false;
+  #terminalError: unknown;
 
   constructor(
     backend: Minip2pBackend,
@@ -237,15 +238,15 @@ export class Stream {
       );
     }
     this.#mode = "pull";
+    if (this.#closed) {
+      return Promise.reject(this.#terminalError);
+    }
     const buffered = this.#shift();
     if (buffered !== undefined) {
       return Promise.resolve(buffered);
     }
     if (this.#remoteWriteClosed) {
       return Promise.resolve(this.#shift());
-    }
-    if (this.#closed) {
-      return Promise.reject(new ClosedError());
     }
     return new Promise((resolve, reject) => {
       this.#reads.push({ reject, resolve });
@@ -357,6 +358,7 @@ export class Stream {
       return;
     }
     this.#closed = true;
+    this.#terminalError = error;
     this.#fifo.length = 0;
     this.#fifoBytes = 0;
     for (const read of this.#reads.splice(0)) {
@@ -510,14 +512,15 @@ export class Minip2pBase {
       }
       wake?.();
     });
+    const offClose = this.onClose(finish);
     const abort = () => {
       aborted = true;
       finish();
       offEvents();
+      offClose();
       buffer.clear();
       dropped = 0;
     };
-    const offClose = this.onClose(finish);
     const removeAbort = listenAbort(options.signal, abort);
     try {
       while (true) {

--- a/bindings/ts/core/src/sdk.ts
+++ b/bindings/ts/core/src/sdk.ts
@@ -495,8 +495,12 @@ export class Minip2pBase {
     const buffer = new BoundedQueue<Minip2pEvent>(bufferCap);
     let dropped = 0;
     let done = false;
+    let aborted = false;
     let wake: (() => void) | undefined;
     const finish = () => {
+      if (done) {
+        return;
+      }
       done = true;
       wake?.();
     };
@@ -506,10 +510,20 @@ export class Minip2pBase {
       }
       wake?.();
     });
+    const abort = () => {
+      aborted = true;
+      finish();
+      offEvents();
+      buffer.clear();
+      dropped = 0;
+    };
     const offClose = this.onClose(finish);
-    const removeAbort = listenAbort(options.signal, finish);
+    const removeAbort = listenAbort(options.signal, abort);
     try {
       while (true) {
+        if (aborted) {
+          return;
+        }
         if (dropped > 0) {
           const count = dropped;
           dropped = 0;
@@ -1296,7 +1310,7 @@ export class Minip2pBase {
         clearPendingOpen(pending);
         pending.reject(new StreamClosedError());
       }
-      stream?.terminal();
+      stream?.terminal(new StreamClosedError("The stream closed"));
     } else if (event.tag === P2pEvent_Tags.StreamData) {
       stream?.receive(event.inner.data);
     } else {

--- a/bindings/ts/core/src/sdk.ts
+++ b/bindings/ts/core/src/sdk.ts
@@ -1,4 +1,4 @@
-/* oxlint-disable default-case, func-style, max-classes-per-file, no-empty-function, no-use-before-define, promise/avoid-new, promise/prefer-await-to-callbacks, promise/prefer-await-to-then, typescript/no-invalid-void-type, unicorn/consistent-function-scoping, unicorn/no-new-array, unicorn/no-useless-spread, unicorn/no-useless-undefined -- Promise adapters, void event payloads, snapshot fan-out, and bounded queues are deliberate SDK internals. */
+/* oxlint-disable default-case, func-style, max-classes-per-file, no-await-in-loop, no-empty-function, no-loop-func, no-use-before-define, promise/avoid-new, promise/prefer-await-to-callbacks, promise/prefer-await-to-then, typescript/no-invalid-void-type, unicorn/consistent-function-scoping, unicorn/no-new-array, unicorn/no-useless-spread, unicorn/no-useless-undefined -- Promise adapters, sequential async iterators, void event payloads, snapshot fan-out, and bounded queues are deliberate SDK internals. */
 
 import type { Minip2pBackend } from "./backend.js";
 import {
@@ -18,6 +18,7 @@ import type {
   Bytes,
   CloseReason,
   ConnectResult,
+  EventsOptions,
   IdentifyInfo,
   InboundStreamMeta,
   KnownPeerInfo,
@@ -286,6 +287,27 @@ export class Stream {
     this.abandon();
   }
 
+  /**
+   * Iterates received chunks until the remote peer closes its write side.
+   *
+   * @yields {Uint8Array} Received binary chunks in order.
+   */
+  async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array, void, void> {
+    try {
+      while (true) {
+        const chunk = await this.read();
+        if (chunk === undefined) {
+          return;
+        }
+        yield chunk;
+      }
+    } catch (error) {
+      if (!(error instanceof ClosedError)) {
+        throw error;
+      }
+    }
+  }
+
   /** @internal */
   receive(data: ArrayBuffer): void {
     if (this.#closed) {
@@ -453,6 +475,65 @@ export class Minip2pBase {
       handlers,
       maybeHandler as unknown as (payload: AnyPayload) => void
     );
+  }
+
+  /**
+   * Iterates endpoint events until the endpoint closes or the caller aborts.
+   *
+   * @yields {Minip2pEvent} Endpoint events in delivery order.
+   */
+  async *events(
+    options: EventsOptions = {}
+  ): AsyncGenerator<Minip2pEvent, void, void> {
+    if (options.signal?.aborted === true) {
+      return;
+    }
+    const bufferCap = options.bufferCap ?? EVENT_QUEUE_CAP;
+    if (!Number.isSafeInteger(bufferCap) || bufferCap < 1) {
+      throw new RangeError("bufferCap must be a positive safe integer");
+    }
+    const buffer = new BoundedQueue<Minip2pEvent>(bufferCap);
+    let dropped = 0;
+    let done = false;
+    let wake: (() => void) | undefined;
+    const finish = () => {
+      done = true;
+      wake?.();
+    };
+    const offEvents = this.on((event) => {
+      if (buffer.push(event) !== undefined) {
+        dropped += 1;
+      }
+      wake?.();
+    });
+    const offClose = this.onClose(finish);
+    const removeAbort = listenAbort(options.signal, finish);
+    try {
+      while (true) {
+        if (dropped > 0) {
+          const count = dropped;
+          dropped = 0;
+          yield { dropped: count, type: "queueOverflow" };
+          continue;
+        }
+        const event = buffer.shift();
+        if (event !== undefined) {
+          yield event;
+          continue;
+        }
+        if (done) {
+          return;
+        }
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+        wake = undefined;
+      }
+    } finally {
+      offEvents();
+      offClose();
+      removeAbort?.();
+    }
   }
 
   /** Resolves with the next event of `type`. */

--- a/bindings/ts/core/src/types.ts
+++ b/bindings/ts/core/src/types.ts
@@ -313,6 +313,14 @@ export interface WaitForOptions<Event> extends OpOptions {
   readonly predicate?: (event: Event) => boolean;
 }
 
+/** Controls one endpoint event iterator. */
+export interface EventsOptions {
+  /** Ends iteration without throwing when aborted. */
+  readonly signal?: AbortSignal;
+  /** Maximum events buffered for this iterator. */
+  readonly bufferCap?: number;
+}
+
 /** First usable path produced by a connection attempt. */
 export interface ConnectResult {
   readonly connectId: number;

--- a/bindings/ts/core/tests/sdk.test.mjs
+++ b/bindings/ts/core/tests/sdk.test.mjs
@@ -75,10 +75,18 @@ test("events iteration yields endpoint events in order and ends on close", async
   endpoint.close();
 
   await reading;
-  assert.deepEqual(
-    events.map((event) => event.peerId),
-    ["first", "second"]
-  );
+  assert.deepEqual(events, [
+    {
+      peerId: "first",
+      protocols: ["/test/1"],
+      type: "peerReady",
+    },
+    {
+      peerId: "second",
+      protocols: ["/test/2"],
+      type: "peerReady",
+    },
+  ]);
 });
 
 test("events iteration ends quietly on abort", async () => {
@@ -96,6 +104,18 @@ test("events iteration ends quietly on abort", async () => {
   controller.abort();
 
   await reading;
+  endpoint.close();
+});
+
+test("events iteration ends immediately for a pre-aborted signal", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+  const controller = new AbortController();
+  controller.abort();
+
+  const iterator = endpoint.events({ signal: controller.signal });
+
+  assert.equal((await iterator.next()).done, true);
   endpoint.close();
 });
 
@@ -507,6 +527,36 @@ test("stream async iteration rejects when the remote stream resets", async () =>
     inner: { connId: 2, peerId: "peer", streamId: 3 },
     tag: P2pEvent_Tags.StreamClosed,
   });
+
+  await assert.rejects(reading, StreamClosedError);
+  endpoint.close();
+});
+
+test("stream async iteration remembers a reset while the loop body runs", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+  const opening = endpoint.openStream("peer", "/test/1", { timeoutMs: 1000 });
+  backend.emit(streamReady({ initiatedLocally: true, streamId: 3 }));
+  const stream = await opening;
+  const { promise: paused, resolve: resume } = Promise.withResolvers();
+  const reading = (async () => {
+    for await (const _chunk of stream) {
+      await paused;
+    }
+  })();
+
+  backend.emit(streamData(new Uint8Array([1]), 3));
+  await tick();
+  backend.emit({
+    inner: { connId: 2, peerId: "peer", streamId: 3 },
+    tag: P2pEvent_Tags.StreamRemoteWriteClosed,
+  });
+  backend.emit({
+    inner: { connId: 2, peerId: "peer", streamId: 3 },
+    tag: P2pEvent_Tags.StreamClosed,
+  });
+  await tick();
+  resume();
 
   await assert.rejects(reading, StreamClosedError);
   endpoint.close();

--- a/bindings/ts/core/tests/sdk.test.mjs
+++ b/bindings/ts/core/tests/sdk.test.mjs
@@ -494,6 +494,32 @@ test("stream async iteration yields chunks in order and ends on remote write clo
   endpoint.close();
 });
 
+test("stream async iteration keeps half-close EOF final when StreamClosed follows", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+  const opening = endpoint.openStream("peer", "/test/1", { timeoutMs: 1000 });
+  backend.emit(streamReady({ initiatedLocally: true, streamId: 3 }));
+  const stream = await opening;
+  const reading = (async () => {
+    for await (const _chunk of stream) {
+      // Wait for read-side EOF.
+    }
+  })();
+
+  backend.emit({
+    inner: { connId: 2, peerId: "peer", streamId: 3 },
+    tag: P2pEvent_Tags.StreamRemoteWriteClosed,
+  });
+  await reading;
+  backend.emit({
+    inner: { connId: 2, peerId: "peer", streamId: 3 },
+    tag: P2pEvent_Tags.StreamClosed,
+  });
+  await tick();
+
+  endpoint.close();
+});
+
 test("stream async iteration ends quietly when the endpoint closes", async () => {
   const backend = new MockBackend();
   const endpoint = new TestMinip2p(backend);

--- a/bindings/ts/core/tests/sdk.test.mjs
+++ b/bindings/ts/core/tests/sdk.test.mjs
@@ -53,6 +53,122 @@ test("named and catch-all subscribers receive flattened events", async () => {
   endpoint.close();
 });
 
+test("events iteration yields endpoint events in order and ends on close", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+  const events = [];
+  const reading = (async () => {
+    for await (const event of endpoint.events()) {
+      events.push(event);
+    }
+  })();
+
+  backend.emit({
+    inner: { peerId: "first", protocols: ["/test/1"] },
+    tag: P2pEvent_Tags.PeerReady,
+  });
+  backend.emit({
+    inner: { peerId: "second", protocols: ["/test/2"] },
+    tag: P2pEvent_Tags.PeerReady,
+  });
+  await tick();
+  endpoint.close();
+
+  await reading;
+  assert.deepEqual(
+    events.map((event) => event.peerId),
+    ["first", "second"]
+  );
+});
+
+test("events iteration ends quietly on abort", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+  const controller = new AbortController();
+  const reading = (async () => {
+    for await (const _event of endpoint.events({
+      signal: controller.signal,
+    })) {
+      // Wait for cancellation.
+    }
+  })();
+
+  controller.abort();
+
+  await reading;
+  endpoint.close();
+});
+
+test("events iteration drops oldest buffered events and reports the drop", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+  const iterator = endpoint.events({ bufferCap: 2 });
+  const first = iterator.next();
+  backend.emit(peerReady("first"));
+  assert.equal((await first).value.peerId, "first");
+
+  backend.emit(peerReady("dropped"));
+  backend.emit(peerReady("second"));
+  backend.emit(peerReady("third"));
+  await tick();
+
+  assert.deepEqual((await iterator.next()).value, {
+    dropped: 1,
+    type: "queueOverflow",
+  });
+  assert.equal((await iterator.next()).value.peerId, "second");
+  assert.equal((await iterator.next()).value.peerId, "third");
+  endpoint.close();
+  assert.equal((await iterator.next()).done, true);
+});
+
+test("events iteration drains retained events before ending after abort", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+  const controller = new AbortController();
+  const iterator = endpoint.events({ bufferCap: 1, signal: controller.signal });
+  const first = iterator.next();
+  backend.emit(peerReady("first"));
+  await first;
+
+  backend.emit(peerReady("dropped"));
+  backend.emit(peerReady("retained"));
+  await tick();
+  controller.abort();
+
+  assert.deepEqual((await iterator.next()).value, {
+    dropped: 1,
+    type: "queueOverflow",
+  });
+  assert.equal((await iterator.next()).value.peerId, "retained");
+  assert.equal((await iterator.next()).done, true);
+  endpoint.close();
+});
+
+test("events rejects invalid buffer caps", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+
+  await assert.rejects(endpoint.events({ bufferCap: 0 }).next(), RangeError);
+  await assert.rejects(
+    endpoint.events({ bufferCap: Number.POSITIVE_INFINITY }).next(),
+    RangeError
+  );
+  endpoint.close();
+});
+
+test("await using falls back to Symbol.dispose", async () => {
+  const backend = new MockBackend();
+  assert.equal(Symbol.asyncDispose in Minip2pBase.prototype, false);
+
+  {
+    await using endpoint = new TestMinip2p(backend);
+    assert.equal(endpoint.peerId(), "local-peer");
+  }
+
+  assert.equal(backend.closed, true);
+});
+
 test("inbound relayed path events preserve relay provenance", async () => {
   const backend = new MockBackend();
   const endpoint = new TestMinip2p(backend);
@@ -335,6 +451,48 @@ test("stream FIFO counts only queued data and cleans up after terminal", async (
   stream.reset();
   stream.abandon();
   endpoint.close();
+});
+
+test("stream async iteration yields chunks in order and ends on remote write close", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+  const opening = endpoint.openStream("peer", "/test/1", { timeoutMs: 1000 });
+  backend.emit(streamReady({ initiatedLocally: true, streamId: 3 }));
+  const stream = await opening;
+  const chunks = [];
+  const reading = (async () => {
+    for await (const chunk of stream) {
+      chunks.push([...chunk]);
+    }
+  })();
+
+  backend.emit(streamData(new Uint8Array([1, 2]), 3));
+  backend.emit(streamData(new Uint8Array([3]), 3));
+  backend.emit({
+    inner: { connId: 2, peerId: "peer", streamId: 3 },
+    tag: P2pEvent_Tags.StreamRemoteWriteClosed,
+  });
+
+  await reading;
+  assert.deepEqual(chunks, [[1, 2], [3]]);
+  endpoint.close();
+});
+
+test("stream async iteration ends quietly when the endpoint closes", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+  const opening = endpoint.openStream("peer", "/test/1", { timeoutMs: 1000 });
+  backend.emit(streamReady({ initiatedLocally: true, streamId: 3 }));
+  const stream = await opening;
+  const reading = (async () => {
+    for await (const _chunk of stream) {
+      // Wait for endpoint shutdown.
+    }
+  })();
+
+  endpoint.close();
+
+  await reading;
 });
 
 test("local stream reset and abandon emit closed exactly once", async () => {
@@ -658,6 +816,13 @@ function streamReady(overrides = {}) {
       ...overrides,
     },
     tag: P2pEvent_Tags.StreamReady,
+  };
+}
+
+function peerReady(peerId) {
+  return {
+    inner: { peerId, protocols: ["/test/1"] },
+    tag: P2pEvent_Tags.PeerReady,
   };
 }
 

--- a/bindings/ts/core/tests/sdk.test.mjs
+++ b/bindings/ts/core/tests/sdk.test.mjs
@@ -122,7 +122,7 @@ test("events iteration drops oldest buffered events and reports the drop", async
   assert.equal((await iterator.next()).done, true);
 });
 
-test("events iteration drains retained events before ending after abort", async () => {
+test("events iteration stops immediately on abort while events keep arriving", async () => {
   const backend = new MockBackend();
   const endpoint = new TestMinip2p(backend);
   const controller = new AbortController();
@@ -131,16 +131,12 @@ test("events iteration drains retained events before ending after abort", async 
   backend.emit(peerReady("first"));
   await first;
 
-  backend.emit(peerReady("dropped"));
-  backend.emit(peerReady("retained"));
+  backend.emit(peerReady("buffered"));
   await tick();
   controller.abort();
+  backend.emit(peerReady("after-abort"));
+  await tick();
 
-  assert.deepEqual((await iterator.next()).value, {
-    dropped: 1,
-    type: "queueOverflow",
-  });
-  assert.equal((await iterator.next()).value.peerId, "retained");
   assert.equal((await iterator.next()).done, true);
   endpoint.close();
 });
@@ -493,6 +489,27 @@ test("stream async iteration ends quietly when the endpoint closes", async () =>
   endpoint.close();
 
   await reading;
+});
+
+test("stream async iteration rejects when the remote stream resets", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+  const opening = endpoint.openStream("peer", "/test/1", { timeoutMs: 1000 });
+  backend.emit(streamReady({ initiatedLocally: true, streamId: 3 }));
+  const stream = await opening;
+  const reading = (async () => {
+    for await (const _chunk of stream) {
+      // Wait for the remote terminal event.
+    }
+  })();
+
+  backend.emit({
+    inner: { connId: 2, peerId: "peer", streamId: 3 },
+    tag: P2pEvent_Tags.StreamClosed,
+  });
+
+  await assert.rejects(reading, StreamClosedError);
+  endpoint.close();
 });
 
 test("local stream reset and abandon emit closed exactly once", async () => {


### PR DESCRIPTION
Closes #99

## Summary

- make `Stream` async iterable with ordered reads and clean termination
- add `events()` with per-iterator bounded drop-oldest buffering, in-band overflow reports, close, and abort handling
- document the new iteration APIs and `Symbol.dispose` fallback

## Verification

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @minip2p/core build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds async iteration to `@minip2p/core` streams and endpoints. `Stream` is now an async iterable that yields received chunks in order, ends quietly on remote write close or endpoint shutdown, and rejects with `StreamClosedError` when the remote resets. The first terminal state wins: a clean half-close EOF is final, and a reset observed while iteration still runs beats a prior half-close. `endpoint.events()` provides an async iterable of endpoint events with per-iterator bounded buffering and abort support.

**New Features**
- `events()` delivers endpoint events in order with a drop-oldest buffer capped by `bufferCap` (default 4096) and reports overflows in-band as `queueOverflow` events.
- Passing `signal` ends iteration on abort without throwing; buffered events are dropped immediately.
- Endpoints and streams implement `Symbol.dispose` (with `await using` fallback), not `Symbol.asyncDispose`.
- Documents the new iteration APIs in the README.

<sup>Written for commit 29dad7c54ebb6e98b2caa02f4574ce4e1637308d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

