### PR TITLE
ci: test weekly Node target matrix

### DIFF
--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -2,6 +2,11 @@ name: Native binding builds
 
 on:
   workflow_dispatch:
+    inputs:
+      include_mobile:
+        description: Also build the React Native Android and iOS artifacts
+        type: boolean
+        default: false
   schedule:
     - cron: "17 4 * * 1"
 
@@ -127,6 +132,7 @@ jobs:
             '
 
   android:
+    if: github.event_name == 'schedule' || inputs.include_mobile
     runs-on: ubuntu-latest
     timeout-minutes: 60
     defaults:
@@ -163,11 +169,6 @@ jobs:
       - name: Validate Android ELF alignment and allocator hooks
         run: node react-native/scripts/check-android-elf.mjs
       - run: pnpm example prebuild
-      - name: Match Gradle wrapper to the generated Android plugin
-        run: |
-          sed -i \
-            's/gradle-9\.3\.1-bin\.zip/gradle-9.4.1-bin.zip/' \
-            react-native/example/android/gradle/wrapper/gradle-wrapper.properties
       - name: Build both Android ABIs
         working-directory: bindings/ts/react-native/example/android
         run: ./gradlew :app:assembleDebug -PreactNativeArchitectures=arm64-v8a,x86_64
@@ -185,6 +186,7 @@ jobs:
           if-no-files-found: error
 
   ios:
+    if: github.event_name == 'schedule' || inputs.include_mobile
     runs-on: macos-26
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -40,18 +40,18 @@ jobs:
       run:
         working-directory: bindings/ts
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24.19.0"
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: "11.24.0"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: "1.91"
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: pnpm install --frozen-lockfile
       - name: Build addon
         shell: bash
@@ -88,7 +88,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Build addon
         env:
           NAPI_BUILD_IMAGE: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:caac2d1b9194eada0c69e669e72763869701351d8957ab805cc45a43999d8be2

--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -99,7 +99,6 @@ jobs:
                 *) echo "Unsupported musl target: $TARGET" >&2; exit 1 ;;
               esac
               install ../../target/release/libminip2p_nodejs.so "node/$output"
-              unset RUSTFLAGS
               pnpm install --frozen-lockfile
               pnpm test
             '

--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -163,6 +163,11 @@ jobs:
       - name: Validate Android ELF alignment and allocator hooks
         run: node react-native/scripts/check-android-elf.mjs
       - run: pnpm example prebuild
+      - name: Match Gradle wrapper to the generated Android plugin
+        run: |
+          sed -i \
+            's/gradle-9\.3\.1-bin\.zip/gradle-9.4.1-bin.zip/' \
+            react-native/example/android/gradle/wrapper/gradle-wrapper.properties
       - name: Build both Android ABIs
         working-directory: bindings/ts/react-native/example/android
         run: ./gradlew :app:assembleDebug -PreactNativeArchitectures=arm64-v8a,x86_64

--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -67,24 +67,6 @@ jobs:
             target: aarch64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: "1.91"
-          targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
-      - name: Build musl relay fixture
-        working-directory: bindings/ts
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
-          TARGET: ${{ matrix.target }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes musl-tools
-          cargo build --locked --target "$TARGET" -p minip2p-relay-server-example
-          install -D \
-            "../../target/$TARGET/debug/minip2p-relay" \
-            ../../target/debug/minip2p-relay
       - name: Build addon
         env:
           NAPI_BUILD_IMAGE: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:caac2d1b9194eada0c69e669e72763869701351d8957ab805cc45a43999d8be2
@@ -117,6 +99,10 @@ jobs:
                 *) echo "Unsupported musl target: $TARGET" >&2; exit 1 ;;
               esac
               install ../../target/release/libminip2p_nodejs.so "node/$output"
+              cargo build --release --locked -p minip2p-relay-server-example
+              install -D \
+                ../../target/release/minip2p-relay \
+                ../../target/debug/minip2p-relay
               pnpm install --frozen-lockfile
               pnpm --filter @minip2p/node exec vitest run \
                 --config ../vitest.config.ts \

--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -1,4 +1,4 @@
-name: React Native native builds
+name: Native binding builds
 
 on:
   workflow_dispatch:
@@ -13,6 +13,94 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  node-native:
+    name: Build and test Node addon (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - runner: macos-26-intel
+            target: x86_64-apple-darwin
+          - runner: macos-26
+            target: aarch64-apple-darwin
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+    defaults:
+      run:
+        working-directory: bindings/ts
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24.19.0"
+      - uses: pnpm/action-setup@v6
+        with:
+          version: "11.24.0"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.91"
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - run: pnpm install --frozen-lockfile
+      - name: Build addon
+        shell: bash
+        run: pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
+      - run: pnpm test
+
+  node-musl:
+    name: Build and test Node addon (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build addon
+        env:
+          NAPI_BUILD_IMAGE: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:caac2d1b9194eada0c69e669e72763869701351d8957ab805cc45a43999d8be2
+          TARGET: ${{ matrix.target }}
+        run: |
+          docker run --rm \
+            --env TARGET \
+            --volume "$GITHUB_WORKSPACE:/work" \
+            --workdir /work/bindings/ts \
+            "$NAPI_BUILD_IMAGE" \
+            bash -lc '
+              set -euo pipefail
+              apk add --no-cache --upgrade \
+                --repository https://dl-cdn.alpinelinux.org/alpine/v3.23/main \
+                clang20-libclang=20.1.8-r1 \
+                nodejs npm
+              npm install --global pnpm@11.24.0
+              rustup toolchain install 1.91 --profile minimal
+              rustup default 1.91
+              export CC=gcc
+              export CXX=g++
+              export LIBCLANG_PATH=/usr/lib/llvm20/lib
+              export RUSTFLAGS="-C target-feature=-crt-static"
+              cargo build --release --locked --manifest-path ../../crates/nodejs/Cargo.toml
+              case "$TARGET" in
+                x86_64-unknown-linux-musl) output=minip2p.linux-x64-musl.node ;;
+                aarch64-unknown-linux-musl) output=minip2p.linux-arm64-musl.node ;;
+                *) echo "Unsupported musl target: $TARGET" >&2; exit 1 ;;
+              esac
+              install ../../target/release/libminip2p_nodejs.so "node/$output"
+              pnpm install --frozen-lockfile
+              pnpm test
+            '
+
   android:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -83,7 +83,9 @@ jobs:
                 --repository https://dl-cdn.alpinelinux.org/alpine/v3.23/main \
                 clang20-libclang=20.1.8-r1 \
                 nodejs npm
-              npm install --global pnpm@11.24.0
+              export PATH=/usr/bin:$PATH
+              npm install --global --prefix /opt/pnpm pnpm@11.24.0
+              export PATH=/opt/pnpm/bin:/usr/bin:$PATH
               rustup toolchain install 1.91 --profile minimal
               rustup default 1.91
               export CC=gcc

--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -63,7 +63,8 @@ jobs:
           fi
           mkdir -p ../../target/debug
           cp "../../target/release/$relay" "../../target/debug/$relay"
-      - run: |
+      - shell: bash
+        run: |
           pnpm --filter @minip2p/node exec vitest run \
             --config ../vitest.config.ts \
             --root . \

--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -51,7 +51,22 @@ jobs:
       - name: Build addon
         shell: bash
         run: pnpm --filter @minip2p/node native:build:target --target ${{ matrix.target }} -- --locked
-      - run: pnpm test
+      - name: Build relay fixture
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          cargo build --release --locked -p minip2p-relay-server-example
+          relay=minip2p-relay
+          if [[ "$TARGET" == x86_64-pc-windows-msvc ]]; then
+            relay+=.exe
+          fi
+          install -D "../../target/release/$relay" "../../target/debug/$relay"
+      - run: |
+          pnpm --filter @minip2p/node exec vitest run \
+            --config ../vitest.config.ts \
+            --root . \
+            --no-file-parallelism
 
   node-musl:
     name: Build and test Node addon (${{ matrix.target }})

--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -61,7 +61,8 @@ jobs:
           if [[ "$TARGET" == x86_64-pc-windows-msvc ]]; then
             relay+=.exe
           fi
-          install -D "../../target/release/$relay" "../../target/debug/$relay"
+          mkdir -p ../../target/debug
+          cp "../../target/release/$relay" "../../target/debug/$relay"
       - run: |
           pnpm --filter @minip2p/node exec vitest run \
             --config ../vitest.config.ts \
@@ -115,9 +116,8 @@ jobs:
               esac
               install ../../target/release/libminip2p_nodejs.so "node/$output"
               cargo build --release --locked -p minip2p-relay-server-example
-              install -D \
-                ../../target/release/minip2p-relay \
-                ../../target/debug/minip2p-relay
+              mkdir -p ../../target/debug
+              cp ../../target/release/minip2p-relay ../../target/debug/minip2p-relay
               pnpm install --frozen-lockfile
               pnpm --filter @minip2p/node exec vitest run \
                 --config ../vitest.config.ts \

--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -99,6 +99,7 @@ jobs:
                 *) echo "Unsupported musl target: $TARGET" >&2; exit 1 ;;
               esac
               install ../../target/release/libminip2p_nodejs.so "node/$output"
+              unset RUSTFLAGS
               pnpm install --frozen-lockfile
               pnpm test
             '

--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -67,6 +67,24 @@ jobs:
             target: aarch64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.91"
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build musl relay fixture
+        working-directory: bindings/ts
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
+          TARGET: ${{ matrix.target }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes musl-tools
+          cargo build --locked --target "$TARGET" -p minip2p-relay-server-example
+          install -D \
+            "../../target/$TARGET/debug/minip2p-relay" \
+            ../../target/debug/minip2p-relay
       - name: Build addon
         env:
           NAPI_BUILD_IMAGE: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:caac2d1b9194eada0c69e669e72763869701351d8957ab805cc45a43999d8be2
@@ -100,7 +118,10 @@ jobs:
               esac
               install ../../target/release/libminip2p_nodejs.so "node/$output"
               pnpm install --frozen-lockfile
-              pnpm test
+              pnpm --filter @minip2p/node exec vitest run \
+                --config ../vitest.config.ts \
+                --root . \
+                --no-file-parallelism
             '
 
   android:

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: pnpm install --frozen-lockfile
+      - run: pnpm test:workflows
       - run: pnpm typecheck
       - run: pnpm --filter @minip2p/node native:build
       - run: pnpm test

--- a/bindings/ts/node/tests/fixtures/lifecycle.mjs
+++ b/bindings/ts/node/tests/fixtures/lifecycle.mjs
@@ -12,7 +12,7 @@ const libc =
 const target =
   process.platform === "linux"
     ? `${process.platform}-${process.arch}-${libc}`
-    : `${process.platform}-${process.arch}`;
+    : `${process.platform}-${process.arch}${process.platform === "win32" ? "-msvc" : ""}`;
 const binding = require(`../../minip2p.${target}.node`);
 const endpoint = new binding.NodeEndpoint(binding.generateSecretKey(), {
   allowUnsigned: false,

--- a/bindings/ts/node/tests/native-events.test.ts
+++ b/bindings/ts/node/tests/native-events.test.ts
@@ -28,7 +28,10 @@ describe("native event payloads", () => {
     ]);
 
     const stream = a.openStream(b.peerId(), protocol);
-    await waitForEvent(b, "StreamReady");
+    await Promise.all([
+      waitForEvent(a, "StreamReady"),
+      waitForEvent(b, "StreamReady"),
+    ]);
     a.sendStream(b.peerId(), stream.streamId, Uint8Array.of(0, 127, 255));
 
     const event = await waitForEvent(b, "StreamData");

--- a/bindings/ts/node/tests/unsupported-platform.test.ts
+++ b/bindings/ts/node/tests/unsupported-platform.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 
 const originalPlatform = process.platform;
 const originalGetReport = process.report.getReport;
+const FakeNodeEndpoint = vi.fn();
 
 afterEach(() => {
   Object.defineProperty(process, "platform", { value: originalPlatform });
@@ -18,12 +19,25 @@ describe("@minip2p/node native loader", () => {
 
     const loading = import("../src/native.js");
     await expect(loading).rejects.toThrow(
-      /Unsupported minip2p Node target plan9-x64.*linux-x64-gnu.*darwin-arm64.*win32-x64/su
+      new RegExp(
+        `Unsupported minip2p Node target plan9-${process.arch}.*linux-x64-gnu.*darwin-arm64.*win32-x64`,
+        "su"
+      )
     );
     await expect(loading).rejects.not.toThrow(/optional dependencies/u);
   });
 
   test("recognizes glibc from the compiler version", async () => {
+    const requested: string[] = [];
+    vi.doMock("node:module", () => ({
+      createRequire: () => (specifier: string) => {
+        requested.push(specifier);
+        return {
+          NodeEndpoint: FakeNodeEndpoint,
+          generateSecretKey: () => new Uint8Array(),
+        };
+      },
+    }));
     Object.defineProperty(process, "platform", { value: "linux" });
     Object.defineProperty(process.report, "getReport", {
       value: () => ({ header: { glibcVersionCompiler: "2.28" } }),
@@ -32,6 +46,7 @@ describe("@minip2p/node native loader", () => {
     await expect(import("../src/native.js")).resolves.toHaveProperty(
       "nativeBinding"
     );
+    expect(requested).toEqual([`../minip2p.linux-${process.arch}-gnu.node`]);
   });
 
   test("preserves the loader error for a present but broken local addon", async () => {

--- a/bindings/ts/package.json
+++ b/bindings/ts/package.json
@@ -9,6 +9,7 @@
     "format": "ultracite fix",
     "lint": "ultracite check",
     "test": "turbo run test",
+    "test:workflows": "node --test tests/workflows/*.test.mjs",
     "typecheck": "turbo run typecheck",
     "rn:android": "pnpm --filter @minip2p/react-native ubrn:android",
     "rn:generate": "pnpm --filter @minip2p/react-native ubrn:generate",
@@ -20,7 +21,8 @@
     "turbo": "2.10.12",
     "typescript": "catalog:",
     "ultracite": "7.10.6",
-    "vitest": "4.1.11"
+    "vitest": "4.1.11",
+    "yaml": "2.9.0"
   },
   "packageManager": "pnpm@11.24.0+sha512.bd27e345e976dcb0be0b7a1228217b049a817e21b1f355c90dbe7dc46671895a8bc1e6d06c24554505ea93ea0b45f489a27ec1bfbc8de6a9659fca0f16fa0000"
 }

--- a/bindings/ts/pnpm-lock.yaml
+++ b/bindings/ts/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       vitest:
         specifier: 4.1.11
         version: 4.1.11(@types/node@26.2.0)(vite@7.3.6(@types/node@26.3.0)(lightningcss@1.33.0)(terser@5.50.0)(yaml@2.9.0))
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
 
   core:
     devDependencies:

--- a/bindings/ts/tests/workflows/bindings-native.test.mjs
+++ b/bindings/ts/tests/workflows/bindings-native.test.mjs
@@ -47,7 +47,12 @@ test("weekly workflow executes the suite on native runners and musl containers",
     "x86_64-pc-windows-msvc": "windows-latest",
     "x86_64-unknown-linux-gnu": "ubuntu-24.04",
   });
-  assert.ok(nativeJob.steps.some(({ run }) => run === "pnpm test"));
+  assert.ok(nativeJob.steps.some(({ name }) => name === "Build relay fixture"));
+  assert.ok(
+    nativeJob.steps.some(({ run }) =>
+      run?.startsWith("pnpm --filter @minip2p/node exec vitest run")
+    )
+  );
 
   const muslBuild = workflow.jobs["node-musl"].steps.find(
     ({ name }) => name === "Build addon"

--- a/bindings/ts/tests/workflows/bindings-native.test.mjs
+++ b/bindings/ts/tests/workflows/bindings-native.test.mjs
@@ -54,6 +54,5 @@ test("weekly workflow executes the suite on native runners and musl containers",
   ).run;
   assert.match(muslBuild, /PATH=\/opt\/pnpm\/bin:\/usr\/bin:/u);
   assert.match(muslBuild, /--prefix \/opt\/pnpm pnpm@11\.24\.0/u);
-  assert.match(muslBuild, /install .*\n\s+unset RUSTFLAGS/u);
   assert.match(muslBuild, /pnpm test/u);
 });

--- a/bindings/ts/tests/workflows/bindings-native.test.mjs
+++ b/bindings/ts/tests/workflows/bindings-native.test.mjs
@@ -54,6 +54,6 @@ test("weekly workflow executes the suite on native runners and musl containers",
   ).run;
   assert.match(muslBuild, /PATH=\/opt\/pnpm\/bin:\/usr\/bin:/u);
   assert.match(muslBuild, /--prefix \/opt\/pnpm pnpm@11\.24\.0/u);
-  assert.match(muslBuild, /install .*\.node"\n\s+unset RUSTFLAGS/u);
+  assert.match(muslBuild, /install .*\n\s+unset RUSTFLAGS/u);
   assert.match(muslBuild, /pnpm test/u);
 });

--- a/bindings/ts/tests/workflows/bindings-native.test.mjs
+++ b/bindings/ts/tests/workflows/bindings-native.test.mjs
@@ -52,12 +52,11 @@ test("weekly workflow executes the suite on native runners and musl containers",
   const muslBuild = workflow.jobs["node-musl"].steps.find(
     ({ name }) => name === "Build addon"
   ).run;
-  assert.ok(
-    workflow.jobs["node-musl"].steps.some(
-      ({ name }) => name === "Build musl relay fixture"
-    )
-  );
   assert.match(muslBuild, /PATH=\/opt\/pnpm\/bin:\/usr\/bin:/u);
   assert.match(muslBuild, /--prefix \/opt\/pnpm pnpm@11\.24\.0/u);
+  assert.match(
+    muslBuild,
+    /cargo build --release --locked -p minip2p-relay-server-example/u
+  );
   assert.match(muslBuild, /pnpm --filter @minip2p\/node exec vitest run/u);
 });

--- a/bindings/ts/tests/workflows/bindings-native.test.mjs
+++ b/bindings/ts/tests/workflows/bindings-native.test.mjs
@@ -67,3 +67,15 @@ test("weekly workflow executes the suite on native runners and musl containers",
   );
   assert.match(muslBuild, /pnpm --filter @minip2p\/node exec vitest run/u);
 });
+
+test("weekly Node jobs pin actions to immutable commits", () => {
+  for (const jobName of ["node-native", "node-musl"]) {
+    const actions = workflow.jobs[jobName].steps
+      .map(({ uses }) => uses)
+      .filter((uses) => uses !== undefined);
+
+    for (const action of actions) {
+      assert.match(action, /@[0-9a-f]{40}$/u, `${jobName}: ${action}`);
+    }
+  }
+});

--- a/bindings/ts/tests/workflows/bindings-native.test.mjs
+++ b/bindings/ts/tests/workflows/bindings-native.test.mjs
@@ -52,5 +52,7 @@ test("weekly workflow executes the suite on native runners and musl containers",
   const muslBuild = workflow.jobs["node-musl"].steps.find(
     ({ name }) => name === "Build addon"
   ).run;
+  assert.match(muslBuild, /PATH=\/opt\/pnpm\/bin:\/usr\/bin:/u);
+  assert.match(muslBuild, /--prefix \/opt\/pnpm pnpm@11\.24\.0/u);
   assert.match(muslBuild, /pnpm test/u);
 });

--- a/bindings/ts/tests/workflows/bindings-native.test.mjs
+++ b/bindings/ts/tests/workflows/bindings-native.test.mjs
@@ -49,8 +49,10 @@ test("weekly workflow executes the suite on native runners and musl containers",
   });
   assert.ok(nativeJob.steps.some(({ name }) => name === "Build relay fixture"));
   assert.ok(
-    nativeJob.steps.some(({ run }) =>
-      run?.startsWith("pnpm --filter @minip2p/node exec vitest run")
+    nativeJob.steps.some(
+      ({ run, shell }) =>
+        shell === "bash" &&
+        run?.startsWith("pnpm --filter @minip2p/node exec vitest run")
     )
   );
 

--- a/bindings/ts/tests/workflows/bindings-native.test.mjs
+++ b/bindings/ts/tests/workflows/bindings-native.test.mjs
@@ -54,5 +54,6 @@ test("weekly workflow executes the suite on native runners and musl containers",
   ).run;
   assert.match(muslBuild, /PATH=\/opt\/pnpm\/bin:\/usr\/bin:/u);
   assert.match(muslBuild, /--prefix \/opt\/pnpm pnpm@11\.24\.0/u);
+  assert.match(muslBuild, /install .*\.node"\n\s+unset RUSTFLAGS/u);
   assert.match(muslBuild, /pnpm test/u);
 });

--- a/bindings/ts/tests/workflows/bindings-native.test.mjs
+++ b/bindings/ts/tests/workflows/bindings-native.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { parse } from "yaml";
+
+const workflowPath = new URL(
+  "../../../../.github/workflows/bindings-native.yml",
+  import.meta.url
+);
+const workflow = parse(await readFile(workflowPath, "utf-8"));
+
+test("native workflow runs weekly and on manual dispatch", () => {
+  assert.ok(workflow.on.workflow_dispatch !== undefined);
+  assert.equal(workflow.on.schedule[0].cron, "17 4 * * 1");
+});
+
+test("weekly workflow builds all seven Node targets", () => {
+  const targets = [
+    ...workflow.jobs["node-native"].strategy.matrix.include,
+    ...workflow.jobs["node-musl"].strategy.matrix.include,
+  ].map(({ target }) => target);
+
+  assert.deepEqual(targets.toSorted(), [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+  ]);
+});
+
+test("weekly workflow executes the suite on native runners and musl containers", () => {
+  const nativeJob = workflow.jobs["node-native"];
+  const runners = Object.fromEntries(
+    nativeJob.strategy.matrix.include.map(({ runner, target }) => [
+      target,
+      runner,
+    ])
+  );
+  assert.deepEqual(runners, {
+    "aarch64-apple-darwin": "macos-26",
+    "aarch64-unknown-linux-gnu": "ubuntu-24.04-arm",
+    "x86_64-apple-darwin": "macos-26-intel",
+    "x86_64-pc-windows-msvc": "windows-latest",
+    "x86_64-unknown-linux-gnu": "ubuntu-24.04",
+  });
+  assert.ok(nativeJob.steps.some(({ run }) => run === "pnpm test"));
+
+  const muslBuild = workflow.jobs["node-musl"].steps.find(
+    ({ name }) => name === "Build addon"
+  ).run;
+  assert.match(muslBuild, /pnpm test/u);
+});

--- a/bindings/ts/tests/workflows/bindings-native.test.mjs
+++ b/bindings/ts/tests/workflows/bindings-native.test.mjs
@@ -52,7 +52,12 @@ test("weekly workflow executes the suite on native runners and musl containers",
   const muslBuild = workflow.jobs["node-musl"].steps.find(
     ({ name }) => name === "Build addon"
   ).run;
+  assert.ok(
+    workflow.jobs["node-musl"].steps.some(
+      ({ name }) => name === "Build musl relay fixture"
+    )
+  );
   assert.match(muslBuild, /PATH=\/opt\/pnpm\/bin:\/usr\/bin:/u);
   assert.match(muslBuild, /--prefix \/opt\/pnpm pnpm@11\.24\.0/u);
-  assert.match(muslBuild, /pnpm test/u);
+  assert.match(muslBuild, /pnpm --filter @minip2p\/node exec vitest run/u);
 });


### PR DESCRIPTION
Closes #103

## Summary

- build all seven Node targets in the weekly native workflow
- run the TypeScript suite on architecture-matched native runners and in musl containers
- keep manual dispatch focused on the Node matrix by default, with mobile builds available through `include_mobile`
- add parsed workflow contract tests for triggers, targets, runner routing, and test execution

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm test` (76 tests)
- `pnpm lint`
- `pnpm test:workflows`
- `actionlint`
- `git diff --check`
- [manual native workflow: all seven Node jobs passed](https://github.com/deepso7/minip2p/actions/runs/33102995061)
- final Standards review: clean
- final Spec review: clean