### PR TITLE
Wire prebuilt distribution for @minip2p/node

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -689,19 +689,19 @@ jobs:
       run:
         working-directory: bindings/ts
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.release.tag_name || github.sha }}
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
         with:
           version: ${{ env.PNPM_VERSION }}
       - run: pnpm install --frozen-lockfile
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: node-binding-*
           path: bindings/ts/node/artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -249,6 +249,7 @@ jobs:
               export CC_x86_64_unknown_linux_musl=gcc
               export CXX_x86_64_unknown_linux_musl=g++
               export LIBCLANG_PATH=/usr/lib/llvm20/lib
+              export CARGO_BUILD_RUSTFLAGS="-C target-feature=-crt-static"
               export RUSTFLAGS="-C target-feature=-crt-static"
               pnpm install --frozen-lockfile --force
               pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -243,6 +243,8 @@ jobs:
               rustup toolchain install 1.91 --profile minimal --target ${{ matrix.target }}
               rustup default 1.91
               ln -sf /usr/bin/gcc "/usr/local/bin/${TARGET%%-*}-linux-musl-gcc"
+              export CC_aarch64_unknown_linux_musl=gcc
+              export CXX_aarch64_unknown_linux_musl=g++
               pnpm install --frozen-lockfile --force
               pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
             '

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -225,9 +225,11 @@ jobs:
       - name: Build addon
         env:
           NAPI_BUILD_IMAGE: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:caac2d1b9194eada0c69e669e72763869701351d8957ab805cc45a43999d8be2
+          TARGET: ${{ matrix.target }}
         run: |
           docker run --rm \
             --env PNPM_VERSION \
+            --env TARGET \
             --volume "$GITHUB_WORKSPACE:/work" \
             --workdir /work/bindings/ts \
             "$NAPI_BUILD_IMAGE" \
@@ -240,6 +242,7 @@ jobs:
               npm install --global --force "pnpm@$PNPM_VERSION"
               rustup toolchain install 1.91 --profile minimal --target ${{ matrix.target }}
               rustup default 1.91
+              ln -sf /usr/bin/gcc "/usr/local/bin/${TARGET%%-*}-linux-musl-gcc"
               pnpm install --frozen-lockfile --force
               pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
             '

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -231,7 +231,7 @@ jobs:
             --volume "$GITHUB_WORKSPACE:/work" \
             --workdir /work/bindings/ts \
             "$NAPI_BUILD_IMAGE" \
-            bash -lc 'corepack prepare "pnpm@$PNPM_VERSION" --activate && pnpm install --frozen-lockfile --force && pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked'
+            bash -lc 'npm install --global --force "@pnpm/exe@$PNPM_VERSION" && pnpm install --frozen-lockfile --force && pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked'
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: node-binding-${{ matrix.target }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -238,6 +238,8 @@ jobs:
                 nodejs=24.18.1-r0
               export PATH="/usr/bin:$PATH"
               npm install --global --force "pnpm@$PNPM_VERSION"
+              rustup toolchain install 1.91 --profile minimal --target ${{ matrix.target }}
+              rustup default 1.91
               pnpm install --frozen-lockfile --force
               pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
             '

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,12 +3,13 @@ name: Publish release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.event.release.tag_name }}
+  group: release-${{ github.event.release.tag_name || github.sha }}
   cancel-in-progress: false
 
 # Every rust-cache below runs with `save-if: false`. These jobs check out a tag,
@@ -30,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.sha }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -39,12 +40,13 @@ jobs:
       - name: Verify release tag and package versions
         id: release
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           metadata="$(cargo metadata --no-deps --format-version 1)"
           version="$(jq -r '.packages[] | select(.name == "minip2p-rs") | .version' <<<"$metadata")"
-          if [[ "$RELEASE_TAG" != "v$version" ]]; then
+          if [[ "$EVENT_NAME" == "release" && "$RELEASE_TAG" != "v$version" ]]; then
             echo "::error::Release tag $RELEASE_TAG does not match workspace version $version (expected v$version)"
             exit 1
           fi
@@ -89,12 +91,34 @@ jobs:
 
           core_version="$(jq -r '.version' bindings/ts/core/package.json)"
           react_native_version="$(jq -r '.version' bindings/ts/react-native/package.json)"
-          if [[ "$core_version" != "$version" || "$react_native_version" != "$version" ]]; then
-            echo "::error::Rust and public TypeScript packages must use $version; core=$core_version react-native=$react_native_version"
+          node_version="$(jq -r '.version' bindings/ts/node/package.json)"
+          if [[ "$core_version" != "$version" || "$react_native_version" != "$version" || "$node_version" != "$version" ]]; then
+            echo "::error::Rust and public TypeScript packages must use $version; core=$core_version react-native=$react_native_version node=$node_version"
             exit 1
           fi
-          if [[ "$(jq -r '.private' bindings/ts/node/package.json)" != "true" ]]; then
-            echo "::error::@minip2p/node must remain private until its native backend is implemented"
+          if [[ "$(jq -r '.private // false' bindings/ts/node/package.json)" == "true" ]]; then
+            echo "::error::@minip2p/node must be public"
+            exit 1
+          fi
+          platform_errors="$({
+            for manifest in bindings/ts/node/npm/*/package.json; do
+              jq -r --arg version "$version" '
+                select(.version != $version or .publishConfig.access != "public")
+                | "\(.name) is not public at \($version)"
+              ' "$manifest"
+            done
+            jq -r --arg version "$version" '
+              .optionalDependencies // {}
+              | to_entries[]
+              | select(.key | startswith("@minip2p/node-"))
+              | select(.value != $version)
+              | "\(.key) uses \(.value), expected \($version)"
+            ' bindings/ts/node/package.json
+          } )"
+          if [[ -n "$platform_errors" ]] ||
+            [[ "$(jq '[.optionalDependencies | to_entries[] | select(.key | startswith("@minip2p/node-"))] | length' bindings/ts/node/package.json)" != 7 ]]; then
+            echo "::error::Node platform packages must be public and lockstep-versioned"
+            echo "$platform_errors"
             exit 1
           fi
           if [[ "$(jq -r '.dependencies["@minip2p/core"]' bindings/ts/react-native/package.json)" != "workspace:*" ]]; then
@@ -111,7 +135,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.91"
@@ -130,6 +154,99 @@ jobs:
           cargo doc -p minip2p-mdns --features smoltcp --no-deps --locked
           cargo doc -p minip2p-rs --no-default-features --features smoltcp --no-deps --locked
 
+  node-native:
+    name: Build Node addon (${{ matrix.target }})
+    needs: verify-release
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - runner: macos-26
+            target: x86_64-apple-darwin
+          - runner: macos-26
+            target: aarch64-apple-darwin
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+    defaults:
+      run:
+        working-directory: bindings/ts
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name || github.sha }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.91"
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
+      - run: pnpm install --frozen-lockfile
+      - name: Build addon
+        shell: bash
+        run: pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
+      - uses: actions/upload-artifact@v7
+        with:
+          name: node-binding-${{ matrix.target }}
+          path: bindings/ts/node/minip2p.*.node
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
+
+  node-musl:
+    name: Build Node addon (${{ matrix.target }})
+    needs: verify-release
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    container: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+    defaults:
+      run:
+        working-directory: bindings/ts
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name || github.sha }}
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.91"
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
+      - run: pnpm install --frozen-lockfile --force
+      - name: Build addon
+        run: pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
+      - uses: actions/upload-artifact@v7
+        with:
+          name: node-binding-${{ matrix.target }}
+          path: bindings/ts/node/minip2p.*.node
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
+
   relay-server-binaries:
     name: Build relay server (${{ matrix.target }})
     needs: verify-release
@@ -146,7 +263,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.sha }}
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.91"
@@ -188,6 +305,7 @@ jobs:
 
   publish-relay-server-binaries:
     name: Publish relay server binaries
+    if: github.event_name == 'release'
     needs: [verify-release, relay-server-binaries]
     runs-on: ubuntu-latest
     permissions:
@@ -201,7 +319,7 @@ jobs:
       - name: Attach binaries and checksums to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.sha }}
         working-directory: ${{ runner.temp }}/relay-release
         run: |
           set -euo pipefail
@@ -218,6 +336,7 @@ jobs:
 
   publish-relay-container:
     name: Publish relay container
+    if: github.event_name == 'release'
     needs: [verify-release, publish-relay-server-binaries]
     permissions:
       contents: read
@@ -237,7 +356,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.sha }}
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -306,7 +425,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.sha }}
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -345,7 +464,7 @@ jobs:
 
   package-typescript:
     name: Assemble TypeScript packages
-    needs: [verify-release, android-native, ios-native]
+    needs: [verify-release, android-native, ios-native, node-native, node-musl]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -354,7 +473,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.sha }}
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -394,12 +513,25 @@ jobs:
             -C react-native/android/src/main
           tar -xzf "$RUNNER_TEMP/native/minip2p-ios-native.tar.gz" \
             -C react-native/build
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: node-binding-*
+          path: bindings/ts/node/artifacts
+          merge-multiple: true
+      - name: Assemble Node platform packages
+        run: |
+          pnpm --filter @minip2p/node exec napi create-npm-dirs
+          pnpm --filter @minip2p/node exec napi artifacts --output-dir artifacts
       - name: Pack public packages
         run: |
           mkdir -p release-packages
           pnpm --filter @minip2p/core pack \
             --pack-destination "$PWD/release-packages"
           pnpm --filter @minip2p/react-native pack \
+            --pack-destination "$PWD/release-packages"
+          pnpm --filter @minip2p/node pack \
+            --pack-destination "$PWD/release-packages"
+          pnpm --dir node/npm/linux-x64-gnu pack \
             --pack-destination "$PWD/release-packages"
       - name: Verify packed contents and dependency versions
         env:
@@ -409,7 +541,9 @@ jobs:
             "$RELEASE_VERSION" \
             "release-packages/minip2p-core-$RELEASE_VERSION.tgz" \
             "release-packages/minip2p-react-native-$RELEASE_VERSION.tgz" \
-            react-native
+            react-native \
+            "release-packages/minip2p-node-$RELEASE_VERSION.tgz" \
+            node/npm
       - name: Smoke-test installation from tarballs
         env:
           RELEASE_VERSION: ${{ needs.verify-release.outputs.version }}
@@ -420,7 +554,9 @@ jobs:
             --ignore-scripts \
             --legacy-peer-deps \
             "$PWD/release-packages/minip2p-core-$RELEASE_VERSION.tgz" \
-            "$PWD/release-packages/minip2p-react-native-$RELEASE_VERSION.tgz"
+            "$PWD/release-packages/minip2p-react-native-$RELEASE_VERSION.tgz" \
+            "$PWD/release-packages/minip2p-node-$RELEASE_VERSION.tgz" \
+            "$PWD/release-packages/minip2p-node-linux-x64-gnu-$RELEASE_VERSION.tgz"
           node scripts/smoke-release-install.mjs "$consumer"
       - uses: actions/upload-artifact@v7
         with:
@@ -432,6 +568,7 @@ jobs:
 
   publish-crates:
     name: Publish to crates.io
+    if: github.event_name == 'release'
     needs: [verify-release, test-rust, package-typescript]
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -442,7 +579,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.91"
@@ -538,9 +675,49 @@ jobs:
             done
           done
 
+  publish-node-platforms:
+    name: Publish Node platform packages
+    if: github.event_name == 'release'
+    needs: [verify-release, publish-crates, node-native, node-musl]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: bindings/ts
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name || github.sha }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: node-binding-*
+          path: bindings/ts/node/artifacts
+          merge-multiple: true
+      - name: Assemble and validate all platform packages
+        run: |
+          pnpm --filter @minip2p/node exec napi create-npm-dirs
+          pnpm --filter @minip2p/node exec napi artifacts --output-dir artifacts
+          test "$(find node/npm -name 'minip2p.*.node' -type f | wc -l)" -eq 7
+      - name: Publish platform packages with npm trusted publishing
+        run: pnpm --filter @minip2p/node exec napi prepublish -t npm --no-gh-release
+
   publish-typescript:
     name: Publish to npm
-    needs: [verify-release, publish-crates]
+    if: github.event_name == 'release'
+    needs: [verify-release, publish-crates, publish-node-platforms]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: npm
@@ -601,3 +778,6 @@ jobs:
           publish_package \
             "@minip2p/react-native" \
             "packages/minip2p-react-native-$RELEASE_VERSION.tgz"
+          publish_package \
+            "@minip2p/node" \
+            "packages/minip2p-node-$RELEASE_VERSION.tgz"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -400,11 +400,6 @@ jobs:
       - name: Validate Android ELF alignment and allocator hooks
         run: node react-native/scripts/check-android-elf.mjs
       - run: pnpm example prebuild
-      - name: Use Gradle version required by the Android plugin
-        run: |
-          wrapper=react-native/example/android/gradle/wrapper/gradle-wrapper.properties
-          sed -i 's/gradle-9\.3\.1-bin\.zip/gradle-9.4.1-bin.zip/' "$wrapper"
-          grep -Fq 'gradle-9.4.1-bin.zip' "$wrapper"
       - name: Build both Android ABIs
         working-directory: bindings/ts/react-native/example/android
         run: ./gradlew :app:assembleDebug -PreactNativeArchitectures=arm64-v8a,x86_64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -228,7 +228,6 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: |
           docker run --rm \
-            --env PNPM_VERSION \
             --env TARGET \
             --volume "$GITHUB_WORKSPACE:/work" \
             --workdir /work/bindings/ts \
@@ -237,22 +236,20 @@ jobs:
               set -euo pipefail
               apk add --no-cache --upgrade \
                 --repository https://dl-cdn.alpinelinux.org/alpine/v3.23/main \
-                clang20-libclang=20.1.8-r1 \
-                nodejs=24.18.1-r0
-              export PATH="/usr/bin:$PATH"
-              npm install --global --force "pnpm@$PNPM_VERSION"
-              rustup toolchain install 1.91 --profile minimal --target ${{ matrix.target }}
+                clang20-libclang=20.1.8-r1
+              rustup toolchain install 1.91 --profile minimal
               rustup default 1.91
-              ln -sf /usr/bin/gcc "/usr/local/bin/${TARGET%%-*}-linux-musl-gcc"
-              export CC_aarch64_unknown_linux_musl=gcc
-              export CXX_aarch64_unknown_linux_musl=g++
-              export CC_x86_64_unknown_linux_musl=gcc
-              export CXX_x86_64_unknown_linux_musl=g++
+              export CC=gcc
+              export CXX=g++
               export LIBCLANG_PATH=/usr/lib/llvm20/lib
-              export CARGO_BUILD_RUSTFLAGS="-C target-feature=-crt-static"
               export RUSTFLAGS="-C target-feature=-crt-static"
-              pnpm install --frozen-lockfile --force
-              pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
+              cargo build --release --locked --manifest-path ../../crates/nodejs/Cargo.toml
+              case "$TARGET" in
+                x86_64-unknown-linux-musl) output=minip2p.linux-x64-musl.node ;;
+                aarch64-unknown-linux-musl) output=minip2p.linux-arm64-musl.node ;;
+                *) echo "Unsupported musl target: $TARGET" >&2; exit 1 ;;
+              esac
+              install ../../target/release/libminip2p_nodejs.so "node/$output"
             '
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -234,6 +234,7 @@ jobs:
             "$NAPI_BUILD_IMAGE" \
             bash -lc '
               set -euo pipefail
+              # Build with Cargo because napi CLI needs a compatible Node host inside Alpine.
               apk add --no-cache --upgrade \
                 --repository https://dl-cdn.alpinelinux.org/alpine/v3.23/main \
                 clang20-libclang=20.1.8-r1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
@@ -489,7 +489,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
@@ -716,7 +716,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
-      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: ${{ env.PNPM_VERSION }}
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -233,20 +233,12 @@ jobs:
             "$NAPI_BUILD_IMAGE" \
             bash -lc '
               set -euo pipefail
-              case "$(uname -m)" in
-                x86_64) pnpm_arch=x64 ;;
-                aarch64) pnpm_arch=arm64 ;;
-                *) echo "Unsupported pnpm architecture: $(uname -m)" >&2; exit 1 ;;
-              esac
-              mkdir -p /tmp/pnpm-exe /tmp/pnpm-platform
-              pnpm_exe_tarball=$(npm pack --silent "@pnpm/exe@$PNPM_VERSION" --pack-destination /tmp)
-              pnpm_platform_tarball=$(npm pack --silent "@pnpm/linuxstatic-$pnpm_arch@$PNPM_VERSION" --pack-destination /tmp)
-              tar -xzf "/tmp/$pnpm_exe_tarball" -C /tmp/pnpm-exe
-              tar -xzf "/tmp/$pnpm_platform_tarball" -C /tmp/pnpm-platform
-              install /tmp/pnpm-platform/package/pnpm /tmp/pnpm-exe/package/pnpm
-              pnpm_bin=/tmp/pnpm-exe/package/pnpm
-              "$pnpm_bin" install --frozen-lockfile --force
-              "$pnpm_bin" --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
+              apk add --no-cache --upgrade \
+                --repository https://dl-cdn.alpinelinux.org/alpine/v3.23/main \
+                nodejs=24.18.1-r0
+              npm install --global --force "pnpm@$PNPM_VERSION"
+              pnpm install --frozen-lockfile --force
+              pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
             '
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -400,6 +400,11 @@ jobs:
       - name: Validate Android ELF alignment and allocator hooks
         run: node react-native/scripts/check-android-elf.mjs
       - run: pnpm example prebuild
+      - name: Use Gradle version required by the Android plugin
+        run: |
+          wrapper=react-native/example/android/gradle/wrapper/gradle-wrapper.properties
+          sed -i 's/gradle-9\.3\.1-bin\.zip/gradle-9.4.1-bin.zip/' "$wrapper"
+          grep -Fq 'gradle-9.4.1-bin.zip' "$wrapper"
       - name: Build both Android ABIs
         working-directory: bindings/ts/react-native/example/android
         run: ./gradlew :app:assembleDebug -PreactNativeArchitectures=arm64-v8a,x86_64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.release.tag_name || github.sha }}
 
@@ -177,27 +177,27 @@ jobs:
       run:
         working-directory: bindings/ts
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.release.tag_name || github.sha }}
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.91"
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           save-if: false
       - run: pnpm install --frozen-lockfile
       - name: Build addon
         shell: bash
         run: pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: node-binding-${{ matrix.target }}
           path: bindings/ts/node/minip2p.*.node
@@ -210,7 +210,7 @@ jobs:
     needs: verify-release
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
-    container: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+    container: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:caac2d1b9194eada0c69e669e72763869701351d8957ab805cc45a43999d8be2
     strategy:
       fail-fast: false
       matrix:
@@ -223,23 +223,23 @@ jobs:
       run:
         working-directory: bindings/ts
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.release.tag_name || github.sha }}
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.91"
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           save-if: false
       - run: pnpm install --frozen-lockfile --force
       - name: Build addon
         run: pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: node-binding-${{ matrix.target }}
           path: bindings/ts/node/minip2p.*.node

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -740,12 +740,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: minip2p-npm-packages
           path: packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -210,7 +210,6 @@ jobs:
     needs: verify-release
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
-    container: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:caac2d1b9194eada0c69e669e72763869701351d8957ab805cc45a43999d8be2
     strategy:
       fail-fast: false
       matrix:
@@ -219,26 +218,19 @@ jobs:
             target: x86_64-unknown-linux-musl
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
-    defaults:
-      run:
-        working-directory: bindings/ts
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.release.tag_name || github.sha }}
-      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          toolchain: "1.91"
-          targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-        with:
-          save-if: false
-      - run: pnpm install --frozen-lockfile --force
       - name: Build addon
-        run: pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
+        env:
+          NAPI_BUILD_IMAGE: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:caac2d1b9194eada0c69e669e72763869701351d8957ab805cc45a43999d8be2
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/work" \
+            --workdir /work/bindings/ts \
+            "$NAPI_BUILD_IMAGE" \
+            bash -lc 'pnpm install --frozen-lockfile --force && pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked'
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: node-binding-${{ matrix.target }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -227,10 +227,11 @@ jobs:
           NAPI_BUILD_IMAGE: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:caac2d1b9194eada0c69e669e72763869701351d8957ab805cc45a43999d8be2
         run: |
           docker run --rm \
+            --env PNPM_VERSION \
             --volume "$GITHUB_WORKSPACE:/work" \
             --workdir /work/bindings/ts \
             "$NAPI_BUILD_IMAGE" \
-            bash -lc 'pnpm install --frozen-lockfile --force && pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked'
+            bash -lc 'corepack prepare "pnpm@$PNPM_VERSION" --activate && pnpm install --frozen-lockfile --force && pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked'
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: node-binding-${{ matrix.target }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -238,11 +238,15 @@ jobs:
                 aarch64) pnpm_arch=arm64 ;;
                 *) echo "Unsupported pnpm architecture: $(uname -m)" >&2; exit 1 ;;
               esac
-              pnpm_tarball=$(npm pack --silent "@pnpm/linuxstatic-$pnpm_arch@$PNPM_VERSION" --pack-destination /tmp)
-              tar -xzf "/tmp/$pnpm_tarball" -C /tmp
-              install /tmp/package/pnpm /usr/local/bin/pnpm
-              pnpm install --frozen-lockfile --force
-              pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
+              mkdir -p /tmp/pnpm-exe /tmp/pnpm-platform
+              pnpm_exe_tarball=$(npm pack --silent "@pnpm/exe@$PNPM_VERSION" --pack-destination /tmp)
+              pnpm_platform_tarball=$(npm pack --silent "@pnpm/linuxstatic-$pnpm_arch@$PNPM_VERSION" --pack-destination /tmp)
+              tar -xzf "/tmp/$pnpm_exe_tarball" -C /tmp/pnpm-exe
+              tar -xzf "/tmp/$pnpm_platform_tarball" -C /tmp/pnpm-platform
+              install /tmp/pnpm-platform/package/pnpm /tmp/pnpm-exe/package/pnpm
+              pnpm_bin=/tmp/pnpm-exe/package/pnpm
+              "$pnpm_bin" install --frozen-lockfile --force
+              "$pnpm_bin" --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
             '
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -471,25 +471,32 @@ jobs:
       run:
         working-directory: bindings/ts
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.release.tag_name || github.sha }}
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: android-actions/setup-android@v4
+      - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
       - name: Install Android NDK r28c for package validation
         run: |
           sdkmanager "ndk;28.2.13676358"
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/28.2.13676358" >> "$GITHUB_ENV"
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           save-if: false
       - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: node-binding-*
+          path: bindings/ts/node/artifacts
+          merge-multiple: true
+      - name: Assemble Node platform packages
+        run: pnpm --filter @minip2p/node exec napi artifacts --output-dir artifacts
       - run: pnpm typecheck
       - run: pnpm test
       - run: pnpm lint
@@ -498,11 +505,11 @@ jobs:
       - run: pnpm rn:generate
       - name: Generated files are current
         run: test -z "$(git status --porcelain)"
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: minip2p-android-native
           path: ${{ runner.temp }}/native
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: minip2p-ios-native
           path: ${{ runner.temp }}/native
@@ -513,15 +520,6 @@ jobs:
             -C react-native/android/src/main
           tar -xzf "$RUNNER_TEMP/native/minip2p-ios-native.tar.gz" \
             -C react-native/build
-      - uses: actions/download-artifact@v8
-        with:
-          pattern: node-binding-*
-          path: bindings/ts/node/artifacts
-          merge-multiple: true
-      - name: Assemble Node platform packages
-        run: |
-          pnpm --filter @minip2p/node exec napi create-npm-dirs
-          pnpm --filter @minip2p/node exec napi artifacts --output-dir artifacts
       - name: Pack public packages
         run: |
           mkdir -p release-packages
@@ -531,8 +529,10 @@ jobs:
             --pack-destination "$PWD/release-packages"
           pnpm --filter @minip2p/node pack \
             --pack-destination "$PWD/release-packages"
-          pnpm --dir node/npm/linux-x64-gnu pack \
-            --pack-destination "$PWD/release-packages"
+          for platform_dir in node/npm/*; do
+            pnpm --dir "$platform_dir" pack \
+              --pack-destination "$PWD/release-packages"
+          done
       - name: Verify packed contents and dependency versions
         env:
           RELEASE_VERSION: ${{ needs.verify-release.outputs.version }}
@@ -558,7 +558,14 @@ jobs:
             "$PWD/release-packages/minip2p-node-$RELEASE_VERSION.tgz" \
             "$PWD/release-packages/minip2p-node-linux-x64-gnu-$RELEASE_VERSION.tgz"
           node scripts/smoke-release-install.mjs "$consumer"
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: minip2p-node-platform-packages
+          path: bindings/ts/node/npm
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: minip2p-npm-packages
           path: bindings/ts/release-packages/*.tgz
@@ -678,7 +685,7 @@ jobs:
   publish-node-platforms:
     name: Publish Node platform packages
     if: github.event_name == 'release'
-    needs: [verify-release, publish-crates, node-native, node-musl]
+    needs: [verify-release, package-typescript]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: npm
@@ -703,14 +710,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          pattern: node-binding-*
-          path: bindings/ts/node/artifacts
-          merge-multiple: true
-      - name: Assemble and validate all platform packages
-        run: |
-          pnpm --filter @minip2p/node exec napi create-npm-dirs
-          pnpm --filter @minip2p/node exec napi artifacts --output-dir artifacts
-          test "$(find node/npm -name 'minip2p.*.node' -type f | wc -l)" -eq 7
+          name: minip2p-node-platform-packages
+          path: bindings/ts/node/npm
+      - name: Check verified platform artifacts
+        run: test "$(find node/npm -name 'minip2p.*.node' -type f -size +0c | wc -l)" -eq 7
       - name: Publish platform packages with npm trusted publishing
         run: pnpm --filter @minip2p/node exec napi prepublish -t npm --no-gh-release
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -237,6 +237,7 @@ jobs:
               set -euo pipefail
               apk add --no-cache --upgrade \
                 --repository https://dl-cdn.alpinelinux.org/alpine/v3.23/main \
+                clang20-libclang=20.1.8-r1 \
                 nodejs=24.18.1-r0
               export PATH="/usr/bin:$PATH"
               npm install --global --force "pnpm@$PNPM_VERSION"
@@ -245,6 +246,9 @@ jobs:
               ln -sf /usr/bin/gcc "/usr/local/bin/${TARGET%%-*}-linux-musl-gcc"
               export CC_aarch64_unknown_linux_musl=gcc
               export CXX_aarch64_unknown_linux_musl=g++
+              export CC_x86_64_unknown_linux_musl=gcc
+              export CXX_x86_64_unknown_linux_musl=g++
+              export LIBCLANG_PATH=/usr/lib/llvm20/lib
               pnpm install --frozen-lockfile --force
               pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
             '

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -231,7 +231,19 @@ jobs:
             --volume "$GITHUB_WORKSPACE:/work" \
             --workdir /work/bindings/ts \
             "$NAPI_BUILD_IMAGE" \
-            bash -lc 'npm install --global --force "@pnpm/exe@$PNPM_VERSION" && pnpm install --frozen-lockfile --force && pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked'
+            bash -lc '
+              set -euo pipefail
+              case "$(uname -m)" in
+                x86_64) pnpm_arch=x64 ;;
+                aarch64) pnpm_arch=arm64 ;;
+                *) echo "Unsupported pnpm architecture: $(uname -m)" >&2; exit 1 ;;
+              esac
+              pnpm_tarball=$(npm pack --silent "@pnpm/linuxstatic-$pnpm_arch@$PNPM_VERSION" --pack-destination /tmp)
+              tar -xzf "/tmp/$pnpm_tarball" -C /tmp
+              install /tmp/package/pnpm /usr/local/bin/pnpm
+              pnpm install --frozen-lockfile --force
+              pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
+            '
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: node-binding-${{ matrix.target }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -249,6 +249,7 @@ jobs:
               export CC_x86_64_unknown_linux_musl=gcc
               export CXX_x86_64_unknown_linux_musl=g++
               export LIBCLANG_PATH=/usr/lib/llvm20/lib
+              export RUSTFLAGS="-C target-feature=-crt-static"
               pnpm install --frozen-lockfile --force
               pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
             '

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -236,6 +236,7 @@ jobs:
               apk add --no-cache --upgrade \
                 --repository https://dl-cdn.alpinelinux.org/alpine/v3.23/main \
                 nodejs=24.18.1-r0
+              export PATH="/usr/bin:$PATH"
               npm install --global --force "pnpm@$PNPM_VERSION"
               pnpm install --frozen-lockfile --force
               pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 /tmp
 /bindings/ts/node/*.node
+/bindings/ts/node/npm/*/*.node
 /crates/nodejs/*.node
 
 # Demo peer identity files contain raw Ed25519 secrets.

--- a/bindings/ts/node/LICENSE
+++ b/bindings/ts/node/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Deepso
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bindings/ts/node/README.md
+++ b/bindings/ts/node/README.md
@@ -21,7 +21,7 @@ endpoint.close();
 
 The Node binding accepts the same TCP, QUIC, circuit-relay, signed-discovery, and mDNS configuration as `@minip2p/react-native`.
 
-The package is private until the platform-package publishing work lands. Build the local addon and run its suite with:
+Published installs select a prebuilt binary from an optional platform package. No Rust toolchain or install script is required. Build the local addon and run its suite with:
 
 ```bash
 pnpm native:build

--- a/bindings/ts/node/npm/darwin-arm64/README.md
+++ b/bindings/ts/node/npm/darwin-arm64/README.md
@@ -1,0 +1,3 @@
+# `@minip2p/node-darwin-arm64`
+
+This is the **aarch64-apple-darwin** binary for `@minip2p/node`

--- a/bindings/ts/node/npm/darwin-arm64/package.json
+++ b/bindings/ts/node/npm/darwin-arm64/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@minip2p/node-darwin-arm64",
   "version": "0.4.6",
-  "cpu": [
-    "arm64"
-  ],
-  "main": "minip2p.darwin-arm64.node",
-  "files": [
-    "minip2p.darwin-arm64.node"
-  ],
   "description": "Node.js bindings for minip2p",
   "keywords": [
     "libp2p",
@@ -19,14 +12,21 @@
     "rust"
   ],
   "license": "MIT",
-  "engines": {
-    "node": ">=24"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
+  "files": [
+    "minip2p.darwin-arm64.node"
+  ],
   "os": [
     "darwin"
-  ]
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "minip2p.darwin-arm64.node",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "engines": {
+    "node": ">=24"
+  }
 }

--- a/bindings/ts/node/npm/darwin-arm64/package.json
+++ b/bindings/ts/node/npm/darwin-arm64/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@minip2p/node-darwin-arm64",
+  "version": "0.4.6",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "minip2p.darwin-arm64.node",
+  "files": [
+    "minip2p.darwin-arm64.node"
+  ],
+  "description": "Node.js bindings for minip2p",
+  "keywords": [
+    "libp2p",
+    "napi-rs",
+    "node",
+    "p2p",
+    "peer-to-peer",
+    "quic",
+    "rust"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "darwin"
+  ]
+}

--- a/bindings/ts/node/npm/darwin-x64/README.md
+++ b/bindings/ts/node/npm/darwin-x64/README.md
@@ -1,0 +1,3 @@
+# `@minip2p/node-darwin-x64`
+
+This is the **x86_64-apple-darwin** binary for `@minip2p/node`

--- a/bindings/ts/node/npm/darwin-x64/package.json
+++ b/bindings/ts/node/npm/darwin-x64/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@minip2p/node-darwin-x64",
+  "version": "0.4.6",
+  "cpu": [
+    "x64"
+  ],
+  "main": "minip2p.darwin-x64.node",
+  "files": [
+    "minip2p.darwin-x64.node"
+  ],
+  "description": "Node.js bindings for minip2p",
+  "keywords": [
+    "libp2p",
+    "napi-rs",
+    "node",
+    "p2p",
+    "peer-to-peer",
+    "quic",
+    "rust"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "darwin"
+  ]
+}

--- a/bindings/ts/node/npm/darwin-x64/package.json
+++ b/bindings/ts/node/npm/darwin-x64/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@minip2p/node-darwin-x64",
   "version": "0.4.6",
-  "cpu": [
-    "x64"
-  ],
-  "main": "minip2p.darwin-x64.node",
-  "files": [
-    "minip2p.darwin-x64.node"
-  ],
   "description": "Node.js bindings for minip2p",
   "keywords": [
     "libp2p",
@@ -19,14 +12,21 @@
     "rust"
   ],
   "license": "MIT",
-  "engines": {
-    "node": ">=24"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
+  "files": [
+    "minip2p.darwin-x64.node"
+  ],
   "os": [
     "darwin"
-  ]
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "minip2p.darwin-x64.node",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "engines": {
+    "node": ">=24"
+  }
 }

--- a/bindings/ts/node/npm/linux-arm64-gnu/README.md
+++ b/bindings/ts/node/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@minip2p/node-linux-arm64-gnu`
+
+This is the **aarch64-unknown-linux-gnu** binary for `@minip2p/node`

--- a/bindings/ts/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/ts/node/npm/linux-arm64-gnu/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@minip2p/node-linux-arm64-gnu",
   "version": "0.4.6",
-  "cpu": [
-    "arm64"
-  ],
-  "main": "minip2p.linux-arm64-gnu.node",
-  "files": [
-    "minip2p.linux-arm64-gnu.node"
-  ],
   "description": "Node.js bindings for minip2p",
   "keywords": [
     "libp2p",
@@ -19,17 +12,24 @@
     "rust"
   ],
   "license": "MIT",
-  "engines": {
-    "node": ">=24"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
+  "files": [
+    "minip2p.linux-arm64-gnu.node"
+  ],
   "os": [
     "linux"
   ],
+  "cpu": [
+    "arm64"
+  ],
   "libc": [
     "glibc"
-  ]
+  ],
+  "main": "minip2p.linux-arm64-gnu.node",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "engines": {
+    "node": ">=24"
+  }
 }

--- a/bindings/ts/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/ts/node/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@minip2p/node-linux-arm64-gnu",
+  "version": "0.4.6",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "minip2p.linux-arm64-gnu.node",
+  "files": [
+    "minip2p.linux-arm64-gnu.node"
+  ],
+  "description": "Node.js bindings for minip2p",
+  "keywords": [
+    "libp2p",
+    "napi-rs",
+    "node",
+    "p2p",
+    "peer-to-peer",
+    "quic",
+    "rust"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ]
+}

--- a/bindings/ts/node/npm/linux-arm64-musl/README.md
+++ b/bindings/ts/node/npm/linux-arm64-musl/README.md
@@ -1,0 +1,3 @@
+# `@minip2p/node-linux-arm64-musl`
+
+This is the **aarch64-unknown-linux-musl** binary for `@minip2p/node`

--- a/bindings/ts/node/npm/linux-arm64-musl/package.json
+++ b/bindings/ts/node/npm/linux-arm64-musl/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@minip2p/node-linux-arm64-musl",
   "version": "0.4.6",
-  "cpu": [
-    "arm64"
-  ],
-  "main": "minip2p.linux-arm64-musl.node",
-  "files": [
-    "minip2p.linux-arm64-musl.node"
-  ],
   "description": "Node.js bindings for minip2p",
   "keywords": [
     "libp2p",
@@ -19,17 +12,24 @@
     "rust"
   ],
   "license": "MIT",
-  "engines": {
-    "node": ">=24"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
+  "files": [
+    "minip2p.linux-arm64-musl.node"
+  ],
   "os": [
     "linux"
   ],
+  "cpu": [
+    "arm64"
+  ],
   "libc": [
     "musl"
-  ]
+  ],
+  "main": "minip2p.linux-arm64-musl.node",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "engines": {
+    "node": ">=24"
+  }
 }

--- a/bindings/ts/node/npm/linux-arm64-musl/package.json
+++ b/bindings/ts/node/npm/linux-arm64-musl/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@minip2p/node-linux-arm64-musl",
+  "version": "0.4.6",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "minip2p.linux-arm64-musl.node",
+  "files": [
+    "minip2p.linux-arm64-musl.node"
+  ],
+  "description": "Node.js bindings for minip2p",
+  "keywords": [
+    "libp2p",
+    "napi-rs",
+    "node",
+    "p2p",
+    "peer-to-peer",
+    "quic",
+    "rust"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "musl"
+  ]
+}

--- a/bindings/ts/node/npm/linux-x64-gnu/README.md
+++ b/bindings/ts/node/npm/linux-x64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@minip2p/node-linux-x64-gnu`
+
+This is the **x86_64-unknown-linux-gnu** binary for `@minip2p/node`

--- a/bindings/ts/node/npm/linux-x64-gnu/package.json
+++ b/bindings/ts/node/npm/linux-x64-gnu/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@minip2p/node-linux-x64-gnu",
+  "version": "0.4.6",
+  "cpu": [
+    "x64"
+  ],
+  "main": "minip2p.linux-x64-gnu.node",
+  "files": [
+    "minip2p.linux-x64-gnu.node"
+  ],
+  "description": "Node.js bindings for minip2p",
+  "keywords": [
+    "libp2p",
+    "napi-rs",
+    "node",
+    "p2p",
+    "peer-to-peer",
+    "quic",
+    "rust"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ]
+}

--- a/bindings/ts/node/npm/linux-x64-gnu/package.json
+++ b/bindings/ts/node/npm/linux-x64-gnu/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@minip2p/node-linux-x64-gnu",
   "version": "0.4.6",
-  "cpu": [
-    "x64"
-  ],
-  "main": "minip2p.linux-x64-gnu.node",
-  "files": [
-    "minip2p.linux-x64-gnu.node"
-  ],
   "description": "Node.js bindings for minip2p",
   "keywords": [
     "libp2p",
@@ -19,17 +12,24 @@
     "rust"
   ],
   "license": "MIT",
-  "engines": {
-    "node": ">=24"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
+  "files": [
+    "minip2p.linux-x64-gnu.node"
+  ],
   "os": [
     "linux"
   ],
+  "cpu": [
+    "x64"
+  ],
   "libc": [
     "glibc"
-  ]
+  ],
+  "main": "minip2p.linux-x64-gnu.node",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "engines": {
+    "node": ">=24"
+  }
 }

--- a/bindings/ts/node/npm/linux-x64-musl/README.md
+++ b/bindings/ts/node/npm/linux-x64-musl/README.md
@@ -1,0 +1,3 @@
+# `@minip2p/node-linux-x64-musl`
+
+This is the **x86_64-unknown-linux-musl** binary for `@minip2p/node`

--- a/bindings/ts/node/npm/linux-x64-musl/package.json
+++ b/bindings/ts/node/npm/linux-x64-musl/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@minip2p/node-linux-x64-musl",
+  "version": "0.4.6",
+  "cpu": [
+    "x64"
+  ],
+  "main": "minip2p.linux-x64-musl.node",
+  "files": [
+    "minip2p.linux-x64-musl.node"
+  ],
+  "description": "Node.js bindings for minip2p",
+  "keywords": [
+    "libp2p",
+    "napi-rs",
+    "node",
+    "p2p",
+    "peer-to-peer",
+    "quic",
+    "rust"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "musl"
+  ]
+}

--- a/bindings/ts/node/npm/linux-x64-musl/package.json
+++ b/bindings/ts/node/npm/linux-x64-musl/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@minip2p/node-linux-x64-musl",
   "version": "0.4.6",
-  "cpu": [
-    "x64"
-  ],
-  "main": "minip2p.linux-x64-musl.node",
-  "files": [
-    "minip2p.linux-x64-musl.node"
-  ],
   "description": "Node.js bindings for minip2p",
   "keywords": [
     "libp2p",
@@ -19,17 +12,24 @@
     "rust"
   ],
   "license": "MIT",
-  "engines": {
-    "node": ">=24"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
+  "files": [
+    "minip2p.linux-x64-musl.node"
+  ],
   "os": [
     "linux"
   ],
+  "cpu": [
+    "x64"
+  ],
   "libc": [
     "musl"
-  ]
+  ],
+  "main": "minip2p.linux-x64-musl.node",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "engines": {
+    "node": ">=24"
+  }
 }

--- a/bindings/ts/node/npm/win32-x64-msvc/README.md
+++ b/bindings/ts/node/npm/win32-x64-msvc/README.md
@@ -1,0 +1,3 @@
+# `@minip2p/node-win32-x64-msvc`
+
+This is the **x86_64-pc-windows-msvc** binary for `@minip2p/node`

--- a/bindings/ts/node/npm/win32-x64-msvc/package.json
+++ b/bindings/ts/node/npm/win32-x64-msvc/package.json
@@ -1,13 +1,6 @@
 {
   "name": "@minip2p/node-win32-x64-msvc",
   "version": "0.4.6",
-  "cpu": [
-    "x64"
-  ],
-  "main": "minip2p.win32-x64-msvc.node",
-  "files": [
-    "minip2p.win32-x64-msvc.node"
-  ],
   "description": "Node.js bindings for minip2p",
   "keywords": [
     "libp2p",
@@ -19,14 +12,21 @@
     "rust"
   ],
   "license": "MIT",
-  "engines": {
-    "node": ">=24"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
+  "files": [
+    "minip2p.win32-x64-msvc.node"
+  ],
   "os": [
     "win32"
-  ]
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "minip2p.win32-x64-msvc.node",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "engines": {
+    "node": ">=24"
+  }
 }

--- a/bindings/ts/node/npm/win32-x64-msvc/package.json
+++ b/bindings/ts/node/npm/win32-x64-msvc/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@minip2p/node-win32-x64-msvc",
+  "version": "0.4.6",
+  "cpu": [
+    "x64"
+  ],
+  "main": "minip2p.win32-x64-msvc.node",
+  "files": [
+    "minip2p.win32-x64-msvc.node"
+  ],
+  "description": "Node.js bindings for minip2p",
+  "keywords": [
+    "libp2p",
+    "napi-rs",
+    "node",
+    "p2p",
+    "peer-to-peer",
+    "quic",
+    "rust"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "os": [
+    "win32"
+  ]
+}

--- a/bindings/ts/node/package.json
+++ b/bindings/ts/node/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@minip2p/node",
-  "version": "0.1.0",
-  "private": true,
+  "version": "0.4.6",
   "description": "Node.js bindings for minip2p",
   "keywords": [
     "libp2p",
@@ -13,6 +12,10 @@
     "rust"
   ],
   "license": "MIT",
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -23,10 +26,15 @@
     },
     "./package.json": "./package.json"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "build": "del-cli dist && tsc -p tsconfig.build.json",
     "clean": "del-cli dist",
     "native:build": "napi build --platform --no-js --dts ../../../target/minip2p-nodejs.d.ts --release --manifest-path ../../../crates/nodejs/Cargo.toml --output-dir . -- --locked",
+    "native:build:target": "napi build --platform --no-js --dts ../../../target/minip2p-nodejs.d.ts --release --manifest-path ../../../crates/nodejs/Cargo.toml --output-dir .",
     "pretest": "cargo build --locked -p minip2p-relay-server-example",
     "test": "vitest run --config ../vitest.config.ts --root . --no-file-parallelism",
     "test:watch": "vitest --config ../vitest.config.ts --root .",
@@ -41,6 +49,15 @@
     "@types/node": "catalog:",
     "del-cli": "catalog:",
     "typescript": "catalog:"
+  },
+  "optionalDependencies": {
+    "@minip2p/node-darwin-arm64": "0.4.6",
+    "@minip2p/node-darwin-x64": "0.4.6",
+    "@minip2p/node-linux-arm64-gnu": "0.4.6",
+    "@minip2p/node-linux-arm64-musl": "0.4.6",
+    "@minip2p/node-linux-x64-gnu": "0.4.6",
+    "@minip2p/node-linux-x64-musl": "0.4.6",
+    "@minip2p/node-win32-x64-msvc": "0.4.6"
   },
   "napi": {
     "binaryName": "minip2p",

--- a/bindings/ts/node/src/native.ts
+++ b/bindings/ts/node/src/native.ts
@@ -126,21 +126,21 @@ function loadNativeBinding(target: string): NativeBinding {
     throw unsupportedTarget(target);
   }
 
+  let binding: unknown;
   try {
-    let binding: unknown;
-    try {
-      binding = require(`../minip2p.${target}.node`);
-    } catch (error) {
-      if (!isModuleNotFound(error)) {
-        throw error;
-      }
-      binding = require(`@minip2p/node-${target}`);
-    }
-    assertNativeBinding(binding);
-    return binding;
+    binding = require(`../minip2p.${target}.node`);
   } catch (error) {
-    throw unsupportedTarget(target, error);
+    if (!isModuleNotFound(error)) {
+      throw error;
+    }
+    try {
+      binding = require(`@minip2p/node-${target}`);
+    } catch (packageError) {
+      throw unsupportedTarget(target, packageError);
+    }
   }
+  assertNativeBinding(binding);
+  return binding;
 }
 
 function isModuleNotFound(error: unknown): boolean {

--- a/bindings/ts/node/src/native.ts
+++ b/bindings/ts/node/src/native.ts
@@ -11,7 +11,7 @@ const supportedTargets = [
   "linux-arm64-musl",
   "darwin-x64",
   "darwin-arm64",
-  "win32-x64",
+  "win32-x64-msvc",
 ] as const;
 
 type SupportedTarget = (typeof supportedTargets)[number];
@@ -30,6 +30,9 @@ function linuxLibc(): "gnu" | "musl" {
 function currentTarget(): string {
   if (process.platform === "linux") {
     return `${process.platform}-${process.arch}-${linuxLibc()}`;
+  }
+  if (process.platform === "win32") {
+    return `${process.platform}-${process.arch}-msvc`;
   }
   return `${process.platform}-${process.arch}`;
 }
@@ -124,7 +127,12 @@ function loadNativeBinding(target: string): NativeBinding {
   }
 
   try {
-    const binding: unknown = require(`../minip2p.${target}.node`);
+    let binding: unknown;
+    try {
+      binding = require(`../minip2p.${target}.node`);
+    } catch {
+      binding = require(`@minip2p/node-${target}`);
+    }
     assertNativeBinding(binding);
     return binding;
   } catch (error) {

--- a/bindings/ts/node/src/native.ts
+++ b/bindings/ts/node/src/native.ts
@@ -130,7 +130,10 @@ function loadNativeBinding(target: string): NativeBinding {
     let binding: unknown;
     try {
       binding = require(`../minip2p.${target}.node`);
-    } catch {
+    } catch (error) {
+      if (!isModuleNotFound(error)) {
+        throw error;
+      }
       binding = require(`@minip2p/node-${target}`);
     }
     assertNativeBinding(binding);
@@ -138,6 +141,14 @@ function loadNativeBinding(target: string): NativeBinding {
   } catch (error) {
     throw unsupportedTarget(target, error);
   }
+}
+
+function isModuleNotFound(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    Reflect.get(error, "code") === "MODULE_NOT_FOUND"
+  );
 }
 
 function assertNativeBinding(value: unknown): asserts value is NativeBinding {

--- a/bindings/ts/node/tests/distribution.test.ts
+++ b/bindings/ts/node/tests/distribution.test.ts
@@ -31,7 +31,7 @@ describe("@minip2p/node distribution", () => {
     });
   });
 
-  test("platform packages contain only their target binary", () => {
+  test("platform manifests declare only their target binary", () => {
     const targets = Object.keys(
       nodeManifest.optionalDependencies as Record<string, string>
     ).map((name) => name.slice("@minip2p/node-".length));

--- a/bindings/ts/node/tests/distribution.test.ts
+++ b/bindings/ts/node/tests/distribution.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, test } from "vitest";
+
+const nodeManifest = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../package.json", import.meta.url)),
+    "utf-8"
+  )
+) as Record<string, unknown>;
+const coreManifest = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../../core/package.json", import.meta.url)),
+    "utf-8"
+  )
+) as Record<string, unknown>;
+
+describe("@minip2p/node distribution", () => {
+  test("publishes seven lockstep platform packages", () => {
+    expect(nodeManifest.private).not.toBe(true);
+    expect(nodeManifest.version).toBe(coreManifest.version);
+    expect(nodeManifest.optionalDependencies).toEqual({
+      "@minip2p/node-darwin-arm64": coreManifest.version,
+      "@minip2p/node-darwin-x64": coreManifest.version,
+      "@minip2p/node-linux-arm64-gnu": coreManifest.version,
+      "@minip2p/node-linux-arm64-musl": coreManifest.version,
+      "@minip2p/node-linux-x64-gnu": coreManifest.version,
+      "@minip2p/node-linux-x64-musl": coreManifest.version,
+      "@minip2p/node-win32-x64-msvc": coreManifest.version,
+    });
+  });
+
+  test("platform packages contain only their target binary", () => {
+    const targets = Object.keys(
+      nodeManifest.optionalDependencies as Record<string, string>
+    ).map((name) => name.slice("@minip2p/node-".length));
+
+    for (const target of targets) {
+      const manifest = JSON.parse(
+        readFileSync(
+          fileURLToPath(
+            new URL(`../npm/${target}/package.json`, import.meta.url)
+          ),
+          "utf-8"
+        )
+      ) as Record<string, unknown>;
+      expect(manifest.name).toBe(`@minip2p/node-${target}`);
+      expect(manifest.version).toBe(nodeManifest.version);
+      expect(manifest.files).toEqual([`minip2p.${target}.node`]);
+      expect(manifest.main).toBe(`minip2p.${target}.node`);
+    }
+  });
+});

--- a/bindings/ts/node/tests/distribution.test.ts
+++ b/bindings/ts/node/tests/distribution.test.ts
@@ -3,6 +3,11 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, test } from "vitest";
 
+import {
+  assertNodePlatformManifest,
+  nodePlatforms,
+} from "../../scripts/node-platform-manifest.mjs";
+
 const nodeManifest = JSON.parse(
   readFileSync(
     fileURLToPath(new URL("../package.json", import.meta.url)),
@@ -49,6 +54,11 @@ describe("@minip2p/node distribution", () => {
       expect(manifest.version).toBe(nodeManifest.version);
       expect(manifest.files).toEqual([`minip2p.${target}.node`]);
       expect(manifest.main).toBe(`minip2p.${target}.node`);
+      const platform = nodePlatforms.find(
+        ({ target: expectedTarget }) => expectedTarget === target
+      );
+      expect(platform).toBeDefined();
+      assertNodePlatformManifest(manifest, platform);
     }
   });
 });

--- a/bindings/ts/node/tests/platform-manifest.test.mjs
+++ b/bindings/ts/node/tests/platform-manifest.test.mjs
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  assertNodePlatformManifest,
+  nodePlatforms,
+} from "../../scripts/node-platform-manifest.mjs";
+
+describe("@minip2p/node platform selectors", () => {
+  test("rejects the wrong Linux libc", () => {
+    const platform = nodePlatforms.find(
+      ({ target }) => target === "linux-x64-musl"
+    );
+
+    expect(() =>
+      assertNodePlatformManifest(
+        { os: ["linux"], cpu: ["x64"], libc: ["glibc"] },
+        platform
+      )
+    ).toThrow("invalid libc metadata");
+  });
+
+  test("rejects libc metadata on platforms where npm does not use it", () => {
+    const platform = nodePlatforms.find(
+      ({ target }) => target === "darwin-arm64"
+    );
+
+    expect(() =>
+      assertNodePlatformManifest(
+        { os: ["darwin"], cpu: ["arm64"], libc: ["musl"] },
+        platform
+      )
+    ).toThrow("invalid libc metadata");
+  });
+});

--- a/bindings/ts/node/tests/platform-manifest.test.mjs
+++ b/bindings/ts/node/tests/platform-manifest.test.mjs
@@ -13,7 +13,7 @@ describe("@minip2p/node platform selectors", () => {
 
     expect(() =>
       assertNodePlatformManifest(
-        { os: ["linux"], cpu: ["x64"], libc: ["glibc"] },
+        { cpu: ["x64"], libc: ["glibc"], os: ["linux"] },
         platform
       )
     ).toThrow("invalid libc metadata");
@@ -26,7 +26,7 @@ describe("@minip2p/node platform selectors", () => {
 
     expect(() =>
       assertNodePlatformManifest(
-        { os: ["darwin"], cpu: ["arm64"], libc: ["musl"] },
+        { cpu: ["arm64"], libc: ["musl"], os: ["darwin"] },
         platform
       )
     ).toThrow("invalid libc metadata");

--- a/bindings/ts/node/tests/unsupported-platform.test.ts
+++ b/bindings/ts/node/tests/unsupported-platform.test.ts
@@ -9,6 +9,7 @@ afterEach(() => {
     value: originalGetReport,
   });
   vi.resetModules();
+  vi.doUnmock("node:module");
 });
 
 describe("@minip2p/node native loader", () => {
@@ -30,6 +31,23 @@ describe("@minip2p/node native loader", () => {
 
     await expect(import("../src/native.js")).resolves.toHaveProperty(
       "nativeBinding"
+    );
+  });
+
+  test("preserves the loader error for a present but broken local addon", async () => {
+    vi.doMock("node:module", () => ({
+      createRequire: () => (specifier: string) => {
+        if (specifier.startsWith("../minip2p.")) {
+          throw Object.assign(new Error("local addon is corrupt"), {
+            code: "ERR_DLOPEN_FAILED",
+          });
+        }
+        throw new Error(`unexpected package fallback: ${specifier}`);
+      },
+    }));
+
+    await expect(import("../src/native.js")).rejects.toThrow(
+      "local addon is corrupt"
     );
   });
 });

--- a/bindings/ts/pnpm-lock.yaml
+++ b/bindings/ts/pnpm-lock.yaml
@@ -85,6 +85,20 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  node/npm/darwin-arm64: {}
+
+  node/npm/darwin-x64: {}
+
+  node/npm/linux-arm64-gnu: {}
+
+  node/npm/linux-arm64-musl: {}
+
+  node/npm/linux-x64-gnu: {}
+
+  node/npm/linux-x64-musl: {}
+
+  node/npm/win32-x64-msvc: {}
+
   react-native:
     dependencies:
       '@minip2p/core':

--- a/bindings/ts/pnpm-lock.yaml
+++ b/bindings/ts/pnpm-lock.yaml
@@ -68,6 +68,28 @@ importers:
       '@minip2p/core':
         specifier: workspace:*
         version: link:../core
+    optionalDependencies:
+      '@minip2p/node-darwin-arm64':
+        specifier: 0.4.6
+        version: link:npm/darwin-arm64
+      '@minip2p/node-darwin-x64':
+        specifier: 0.4.6
+        version: link:npm/darwin-x64
+      '@minip2p/node-linux-arm64-gnu':
+        specifier: 0.4.6
+        version: link:npm/linux-arm64-gnu
+      '@minip2p/node-linux-arm64-musl':
+        specifier: 0.4.6
+        version: link:npm/linux-arm64-musl
+      '@minip2p/node-linux-x64-gnu':
+        specifier: 0.4.6
+        version: link:npm/linux-x64-gnu
+      '@minip2p/node-linux-x64-musl':
+        specifier: 0.4.6
+        version: link:npm/linux-x64-musl
+      '@minip2p/node-win32-x64-msvc':
+        specifier: 0.4.6
+        version: link:npm/win32-x64-msvc
     devDependencies:
       '@minip2p/test-fixtures':
         specifier: workspace:*

--- a/bindings/ts/pnpm-workspace.yaml
+++ b/bindings/ts/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - core
   - node
+  - node/npm/*
   - react-native
   - react-native/example
   - test-fixtures

--- a/bindings/ts/scripts/node-platform-manifest.mjs
+++ b/bindings/ts/scripts/node-platform-manifest.mjs
@@ -1,34 +1,34 @@
 export const nodePlatforms = [
-  { target: "darwin-arm64", os: ["darwin"], cpu: ["arm64"] },
-  { target: "darwin-x64", os: ["darwin"], cpu: ["x64"] },
+  { cpu: ["arm64"], os: ["darwin"], target: "darwin-arm64" },
+  { cpu: ["x64"], os: ["darwin"], target: "darwin-x64" },
   {
+    cpu: ["arm64"],
+    libc: ["glibc"],
+    os: ["linux"],
     target: "linux-arm64-gnu",
-    os: ["linux"],
-    cpu: ["arm64"],
-    libc: ["glibc"],
   },
   {
+    cpu: ["arm64"],
+    libc: ["musl"],
+    os: ["linux"],
     target: "linux-arm64-musl",
-    os: ["linux"],
-    cpu: ["arm64"],
-    libc: ["musl"],
   },
   {
-    target: "linux-x64-gnu",
-    os: ["linux"],
     cpu: ["x64"],
     libc: ["glibc"],
+    os: ["linux"],
+    target: "linux-x64-gnu",
   },
   {
-    target: "linux-x64-musl",
-    os: ["linux"],
     cpu: ["x64"],
     libc: ["musl"],
+    os: ["linux"],
+    target: "linux-x64-musl",
   },
-  { target: "win32-x64-msvc", os: ["win32"], cpu: ["x64"] },
+  { cpu: ["x64"], os: ["win32"], target: "win32-x64-msvc" },
 ];
 
-export function assertNodePlatformManifest(manifest, platform) {
+export const assertNodePlatformManifest = (manifest, platform) => {
   for (const field of ["os", "cpu", "libc"]) {
     if (JSON.stringify(manifest[field]) !== JSON.stringify(platform[field])) {
       throw new Error(
@@ -36,4 +36,4 @@ export function assertNodePlatformManifest(manifest, platform) {
       );
     }
   }
-}
+};

--- a/bindings/ts/scripts/node-platform-manifest.mjs
+++ b/bindings/ts/scripts/node-platform-manifest.mjs
@@ -1,0 +1,39 @@
+export const nodePlatforms = [
+  { target: "darwin-arm64", os: ["darwin"], cpu: ["arm64"] },
+  { target: "darwin-x64", os: ["darwin"], cpu: ["x64"] },
+  {
+    target: "linux-arm64-gnu",
+    os: ["linux"],
+    cpu: ["arm64"],
+    libc: ["glibc"],
+  },
+  {
+    target: "linux-arm64-musl",
+    os: ["linux"],
+    cpu: ["arm64"],
+    libc: ["musl"],
+  },
+  {
+    target: "linux-x64-gnu",
+    os: ["linux"],
+    cpu: ["x64"],
+    libc: ["glibc"],
+  },
+  {
+    target: "linux-x64-musl",
+    os: ["linux"],
+    cpu: ["x64"],
+    libc: ["musl"],
+  },
+  { target: "win32-x64-msvc", os: ["win32"], cpu: ["x64"] },
+];
+
+export function assertNodePlatformManifest(manifest, platform) {
+  for (const field of ["os", "cpu", "libc"]) {
+    if (JSON.stringify(manifest[field]) !== JSON.stringify(platform[field])) {
+      throw new Error(
+        `@minip2p/node-${platform.target} has invalid ${field} metadata`
+      );
+    }
+  }
+}

--- a/bindings/ts/scripts/smoke-release-install.mjs
+++ b/bindings/ts/scripts/smoke-release-install.mjs
@@ -16,8 +16,10 @@ if (consumerRoot === undefined) {
 const modules = path.resolve(consumerRoot, "node_modules");
 const coreRoot = path.join(modules, "@minip2p/core");
 const reactNativeRoot = path.join(modules, "@minip2p/react-native");
+const nodeRoot = path.join(modules, "@minip2p/node");
 const coreManifest = readManifest(coreRoot);
 const reactNativeManifest = readManifest(reactNativeRoot);
+const nodeManifest = readManifest(nodeRoot);
 
 if (
   reactNativeManifest.dependencies?.["@minip2p/core"] !== coreManifest.version
@@ -46,13 +48,26 @@ requireNamedExport(
   path.join(reactNativeRoot, packageExport(reactNativeManifest, "default")),
   "Minip2p"
 );
+
+if (nodeManifest.dependencies?.["@minip2p/core"] !== coreManifest.version) {
+  throw new Error(
+    `installed @minip2p/node requires core ${nodeManifest.dependencies?.["@minip2p/core"] ?? "missing"}, but ${coreManifest.version} is installed`
+  );
+}
+const nodeBinding = await import(
+  pathToFileURL(path.join(nodeRoot, packageExport(nodeManifest, "default")))
+    .href
+);
+if (typeof nodeBinding.Minip2p !== "function") {
+  throw new TypeError("installed @minip2p/node is missing Minip2p");
+}
 requireNamedExport(
   path.join(reactNativeRoot, packageExport(reactNativeManifest, "types")),
   "Minip2p"
 );
 
 console.log(
-  `smoke-tested installed @minip2p/core and @minip2p/react-native ${coreManifest.version}`
+  `smoke-tested installed @minip2p/core, @minip2p/react-native, and @minip2p/node ${coreManifest.version}`
 );
 
 function readManifest(root) {

--- a/bindings/ts/scripts/verify-release-packages.mjs
+++ b/bindings/ts/scripts/verify-release-packages.mjs
@@ -15,6 +15,10 @@ import path from "node:path";
 import process from "node:process";
 
 import { namedExports } from "./module-exports.mjs";
+import {
+  assertNodePlatformManifest,
+  nodePlatforms,
+} from "./node-platform-manifest.mjs";
 
 const [
   expectedVersion,
@@ -170,7 +174,7 @@ function verifyNodePackages(node, platformRoot) {
   const packageNames = Object.keys(optionalDependencies).filter((name) =>
     name.startsWith("@minip2p/node-")
   );
-  if (packageNames.length !== 7) {
+  if (packageNames.length !== nodePlatforms.length) {
     throw new Error(
       `@minip2p/node must declare seven platform packages, found ${packageNames.length}`
     );
@@ -181,11 +185,12 @@ function verifyNodePackages(node, platformRoot) {
     );
   }
 
-  for (const packageName of packageNames) {
+  for (const platform of nodePlatforms) {
+    const packageName = `@minip2p/node-${platform.target}`;
     if (optionalDependencies[packageName] !== expectedVersion) {
       throw new Error(`${packageName} is not locked to ${expectedVersion}`);
     }
-    const target = packageName.slice("@minip2p/node-".length);
+    const target = platform.target;
     const manifest = JSON.parse(
       readFileSync(path.join(platformRoot, target, "package.json"), "utf-8")
     );
@@ -198,6 +203,7 @@ function verifyNodePackages(node, platformRoot) {
     ) {
       throw new Error(`${packageName} has invalid release metadata`);
     }
+    assertNodePlatformManifest(manifest, platform);
     requireFiles(path.join(platformRoot, target), [binary]);
   }
 }

--- a/bindings/ts/scripts/verify-release-packages.mjs
+++ b/bindings/ts/scripts/verify-release-packages.mjs
@@ -186,11 +186,11 @@ function verifyNodePackages(node, platformRoot) {
   }
 
   for (const platform of nodePlatforms) {
-    const packageName = `@minip2p/node-${platform.target}`;
+    const { target } = platform;
+    const packageName = `@minip2p/node-${target}`;
     if (optionalDependencies[packageName] !== expectedVersion) {
       throw new Error(`${packageName} is not locked to ${expectedVersion}`);
     }
-    const target = platform.target;
     const manifest = JSON.parse(
       readFileSync(path.join(platformRoot, target, "package.json"), "utf-8")
     );

--- a/bindings/ts/scripts/verify-release-packages.mjs
+++ b/bindings/ts/scripts/verify-release-packages.mjs
@@ -59,6 +59,11 @@ try {
       `@minip2p/react-native must depend on @minip2p/core ${expectedVersion}, found ${reactNative.manifest.dependencies?.["@minip2p/core"] ?? "no dependency"}`
     );
   }
+  if (node.manifest.dependencies?.["@minip2p/core"] !== expectedVersion) {
+    throw new Error(
+      `@minip2p/node must depend on @minip2p/core ${expectedVersion}, found ${node.manifest.dependencies?.["@minip2p/core"] ?? "no dependency"}`
+    );
+  }
 
   requireFiles(core.root, [
     "LICENSE",
@@ -193,6 +198,7 @@ function verifyNodePackages(node, platformRoot) {
     ) {
       throw new Error(`${packageName} has invalid release metadata`);
     }
+    requireFiles(path.join(platformRoot, target), [binary]);
   }
 }
 

--- a/bindings/ts/scripts/verify-release-packages.mjs
+++ b/bindings/ts/scripts/verify-release-packages.mjs
@@ -16,17 +16,25 @@ import process from "node:process";
 
 import { namedExports } from "./module-exports.mjs";
 
-const [expectedVersion, coreTarball, reactNativeTarball, nativeSourceRoot] =
-  process.argv.slice(2);
+const [
+  expectedVersion,
+  coreTarball,
+  reactNativeTarball,
+  nativeSourceRoot,
+  nodeTarball,
+  nodePlatformRoot,
+] = process.argv.slice(2);
 
 if (
   expectedVersion === undefined ||
   coreTarball === undefined ||
   reactNativeTarball === undefined ||
-  nativeSourceRoot === undefined
+  nativeSourceRoot === undefined ||
+  nodeTarball === undefined ||
+  nodePlatformRoot === undefined
 ) {
   throw new Error(
-    "usage: verify-release-packages.mjs <version> <core.tgz> <react-native.tgz> <native-source-root>"
+    "usage: verify-release-packages.mjs <version> <core.tgz> <react-native.tgz> <native-source-root> <node.tgz> <node-platform-root>"
   );
 }
 
@@ -38,9 +46,11 @@ const temporaryRoot = mkdtempSync(
 try {
   const core = extractPackage(coreTarball, "core");
   const reactNative = extractPackage(reactNativeTarball, "react-native");
+  const node = extractPackage(nodeTarball, "node");
 
   verifyManifest(core, "@minip2p/core");
   verifyManifest(reactNative, "@minip2p/react-native");
+  verifyManifest(node, "@minip2p/node");
 
   if (
     reactNative.manifest.dependencies?.["@minip2p/core"] !== expectedVersion
@@ -75,9 +85,19 @@ try {
     "lib/typescript/src/index.d.ts",
     "src/index.ts",
   ]);
+  requireFiles(node.root, [
+    "LICENSE",
+    "README.md",
+    "dist/index.d.ts",
+    "dist/index.js",
+    "dist/native.d.ts",
+    "dist/native.js",
+  ]);
 
   rejectPaths(core.root, core.files);
   rejectPaths(reactNative.root, reactNative.files);
+  rejectPaths(node.root, node.files);
+  verifyNodePackages(node, path.resolve(nodePlatformRoot));
   requireNamedExports(reactNative.root, "lib/module/index.js", ["Minip2p"]);
   requireNamedExports(reactNative.root, "lib/typescript/src/index.d.ts", [
     "Minip2p",
@@ -96,7 +116,9 @@ try {
   );
 
   const combinedSize =
-    directorySize(core.root) + directorySize(reactNative.root);
+    directorySize(core.root) +
+    directorySize(reactNative.root) +
+    directorySize(node.root);
   if (combinedSize > maximumUnpackedBytes) {
     throw new Error(
       `release packages unpack to ${combinedSize} bytes, exceeding the ${maximumUnpackedBytes}-byte limit`
@@ -104,7 +126,7 @@ try {
   }
 
   console.log(
-    `verified @minip2p/core and @minip2p/react-native ${expectedVersion} (${combinedSize} unpacked bytes)`
+    `verified @minip2p/core, @minip2p/react-native, and @minip2p/node ${expectedVersion} (${combinedSize} unpacked bytes)`
   );
 } finally {
   rmSync(temporaryRoot, { force: true, recursive: true });
@@ -135,6 +157,42 @@ function verifyManifest(packageInfo, expectedName) {
   }
   if (packageInfo.manifest.private === true) {
     throw new Error(`${expectedName} is marked private`);
+  }
+}
+
+function verifyNodePackages(node, platformRoot) {
+  const optionalDependencies = node.manifest.optionalDependencies ?? {};
+  const packageNames = Object.keys(optionalDependencies).filter((name) =>
+    name.startsWith("@minip2p/node-")
+  );
+  if (packageNames.length !== 7) {
+    throw new Error(
+      `@minip2p/node must declare seven platform packages, found ${packageNames.length}`
+    );
+  }
+  if (node.files.some((file) => file.endsWith(".node"))) {
+    throw new Error(
+      "@minip2p/node root package must not contain a native binary"
+    );
+  }
+
+  for (const packageName of packageNames) {
+    if (optionalDependencies[packageName] !== expectedVersion) {
+      throw new Error(`${packageName} is not locked to ${expectedVersion}`);
+    }
+    const target = packageName.slice("@minip2p/node-".length);
+    const manifest = JSON.parse(
+      readFileSync(path.join(platformRoot, target, "package.json"), "utf-8")
+    );
+    const binary = `minip2p.${target}.node`;
+    if (
+      manifest.name !== packageName ||
+      manifest.version !== expectedVersion ||
+      manifest.main !== binary ||
+      JSON.stringify(manifest.files) !== JSON.stringify([binary])
+    ) {
+      throw new Error(`${packageName} has invalid release metadata`);
+    }
   }
 }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -137,7 +137,9 @@ else
 
   perl -pi -e "s/\"version\": \"\\Q$current_version\\E\"/\"version\": \"$version\"/" \
     bindings/ts/core/package.json \
-    bindings/ts/react-native/package.json
+    bindings/ts/react-native/package.json \
+    bindings/ts/node/npm/*/package.json
+  perl -pi -e "s/\\Q$current_version\\E/$version/g" bindings/ts/node/package.json
 
   echo "release: regenerating lockfiles"
   cargo metadata --format-version 1 >/dev/null
@@ -181,6 +183,14 @@ $mismatched_dependencies"
     die "@minip2p/core version does not match"
   [[ "$(jq -r .version bindings/ts/react-native/package.json)" == "$version" ]] ||
     die "@minip2p/react-native version does not match"
+  [[ "$(jq -r .version bindings/ts/node/package.json)" == "$version" ]] ||
+    die "@minip2p/node version does not match"
+  for manifest in bindings/ts/node/npm/*/package.json; do
+    [[ "$(jq -r .version "$manifest")" == "$version" ]] ||
+      die "$(jq -r .name "$manifest") version does not match"
+  done
+  [[ "$(jq --arg version "$version" '[.optionalDependencies | to_entries[] | select((.key | startswith("@minip2p/node-")) and .value == $version)] | length' bindings/ts/node/package.json)" == 7 ]] ||
+    die "@minip2p/node platform dependencies do not match"
 
   just fmt
   git diff --check
@@ -364,6 +374,13 @@ done
 
 verify_npm_package '%40minip2p%2Fcore' '@minip2p/core'
 verify_npm_package '%40minip2p%2Freact-native' '@minip2p/react-native'
+verify_npm_package '%40minip2p%2Fnode' '@minip2p/node'
+for manifest in bindings/ts/node/npm/*/package.json; do
+  package_name="$(jq -r .name "$manifest")"
+  encoded_name="${package_name/@/%40}"
+  encoded_name="${encoded_name/\//%2F}"
+  verify_npm_package "$encoded_name" "$package_name"
+done
 
 git fetch origin main --tags
 git merge-base --is-ancestor "$head_sha" origin/main ||
@@ -377,4 +394,4 @@ echo "release: commit $head_sha"
 echo "release: GitHub $release_url"
 echo "release: relay server ${#expected_relay_assets[@]}/${#expected_relay_assets[@]} assets"
 echo "release: crates.io ${#publishable_crates[@]}/${#publishable_crates[@]} packages"
-echo "release: npm @minip2p/core@$version and @minip2p/react-native@$version"
+echo "release: npm @minip2p/core, @minip2p/react-native, @minip2p/node, and 7 platform packages at $version"


### PR DESCRIPTION
Closes #102.

## What changed

- add seven lockstep, platform-filtered napi packages and load them through `optionalDependencies`
- build all seven addons in the release workflow and assemble them with the napi artifact flow
- publish platform packages through napi prepublish and npm OIDC, while keeping the root Node package in the verified tarball pipeline
- extend release version bumps, package verification, install smoke tests, and registry checks to cover Node
- add a safe manual workflow dispatch that builds and verifies artifacts without publishing

## Verification

- `pnpm --dir bindings/ts --filter @minip2p/node test`
- `pnpm --dir bindings/ts --filter @minip2p/node typecheck`
- `pnpm --dir bindings/ts lint`
- `bash -n scripts/release.sh`
- parsed `.github/workflows/publish.yml` with the workspace YAML parser
- built, packed, installed with `--ignore-scripts`, and imported `@minip2p/node` plus its linux-x64-gnu package

## Human release setup

Before the first release, register this repository and `publish.yml` as the npm trusted publisher for `@minip2p/node` and all seven `@minip2p/node-*` packages. This is the one-time npm web UI step called out by the issue and is intentionally not automated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes `@minip2p/node` with prebuilt binaries, closing #102. The package becomes public and installs no longer require a Rust toolchain.

**Release pipeline**
- Adds seven lockstep, platform-filtered napi packages loaded through `optionalDependencies`.
- Builds all addons in the release workflow; musl targets build in a pinned docker image with a standalone pnpm, a pinned Node 24 runtime, a pinned Rust 1.91 toolchain, and the native musl C toolchain (gcc/g++ with libclang).
- Platform packages publish via npm OIDC from the verified artifacts, while the root package uses the verified tarball pipeline.
- Pins the Node publisher and artifact producer workflow actions to specific commits.
- Extends version bumps, package verification, install smoke tests, and registry checks to cover the Node packages.
- Validates platform distribution metadata, including OS/CPU/libc selectors and lockstep versions.
- Renames the Windows target from `win32-x64` to `win32-x64-msvc`.
- Adds a manual workflow dispatch that builds and verifies artifacts without publishing.
- Falls back to the platform package only when a local addon is absent, preserving the original load error for a present-but-broken addon.

**Before first release**
- Register this repository as the npm trusted publisher for `@minip2p/node` and all seven `@minip2p/node-*` packages; this one-time npm web UI step is intentionally not automated.

<sup>Written for commit 1cfd7ff35778239675e384ecc933abcd7edabf96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

