### PR TITLE
fix(relay): close circuits with relay connection

### DIFF
--- a/bindings/ts/core/src/sdk.ts
+++ b/bindings/ts/core/src/sdk.ts
@@ -1365,15 +1365,13 @@ export class Minip2pBase {
         this.#streams.delete(key);
       }
     }
-    if (!this.#backend.connectedPeers().includes(peerId)) {
-      for (const pending of [...this.#pendingOpens.values()]) {
-        if (pending.peerId === peerId) {
-          this.#pendingOpens.delete(
-            pendingOpenKey(pending.peerId, pending.connId, pending.streamId)
-          );
-          clearPendingOpen(pending);
-          pending.reject(new PeerDisconnectedError(peerId, "openStream"));
-        }
+    for (const pending of [...this.#pendingOpens.values()]) {
+      if (pending.peerId === peerId && pending.connId === connId) {
+        this.#pendingOpens.delete(
+          pendingOpenKey(pending.peerId, pending.connId, pending.streamId)
+        );
+        clearPendingOpen(pending);
+        pending.reject(new PeerDisconnectedError(peerId, "openStream"));
       }
     }
   }

--- a/bindings/ts/core/tests/sdk.test.mjs
+++ b/bindings/ts/core/tests/sdk.test.mjs
@@ -849,6 +849,35 @@ test("openStream rejects close and disconnect before ready", async () => {
   endpoint.close();
 });
 
+test("connection close rejects only opens on that connection", async () => {
+  const backend = new MockBackend();
+  backend.connected = ["peer"];
+  backend.openResults.push(
+    { connId: 2, streamId: 7 },
+    { connId: 3, streamId: 8 }
+  );
+  const endpoint = new TestMinip2p(backend);
+  const closed = endpoint.openStream("peer", "/test/1", { timeoutMs: 1000 });
+  const live = endpoint.openStream("peer", "/test/1", { timeoutMs: 1000 });
+
+  backend.emit({
+    inner: { connId: 2, peerId: "peer" },
+    tag: P2pEvent_Tags.ConnectionClosed,
+  });
+
+  await assert.rejects(closed, PeerDisconnectedError);
+  assert.equal(await remainsPending(live), true);
+  backend.emit(
+    streamReady({
+      connId: 3,
+      initiatedLocally: true,
+      streamId: 8,
+    })
+  );
+  assert.equal((await live).connId, 3);
+  endpoint.close();
+});
+
 test("waitPeerReady ignores a superseded connection but rejects final disconnect", async () => {
   const backend = new MockBackend();
   backend.connected = ["peer"];

--- a/bindings/ts/core/tests/sdk.test.mjs
+++ b/bindings/ts/core/tests/sdk.test.mjs
@@ -558,6 +558,24 @@ test("stream async iteration rejects when the remote stream resets", async () =>
   endpoint.close();
 });
 
+test("pending stream read rejects when its connection closes", async () => {
+  const backend = new MockBackend();
+  backend.connected = ["peer"];
+  const endpoint = new TestMinip2p(backend);
+  const opening = endpoint.openStream("peer", "/test/1", { timeoutMs: 1000 });
+  backend.emit(streamReady({ initiatedLocally: true, streamId: 3 }));
+  const stream = await opening;
+  const reading = stream.read();
+
+  backend.emit({
+    inner: { connId: 2, peerId: "peer" },
+    tag: P2pEvent_Tags.ConnectionClosed,
+  });
+
+  await assert.rejects(reading, PeerDisconnectedError);
+  endpoint.close();
+});
+
 test("stream async iteration remembers a reset while the loop body runs", async () => {
   const backend = new MockBackend();
   const endpoint = new TestMinip2p(backend);
@@ -823,7 +841,6 @@ test("openStream rejects close and disconnect before ready", async () => {
   const disconnected = endpoint.openStream("peer", "/test/1", {
     timeoutMs: 1000,
   });
-  backend.connected = [];
   backend.emit({
     inner: { connId: 2, peerId: "peer" },
     tag: P2pEvent_Tags.ConnectionClosed,

--- a/crates/minip2p/src/portable/nat.rs
+++ b/crates/minip2p/src/portable/nat.rs
@@ -114,6 +114,21 @@ impl PortableNatDriver {
         } = event
         {
             #[cfg(feature = "portable-relay")]
+            {
+                let closed_bridges: Vec<_> = self
+                    .promoted
+                    .keys()
+                    .filter(|(inner_conn, _)| inner_conn == conn_id)
+                    .copied()
+                    .collect();
+                for (inner_conn, stream_id) in closed_bridges {
+                    endpoint
+                        .runtime_mut()
+                        .transport_mut()
+                        .inject_bridge_closed(inner_conn, stream_id);
+                }
+            }
+            #[cfg(feature = "portable-relay")]
             self.promoted
                 .retain(|(inner_conn, _), circuit| inner_conn != conn_id && circuit != conn_id);
             #[cfg(not(feature = "portable-relay"))]

--- a/crates/minip2p/src/std/nat.rs
+++ b/crates/minip2p/src/std/nat.rs
@@ -1014,23 +1014,6 @@ mod tests {
         assert!(events.iter().any(
             |event| matches!(event, minip2p_transport::TransportEvent::Closed { id } if *id == promoted)
         ));
-        inner.ingest(
-            &SwarmEvent::ConnectionClosed {
-                peer_id: inner_pair.relay_addr.peer_id().clone(),
-                conn_id: inner_pair.inner_conn,
-                cause: minip2p_swarm::ConnectionCloseCause::Transport,
-            },
-            &mut inner_pair.local.swarm,
-        );
-        assert!(
-            inner_pair
-                .local
-                .swarm
-                .transport_mut()
-                .poll(minip2p_platform::Now::from_millis(0))
-                .expect("idempotent relay closure")
-                .is_empty()
-        );
 
         // A circuit lifecycle close also removes its reverse map entry.
         let mut circuit_pair = negotiated_bridge();

--- a/crates/minip2p/src/std/nat.rs
+++ b/crates/minip2p/src/std/nat.rs
@@ -91,6 +91,17 @@ impl NatDriver {
             peer_id, conn_id, ..
         } = event
         {
+            let closed_bridges: Vec<_> = self
+                .promoted
+                .keys()
+                .filter(|(inner_conn, _)| inner_conn == conn_id)
+                .copied()
+                .collect();
+            for (inner_conn, stream_id) in closed_bridges {
+                swarm
+                    .transport_mut()
+                    .inject_bridge_closed(inner_conn, stream_id);
+            }
             self.promoted
                 .retain(|(inner_conn, _), circuit| inner_conn != conn_id && circuit != conn_id);
             if !swarm.connected_peers().contains(peer_id) {
@@ -984,6 +995,7 @@ mod tests {
         let inner_key = (inner_pair.inner_conn, inner_pair.stream);
         let (mut inner, action) = promotion_driver(&inner_pair, false);
         execute(&mut inner, action, &mut inner_pair.local);
+        let promoted = circuit_id(&inner, inner_key);
         inner.ingest(
             &SwarmEvent::ConnectionClosed {
                 peer_id: inner_pair.relay_addr.peer_id().clone(),
@@ -993,6 +1005,32 @@ mod tests {
             &mut inner_pair.local.swarm,
         );
         assert!(!inner.promoted.contains_key(&inner_key));
+        let events = inner_pair
+            .local
+            .swarm
+            .transport_mut()
+            .poll(minip2p_platform::Now::from_millis(0))
+            .expect("promoted circuit closure");
+        assert!(events.iter().any(
+            |event| matches!(event, minip2p_transport::TransportEvent::Closed { id } if *id == promoted)
+        ));
+        inner.ingest(
+            &SwarmEvent::ConnectionClosed {
+                peer_id: inner_pair.relay_addr.peer_id().clone(),
+                conn_id: inner_pair.inner_conn,
+                cause: minip2p_swarm::ConnectionCloseCause::Transport,
+            },
+            &mut inner_pair.local.swarm,
+        );
+        assert!(
+            inner_pair
+                .local
+                .swarm
+                .transport_mut()
+                .poll(minip2p_platform::Now::from_millis(0))
+                .expect("idempotent relay closure")
+                .is_empty()
+        );
 
         // A circuit lifecycle close also removes its reverse map entry.
         let mut circuit_pair = negotiated_bridge();

--- a/crates/minip2p/tests/smoltcp_relay.rs
+++ b/crates/minip2p/tests/smoltcp_relay.rs
@@ -346,6 +346,8 @@ fn tcp_smoltcp_peers_establish_and_use_a_relay_circuit() {
     let mut b_events = Vec::new();
     let mut app_stream = None;
     let mut sent = false;
+    let mut relay_cut = false;
+    let mut polls_after_circuit_close = 0;
     for _ in 0..MAX_STEPS {
         let now = Now::from_millis(now_ms);
         a_events.extend(a.poll(now).unwrap());
@@ -387,20 +389,38 @@ fn tcp_smoltcp_peers_establish_and_use_a_relay_circuit() {
                 .unwrap();
             sent = true;
         }
-        if app_stream.is_some_and(|stream| {
+        let received = app_stream.is_some_and(|stream| {
             b_events.iter().any(|event| {
                 matches!(event, SmoltcpEvent::Endpoint(SwarmEvent::StreamData {
                     peer_id, stream_id, data, ..
                 }) if peer_id == &a_peer && *stream_id == stream && data == PAYLOAD)
             })
-        }) {
+        });
+        if received && !relay_cut {
             assert!(
                 matches!(a.path(&b_peer), Some(Path::Relayed { relay }) if relay == relay_peer)
             );
             assert!(
                 matches!(b.path(&a_peer), Some(Path::Relayed { relay }) if relay == relay_peer)
             );
-            return;
+            a.disconnect(&relay_peer, now).unwrap();
+            relay_cut = true;
+        }
+
+        let circuit_closes = a_events
+            .iter()
+            .filter(|event| {
+                matches!(event, SmoltcpEvent::Endpoint(SwarmEvent::ConnectionClosed {
+                    peer_id, conn_id, ..
+                }) if peer_id == &b_peer && conn_id.is_circuit())
+            })
+            .count();
+        if circuit_closes > 0 {
+            assert_eq!(circuit_closes, 1, "circuit closes exactly once");
+            polls_after_circuit_close += 1;
+            if polls_after_circuit_close == 100 {
+                return;
+            }
         }
 
         if bus.is_quiet() {
@@ -416,7 +436,9 @@ fn tcp_smoltcp_peers_establish_and_use_a_relay_circuit() {
             now_ms = now_ms.max(deadline.as_millis());
         }
     }
-    panic!("relay circuit did not carry application data\n  a: {a_events:?}\n  b: {b_events:?}");
+    panic!(
+        "relay circuit did not close after its relay link\n  a: {a_events:?}\n  b: {b_events:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #115

## What changed

- terminate promoted circuits when their underlying relay connection closes
- apply the same cleanup to std and portable relay endpoints
- reject pending TypeScript stream reads and opens for the exact closed connection
- cover circuit termination, reordered close events, pending reads, and pending opens

## Verification

- `cargo test -p minip2p-rs --features nat`
- `cargo check -p minip2p-rs --no-default-features --features portable-relay`
- `cargo clippy -p minip2p-rs --features nat --all-targets -- -D warnings`
- `cargo clippy -p minip2p-rs --no-default-features --features portable-relay --all-targets -- -D warnings`
- `npm test --prefix bindings/ts/core -- --run`
- `npm test --prefix bindings/ts/node -- --run`
- `npm run --prefix bindings/ts lint -- core/src/sdk.ts core/tests/sdk.test.mjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #115 by terminating promoted relay circuits when the underlying relay connection closes. Pending stream opens now reject immediately when their exact connection closes, instead of waiting for the peer to fully disconnect.

- Applies the cleanup to both std and portable relay endpoints.
- Pending opens on other connections to the same peer stay pending.
- Adds tests covering circuit termination, reordered close events, pending reads, and connection-scoped opens.

<sup>Written for commit 72cd3b74c37e1660cdf511a393c07cb2b79be3a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

