### PR TITLE
fix(nat): establish relayed path before DCUtR

### DIFF
--- a/crates/nat/README.md
+++ b/crates/nat/README.md
@@ -3,8 +3,8 @@
 Sans-I/O NAT-traversal orchestrator for minip2p. The protocol machines
 (Circuit Relay v2, DCUtR, AutoNAT) live in their own crates; `NatAgent` is
 the missing conductor: it races direct dials against a relayed circuit,
-starts a DCUtR hole punch over the bridge the moment it exists, and reports
-every path decision explicitly.
+promotes the circuit through Noise and Yamux, then runs DCUtR on that
+Relayed path.
 
 `no_std + alloc`, no I/O, no clocks, no async.
 
@@ -16,9 +16,9 @@ Parallel racing with convergence — not sequential fallback:
 t0      direct leg: dial every validated candidate address
 t0+δ    relay leg (stagger δ, default 200 ms; 0 = fully parallel):
           ensure relay session → HOP CONNECT(target)
-          → Bridged ⇒ DCUtR punch starts over the bridge
-          → after SYNC, promote bridge through Noise + Yamux
+          → Bridged ⇒ promote bridge through Noise + Yamux
           → circuit Connected ⇒ PathEstablished(Relayed)
+          → reserved peer opens /libp2p/dcutr on the Relayed path
 inbound STOP circuit Connected ⇒ InboundPathEstablished(Relayed)
 first usable path wins
 a better path later  ⇒ PathUpgraded { from, to }  (+ the circuit closes)
@@ -128,14 +128,14 @@ Independent of connect attempts, the agent also runs:
 ## Responder side
 
 A NAT'd listener holding a reservation handles inbound circuits
-automatically: the relay's STOP CONNECT is auto-accepted, the initiator's
-DCUtR exchange is answered with our validated addresses, and on SYNC the
-agent emits `SendRandomUdp` blasts at the initiator's observed addresses
+automatically: the relay's STOP CONNECT is auto-accepted and the bridge is
+promoted into a normal circuit connection. The agent announces that Relayed
+path, opens `/libp2p/dcutr`, and sends CONNECT followed by SYNC. It emits
+`SendRandomUdp` blasts at the original circuit dialer's observed addresses
 to open its own NAT mapping (first after `responder_sync_delay_ms`, then
-every `blast_interval_ms` until `punch_deadline_ms`). Per DCUtR for QUIC
-only the initiator dials — the blasts make that dial land. The bridge is
-promoted into a normal circuit connection; a landed punch is announced with
-`InboundDirectUpgrade` and supersedes that circuit.
+every `blast_interval_ms` until `punch_deadline_ms`). The original circuit
+dialer makes the QUIC simultaneous-open dial. A landed punch is announced
+with `InboundDirectUpgrade` and supersedes the circuit.
 
 ## Status
 

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -21,8 +21,8 @@ use crate::types::{ConnectId, NatToken, Now, PromoteError, ReachabilityState, Re
 /// belong to the application (`Released` is modeled as removal).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum StreamRole {
-    /// Outbound HOP CONNECT stream for a dialer-side attempt; after the
-    /// relay reports `Bridged` the same stream carries the DCUtR exchange.
+    /// Outbound HOP CONNECT stream for a dialer-side attempt. After the
+    /// relay reports `Bridged`, the circuit transport adopts this stream.
     HopConnect(ConnectId),
     /// Outbound HOP RESERVE stream (reservation manager).
     HopReserve,
@@ -30,6 +30,10 @@ pub(crate) enum StreamRole {
     AutonatProbe,
     /// Inbound STOP stream from a relay (responder-side circuit).
     StopInbound(u64),
+    /// Inbound DCUtR stream handled by the original circuit dialer.
+    DcutrAttempt(ConnectId),
+    /// Locally opened DCUtR stream handled by the reserved peer.
+    DcutrInbound(u64),
     /// Inbound NAT control stream this node does not serve. Kept owned until
     /// terminal close so its reset lifecycle cannot leak into the application.
     RejectedControl,
@@ -59,6 +63,8 @@ pub(crate) enum TokenPurpose {
     PromoteAttempt(ConnectId),
     /// Relay bridge promotion for an inbound circuit.
     PromoteInbound(u64),
+    /// DCUtR stream opened by the reserved peer after circuit promotion.
+    OpenDcutrInbound(u64, PeerId),
 }
 
 impl TokenPurpose {
@@ -488,7 +494,7 @@ impl NatAgent {
                     }
                 }
                 for attempt in self.attempts.values_mut() {
-                    attempt.on_connection_closed(peer_id, *conn_id, &mut self.shared, now);
+                    attempt.on_connection_closed(peer_id, *conn_id, &mut self.shared);
                 }
                 if peer_disconnected {
                     self.pending_peer_disconnects.insert(peer_id.clone());
@@ -563,7 +569,21 @@ impl NatAgent {
                             .relays
                             .iter()
                             .any(|relay| relay.peer_id() == peer_id);
-                    if !trusted_stop {
+                    let dcutr_attempt = (protocol_id == DCUTR_PROTOCOL_ID)
+                        .then(|| {
+                            self.attempts.iter().find_map(|(id, attempt)| {
+                                attempt.accepts_dcutr(peer_id, *conn_id).then_some(*id)
+                            })
+                        })
+                        .flatten();
+                    if let Some(id) = dcutr_attempt {
+                        self.shared
+                            .own_stream(peer_id, *stream_id, StreamRole::DcutrAttempt(id));
+                        if let Some(attempt) = self.attempts.get_mut(&id) {
+                            attempt.on_dcutr_stream_opened(*stream_id, &mut self.shared);
+                        }
+                        handled = true;
+                    } else if !trusted_stop {
                         // All four ids are registered so the client-side NAT
                         // machines can negotiate outbound streams and advertise
                         // support through Identify. This node serves only STOP,
@@ -768,6 +788,18 @@ impl NatAgent {
                     now,
                 );
             }
+            TokenPurpose::OpenDcutrInbound(id, peer) => match self.inbound.get_mut(&id) {
+                Some(circuit) => {
+                    circuit.on_dcutr_open_result(&peer, result, &mut self.shared);
+                    self.reap_done();
+                }
+                None => {
+                    if let Ok(stream_id) = result {
+                        self.shared
+                            .push_action(NatAction::ResetStream { peer, stream_id });
+                    }
+                }
+            },
             _ => {}
         }
     }
@@ -884,7 +916,7 @@ impl NatAgent {
         match role {
             StreamRole::HopConnect(id) => {
                 if let Some(attempt) = self.attempts.get_mut(&id) {
-                    attempt.on_stream_input(conn_id, stream, input, &mut self.shared, now);
+                    attempt.on_stream_input(conn_id, stream, input, &mut self.shared);
                 }
             }
             StreamRole::HopReserve | StreamRole::AutonatProbe => {
@@ -893,7 +925,17 @@ impl NatAgent {
             }
             StreamRole::StopInbound(id) => {
                 if let Some(circuit) = self.inbound.get_mut(&id) {
-                    circuit.on_stream_input(conn_id, stream, input, &mut self.shared, now);
+                    circuit.on_stream_input(conn_id, stream, input, &mut self.shared);
+                }
+            }
+            StreamRole::DcutrAttempt(id) => {
+                if let Some(attempt) = self.attempts.get_mut(&id) {
+                    attempt.on_dcutr_stream_input(stream, input, &mut self.shared, now);
+                }
+            }
+            StreamRole::DcutrInbound(id) => {
+                if let Some(circuit) = self.inbound.get_mut(&id) {
+                    circuit.on_dcutr_stream_input(stream, input, &mut self.shared, now);
                 }
             }
             StreamRole::RejectedControl => {}

--- a/crates/nat/src/agent.rs
+++ b/crates/nat/src/agent.rs
@@ -790,7 +790,7 @@ impl NatAgent {
             }
             TokenPurpose::OpenDcutrInbound(id, peer) => match self.inbound.get_mut(&id) {
                 Some(circuit) => {
-                    circuit.on_dcutr_open_result(&peer, result, &mut self.shared);
+                    circuit.on_dcutr_open_result(&peer, result, &mut self.shared, now);
                     self.reap_done();
                 }
                 None => {

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -3,7 +3,7 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use minip2p_core::{Multiaddr, PeerAddr, PeerId, SansIoProtocol, select_direct_addrs};
-use minip2p_dcutr::{DcutrInitiator, DcutrInitiatorInput, DcutrInitiatorOutput, InitiatorOutcome};
+use minip2p_dcutr::{DcutrResponder, DcutrResponderInput, DcutrResponderOutput, ResponderEvent};
 use minip2p_relay::{
     ConnectOutcome, HOP_PROTOCOL_ID, HopConnect, HopConnectInput, HopConnectOutput,
 };
@@ -29,16 +29,15 @@ enum RelayLeg {
     WaitHopReady { stream: StreamId },
     /// HOP CONNECT sent; waiting for the relay's STATUS response.
     AwaitHopStatus { stream: StreamId },
-    /// Circuit bridged; the stream carries DCUtR and then application bytes.
+    /// Circuit bridged; the stream is being promoted through secure-mux.
     Bridged { stream: StreamId },
     /// The leg failed; only the direct leg (if any) can still win.
     Failed,
 }
 
 /// Per-target dialer-race arbiter: direct candidate dials at `t0` racing a
-/// staggered relay leg, with a DCUtR punch attempted over the bridge as soon
-/// as it exists. The best path wins; improvements are announced as explicit
-/// upgrades.
+/// staggered relay leg. A bridged circuit becomes a Relayed path first;
+/// DCUtR may then upgrade it. Improvements are announced explicitly.
 pub(crate) struct ConnectAttempt {
     id: ConnectId,
     peer: PeerId,
@@ -52,8 +51,8 @@ pub(crate) struct ConnectAttempt {
     /// Absolute deadline for the relay leg to reach `Bridged`.
     relay_deadline: Option<u64>,
     hop: Option<HopConnect>,
-    dcutr: Option<DcutrInitiator>,
-    dcutr_sent_at: Option<u64>,
+    dcutr: Option<DcutrResponder>,
+    dcutr_stream: Option<StreamId>,
     /// The bridge exists and has not been torn down by a close/disconnect.
     bridge_alive: bool,
     /// The bridge stream has been handed to the circuit transport.
@@ -66,8 +65,8 @@ pub(crate) struct ConnectAttempt {
     promotion_requested: bool,
     /// The remote write half reached EOF while the bridge was agent-owned.
     bridge_remote_write_closed: bool,
-    /// Application bytes coalesced behind the initiator-side DCUtR reply.
-    /// Drained exactly once into the first relayed `PathEstablished` event.
+    /// Secure-mux bytes coalesced behind the HOP success response. Passed to
+    /// the circuit transport with `PromoteBridge`.
     bridge_pending_data: Vec<u8>,
     punch_addrs: Vec<Multiaddr>,
     punch_dials_issued: bool,
@@ -123,7 +122,7 @@ impl ConnectAttempt {
             relay_deadline: None,
             hop: None,
             dcutr: None,
-            dcutr_sent_at: None,
+            dcutr_stream: None,
             bridge_alive: false,
             bridge_released: false,
             bridge_inner_conn: None,
@@ -181,6 +180,101 @@ impl ConnectAttempt {
         self.done
     }
 
+    pub(crate) fn accepts_dcutr(&self, peer: &PeerId, conn_id: ConnectionId) -> bool {
+        !self.done
+            && !self.punch_settled
+            && &self.peer == peer
+            && self.promoted == Some(conn_id)
+            && self
+                .best
+                .as_ref()
+                .is_some_and(|path| matches!(path, Path::Relayed { .. }))
+            && self.dcutr_stream.is_none()
+    }
+
+    pub(crate) fn on_dcutr_stream_opened(&mut self, stream: StreamId, shared: &mut Shared) {
+        self.dcutr_stream = Some(stream);
+        self.dcutr = Some(DcutrResponder::new(&shared.punch_candidates()));
+    }
+
+    pub(crate) fn on_dcutr_stream_input(
+        &mut self,
+        stream: StreamId,
+        input: StreamInput<'_>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        if self.dcutr_stream != Some(stream) {
+            return;
+        }
+        let machine_input = match input {
+            StreamInput::Data(data) => DcutrResponderInput::Data(data.to_vec()),
+            StreamInput::RemoteWriteClosed | StreamInput::Closed => {
+                DcutrResponderInput::RemoteWriteClosed
+            }
+            StreamInput::Ready => return,
+        };
+        let Some(dcutr) = self.dcutr.as_mut() else {
+            return;
+        };
+        if let Err(error) = dcutr.handle_input(machine_input) {
+            self.finish_failed_dcutr(stream, error.to_string(), shared);
+            return;
+        }
+        let mut outputs = Vec::new();
+        while let Some(output) = dcutr.poll_output() {
+            outputs.push(output);
+        }
+        for output in outputs {
+            match output {
+                DcutrResponderOutput::Outbound(data) => shared.push_action(NatAction::SendStream {
+                    peer: self.peer.clone(),
+                    stream_id: stream,
+                    data,
+                }),
+                DcutrResponderOutput::Event(ResponderEvent::ConnectReceived {
+                    remote_addrs,
+                    ..
+                }) => {
+                    self.punch_addrs = select_global_punch_candidates(&remote_addrs);
+                }
+                DcutrResponderOutput::Event(ResponderEvent::SyncReceived) => {
+                    self.dcutr = None;
+                    shared.release_stream(&self.peer, stream);
+                    self.dcutr_stream = None;
+                    if self.punch_addrs.is_empty() {
+                        self.punch_failed_permanently(
+                            shared,
+                            "no dialable remote addresses in DCUtR CONNECT".into(),
+                            now,
+                        );
+                    } else {
+                        self.issue_punch_dials(shared);
+                        self.punch_window = 1;
+                        self.punch_deadline = Some(now.mono_ms + shared.config.punch_deadline_ms);
+                    }
+                }
+            }
+        }
+    }
+
+    fn finish_failed_dcutr(&mut self, stream: StreamId, reason: String, shared: &mut Shared) {
+        self.dcutr = None;
+        self.dcutr_stream = None;
+        shared.release_stream(&self.peer, stream);
+        shared.push_event(NatEvent::HolePunchFailed {
+            connect_id: self.id,
+            attempt: 1,
+            reason,
+        });
+        self.punch_settled = true;
+        shared.push_event(NatEvent::FellBackToRelay {
+            connect_id: self.id,
+            peer: self.peer.clone(),
+        });
+        self.done = true;
+    }
+
     /// Earliest pending absolute deadline, for the driver's timer fold-in.
     pub(crate) fn next_deadline(&self) -> Option<u64> {
         if self.done {
@@ -223,7 +317,9 @@ impl ConnectAttempt {
         if is_circuit {
             if self.promoted == Some(conn_id) {
                 self.announce_relay_path(shared);
-                if self.punch_settled || shared.config.force_relay {
+                if shared.config.force_relay {
+                    self.done = true;
+                } else if self.punch_settled {
                     shared.push_event(NatEvent::FellBackToRelay {
                         connect_id: self.id,
                         peer: self.peer.clone(),
@@ -275,7 +371,6 @@ impl ConnectAttempt {
         peer: &PeerId,
         conn_id: ConnectionId,
         shared: &mut Shared,
-        now: Now,
     ) {
         if self.done {
             return;
@@ -320,7 +415,7 @@ impl ConnectAttempt {
                 self.last_error = Some(NatError::DialFailed("relay connection closed".into()));
                 self.fail_if_no_legs_remain(shared);
             }
-            RelayLeg::Bridged { .. } => self.on_bridge_lost(shared, now),
+            RelayLeg::Bridged { .. } => self.on_bridge_lost(shared),
             _ => {}
         }
     }
@@ -472,7 +567,6 @@ impl ConnectAttempt {
         stream: StreamId,
         input: StreamInput<'_>,
         shared: &mut Shared,
-        now: Now,
     ) {
         if self.done {
             return;
@@ -485,22 +579,22 @@ impl ConnectAttempt {
                 self.flush_hop_connect(stream, shared);
             }
             (RelayLeg::AwaitHopStatus { stream: s }, StreamInput::Data(data)) if s == stream => {
-                self.on_hop_data(stream, data, shared, now);
+                self.on_hop_data(stream, data, shared);
             }
             (RelayLeg::Bridged { stream: s }, StreamInput::Data(data)) if s == stream => {
-                self.on_bridge_data(stream, data, shared, now);
+                self.bridge_pending_data.extend_from_slice(data);
             }
             (
                 RelayLeg::WaitHopReady { stream: s } | RelayLeg::AwaitHopStatus { stream: s },
                 StreamInput::RemoteWriteClosed,
             ) if s == stream => {
-                self.on_hop_remote_write_closed(stream, shared, now);
+                self.on_hop_remote_write_closed(stream, shared);
             }
             (RelayLeg::Bridged { stream: s }, StreamInput::RemoteWriteClosed) if s == stream => {
-                self.on_bridge_remote_write_closed(stream, shared, now);
+                self.bridge_remote_write_closed = true;
             }
             (_, StreamInput::Closed) => {
-                self.on_stream_closed(stream, shared, now);
+                self.on_stream_closed(stream, shared);
             }
             _ => {}
         }
@@ -626,7 +720,7 @@ impl ConnectAttempt {
         self.leg = RelayLeg::AwaitHopStatus { stream };
     }
 
-    fn on_hop_data(&mut self, stream: StreamId, data: &[u8], shared: &mut Shared, now: Now) {
+    fn on_hop_data(&mut self, stream: StreamId, data: &[u8], shared: &mut Shared) {
         let Some(hop) = self.hop.as_mut() else {
             return;
         };
@@ -639,10 +733,7 @@ impl ConnectAttempt {
         while let Some(output) = hop.poll_output() {
             outputs.push(output);
         }
-        self.capture_force_relay_bridge_data(&outputs, shared);
-        // `HopConnect` yields `Outcome(Bridged)` before any `BridgeData`, so
-        // pipelined peer bytes reach the DCUtR machine created below inside
-        // this same cascade — before any later `StreamData` event.
+        self.capture_bridge_data(&outputs);
         for output in outputs {
             match output {
                 HopConnectOutput::Outbound(data) => {
@@ -655,7 +746,7 @@ impl ConnectAttempt {
                     }
                 }
                 HopConnectOutput::Outcome(ConnectOutcome::Bridged { .. }) => {
-                    self.on_bridged(stream, shared, now);
+                    self.on_bridged(stream, shared);
                 }
                 HopConnectOutput::Outcome(ConnectOutcome::Refused { status, reason }) => {
                     self.fail_relay_leg(
@@ -664,23 +755,18 @@ impl ConnectAttempt {
                     );
                     return;
                 }
-                HopConnectOutput::BridgeData(bytes) => {
-                    if !shared.config.force_relay {
-                        self.on_bridge_data(stream, &bytes, shared, now);
-                    }
-                }
+                HopConnectOutput::BridgeData(_) => {}
             }
         }
     }
 
-    /// The relay bridged the circuit: start the DCUtR punch immediately.
-    /// The raw stream stays agent-owned until SYNC is sent, at which point it
-    /// becomes safe to announce as an application-usable relayed path.
-    fn on_bridged(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
+    /// The relay bridged the circuit: promote the raw pipe through Noise and
+    /// Yamux. DCUtR runs later on the established circuit connection.
+    fn on_bridged(&mut self, stream: StreamId, shared: &mut Shared) {
         let RelayLeg::AwaitHopStatus { .. } = self.leg else {
             return;
         };
-        let Some(relay_peer) = self.relay_peer().cloned() else {
+        let Some(_) = self.relay_peer() else {
             return;
         };
         self.leg = RelayLeg::Bridged { stream };
@@ -690,57 +776,13 @@ impl ConnectAttempt {
 
         if shared.config.force_relay {
             self.punch_settled = true;
-            self.promote_bridge(stream, shared);
-            return;
         }
-
-        let mut dcutr = DcutrInitiator::new(&shared.punch_candidates());
-        if let Err(e) = dcutr.handle_input(DcutrInitiatorInput::Flush) {
-            // Deferred construction error (e.g. oversized CONNECT): the
-            // punch cannot even start, but the relayed path stands and is
-            // already safe to hand to the application.
-            self.promote_bridge(stream, shared);
-            self.punch_failed_permanently(shared, e.to_string(), now);
-            return;
-        }
-        while let Some(output) = dcutr.poll_output() {
-            if let DcutrInitiatorOutput::Outbound(data) = output {
-                shared.push_action(NatAction::SendStream {
-                    peer: relay_peer.clone(),
-                    stream_id: stream,
-                    data,
-                });
-            }
-        }
-        self.dcutr_sent_at = Some(now.mono_ms);
-        self.dcutr = Some(dcutr);
+        self.promote_bridge(stream, shared);
     }
 
-    fn on_bridge_data(&mut self, stream: StreamId, data: &[u8], shared: &mut Shared, now: Now) {
-        let Some(dcutr) = self.dcutr.as_mut() else {
-            return;
-        };
-        let rtt_ms = now
-            .mono_ms
-            .saturating_sub(self.dcutr_sent_at.unwrap_or(now.mono_ms));
-        if let Err(e) = dcutr.handle_input(DcutrInitiatorInput::Data {
-            bytes: data.to_vec(),
-            rtt_ms,
-        }) {
-            self.dcutr = None;
-            self.punch_failed_permanently(shared, e.to_string(), now);
-            return;
-        }
-        self.drain_dcutr_outputs(stream, shared, now);
-    }
-
-    /// In relay-only mode promotion happens as soon as HOP accepts. Capture
-    /// bytes coalesced behind STATUS:OK before processing the preceding
-    /// `Outcome(Bridged)`, which queues the promotion action.
-    fn capture_force_relay_bridge_data(&mut self, outputs: &[HopConnectOutput], shared: &Shared) {
-        if !shared.config.force_relay {
-            return;
-        }
+    /// Capture bytes coalesced behind STATUS:OK before processing the
+    /// preceding `Outcome(Bridged)`, which queues the promotion action.
+    fn capture_bridge_data(&mut self, outputs: &[HopConnectOutput]) {
         for output in outputs {
             if let HopConnectOutput::BridgeData(bytes) = output {
                 self.bridge_pending_data.extend_from_slice(bytes);
@@ -748,38 +790,10 @@ impl ConnectAttempt {
         }
     }
 
-    fn drain_dcutr_outputs(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
-        let Some(dcutr) = self.dcutr.as_mut() else {
-            return;
-        };
-        let mut outputs = Vec::new();
-        while let Some(output) = dcutr.poll_output() {
-            outputs.push(output);
-        }
-        for output in outputs {
-            match output {
-                DcutrInitiatorOutput::Outbound(data) => {
-                    if let Some(relay_peer) = self.relay_peer().cloned() {
-                        shared.push_action(NatAction::SendStream {
-                            peer: relay_peer,
-                            stream_id: stream,
-                            data,
-                        });
-                    }
-                }
-                DcutrInitiatorOutput::Outcome(InitiatorOutcome::DialNow {
-                    remote_addrs, ..
-                }) => {
-                    self.on_dial_now(stream, remote_addrs, shared, now);
-                }
-            }
-        }
-    }
-
     /// A remote half-close still permits local protocol writes. Let the
     /// sans-I/O machine consume it rather than treating it as a full circuit
     /// teardown; it may have a complete frame buffered already.
-    fn on_hop_remote_write_closed(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
+    fn on_hop_remote_write_closed(&mut self, stream: StreamId, shared: &mut Shared) {
         let Some(hop) = self.hop.as_mut() else {
             return;
         };
@@ -791,7 +805,7 @@ impl ConnectAttempt {
         while let Some(output) = hop.poll_output() {
             outputs.push(output);
         }
-        self.capture_force_relay_bridge_data(&outputs, shared);
+        self.capture_bridge_data(&outputs);
         for output in outputs {
             match output {
                 HopConnectOutput::Outbound(data) => {
@@ -804,7 +818,7 @@ impl ConnectAttempt {
                     }
                 }
                 HopConnectOutput::Outcome(ConnectOutcome::Bridged { .. }) => {
-                    self.on_bridged(stream, shared, now);
+                    self.on_bridged(stream, shared);
                 }
                 HopConnectOutput::Outcome(ConnectOutcome::Refused { status, reason }) => {
                     self.fail_relay_leg(
@@ -813,108 +827,9 @@ impl ConnectAttempt {
                     );
                     return;
                 }
-                HopConnectOutput::BridgeData(bytes) => {
-                    if !shared.config.force_relay {
-                        self.on_bridge_data(stream, &bytes, shared, now);
-                    }
-                }
+                HopConnectOutput::BridgeData(_) => {}
             }
         }
-    }
-
-    fn on_bridge_remote_write_closed(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
-        self.bridge_remote_write_closed = true;
-        let Some(dcutr) = self.dcutr.as_mut() else {
-            return;
-        };
-        if let Err(e) = dcutr.handle_input(DcutrInitiatorInput::RemoteWriteClosed) {
-            self.dcutr = None;
-            self.punch_failed_permanently(shared, e.to_string(), now);
-            return;
-        }
-        self.drain_dcutr_outputs(stream, shared, now);
-        if self.dcutr.is_some() {
-            // No more inbound bytes can complete the CONNECT reply. Release
-            // the still-writable relay bridge immediately, but keep original
-            // direct candidate dials alive so a late direct path can upgrade
-            // it before the connect deadline.
-            self.dcutr = None;
-            shared.push_event(NatEvent::HolePunchFailed {
-                connect_id: self.id,
-                attempt: self.punch_window.max(1),
-                reason: "relay bridge reached EOF before the DCUtR reply completed".into(),
-            });
-            self.punch_deadline = None;
-            self.promote_bridge(stream, shared);
-            if self.direct_live == 0 {
-                self.settle_after_punch(shared);
-            }
-        }
-    }
-
-    /// The remote's observed addresses arrived: dial them all, send SYNC,
-    /// hand the bridge back to the application, and open the punch window.
-    fn on_dial_now(
-        &mut self,
-        stream: StreamId,
-        remote_addrs: Vec<Multiaddr>,
-        shared: &mut Shared,
-        now: Now,
-    ) {
-        // Unlike caller-configured direct candidates, these addresses are
-        // supplied by the remote peer. Restrict them to global IP QUIC
-        // endpoints before allowing either a dial or UDP punch traffic.
-        self.punch_addrs = select_global_punch_candidates(&remote_addrs);
-
-        // Per the spec the initiator dials first, then signals SYNC.
-        if !self.punch_addrs.is_empty() {
-            self.issue_punch_dials(shared);
-        }
-
-        let relay_peer = self.relay_peer().cloned();
-        if let Some(dcutr) = self.dcutr.as_mut() {
-            match dcutr.handle_input(DcutrInitiatorInput::SendSync) {
-                Ok(()) => {
-                    let mut sync_frames = Vec::new();
-                    while let Some(output) = dcutr.poll_output() {
-                        if let DcutrInitiatorOutput::Outbound(data) = output {
-                            sync_frames.push(data);
-                        }
-                    }
-                    if let Some(relay_peer) = relay_peer {
-                        for data in sync_frames {
-                            shared.push_action(NatAction::SendStream {
-                                peer: relay_peer.clone(),
-                                stream_id: stream,
-                                data,
-                            });
-                        }
-                    }
-                    self.bridge_pending_data = dcutr.take_trailing_data().unwrap_or_default();
-                }
-                Err(e) => {
-                    self.dcutr = None;
-                    self.punch_failed_permanently(shared, e.to_string(), now);
-                    return;
-                }
-            }
-        }
-
-        // No further DCUtR frames are expected: from here every byte on the
-        // bridge belongs to the application.
-        self.dcutr = None;
-        self.promote_bridge(stream, shared);
-
-        if self.punch_addrs.is_empty() {
-            self.punch_failed_permanently(
-                shared,
-                "no dialable remote addresses in DCUtR reply".into(),
-                now,
-            );
-            return;
-        }
-        self.punch_window = 1;
-        self.punch_deadline = Some(now.mono_ms + shared.config.punch_deadline_ms);
     }
 
     fn issue_punch_dials(&mut self, shared: &mut Shared) {
@@ -1042,7 +957,7 @@ impl ConnectAttempt {
         });
     }
 
-    fn on_stream_closed(&mut self, stream: StreamId, shared: &mut Shared, now: Now) {
+    fn on_stream_closed(&mut self, stream: StreamId, shared: &mut Shared) {
         match self.leg {
             RelayLeg::WaitHopReady { stream: s } | RelayLeg::AwaitHopStatus { stream: s }
                 if s == stream =>
@@ -1052,13 +967,13 @@ impl ConnectAttempt {
                     NatError::Protocol("HOP stream closed before the circuit was bridged".into()),
                 );
             }
-            RelayLeg::Bridged { stream: s } if s == stream => self.on_bridge_lost(shared, now),
+            RelayLeg::Bridged { stream: s } if s == stream => self.on_bridge_lost(shared),
             _ => {}
         }
     }
 
     /// The bridge died (stream closed or relay connection lost).
-    fn on_bridge_lost(&mut self, shared: &mut Shared, now: Now) {
+    fn on_bridge_lost(&mut self, shared: &mut Shared) {
         if !self.bridge_alive {
             return;
         }
@@ -1074,18 +989,6 @@ impl ConnectAttempt {
         self.last_error = Some(NatError::DialFailed(
             "relay bridge lost before the attempt settled".into(),
         ));
-        if self.dcutr.is_some() {
-            // The DCUtR exchange can never complete now.
-            self.dcutr = None;
-            self.punch_deadline = None;
-            if self.direct_live == 0 {
-                self.punch_failed_permanently(
-                    shared,
-                    "relay bridge lost during the DCUtR exchange".into(),
-                    now,
-                );
-            }
-        }
         // If punch windows are already running, the punch itself may still
         // succeed via `ConnectionEstablished`; the window deadline settles
         // the rest.
@@ -1159,6 +1062,14 @@ impl ConnectAttempt {
     /// still holds (including a bridge the application was told about — the
     /// caller emits the explaining event first).
     fn teardown_relay_leg(&mut self, shared: &mut Shared) {
+        if let Some(stream_id) = self.dcutr_stream.take() {
+            shared.push_action(NatAction::ResetStream {
+                peer: self.peer.clone(),
+                stream_id,
+            });
+            shared.release_stream(&self.peer, stream_id);
+        }
+        self.dcutr = None;
         match self.leg {
             RelayLeg::WaitHopReady { stream } | RelayLeg::AwaitHopStatus { stream } => {
                 if let Some(relay_peer) = self.relay_peer().cloned() {
@@ -1187,6 +1098,7 @@ impl ConnectAttempt {
         self.punch_deadline = None;
         self.hop = None;
         self.dcutr = None;
+        self.dcutr_stream = None;
         self.bridge_alive = false;
         if let Some(conn_id) = self.promoted.take() {
             shared.push_action(NatAction::CloseCircuit { conn_id });

--- a/crates/nat/src/attempt.rs
+++ b/crates/nat/src/attempt.rs
@@ -183,6 +183,7 @@ impl ConnectAttempt {
     pub(crate) fn accepts_dcutr(&self, peer: &PeerId, conn_id: ConnectionId) -> bool {
         !self.done
             && !self.punch_settled
+            && !self.punch_dials_issued
             && &self.peer == peer
             && self.promoted == Some(conn_id)
             && self
@@ -207,6 +208,7 @@ impl ConnectAttempt {
         if self.dcutr_stream != Some(stream) {
             return;
         }
+        let exchange_closed = matches!(input, StreamInput::RemoteWriteClosed | StreamInput::Closed);
         let machine_input = match input {
             StreamInput::Data(data) => DcutrResponderInput::Data(data.to_vec()),
             StreamInput::RemoteWriteClosed | StreamInput::Closed => {
@@ -239,9 +241,7 @@ impl ConnectAttempt {
                     self.punch_addrs = select_global_punch_candidates(&remote_addrs);
                 }
                 DcutrResponderOutput::Event(ResponderEvent::SyncReceived) => {
-                    self.dcutr = None;
-                    shared.release_stream(&self.peer, stream);
-                    self.dcutr_stream = None;
+                    self.teardown_dcutr_stream(shared);
                     if self.punch_addrs.is_empty() {
                         self.punch_failed_permanently(
                             shared,
@@ -256,12 +256,14 @@ impl ConnectAttempt {
                 }
             }
         }
+        if exchange_closed && self.dcutr_stream == Some(stream) {
+            self.finish_failed_dcutr(stream, "DCUtR stream closed before SYNC".into(), shared);
+        }
     }
 
     fn finish_failed_dcutr(&mut self, stream: StreamId, reason: String, shared: &mut Shared) {
-        self.dcutr = None;
-        self.dcutr_stream = None;
-        shared.release_stream(&self.peer, stream);
+        debug_assert_eq!(self.dcutr_stream, Some(stream));
+        self.teardown_dcutr_stream(shared);
         shared.push_event(NatEvent::HolePunchFailed {
             connect_id: self.id,
             attempt: 1,
@@ -507,15 +509,7 @@ impl ConnectAttempt {
             TokenPurpose::DirectDial(_) => {
                 self.direct_live = self.direct_live.saturating_sub(1);
                 self.last_error = Some(NatError::DialFailed(reason));
-                if self.direct_live == 0
-                    && matches!(self.best, Some(Path::Relayed { .. }))
-                    && self.dcutr.is_none()
-                    && self.punch_deadline.is_none()
-                {
-                    self.settle_after_punch(shared);
-                } else {
-                    self.fail_if_no_legs_remain(shared);
-                }
+                self.fail_if_no_legs_remain(shared);
             }
             TokenPurpose::RelayDial(_) => {
                 self.fail_relay_leg(shared, NatError::DialFailed(reason));
@@ -882,6 +876,7 @@ impl ConnectAttempt {
         if self.done {
             return;
         }
+        self.teardown_dcutr_stream(shared);
         if self.bridge_alive {
             self.punch_settled = true;
             if let RelayLeg::Bridged { stream } = self.leg {
@@ -1062,14 +1057,7 @@ impl ConnectAttempt {
     /// still holds (including a bridge the application was told about — the
     /// caller emits the explaining event first).
     fn teardown_relay_leg(&mut self, shared: &mut Shared) {
-        if let Some(stream_id) = self.dcutr_stream.take() {
-            shared.push_action(NatAction::ResetStream {
-                peer: self.peer.clone(),
-                stream_id,
-            });
-            shared.release_stream(&self.peer, stream_id);
-        }
-        self.dcutr = None;
+        self.teardown_dcutr_stream(shared);
         match self.leg {
             RelayLeg::WaitHopReady { stream } | RelayLeg::AwaitHopStatus { stream } => {
                 if let Some(relay_peer) = self.relay_peer().cloned() {
@@ -1097,12 +1085,21 @@ impl ConnectAttempt {
         self.relay_deadline = None;
         self.punch_deadline = None;
         self.hop = None;
-        self.dcutr = None;
-        self.dcutr_stream = None;
         self.bridge_alive = false;
         if let Some(conn_id) = self.promoted.take() {
             shared.push_action(NatAction::CloseCircuit { conn_id });
         }
+    }
+
+    fn teardown_dcutr_stream(&mut self, shared: &mut Shared) {
+        if let Some(stream_id) = self.dcutr_stream.take() {
+            shared.push_action(NatAction::ResetStream {
+                peer: self.peer.clone(),
+                stream_id,
+            });
+            shared.release_stream(&self.peer, stream_id);
+        }
+        self.dcutr = None;
     }
 
     fn relay_peer(&self) -> Option<&PeerId> {

--- a/crates/nat/src/housekeeping.rs
+++ b/crates/nat/src/housekeeping.rs
@@ -1064,6 +1064,8 @@ impl Housekeeping {
             }
             StreamRole::HopConnect(_)
             | StreamRole::StopInbound(_)
+            | StreamRole::DcutrAttempt(_)
+            | StreamRole::DcutrInbound(_)
             | StreamRole::RejectedControl => {}
         }
     }

--- a/crates/nat/src/inbound.rs
+++ b/crates/nat/src/inbound.rs
@@ -1,22 +1,21 @@
-//! Responder-side hole punching: a NAT'd listener holding a relay
-//! reservation accepts inbound STOP circuits, answers the initiator's DCUtR
-//! exchange, and blasts random UDP datagrams at the initiator's observed
-//! addresses to open its own NAT mapping. Only the initiator dials (DCUtR
-//! for QUIC): the blasts make that dial land.
+//! Inbound circuit and hole-punch coordination for a listener holding a
+//! relay reservation. The STOP bridge is promoted first. Once the Relayed
+//! path is usable, this reserved peer opens `/libp2p/dcutr` and sends CONNECT
+//! and SYNC. The original circuit dialer performs the QUIC dial while this
+//! peer sends random UDP to open its NAT mapping.
 //!
 //! ```text
 //! relay opens STOP stream ──▶ CONNECT ──▶ auto-Accept (STATUS:OK)
-//!   ──▶ DCUtR CONNECT arrives ──▶ reply with our observed addresses
-//!   ──▶ SYNC arrives ──▶ schedule UDP blasts,
-//!       promote the bridge into a circuit connection
-//!   ──▶ circuit Connected ──▶ InboundPathEstablished(Relayed)
-//! initiator's dial lands ──▶ cancel blasts, InboundDirectUpgrade
+//!   ──▶ promote bridge ──▶ circuit Connected
+//!   ──▶ InboundPathEstablished(Relayed)
+//!   ──▶ open DCUtR ──▶ send CONNECT, then SYNC
+//! circuit dialer's punch lands ──▶ InboundDirectUpgrade
 //! ```
 
 use alloc::vec::Vec;
 
 use minip2p_core::{Multiaddr, PeerId, Protocol, SansIoProtocol, select_direct_addrs};
-use minip2p_dcutr::{DcutrResponder, DcutrResponderInput, DcutrResponderOutput, ResponderEvent};
+use minip2p_dcutr::{DcutrInitiator, DcutrInitiatorInput, DcutrInitiatorOutput, InitiatorOutcome};
 use minip2p_relay::{Status, StopResponder, StopResponderInput, StopResponderOutput};
 use minip2p_transport::{ConnectionId, StreamId};
 
@@ -43,16 +42,16 @@ pub(crate) struct InboundCircuit {
     /// The initiating peer, once the STOP CONNECT names it.
     source: Option<PeerId>,
     stop: Option<StopResponder>,
-    dcutr: Option<DcutrResponder>,
+    dcutr: Option<DcutrInitiator>,
+    dcutr_stream: Option<StreamId>,
     remote_addrs: Vec<Multiaddr>,
-    /// Application bytes received after the final DCUtR SYNC frame in the
-    /// same stream read. These must accompany circuit promotion.
+    /// Secure-mux bytes coalesced behind the STOP success response. These
+    /// must accompany circuit promotion.
     pending_data: Vec<u8>,
     /// The remote write half reached EOF while the control plane still owned
     /// the bridge. The transport will not repeat that event after handoff.
     remote_write_closed: bool,
-    /// Deadline for the STOP + DCUtR exchange to finish; after it the
-    /// bridge is released to the app punch-less rather than abandoned.
+    /// Deadline for STOP acceptance and handing the bridge to circuit promotion.
     exchange_deadline: u64,
     blast: Option<BlastSchedule>,
     /// Keep the circuit alive for upgrade detection until this instant
@@ -85,6 +84,7 @@ impl InboundCircuit {
             source: None,
             stop: Some(StopResponder::new()),
             dcutr: None,
+            dcutr_stream: None,
             remote_addrs: Vec::new(),
             pending_data: Vec::new(),
             remote_write_closed: false,
@@ -130,7 +130,6 @@ impl InboundCircuit {
         stream: StreamId,
         input: StreamInput<'_>,
         shared: &mut Shared,
-        now: Now,
     ) {
         if self.done || conn_id != self.inner_conn || stream != self.stream {
             return;
@@ -138,9 +137,7 @@ impl InboundCircuit {
         match input {
             StreamInput::Data(data) => {
                 if self.source.is_none() {
-                    self.on_stop_data(data, shared, now);
-                } else {
-                    self.on_bridge_data(data, shared, now);
+                    self.on_stop_data(data, shared);
                 }
             }
             StreamInput::RemoteWriteClosed => {
@@ -149,9 +146,7 @@ impl InboundCircuit {
                 // usable. Let the protocol parser consume that boundary and
                 // retain the circuit until its normal exchange deadline.
                 if self.source.is_none() {
-                    self.on_stop_input(StopResponderInput::RemoteWriteClosed, shared, now);
-                } else {
-                    self.on_dcutr_input(DcutrResponderInput::RemoteWriteClosed, shared, now);
+                    self.on_stop_input(StopResponderInput::RemoteWriteClosed, shared);
                 }
             }
             StreamInput::Closed => {
@@ -163,12 +158,12 @@ impl InboundCircuit {
     }
 
     /// Feeds bytes into the STOP responder until the CONNECT request is
-    /// decoded, then auto-accepts and starts the DCUtR responder.
-    fn on_stop_data(&mut self, data: &[u8], shared: &mut Shared, now: Now) {
-        self.on_stop_input(StopResponderInput::Data(data.to_vec()), shared, now);
+    /// decoded, then auto-accepts and hands the bridge to circuit promotion.
+    fn on_stop_data(&mut self, data: &[u8], shared: &mut Shared) {
+        self.on_stop_input(StopResponderInput::Data(data.to_vec()), shared);
     }
 
-    fn on_stop_input(&mut self, input: StopResponderInput, shared: &mut Shared, now: Now) {
+    fn on_stop_input(&mut self, input: StopResponderInput, shared: &mut Shared) {
         let Some(stop) = self.stop.as_mut() else {
             return;
         };
@@ -234,97 +229,9 @@ impl InboundCircuit {
             });
         }
 
-        if shared.config.force_relay {
-            // STOP yields the CONNECT request before the bytes trailing its
-            // frame. In force-relay mode there is no DCUtR machine to consume
-            // that remainder: it is already circuit transport data and must
-            // cross the ownership boundary with the promoted bridge.
-            self.pending_data = pipelined;
-            self.promote(shared);
-            return;
-        }
-        self.dcutr = Some(DcutrResponder::new(&shared.punch_candidates()));
-        if !pipelined.is_empty() {
-            self.on_bridge_data(&pipelined, shared, now);
-        }
-    }
-
-    /// Feeds bridge bytes into the DCUtR responder.
-    fn on_bridge_data(&mut self, data: &[u8], shared: &mut Shared, now: Now) {
-        self.on_dcutr_input(DcutrResponderInput::Data(data.to_vec()), shared, now);
-    }
-
-    fn on_dcutr_input(&mut self, input: DcutrResponderInput, shared: &mut Shared, now: Now) {
-        let Some(dcutr) = self.dcutr.as_mut() else {
-            return;
-        };
-        if dcutr.handle_input(input).is_err() {
-            // The punch cannot proceed (malformed exchange or our own
-            // oversized reply), but the bridge itself is fine: hand it to
-            // the app without punching.
-            self.dcutr = None;
-            self.promote(shared);
-            return;
-        }
-        let mut outputs = Vec::new();
-        while let Some(output) = dcutr.poll_output() {
-            outputs.push(output);
-        }
-        let mut sync_received = false;
-        for output in outputs {
-            match output {
-                DcutrResponderOutput::Outbound(bytes) => {
-                    shared.push_action(NatAction::SendStream {
-                        peer: self.relay.clone(),
-                        stream_id: self.stream,
-                        data: bytes,
-                    });
-                }
-                DcutrResponderOutput::Event(ResponderEvent::ConnectReceived {
-                    remote_addrs,
-                    ..
-                }) => {
-                    self.remote_addrs = select_global_punch_candidates(&remote_addrs);
-                }
-                DcutrResponderOutput::Event(ResponderEvent::SyncReceived) => {
-                    sync_received = true;
-                }
-            }
-        }
-        if sync_received {
-            self.pending_data = dcutr.take_trailing_data().unwrap_or_default();
-            self.on_sync(shared, now);
-        }
-    }
-
-    /// SYNC arrived: open our NAT mapping with random-UDP blasts and hand
-    /// the bridge to the application.
-    ///
-    /// Per the DCUtR spec for QUIC, only the initiator dials. A responder
-    /// dial would race the initiator's — when both land (guaranteed
-    /// without NATs, common with cone NATs) the second connection
-    /// supersedes the first and the supersede scrubs every stream the
-    /// application just opened on the announced path.
-    fn on_sync(&mut self, shared: &mut Shared, now: Now) {
-        self.dcutr = None;
-        if self.source.is_none() {
-            return;
-        }
-
-        if !self.remote_addrs.is_empty() {
-            self.blast = Some(BlastSchedule {
-                addrs: self.remote_addrs.clone(),
-                // The spec says wait ~RTT/2 after SYNC; without a measured
-                // RTT this configured floor stands in for it.
-                next_at: now.mono_ms + shared.config.responder_sync_delay_ms,
-                until: now.mono_ms + shared.config.punch_deadline_ms,
-            });
-        }
-        // Stay alive for upgrade detection across the initiator's full
-        // retry window.
-        let window =
-            shared.config.punch_deadline_ms * (1 + u64::from(shared.config.punch_max_retries));
-        self.linger_until = Some(now.mono_ms + window);
+        // Bytes behind STOP STATUS belong to the circuit's secure-mux
+        // handshake. DCUtR is opened later on the promoted connection.
+        self.pending_data = pipelined;
         self.promote(shared);
     }
 
@@ -356,9 +263,8 @@ impl InboundCircuit {
         }
         if !self.released && now.mono_ms >= self.exchange_deadline {
             if self.source.is_some() {
-                // The punch exchange stalled, but the accepted bridge is
-                // perfectly usable: give it to the app without punching.
-                self.dcutr = None;
+                // STOP completed but promotion did not run. Preserve the
+                // accepted bridge rather than abandoning it.
                 self.promote(shared);
             } else {
                 // The relay never even sent CONNECT.
@@ -433,12 +339,24 @@ impl InboundCircuit {
                             relay: self.relay.clone(),
                         },
                     });
+                    if !shared.config.force_relay {
+                        let token = shared
+                            .alloc_token(TokenPurpose::OpenDcutrInbound(self.id, peer.clone()));
+                        shared.push_action(NatAction::OpenStream {
+                            token,
+                            peer: peer.clone(),
+                            protocol_id: minip2p_dcutr::DCUTR_PROTOCOL_ID.into(),
+                        });
+                    }
                 }
                 if directly_connected {
                     self.blast = None;
                     self.linger_until = None;
                     self.done = true;
-                } else if self.blast.is_none() && self.linger_until.is_none() {
+                } else if shared.config.force_relay
+                    && self.blast.is_none()
+                    && self.linger_until.is_none()
+                {
                     self.done = true;
                 }
             }
@@ -505,6 +423,117 @@ impl InboundCircuit {
                     Some(now.mono_ms + shared.config.circuit_handshake_timeout_ms);
             }
             Err(_) => self.done = true,
+        }
+    }
+
+    pub(crate) fn on_dcutr_open_result(
+        &mut self,
+        peer: &PeerId,
+        result: Result<StreamId, alloc::string::String>,
+        shared: &mut Shared,
+    ) {
+        match result {
+            Ok(stream) => {
+                self.dcutr_stream = Some(stream);
+                self.dcutr = Some(DcutrInitiator::new(&shared.punch_candidates()));
+                shared.own_stream(
+                    peer,
+                    stream,
+                    crate::agent::StreamRole::DcutrInbound(self.id),
+                );
+            }
+            Err(_) => {
+                self.linger_until = None;
+                self.done = true;
+            }
+        }
+    }
+
+    pub(crate) fn on_dcutr_stream_input(
+        &mut self,
+        stream: StreamId,
+        input: StreamInput<'_>,
+        shared: &mut Shared,
+        now: Now,
+    ) {
+        if self.dcutr_stream != Some(stream) {
+            return;
+        }
+        let Some(dcutr) = self.dcutr.as_mut() else {
+            return;
+        };
+        let machine_input = match input {
+            StreamInput::Ready => DcutrInitiatorInput::Flush,
+            StreamInput::Data(bytes) => DcutrInitiatorInput::Data {
+                bytes: bytes.to_vec(),
+                rtt_ms: 0,
+            },
+            StreamInput::RemoteWriteClosed | StreamInput::Closed => {
+                DcutrInitiatorInput::RemoteWriteClosed
+            }
+        };
+        if dcutr.handle_input(machine_input).is_err() {
+            self.dcutr = None;
+            self.dcutr_stream = None;
+            if let Some(peer) = self.source.as_ref() {
+                shared.release_stream(peer, stream);
+            }
+            self.done = true;
+            return;
+        }
+        let mut outputs = Vec::new();
+        while let Some(output) = dcutr.poll_output() {
+            outputs.push(output);
+        }
+        let mut completed = false;
+        for output in outputs {
+            match output {
+                DcutrInitiatorOutput::Outbound(data) => {
+                    if let Some(peer) = self.source.as_ref() {
+                        shared.push_action(NatAction::SendStream {
+                            peer: peer.clone(),
+                            stream_id: stream,
+                            data,
+                        });
+                    }
+                }
+                DcutrInitiatorOutput::Outcome(InitiatorOutcome::DialNow {
+                    remote_addrs, ..
+                }) => {
+                    self.remote_addrs = select_global_punch_candidates(&remote_addrs);
+                    if dcutr.handle_input(DcutrInitiatorInput::SendSync).is_ok() {
+                        while let Some(DcutrInitiatorOutput::Outbound(data)) = dcutr.poll_output() {
+                            if let Some(peer) = self.source.as_ref() {
+                                shared.push_action(NatAction::SendStream {
+                                    peer: peer.clone(),
+                                    stream_id: stream,
+                                    data,
+                                });
+                            }
+                        }
+                    }
+                    completed = true;
+                    if !self.remote_addrs.is_empty() {
+                        self.blast = Some(BlastSchedule {
+                            addrs: self.remote_addrs.clone(),
+                            next_at: now.mono_ms + shared.config.responder_sync_delay_ms,
+                            until: now.mono_ms + shared.config.punch_deadline_ms,
+                        });
+                    }
+                    self.linger_until = Some(
+                        now.mono_ms
+                            + shared.config.punch_deadline_ms
+                                * (1 + u64::from(shared.config.punch_max_retries)),
+                    );
+                }
+            }
+        }
+        if completed {
+            self.dcutr = None;
+            self.dcutr_stream = None;
+            if let Some(peer) = self.source.as_ref() {
+                shared.release_stream(peer, stream);
+            }
         }
     }
 }

--- a/crates/nat/src/inbound.rs
+++ b/crates/nat/src/inbound.rs
@@ -44,13 +44,11 @@ pub(crate) struct InboundCircuit {
     stop: Option<StopResponder>,
     dcutr: Option<DcutrInitiator>,
     dcutr_stream: Option<StreamId>,
+    dcutr_deadline: Option<u64>,
     remote_addrs: Vec<Multiaddr>,
     /// Secure-mux bytes coalesced behind the STOP success response. These
     /// must accompany circuit promotion.
     pending_data: Vec<u8>,
-    /// The remote write half reached EOF while the control plane still owned
-    /// the bridge. The transport will not repeat that event after handoff.
-    remote_write_closed: bool,
     /// Deadline for STOP acceptance and handing the bridge to circuit promotion.
     exchange_deadline: u64,
     blast: Option<BlastSchedule>,
@@ -85,9 +83,9 @@ impl InboundCircuit {
             stop: Some(StopResponder::new()),
             dcutr: None,
             dcutr_stream: None,
+            dcutr_deadline: None,
             remote_addrs: Vec::new(),
             pending_data: Vec::new(),
-            remote_write_closed: false,
             exchange_deadline: now.mono_ms + shared.config.relay_leg_deadline_ms,
             blast: None,
             linger_until: None,
@@ -121,6 +119,9 @@ impl InboundCircuit {
         if let Some(handshake) = self.handshake_deadline {
             due = Some(due.map_or(handshake, |d| d.min(handshake)));
         }
+        if let Some(deadline) = self.dcutr_deadline {
+            due = Some(due.map_or(deadline, |d| d.min(deadline)));
+        }
         due
     }
 
@@ -141,7 +142,6 @@ impl InboundCircuit {
                 }
             }
             StreamInput::RemoteWriteClosed => {
-                self.remote_write_closed = true;
                 // A peer can stop sending while the local write half remains
                 // usable. Let the protocol parser consume that boundary and
                 // retain the circuit until its normal exchange deadline.
@@ -208,9 +208,8 @@ impl InboundCircuit {
         }
         self.source = Some(source);
 
-        // STATUS:OK first, then any bytes the relay pipelined behind the
-        // CONNECT — those already belong to the DCUtR exchange and must
-        // reach the machine inside this same cascade.
+        // STATUS:OK first, then preserve any secure-mux bytes the relay
+        // pipelined behind CONNECT for circuit promotion.
         let mut outbound = Vec::new();
         let mut pipelined = Vec::new();
         while let Some(output) = stop.poll_output() {
@@ -252,7 +251,9 @@ impl InboundCircuit {
                 remote_peer: source.clone(),
                 role: BridgeRole::Responder,
                 pending_data: core::mem::take(&mut self.pending_data),
-                remote_write_closed: self.remote_write_closed,
+                // CONNECT completion promotes in the same input cascade, so
+                // no later half-close can arrive while NAT owns the bridge.
+                remote_write_closed: false,
             });
         }
     }
@@ -312,6 +313,12 @@ impl InboundCircuit {
             if let Some(conn_id) = self.promoted.take() {
                 shared.push_action(NatAction::CloseCircuit { conn_id });
             }
+            self.done = true;
+        }
+        if let Some(deadline) = self.dcutr_deadline
+            && now.mono_ms >= deadline
+        {
+            self.finish_dcutr(shared);
             self.done = true;
         }
     }
@@ -431,11 +438,13 @@ impl InboundCircuit {
         peer: &PeerId,
         result: Result<StreamId, alloc::string::String>,
         shared: &mut Shared,
+        now: Now,
     ) {
         match result {
             Ok(stream) => {
                 self.dcutr_stream = Some(stream);
                 self.dcutr = Some(DcutrInitiator::new(&shared.punch_candidates()));
+                self.dcutr_deadline = Some(now.mono_ms + shared.config.relay_leg_deadline_ms);
                 shared.own_stream(
                     peer,
                     stream,
@@ -462,6 +471,7 @@ impl InboundCircuit {
         let Some(dcutr) = self.dcutr.as_mut() else {
             return;
         };
+        let remote_closed = matches!(&input, StreamInput::RemoteWriteClosed | StreamInput::Closed);
         let machine_input = match input {
             StreamInput::Ready => DcutrInitiatorInput::Flush,
             StreamInput::Data(bytes) => DcutrInitiatorInput::Data {
@@ -473,11 +483,7 @@ impl InboundCircuit {
             }
         };
         if dcutr.handle_input(machine_input).is_err() {
-            self.dcutr = None;
-            self.dcutr_stream = None;
-            if let Some(peer) = self.source.as_ref() {
-                shared.release_stream(peer, stream);
-            }
+            self.finish_dcutr(shared);
             self.done = true;
             return;
         }
@@ -528,13 +534,30 @@ impl InboundCircuit {
                 }
             }
         }
-        if completed {
-            self.dcutr = None;
-            self.dcutr_stream = None;
-            if let Some(peer) = self.source.as_ref() {
-                shared.release_stream(peer, stream);
-            }
+        if remote_closed && !completed {
+            self.finish_dcutr(shared);
+            self.done = true;
+            return;
         }
+        if completed {
+            self.finish_dcutr(shared);
+        }
+    }
+
+    fn finish_dcutr(&mut self, shared: &mut Shared) {
+        self.dcutr = None;
+        self.dcutr_deadline = None;
+        let Some(stream_id) = self.dcutr_stream.take() else {
+            return;
+        };
+        let Some(peer) = self.source.as_ref() else {
+            return;
+        };
+        shared.push_action(NatAction::ResetStream {
+            peer: peer.clone(),
+            stream_id,
+        });
+        shared.release_stream(peer, stream_id);
     }
 }
 

--- a/crates/nat/src/lib.rs
+++ b/crates/nat/src/lib.rs
@@ -13,9 +13,9 @@
 //! t0      direct leg: dial every validated candidate address
 //! t0+δ    relay leg (stagger δ, 0 = fully parallel):
 //!           ensure relay session → HOP CONNECT(target)
-//!           → Bridged ⇒ start a DCUtR punch over the bridge
-//!           → after SYNC, promote bridge through Noise + Yamux
+//!           → Bridged ⇒ promote bridge through Noise + Yamux
 //!           → circuit Connected ⇒ PathEstablished(Relayed)
+//!           → reserved peer opens `/libp2p/dcutr` on that connection
 //! inbound STOP circuit Connected ⇒ InboundPathEstablished(Relayed)
 //! first usable path wins; a better path later ⇒ explicit PathUpgraded
 //! "fallback" is not a phase — it is what remains when the punch leg

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -48,37 +48,33 @@ fn drive_to_bridged(h: &mut Harness, t0: u64) -> (ConnectId, StreamId) {
     (id, stream)
 }
 
-/// Continues a bridged attempt through the DCUtR reply: punch dial + SYNC
-/// go out, then the bridge is handed to the circuit transport and announced
-/// only after the promoted connection establishes.
-fn drive_to_sync(h: &mut Harness, stream: StreamId, now_ms: u64) -> Vec<NatAction> {
-    h.stream_data(
-        stream,
-        dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]),
-        at(now_ms),
-    );
-    let actions = drain_actions(&mut h.agent);
-    assert_eq!(
-        dial_count_for(&actions, &h.target),
-        1,
-        "one punch dial for the observed address"
-    );
-    assert_eq!(send_stream_count(&actions), 1, "SYNC must be sent");
-    assert!(
-        !h.agent.owns_stream(&h.relay, stream),
-        "bridge belongs to the circuit transport once SYNC is out"
-    );
+fn advertised_dcutr_addrs(h: &mut Harness, t0: u64) -> Vec<Multiaddr> {
+    drive_to_bridged(h, t0);
+    let promotion = drain_actions(&mut h.agent);
     let target = h.target.clone();
-    complete_promotion(&mut h.agent, &target, &actions, at(now_ms + 1));
-    let events = drain_events(&mut h.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [NatEvent::PathEstablished {
-            path: Path::Relayed { .. },
-            ..
-        }]
-    ));
-    actions
+    complete_promotion(&mut h.agent, &target, &promotion, at(t0 + 301));
+    drain_events(&mut h.agent);
+    let stream = StreamId::new(8_000 + t0);
+    h.agent.handle_event(
+        &SwarmEvent::StreamReady {
+            conn_id: ConnectionId::new(TEST_CIRCUIT_ID),
+            peer_id: target.clone(),
+            stream_id: stream,
+            protocol_id: minip2p_nat::DCUTR_PROTOCOL_ID.into(),
+            initiated_locally: false,
+        },
+        at(t0 + 302),
+    );
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            conn_id: ConnectionId::new(TEST_CIRCUIT_ID),
+            peer_id: target,
+            stream_id: stream,
+            data: dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]),
+        },
+        at(t0 + 303),
+    );
+    dcutr_obs_addrs(&sent_data_on(&drain_actions(&mut h.agent), stream))
 }
 
 #[test]
@@ -184,15 +180,85 @@ fn force_relay_skips_direct_dials_and_dcutr() {
     complete_promotion(&mut h.agent, &target, &promotion, at(31));
     assert!(matches!(
         drain_events(&mut h.agent).as_slice(),
-        [
-            NatEvent::PathEstablished {
-                connect_id,
-                path: Path::Relayed { .. },
-                ..
-            },
-            NatEvent::FellBackToRelay { connect_id: fallback, .. },
-        ] if *connect_id == id && *fallback == id
+        [NatEvent::PathEstablished {
+            connect_id,
+            path: Path::Relayed { .. },
+            ..
+        }] if *connect_id == id
     ));
+}
+
+#[test]
+fn default_connect_promotes_the_bridge_before_dcutr() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (_, stream) = drive_to_bridged(&mut h, 0);
+
+    let actions = drain_actions(&mut h.agent);
+    assert!(actions.iter().any(|action| matches!(
+        action,
+        NatAction::PromoteBridge {
+            role: minip2p_nat::BridgeRole::Initiator,
+            stream_id,
+            ..
+        } if *stream_id == stream
+    )));
+    assert_eq!(
+        send_stream_count(&actions),
+        0,
+        "DCUtR starts on the promoted connection, not the raw bridge"
+    );
+}
+
+#[test]
+fn malformed_dcutr_keeps_the_established_relayed_path() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (id, _) = drive_to_bridged(&mut h, 0);
+    let promotion = drain_actions(&mut h.agent);
+    let target = h.target.clone();
+    complete_promotion(&mut h.agent, &target, &promotion, at(301));
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::PathEstablished { connect_id, path: Path::Relayed { .. }, .. }]
+            if *connect_id == id
+    ));
+
+    let stream = StreamId::new(9_001);
+    h.agent.handle_event(
+        &SwarmEvent::StreamReady {
+            conn_id: ConnectionId::new(TEST_CIRCUIT_ID),
+            peer_id: target.clone(),
+            stream_id: stream,
+            protocol_id: minip2p_nat::DCUTR_PROTOCOL_ID.into(),
+            initiated_locally: false,
+        },
+        at(302),
+    );
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            conn_id: ConnectionId::new(TEST_CIRCUIT_ID),
+            peer_id: target,
+            stream_id: stream,
+            data: b"\x13/multistream/1.0.0\n".to_vec(),
+        },
+        at(303),
+    );
+
+    let events = drain_events(&mut h.agent);
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, NatEvent::HolePunchFailed { .. }))
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, NatEvent::FellBackToRelay { .. }))
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, NatEvent::ConnectFailed { .. }))
+    );
 }
 
 #[test]
@@ -225,35 +291,27 @@ fn force_relay_preserves_bytes_coalesced_behind_hop_success() {
 }
 
 #[test]
-fn stalled_promoted_outbound_circuit_is_closed_at_connect_deadline() {
-    let mut h = Harness::with_relay(NatConfig {
-        connect_deadline_ms: 1_000,
-        ..NatConfig::default()
-    });
-    let (id, stream) = drive_to_bridged(&mut h, 0);
-    drain_actions(&mut h.agent); // DCUtR CONNECT
-    h.stream_data(
-        stream,
-        dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]),
-        at(350),
-    );
+fn default_connect_preserves_noise_bytes_coalesced_behind_hop_success() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    h.agent.connect(h.target.clone(), Vec::new(), at(0));
     let actions = drain_actions(&mut h.agent);
-    let conn_id = ConnectionId::new(TEST_CIRCUIT_ID);
+    let relay_token = dial_token_for(&actions, &h.relay);
     h.agent
-        .promote_result(promote_token(&actions), Ok(conn_id), at(351));
-    assert!(!h.agent.owns_stream(&h.relay, stream));
+        .dial_result(relay_token, Ok(ConnectionId::new(2)), at(5));
+    h.relay_session_ready(at(10));
+    let open = drain_actions(&mut h.agent);
+    let stream = StreamId::new(42);
+    h.agent
+        .stream_open_result(open_stream_token(&open), Ok(stream), at(15));
+    h.stream_ready(stream, at(20));
+    drain_actions(&mut h.agent);
 
-    h.agent.handle_tick(at(1_000));
-    assert!(
-        drain_actions(&mut h.agent).iter().any(
-            |action| matches!(action, NatAction::CloseCircuit { conn_id: id } if *id == conn_id)
-        )
-    );
-    assert!(matches!(
-        drain_events(&mut h.agent).as_slice(),
-        [NatEvent::ConnectFailed { connect_id, error: minip2p_nat::NatError::Timeout, .. }]
-            if *connect_id == id
-    ));
+    let noise = b"\x13/multistream/1.0.0\n\x07/noise\n".to_vec();
+    let mut coalesced = hop_status(Status::Ok);
+    coalesced.extend_from_slice(&noise);
+    h.stream_data(stream, coalesced, at(30));
+
+    assert_eq!(promoted_pending_data(&drain_actions(&mut h.agent)), noise);
 }
 
 #[test]
@@ -266,44 +324,6 @@ fn no_direct_candidates_skip_the_stagger() {
         1,
         "relay leg starts immediately when there is nothing to stagger against"
     );
-}
-
-#[test]
-fn relayed_path_upgrades_to_direct_without_misattribution() {
-    let mut h = Harness::with_relay(NatConfig::default());
-    let (id, stream) = drive_to_bridged(&mut h, 0);
-
-    assert!(drain_events(&mut h.agent).is_empty());
-    assert!(h.agent.owns_stream(&h.relay, stream));
-    let actions = drain_actions(&mut h.agent);
-    assert_eq!(
-        send_stream_count(&actions),
-        1,
-        "DCUtR CONNECT goes out on the bridge"
-    );
-
-    drive_to_sync(&mut h, stream, 350);
-
-    // The punch lands: the direct connection appears.
-    h.target_connected(at(600));
-    let events = drain_events(&mut h.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [NatEvent::PathUpgraded {
-            connect_id,
-            from: Path::Relayed { .. },
-            to: Path::DirectDialed,
-            ..
-        }] if *connect_id == id
-    ));
-    let actions = drain_actions(&mut h.agent);
-    assert!(
-        actions
-            .iter()
-            .any(|action| matches!(action, NatAction::CloseCircuit { .. })),
-        "the superseded promoted circuit must be closed, never silently leaked"
-    );
-    assert!(h.agent.is_idle());
 }
 
 #[test]
@@ -370,90 +390,6 @@ fn unconfigured_peer_cannot_claim_an_inbound_stop_stream() {
         at(3),
     ));
     assert!(!h.agent.owns_stream(&attacker, stream));
-    assert!(drain_actions(&mut h.agent).is_empty());
-    assert!(drain_events(&mut h.agent).is_empty());
-}
-
-#[test]
-fn remote_write_close_during_dcutr_releases_relay_and_keeps_direct_dials_live() {
-    let mut h = Harness::with_relay(NatConfig::default());
-    let (id, stream) = drive_to_bridged(&mut h, 0);
-    drain_actions(&mut h.agent);
-
-    h.agent.handle_event(
-        &SwarmEvent::StreamRemoteWriteClosed {
-            conn_id: minip2p_transport::ConnectionId::new(1),
-            peer_id: h.relay.clone(),
-            stream_id: stream,
-        },
-        at(310),
-    );
-
-    assert!(!h.agent.owns_stream(&h.relay, stream));
-    let actions = drain_actions(&mut h.agent);
-    assert!(promotion_remote_write_closed(&actions));
-    assert!(matches!(
-        drain_events(&mut h.agent).as_slice(),
-        [NatEvent::HolePunchFailed { connect_id: failed, .. }] if *failed == id
-    ));
-
-    h.agent.promote_result(
-        promote_token(&actions),
-        Err(minip2p_nat::PromoteError::Failed("remote EOF".into())),
-        at(311),
-    );
-
-    h.target_connected(at(320));
-    assert!(matches!(
-        drain_events(&mut h.agent).as_slice(),
-        [NatEvent::PathEstablished {
-            connect_id,
-            path: Path::DirectDialed,
-            ..
-        }] if *connect_id == id
-    ));
-}
-
-#[test]
-fn relay_supersede_scrubs_old_stream_ids_without_resetting_the_new_connection() {
-    let mut h = Harness::with_relay(NatConfig::default());
-    let (_, stream) = drive_to_bridged(&mut h, 0);
-    drain_actions(&mut h.agent);
-    assert!(h.agent.owns_stream(&h.relay, stream));
-
-    h.agent.handle_event(
-        &SwarmEvent::ConnectionClosed {
-            conn_id: minip2p_transport::ConnectionId::new(1),
-            peer_id: h.relay.clone(),
-            cause: minip2p_swarm::ConnectionCloseCause::Transport,
-        },
-        at(310),
-    );
-    h.agent.handle_event(
-        &SwarmEvent::ConnectionEstablished {
-            conn_id: minip2p_transport::ConnectionId::new(2),
-            peer_id: h.relay.clone(),
-        },
-        at(311),
-    );
-
-    assert!(!h.agent.owns_stream(&h.relay, stream));
-    assert!(
-        !has_reset_for(&drain_actions(&mut h.agent), stream),
-        "a stale stream id must never reset a colliding stream on the replacement connection"
-    );
-
-    // The replacement connection may reuse the same stream id. Its event
-    // must not be routed into the retired attempt.
-    h.agent.handle_event(
-        &SwarmEvent::StreamData {
-            conn_id: minip2p_transport::ConnectionId::new(2),
-            peer_id: h.relay.clone(),
-            stream_id: stream,
-            data: b"new connection data".to_vec(),
-        },
-        at(311),
-    );
     assert!(drain_actions(&mut h.agent).is_empty());
     assert!(drain_events(&mut h.agent).is_empty());
 }
@@ -560,160 +496,6 @@ fn bridge_close_before_dcutr_finishes_waits_for_live_direct_dials() {
 }
 
 #[test]
-fn established_relay_loss_never_turns_success_into_connect_failed() {
-    let mut h = Harness::with_relay(NatConfig {
-        punch_max_retries: 0,
-        ..NatConfig::default()
-    });
-    let (id, stream) = drive_to_bridged(&mut h, 0);
-    drain_actions(&mut h.agent);
-    drive_to_sync(&mut h, stream, 350);
-
-    // The circuit transport turns bridge termination into the promoted
-    // connection's terminal lifecycle event.
-    h.agent.handle_event_with_disposition_classified(
-        &SwarmEvent::ConnectionClosed {
-            conn_id: minip2p_transport::ConnectionId::new(TEST_CIRCUIT_ID),
-            peer_id: h.target.clone(),
-            cause: minip2p_swarm::ConnectionCloseCause::Transport,
-        },
-        true,
-        at(400),
-    );
-    h.agent.handle_tick(at(3_350));
-    let events = drain_events(&mut h.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [NatEvent::HolePunchFailed { connect_id, .. }] if *connect_id == id
-    ));
-    assert!(
-        !events
-            .iter()
-            .any(|event| matches!(event, NatEvent::FellBackToRelay { .. }))
-    );
-
-    // Once the still-live original dial expires there is nothing left to
-    // upgrade, but PathEstablished remains the terminal result for this id.
-    h.agent.handle_tick(at(60_000));
-    assert!(drain_events(&mut h.agent).is_empty());
-    assert!(h.agent.is_idle());
-}
-
-#[test]
-fn peer_already_direct_promotion_error_waits_for_the_direct_connection() {
-    let mut h = Harness::with_relay(NatConfig::default());
-    let (id, stream) = drive_to_bridged(&mut h, 0);
-    drain_actions(&mut h.agent); // DCUtR CONNECT
-    h.stream_data(
-        stream,
-        dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]),
-        at(350),
-    );
-    let promotion = drain_actions(&mut h.agent);
-
-    // The swarm already knows a direct session won, but the NatAgent has
-    // not consumed its ConnectionEstablished event yet.
-    let token = promote_token(&promotion);
-    h.agent.promote_result(
-        token,
-        Err(minip2p_nat::PromoteError::PeerAlreadyDirect),
-        at(351),
-    );
-    assert!(drain_actions(&mut h.agent).is_empty());
-    assert!(drain_events(&mut h.agent).is_empty());
-
-    h.target_connected(at(352));
-    assert!(matches!(
-        drain_events(&mut h.agent).as_slice(),
-        [NatEvent::PathEstablished {
-            connect_id,
-            path: Path::DirectDialed,
-            ..
-        }] if *connect_id == id
-    ));
-    assert!(h.agent.is_idle());
-
-    // The driver echo is tokenized exactly once; duplicates stay inert.
-    h.agent.promote_result(
-        token,
-        Err(minip2p_nat::PromoteError::PeerAlreadyDirect),
-        at(353),
-    );
-    assert!(drain_actions(&mut h.agent).is_empty());
-    assert!(drain_events(&mut h.agent).is_empty());
-}
-
-#[test]
-fn initiator_dials_only_global_ip_targets_from_peer_dcutr_reply() {
-    let mut h = Harness::with_relay(NatConfig::default());
-    let (_, stream) = drive_to_bridged(&mut h, 0);
-    drain_actions(&mut h.agent); // DCUtR CONNECT
-    let global = maddr("/ip4/9.9.9.9/udp/4002/quic-v1");
-    h.stream_data(
-        stream,
-        dcutr_connect_reply(&[
-            maddr("/ip4/10.0.0.7/udp/4002/quic-v1"),
-            maddr("/dns4/attacker.invalid/udp/4002/quic-v1"),
-            maddr("/ip4/192.0.2.7/udp/4002/quic-v1"),
-            global.clone(),
-        ]),
-        at(350),
-    );
-
-    let dials: Vec<_> = drain_actions(&mut h.agent)
-        .into_iter()
-        .filter_map(|action| match action {
-            NatAction::Dial { addr, .. } if addr.peer_id() == &h.target => {
-                Some(addr.transport().clone())
-            }
-            _ => None,
-        })
-        .collect();
-    assert_eq!(dials, vec![global]);
-}
-
-#[test]
-fn punch_exhaustion_falls_back_to_the_relay() {
-    let mut h = Harness::with_relay(NatConfig::default());
-    let (id, stream) = drive_to_bridged(&mut h, 0);
-    drain_actions(&mut h.agent);
-    drive_to_sync(&mut h, stream, 350);
-
-    // Default config: one window + two retries, 3s each.
-    for (tick_ms, window) in [(3_350, 1u32), (6_350, 2)] {
-        h.agent.handle_tick(at(tick_ms));
-        let events = drain_events(&mut h.agent);
-        assert!(matches!(
-            events.as_slice(),
-            [NatEvent::HolePunchFailed { attempt, .. }] if *attempt == window
-        ));
-        let actions = drain_actions(&mut h.agent);
-        assert_eq!(
-            dial_count_for(&actions, &h.target),
-            1,
-            "each retry re-dials the observed address"
-        );
-    }
-
-    h.agent.handle_tick(at(9_350));
-    let events = drain_events(&mut h.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [
-            NatEvent::HolePunchFailed { attempt: 3, .. },
-            NatEvent::FellBackToRelay { connect_id, .. },
-        ] if *connect_id == id
-    ));
-    let actions = drain_actions(&mut h.agent);
-    assert!(
-        !has_reset_for(&actions, stream),
-        "the surviving relayed path must not be reset"
-    );
-    assert!(!h.agent.owns_stream(&h.relay, stream));
-    assert!(h.agent.is_idle());
-}
-
-#[test]
 fn all_legs_failing_reports_connect_failed() {
     let mut h = Harness::with_relay(NatConfig::default());
     h.agent
@@ -815,135 +597,6 @@ fn relay_refusal_fails_when_no_direct_leg_remains() {
 }
 
 #[test]
-fn initiator_reply_coalesced_with_application_data_preserves_remainder() {
-    let mut h = Harness::with_relay(NatConfig::default());
-    let id = h.agent.connect(h.target.clone(), Vec::new(), at(0));
-    let actions = drain_actions(&mut h.agent);
-    let relay_token = dial_token_for(&actions, &h.relay);
-    h.agent
-        .dial_result(relay_token, Ok(ConnectionId::new(2)), at(5));
-    h.relay_session_ready(at(10));
-
-    let actions = drain_actions(&mut h.agent);
-    let open_token = open_stream_token(&actions);
-    let stream = StreamId::new(9);
-    h.agent.stream_open_result(open_token, Ok(stream), at(15));
-    h.stream_ready(stream, at(20));
-    drain_actions(&mut h.agent);
-
-    // STATUS:OK and the responder's DCUtR CONNECT coalesced in one read:
-    // the pipelined bytes must feed the just-created DCUtR machine inside
-    // the same cascade.
-    let app_data = b"application bytes after dcutr reply";
-    let mut coalesced = hop_status(Status::Ok);
-    coalesced.extend(dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]));
-    coalesced.extend_from_slice(app_data);
-    h.stream_data(stream, coalesced, at(100));
-
-    let actions = drain_actions(&mut h.agent);
-    assert_eq!(promoted_pending_data(&actions), app_data);
-    let target = h.target.clone();
-    complete_promotion(&mut h.agent, &target, &actions, at(101));
-    let events = drain_events(&mut h.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [NatEvent::PathEstablished {
-            connect_id,
-            path: Path::Relayed { .. },
-            ..
-        }] if *connect_id == id
-    ));
-    assert_eq!(
-        dial_count_for(&actions, &h.target),
-        1,
-        "punch dial issued from the pipelined reply"
-    );
-    assert_eq!(
-        send_stream_count(&actions),
-        2,
-        "DCUtR CONNECT and SYNC both go out"
-    );
-    assert!(!h.agent.owns_stream(&h.relay, stream));
-
-    h.target_connected(at(110));
-    assert!(matches!(
-        drain_events(&mut h.agent).as_slice(),
-        [NatEvent::PathUpgraded {
-            connect_id,
-            from: Path::Relayed { .. },
-            to: Path::DirectPunched,
-            ..
-        }] if *connect_id == id
-    ));
-    let actions = drain_actions(&mut h.agent);
-    assert!(
-        actions.iter().any(
-            |action| matches!(action, NatAction::CloseCircuit { conn_id } if conn_id.as_u64() == TEST_CIRCUIT_ID)
-        ),
-        "the punched direct connection must retire the promoted circuit"
-    );
-}
-
-#[test]
-fn oversized_dcutr_connect_falls_back_to_relay() {
-    let mut h = Harness::with_relay(NatConfig::default());
-    // Enough distinct addresses that the encoded DCUtR CONNECT exceeds the
-    // 4 KiB frame cap, tripping the machine's deferred construction error.
-    let addrs: Vec<Multiaddr> = (1u16..=400)
-        .map(|port| maddr(&format!("/ip4/198.51.100.5/udp/{port}/quic-v1")))
-        .collect();
-    h.agent.set_listen_addrs(&addrs);
-
-    let (id, stream) = drive_to_bridged(&mut h, 0);
-    let actions = drain_actions(&mut h.agent);
-    let target = h.target.clone();
-    complete_promotion(&mut h.agent, &target, &actions, at(301));
-    let events = drain_events(&mut h.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [
-            NatEvent::HolePunchFailed { .. },
-            NatEvent::PathEstablished { path: Path::Relayed { .. }, .. },
-            NatEvent::FellBackToRelay { connect_id, .. },
-        ] if *connect_id == id
-    ));
-    assert!(!h.agent.owns_stream(&h.relay, stream));
-    assert!(h.agent.is_idle());
-}
-
-#[test]
-fn foreign_stream_events_are_ignored_without_state_changes() {
-    let mut h = Harness::with_relay(NatConfig::default());
-    let (_, stream) = drive_to_bridged(&mut h, 0);
-    drain_events(&mut h.agent);
-    drain_actions(&mut h.agent);
-
-    // A stream the agent never opened — same peer, different id.
-    let foreign = StreamId::new(1_234);
-    assert!(!h.agent.owns_stream(&h.relay, foreign));
-    h.stream_data(foreign, b"app data".to_vec(), at(320));
-
-    // Same id as the bridge but on a different peer's connection.
-    assert!(!h.agent.owns_stream(&h.target, stream));
-    h.agent.handle_event(
-        &SwarmEvent::StreamData {
-            conn_id: minip2p_transport::ConnectionId::new(1),
-            peer_id: h.target.clone(),
-            stream_id: stream,
-            data: b"app data".to_vec(),
-        },
-        at(321),
-    );
-
-    assert!(drain_actions(&mut h.agent).is_empty());
-    assert!(drain_events(&mut h.agent).is_empty());
-    assert!(
-        h.agent.owns_stream(&h.relay, stream),
-        "bridge is still owned"
-    );
-}
-
-#[test]
 fn duplicate_direct_connection_does_not_double_report() {
     let mut h = Harness::with_relay(NatConfig::default());
     h.agent
@@ -956,27 +609,6 @@ fn duplicate_direct_connection_does_not_double_report() {
     h.target_connected(at(60));
     assert!(drain_events(&mut h.agent).is_empty());
     assert!(drain_actions(&mut h.agent).is_empty());
-}
-
-#[test]
-fn cancel_mid_race_resets_streams_and_goes_quiet() {
-    let mut h = Harness::with_relay(NatConfig::default());
-    let (id, stream) = drive_to_bridged(&mut h, 0);
-    drain_events(&mut h.agent);
-    drain_actions(&mut h.agent);
-
-    h.agent.cancel(id, at(320));
-    let actions = drain_actions(&mut h.agent);
-    assert!(has_reset_for(&actions, stream));
-    assert!(drain_events(&mut h.agent).is_empty(), "cancel is silent");
-    assert!(!h.agent.owns_stream(&h.relay, stream));
-
-    // Late inputs for the dead attempt change nothing.
-    h.stream_data(stream, hop_status(Status::Ok), at(330));
-    h.target_connected(at(340));
-    assert!(drain_actions(&mut h.agent).is_empty());
-    assert!(drain_events(&mut h.agent).is_empty());
-    assert!(h.agent.is_idle());
 }
 
 #[test]
@@ -1104,9 +736,7 @@ fn identify_observed_addr_joins_dcutr_connect() {
         at(0),
     );
 
-    let (_id, stream) = drive_to_bridged(&mut h, 10);
-    let actions = drain_actions(&mut h.agent);
-    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    let obs = advertised_dcutr_addrs(&mut h, 10);
     assert!(
         obs.contains(&maddr(LISTEN_ADDR)),
         "bound addresses stay in the CONNECT"
@@ -1127,9 +757,7 @@ fn latest_observation_per_reporter_wins() {
     identify_observed(&mut h.agent, &relay, &maddr(stale), at(0));
     identify_observed(&mut h.agent, &relay, &maddr(OUR_OBSERVED_ADDR), at(1));
 
-    let (_id, stream) = drive_to_bridged(&mut h, 10);
-    let actions = drain_actions(&mut h.agent);
-    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    let obs = advertised_dcutr_addrs(&mut h, 10);
     assert!(obs.contains(&maddr(OUR_OBSERVED_ADDR)));
     assert!(!obs.contains(&maddr(stale)), "replaced observation leaks");
 }
@@ -1161,9 +789,7 @@ fn reporter_disconnect_drops_its_observation() {
     h.agent.handle_tick(at(1));
     h.agent.handle_tick(at(1));
 
-    let (_id, stream) = drive_to_bridged(&mut h, 10);
-    let actions = drain_actions(&mut h.agent);
-    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    let obs = advertised_dcutr_addrs(&mut h, 10);
     assert_eq!(
         obs,
         vec![maddr(LISTEN_ADDR)],
@@ -1201,9 +827,7 @@ fn observed_addrs_from_untrusted_peers_are_ignored() {
     let other = peer(b"other-peer");
     identify_observed(&mut h.agent, &other, &maddr(attacker_chosen), at(1));
 
-    let (_id, stream) = drive_to_bridged(&mut h, 10);
-    let actions = drain_actions(&mut h.agent);
-    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    let obs = advertised_dcutr_addrs(&mut h, 10);
     assert_eq!(
         obs,
         vec![maddr(LISTEN_ADDR)],
@@ -1222,9 +846,7 @@ fn autonat_server_is_a_trusted_reporter() {
     });
     identify_observed(&mut h.agent, &autonat, &maddr(OUR_OBSERVED_ADDR), at(0));
 
-    let (_id, stream) = drive_to_bridged(&mut h, 10);
-    let actions = drain_actions(&mut h.agent);
-    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    let obs = advertised_dcutr_addrs(&mut h, 10);
     assert!(
         obs.contains(&maddr(OUR_OBSERVED_ADDR)),
         "a configured AutoNAT server's observation must be usable"
@@ -1243,9 +865,7 @@ fn tcp_observation_does_not_replace_a_trusted_quic_punch_candidate() {
         at(1),
     );
 
-    let (_id, stream) = drive_to_bridged(&mut h, 10);
-    let actions = drain_actions(&mut h.agent);
-    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    let obs = advertised_dcutr_addrs(&mut h, 10);
     assert!(
         obs.contains(&maddr(OUR_OBSERVED_ADDR)),
         "a later TCP Identify observation must not evict the relay's QUIC mapping"
@@ -1267,9 +887,7 @@ fn undecodable_observed_addr_bytes_are_ignored() {
         at(0),
     );
 
-    let (_id, stream) = drive_to_bridged(&mut h, 10);
-    let actions = drain_actions(&mut h.agent);
-    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    let obs = advertised_dcutr_addrs(&mut h, 10);
     assert_eq!(
         obs,
         vec![maddr(LISTEN_ADDR)],
@@ -1288,9 +906,7 @@ fn non_quic_observed_addr_is_ignored() {
         at(0),
     );
 
-    let (_id, stream) = drive_to_bridged(&mut h, 10);
-    let actions = drain_actions(&mut h.agent);
-    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
+    let obs = advertised_dcutr_addrs(&mut h, 10);
     assert_eq!(
         obs,
         vec![maddr(LISTEN_ADDR)],

--- a/crates/nat/tests/arbitration.rs
+++ b/crates/nat/tests/arbitration.rs
@@ -244,21 +244,20 @@ fn malformed_dcutr_keeps_the_established_relayed_path() {
     );
 
     let events = drain_events(&mut h.agent);
-    assert!(
-        events
-            .iter()
-            .any(|event| matches!(event, NatEvent::HolePunchFailed { .. }))
-    );
-    assert!(
-        events
-            .iter()
-            .any(|event| matches!(event, NatEvent::FellBackToRelay { .. }))
-    );
-    assert!(
-        !events
-            .iter()
-            .any(|event| matches!(event, NatEvent::ConnectFailed { .. }))
-    );
+    assert!(matches!(
+        events.as_slice(),
+        [
+            NatEvent::HolePunchFailed {
+                connect_id,
+                attempt: 1,
+                ..
+            },
+            NatEvent::FellBackToRelay {
+                connect_id: fallback_id,
+                peer,
+            }
+        ] if *connect_id == id && *fallback_id == id && peer == &h.target
+    ));
 }
 
 #[test]

--- a/crates/nat/tests/arbitration_regressions.rs
+++ b/crates/nat/tests/arbitration_regressions.rs
@@ -1,4 +1,4 @@
-//! Focused lifecycle regressions for Relayed-before-DCUtR ordering.
+//! Focused lifecycle and stream-ownership regressions for Relayed-before-DCUtR.
 
 mod common;
 
@@ -210,4 +210,185 @@ fn established_relay_loss_never_becomes_connect_failed() {
             .iter()
             .any(|event| matches!(event, NatEvent::ConnectFailed { .. }))
     );
+}
+
+#[test]
+fn failed_original_dial_does_not_settle_before_dcutr_starts() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let id = h
+        .agent
+        .connect(h.target.clone(), vec![maddr(TARGET_ADDR)], at(0));
+    let actions = drain_actions(&mut h.agent);
+    let direct = dial_token_for(&actions, &h.target);
+    h.agent.handle_tick(at(200));
+    let actions = drain_actions(&mut h.agent);
+    let relay = dial_token_for(&actions, &h.relay);
+    h.agent
+        .dial_result(relay, Ok(ConnectionId::new(2)), at(205));
+    h.relay_session_ready(at(210));
+    let actions = drain_actions(&mut h.agent);
+    let stream = StreamId::new(7);
+    h.agent
+        .stream_open_result(open_stream_token(&actions), Ok(stream), at(215));
+    h.stream_ready(stream, at(220));
+    drain_actions(&mut h.agent);
+    h.stream_data(stream, hop_status(Status::Ok), at(300));
+    let promotion = drain_actions(&mut h.agent);
+    let target = h.target.clone();
+    let conn = complete_promotion(&mut h.agent, &target, &promotion, at(301));
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::PathEstablished { connect_id, path: Path::Relayed { .. }, .. }]
+            if *connect_id == id
+    ));
+
+    h.agent
+        .dial_result(direct, Err("direct dial failed".into()), at(302));
+
+    assert!(drain_events(&mut h.agent).is_empty());
+    open_inbound_dcutr(&mut h, conn, StreamId::new(90));
+}
+
+#[test]
+fn incomplete_dcutr_close_fails_and_resets_the_exchange() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (id, conn) = drive_to_relayed(&mut h);
+    let stream = StreamId::new(90);
+    open_inbound_dcutr(&mut h, conn, stream);
+
+    h.agent.handle_event(
+        &SwarmEvent::StreamClosed {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: stream,
+        },
+        at(311),
+    );
+
+    assert!(has_reset_for(&drain_actions(&mut h.agent), stream));
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [
+            NatEvent::HolePunchFailed { connect_id, .. },
+            NatEvent::FellBackToRelay { connect_id: fallback_id, .. }
+        ] if *connect_id == id && *fallback_id == id
+    ));
+    assert!(h.agent.is_idle());
+}
+
+fn drive_dcutr_through_sync(
+    h: &mut Harness,
+    conn: ConnectionId,
+    stream: StreamId,
+) -> Vec<NatAction> {
+    open_inbound_dcutr(h, conn, stream);
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: stream,
+            data: dcutr_connect_reply(&[maddr("/ip4/9.9.9.9/udp/4002/quic-v1")]),
+        },
+        at(311),
+    );
+    drain_actions(&mut h.agent);
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: stream,
+            data: dcutr_sync(),
+        },
+        at(312),
+    );
+    drain_actions(&mut h.agent)
+}
+
+#[test]
+fn sync_resets_the_completed_dcutr_control_stream() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (_, conn) = drive_to_relayed(&mut h);
+    let stream = StreamId::new(90);
+    assert!(has_reset_for(
+        &drive_dcutr_through_sync(&mut h, conn, stream),
+        stream
+    ));
+}
+
+#[test]
+fn sync_makes_dcutr_one_shot() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (_, conn) = drive_to_relayed(&mut h);
+    drive_dcutr_through_sync(&mut h, conn, StreamId::new(90));
+
+    let second = StreamId::new(91);
+    h.agent.handle_event(
+        &SwarmEvent::StreamReady {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: second,
+            protocol_id: minip2p_nat::DCUTR_PROTOCOL_ID.into(),
+            initiated_locally: false,
+        },
+        at(313),
+    );
+    assert!(has_reset_for(&drain_actions(&mut h.agent), second));
+}
+
+#[test]
+fn connect_deadline_reaps_an_active_dcutr_stream() {
+    let mut h = Harness::with_relay(NatConfig {
+        connect_deadline_ms: 1_000,
+        ..NatConfig::default()
+    });
+    let (_, conn) = drive_to_relayed(&mut h);
+    let stream = StreamId::new(90);
+    open_inbound_dcutr(&mut h, conn, stream);
+
+    h.agent.handle_tick(at(1_000));
+
+    assert!(has_reset_for(&drain_actions(&mut h.agent), stream));
+    assert!(!h.agent.owns_stream(&h.target, stream));
+    drain_events(&mut h.agent);
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn empty_filtered_dcutr_targets_fail_permanently() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (id, conn) = drive_to_relayed(&mut h);
+    let stream = StreamId::new(90);
+    open_inbound_dcutr(&mut h, conn, stream);
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: stream,
+            data: dcutr_connect_reply(&[maddr("/ip4/10.0.0.7/udp/4002/quic-v1")]),
+        },
+        at(311),
+    );
+    drain_actions(&mut h.agent);
+
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: stream,
+            data: dcutr_sync(),
+        },
+        at(312),
+    );
+
+    assert!(has_reset_for(&drain_actions(&mut h.agent), stream));
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [
+            NatEvent::HolePunchFailed { connect_id, reason, .. },
+            NatEvent::FellBackToRelay { connect_id: fallback_id, .. }
+        ] if *connect_id == id
+            && *fallback_id == id
+            && reason == "no dialable remote addresses in DCUtR CONNECT"
+    ));
+    assert!(h.agent.is_idle());
 }

--- a/crates/nat/tests/arbitration_regressions.rs
+++ b/crates/nat/tests/arbitration_regressions.rs
@@ -1,0 +1,213 @@
+//! Focused lifecycle regressions for Relayed-before-DCUtR ordering.
+
+mod common;
+
+use common::*;
+
+use minip2p_core::Multiaddr;
+use minip2p_nat::{ConnectId, NatAction, NatConfig, NatEvent, Path, PromoteError};
+use minip2p_relay::Status;
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::{ConnectionId, StreamId};
+
+fn drive_to_bridged(h: &mut Harness) -> (ConnectId, StreamId, Vec<NatAction>) {
+    let id = h
+        .agent
+        .connect(h.target.clone(), vec![maddr(TARGET_ADDR)], at(0));
+    let actions = drain_actions(&mut h.agent);
+    let direct = dial_token_for(&actions, &h.target);
+    h.agent.dial_result(direct, Ok(ConnectionId::new(1)), at(5));
+    h.agent.handle_tick(at(200));
+    let actions = drain_actions(&mut h.agent);
+    let relay = dial_token_for(&actions, &h.relay);
+    h.agent
+        .dial_result(relay, Ok(ConnectionId::new(2)), at(205));
+    h.relay_session_ready(at(210));
+    let actions = drain_actions(&mut h.agent);
+    let stream = StreamId::new(7);
+    h.agent
+        .stream_open_result(open_stream_token(&actions), Ok(stream), at(215));
+    h.stream_ready(stream, at(220));
+    drain_actions(&mut h.agent);
+    h.stream_data(stream, hop_status(Status::Ok), at(300));
+    let promotion = drain_actions(&mut h.agent);
+    (id, stream, promotion)
+}
+
+fn drive_to_relayed(h: &mut Harness) -> (ConnectId, ConnectionId) {
+    let (id, _, promotion) = drive_to_bridged(h);
+    let target = h.target.clone();
+    let conn = complete_promotion(&mut h.agent, &target, &promotion, at(301));
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::PathEstablished { connect_id, path: Path::Relayed { .. }, .. }]
+            if *connect_id == id
+    ));
+    (id, conn)
+}
+
+fn open_inbound_dcutr(h: &mut Harness, conn: ConnectionId, stream: StreamId) {
+    h.agent.handle_event(
+        &SwarmEvent::StreamReady {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: stream,
+            protocol_id: minip2p_nat::DCUTR_PROTOCOL_ID.into(),
+            initiated_locally: false,
+        },
+        at(310),
+    );
+    assert!(h.agent.owns_stream(&h.target, stream));
+}
+
+#[test]
+fn stalled_promoted_outbound_circuit_is_closed_at_connect_deadline() {
+    let mut h = Harness::with_relay(NatConfig {
+        connect_deadline_ms: 1_000,
+        ..NatConfig::default()
+    });
+    let (id, _, promotion) = drive_to_bridged(&mut h);
+    let conn = ConnectionId::new(TEST_CIRCUIT_ID);
+    h.agent
+        .promote_result(promote_token(&promotion), Ok(conn), at(301));
+
+    h.agent.handle_tick(at(1_000));
+
+    assert!(
+        drain_actions(&mut h.agent).iter().any(
+            |action| matches!(action, NatAction::CloseCircuit { conn_id } if *conn_id == conn)
+        )
+    );
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::ConnectFailed { connect_id, .. }] if *connect_id == id
+    ));
+}
+
+#[test]
+fn promotion_that_loses_to_a_direct_connection_waits_for_its_event() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (id, _, promotion) = drive_to_bridged(&mut h);
+    let token = promote_token(&promotion);
+    h.agent
+        .promote_result(token, Err(PromoteError::PeerAlreadyDirect), at(301));
+    assert!(drain_events(&mut h.agent).is_empty());
+
+    h.target_connected(at(302));
+
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::PathEstablished { connect_id, path: Path::DirectDialed, .. }]
+            if *connect_id == id
+    ));
+}
+
+#[test]
+fn circuit_dialer_filters_peer_supplied_punch_targets() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (_, conn) = drive_to_relayed(&mut h);
+    let stream = StreamId::new(90);
+    open_inbound_dcutr(&mut h, conn, stream);
+    let global = maddr("/ip4/9.9.9.9/udp/4002/quic-v1");
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: stream,
+            data: dcutr_connect_reply(&[
+                maddr("/ip4/10.0.0.7/udp/4002/quic-v1"),
+                maddr("/dns4/attacker.invalid/udp/4002/quic-v1"),
+                maddr("/ip4/192.0.2.7/udp/4002/quic-v1"),
+                global.clone(),
+            ]),
+        },
+        at(311),
+    );
+    drain_actions(&mut h.agent);
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: stream,
+            data: dcutr_sync(),
+        },
+        at(312),
+    );
+
+    let dials: Vec<Multiaddr> = drain_actions(&mut h.agent)
+        .into_iter()
+        .filter_map(|action| match action {
+            NatAction::Dial { addr, .. } if addr.peer_id() == &h.target => {
+                Some(addr.transport().clone())
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(dials, vec![global]);
+}
+
+#[test]
+fn foreign_streams_do_not_mutate_an_active_dcutr_exchange() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (_, conn) = drive_to_relayed(&mut h);
+    let owned = StreamId::new(90);
+    open_inbound_dcutr(&mut h, conn, owned);
+    let foreign = StreamId::new(91);
+
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: foreign,
+            data: b"foreign".to_vec(),
+        },
+        at(311),
+    );
+
+    assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(h.agent.owns_stream(&h.target, owned));
+}
+
+#[test]
+fn cancelling_an_active_dcutr_resets_it_and_closes_the_circuit() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (id, conn) = drive_to_relayed(&mut h);
+    let stream = StreamId::new(90);
+    open_inbound_dcutr(&mut h, conn, stream);
+
+    h.agent.cancel(id, at(311));
+
+    let actions = drain_actions(&mut h.agent);
+    assert!(has_reset_for(&actions, stream));
+    assert!(
+        actions.iter().any(
+            |action| matches!(action, NatAction::CloseCircuit { conn_id } if *conn_id == conn)
+        )
+    );
+    assert!(!h.agent.owns_stream(&h.target, stream));
+    assert!(drain_events(&mut h.agent).is_empty());
+}
+
+#[test]
+fn established_relay_loss_never_becomes_connect_failed() {
+    let mut h = Harness::with_relay(NatConfig::default());
+    let (_, conn) = drive_to_relayed(&mut h);
+
+    h.agent.handle_event_with_disposition_classified(
+        &SwarmEvent::ConnectionClosed {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            cause: minip2p_swarm::ConnectionCloseCause::Transport,
+        },
+        true,
+        at(400),
+    );
+    h.agent.handle_tick(at(60_000));
+
+    assert!(
+        !drain_events(&mut h.agent)
+            .iter()
+            .any(|event| matches!(event, NatEvent::ConnectFailed { .. }))
+    );
+}

--- a/crates/nat/tests/common/mod.rs
+++ b/crates/nat/tests/common/mod.rs
@@ -281,18 +281,6 @@ pub fn promoted_pending_data(actions: &[NatAction]) -> &[u8] {
         .expect("expected PromoteBridge action")
 }
 
-pub fn promotion_remote_write_closed(actions: &[NatAction]) -> bool {
-    actions.iter().any(|action| {
-        matches!(
-            action,
-            NatAction::PromoteBridge {
-                remote_write_closed: true,
-                ..
-            }
-        )
-    })
-}
-
 pub fn complete_promotion(
     agent: &mut NatAgent,
     target: &PeerId,

--- a/crates/nat/tests/inbound.rs
+++ b/crates/nat/tests/inbound.rs
@@ -40,100 +40,6 @@ fn inbound_stop_stream(h: &mut Harness, stream: StreamId, t: u64) {
     );
 }
 
-/// Drives a claimed circuit through CONNECT-accept and the DCUtR exchange
-/// up to (but not including) SYNC.
-fn drive_to_sync_ready(h: &mut Harness, stream: StreamId) {
-    let target = h.target.clone();
-    h.stream_data(stream, stop_connect(&target), at(10));
-    let actions = drain_actions(&mut h.agent);
-    assert_eq!(send_stream_count(&actions), 1, "STATUS:OK must be sent");
-
-    // The initiator's DCUtR CONNECT (same shape as a reply).
-    h.stream_data(
-        stream,
-        dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]),
-        at(20),
-    );
-    let actions = drain_actions(&mut h.agent);
-    assert_eq!(
-        send_stream_count(&actions),
-        1,
-        "our DCUtR CONNECT reply must be sent"
-    );
-}
-
-#[test]
-fn full_inbound_flow_blasts_and_upgrades() {
-    let mut h = inbound_harness(NatConfig::default());
-    let stream = StreamId::new(STOP_STREAM);
-
-    inbound_stop_stream(&mut h, stream, 0);
-    assert!(h.agent.owns_stream(&h.relay, stream), "STOP stream claimed");
-
-    drive_to_sync_ready(&mut h, stream);
-
-    h.stream_data(stream, dcutr_sync(), at(30));
-    let actions = drain_actions(&mut h.agent);
-    assert!(actions.iter().any(|action| matches!(
-        action,
-        NatAction::PromoteBridge {
-            relay,
-            stream_id,
-            remote_peer,
-            ..
-        } if relay == &h.relay && *stream_id == stream && remote_peer == &h.target
-    )));
-    let target = h.target.clone();
-    complete_promotion(&mut h.agent, &target, &actions, at(31));
-    let events = drain_events(&mut h.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [NatEvent::InboundPathEstablished {
-            peer,
-            path: Path::Relayed { relay },
-        }] if *peer == h.target && *relay == h.relay
-    ));
-    assert_eq!(
-        dial_count_for(&actions, &h.target),
-        0,
-        "only the initiator dials; a responder dial would race it and the \
-         superseded connection would lose its streams"
-    );
-    assert!(
-        !h.agent.owns_stream(&h.relay, stream),
-        "bridge belongs to the circuit transport after SYNC"
-    );
-
-    // First blast waits out the configured sync delay (50ms after SYNC).
-    h.agent.handle_tick(at(79));
-    assert_eq!(blast_count(&drain_actions(&mut h.agent)), 0);
-    h.agent.handle_tick(at(80));
-    let actions = drain_actions(&mut h.agent);
-    assert_eq!(blast_count(&actions), 1);
-    assert!(actions.iter().any(|a| matches!(
-        a,
-        NatAction::SendRandomUdp { target, payload_len: 32 }
-            if *target == maddr(REMOTE_OBSERVED_ADDR)
-    )));
-    h.agent.handle_tick(at(180));
-    assert_eq!(
-        blast_count(&drain_actions(&mut h.agent)),
-        1,
-        "100ms cadence"
-    );
-
-    // The punch lands: blasts stop, the upgrade is announced.
-    h.target_connected(at(250));
-    let events = drain_events(&mut h.agent);
-    assert!(matches!(
-        events.as_slice(),
-        [NatEvent::InboundDirectUpgrade { peer }] if *peer == h.target
-    ));
-    h.agent.handle_tick(at(400));
-    assert_eq!(blast_count(&drain_actions(&mut h.agent)), 0);
-    assert!(h.agent.is_idle());
-}
-
 #[test]
 fn force_relay_promotes_immediately_after_stop_acceptance() {
     let mut h = inbound_harness(NatConfig {
@@ -160,6 +66,54 @@ fn force_relay_promotes_immediately_after_stop_acceptance() {
     complete_promotion(&mut h.agent, &target, &actions, at(11));
     drain_events(&mut h.agent);
     assert!(h.agent.is_idle());
+}
+
+#[test]
+fn default_inbound_promotes_immediately_after_stop_acceptance() {
+    let mut h = inbound_harness(NatConfig::default());
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+    let target = h.target.clone();
+
+    h.stream_data(stream, stop_connect(&target), at(10));
+
+    let actions = drain_actions(&mut h.agent);
+    assert_eq!(send_stream_count(&actions), 1, "STATUS:OK must be sent");
+    assert!(actions.iter().any(|action| matches!(
+        action,
+        NatAction::PromoteBridge {
+            role: minip2p_nat::BridgeRole::Responder,
+            stream_id,
+            remote_peer,
+            ..
+        } if *stream_id == stream && remote_peer == &target
+    )));
+}
+
+#[test]
+fn inbound_relay_path_opens_dcutr_after_the_circuit_is_connected() {
+    let mut h = inbound_harness(NatConfig::default());
+    let stream = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stream, 0);
+    let target = h.target.clone();
+    h.stream_data(stream, stop_connect(&target), at(10));
+    let promotion = drain_actions(&mut h.agent);
+
+    complete_promotion(&mut h.agent, &target, &promotion, at(11));
+
+    let actions = drain_actions(&mut h.agent);
+    assert!(actions.iter().any(|action| matches!(
+        action,
+        NatAction::OpenStream { peer, protocol_id, .. }
+            if peer == &target && protocol_id == DCUTR_PROTOCOL_ID
+    )));
+    assert!(matches!(
+        drain_events(&mut h.agent).as_slice(),
+        [NatEvent::InboundPathEstablished {
+            path: Path::Relayed { .. },
+            ..
+        }]
+    ));
 }
 
 #[test]
@@ -230,279 +184,6 @@ fn established_inbound_circuit_disarms_its_handshake_deadline() {
         "a ready inbound circuit must not be reclaimed by its old handshake deadline"
     );
     assert!(h.agent.is_idle());
-}
-
-#[test]
-fn direct_connection_before_circuit_handshake_does_not_downgrade_the_path() {
-    let mut h = inbound_harness(NatConfig::default());
-    let stream = StreamId::new(STOP_STREAM);
-    inbound_stop_stream(&mut h, stream, 0);
-    drive_to_sync_ready(&mut h, stream);
-
-    // The punch lands before SYNC releases the relay bridge.
-    h.target_connected(at(25));
-    assert!(matches!(
-        drain_events(&mut h.agent).as_slice(),
-        [NatEvent::InboundDirectUpgrade { peer }] if *peer == h.target
-    ));
-
-    h.stream_data(stream, dcutr_sync(), at(30));
-    let actions = drain_actions(&mut h.agent);
-    let target = h.target.clone();
-    complete_promotion(&mut h.agent, &target, &actions, at(31));
-
-    assert!(
-        drain_events(&mut h.agent).is_empty(),
-        "the inferior relay path must not be announced after direct wins"
-    );
-    assert!(h.agent.is_idle());
-}
-
-#[test]
-fn linger_expiry_does_not_reap_a_promoted_circuit_before_connected() {
-    let mut h = inbound_harness(NatConfig::default());
-    let stream = StreamId::new(STOP_STREAM);
-    inbound_stop_stream(&mut h, stream, 0);
-    drive_to_sync_ready(&mut h, stream);
-    h.stream_data(stream, dcutr_sync(), at(30));
-    let actions = drain_actions(&mut h.agent);
-    let conn_id = minip2p_transport::ConnectionId::new(TEST_CIRCUIT_ID);
-    h.agent
-        .promote_result(promote_token(&actions), Ok(conn_id), at(31));
-
-    // The 9-second punch linger ends before the 20-second circuit handshake
-    // deadline, but the pending promotion must remain correlated.
-    h.agent.handle_tick(at(9_030));
-    drain_actions(&mut h.agent);
-    assert!(!h.agent.is_idle());
-    h.agent.handle_event_with_disposition_classified(
-        &SwarmEvent::ConnectionEstablished {
-            peer_id: h.target.clone(),
-            conn_id,
-        },
-        true,
-        at(9_031),
-    );
-
-    assert!(matches!(
-        drain_events(&mut h.agent).as_slice(),
-        [NatEvent::InboundPathEstablished {
-            peer,
-            path: Path::Relayed { relay },
-        }] if *peer == h.target && *relay == h.relay
-    ));
-    assert!(h.agent.is_idle());
-}
-
-#[test]
-fn sync_coalesced_with_application_data_preserves_the_bridge_remainder() {
-    let mut h = inbound_harness(NatConfig::default());
-    let stream = StreamId::new(STOP_STREAM);
-    inbound_stop_stream(&mut h, stream, 0);
-    drive_to_sync_ready(&mut h, stream);
-
-    let app_data = b"first application bytes".to_vec();
-    let mut coalesced = dcutr_sync();
-    coalesced.extend_from_slice(&app_data);
-    h.stream_data(stream, coalesced, at(30));
-
-    let actions = drain_actions(&mut h.agent);
-    assert_eq!(promoted_pending_data(&actions), app_data);
-}
-
-#[test]
-fn zero_blast_interval_is_clamped_to_one_millisecond() {
-    let config = NatConfig {
-        blast_interval_ms: 0,
-        ..NatConfig::default()
-    };
-    let mut h = inbound_harness(config);
-    let stream = StreamId::new(STOP_STREAM);
-    inbound_stop_stream(&mut h, stream, 0);
-    drive_to_sync_ready(&mut h, stream);
-    h.stream_data(stream, dcutr_sync(), at(30));
-    drain_events(&mut h.agent);
-    drain_actions(&mut h.agent);
-
-    // The first due tick completes promptly (rather than repeatedly
-    // scheduling the same instant forever), then the clamped cadence is 1ms.
-    h.agent.handle_tick(at(80));
-    assert_eq!(blast_count(&drain_actions(&mut h.agent)), 1);
-    h.agent.handle_tick(at(81));
-    assert_eq!(blast_count(&drain_actions(&mut h.agent)), 1);
-}
-
-#[test]
-fn blast_schedule_exhausts_at_the_punch_deadline() {
-    let mut h = inbound_harness(NatConfig::default());
-    let stream = StreamId::new(STOP_STREAM);
-    inbound_stop_stream(&mut h, stream, 0);
-    drive_to_sync_ready(&mut h, stream);
-    h.stream_data(stream, dcutr_sync(), at(30));
-    drain_events(&mut h.agent);
-    drain_actions(&mut h.agent);
-
-    // Catch up through the whole window (deadline 30 + 3000).
-    h.agent.handle_tick(at(3_100));
-    assert!(blast_count(&drain_actions(&mut h.agent)) > 0);
-    h.agent.handle_tick(at(3_200));
-    assert_eq!(
-        blast_count(&drain_actions(&mut h.agent)),
-        0,
-        "no blasts after the punch window"
-    );
-
-    // No direct connection ever arrives: the circuit lingers through the
-    // initiator's retry window, then retires with no further events.
-    h.agent.handle_tick(at(9_030));
-    assert!(drain_events(&mut h.agent).is_empty());
-    assert!(h.agent.is_idle());
-}
-
-#[test]
-fn peer_supplied_punch_targets_must_be_global_unicast_quic_ips() {
-    let mut h = inbound_harness(NatConfig::default());
-    let stream = StreamId::new(STOP_STREAM);
-    inbound_stop_stream(&mut h, stream, 0);
-    let target = h.target.clone();
-    h.stream_data(stream, stop_connect(&target), at(10));
-    drain_actions(&mut h.agent);
-
-    let global_v4 = maddr("/ip4/8.8.8.8/udp/4001/quic-v1");
-    let global_v6 = maddr("/ip6/2606:4700:4700::1111/udp/4001/quic-v1");
-    let supplied = vec![
-        global_v4.clone(),
-        global_v6.clone(),
-        maddr("/dns4/attacker.invalid/udp/4001/quic-v1"),
-        maddr("/ip4/10.0.0.1/udp/4001/quic-v1"),
-        maddr("/ip4/100.64.0.1/udp/4001/quic-v1"),
-        maddr("/ip4/127.0.0.1/udp/4001/quic-v1"),
-        maddr("/ip4/169.254.1.1/udp/4001/quic-v1"),
-        maddr("/ip4/192.0.2.1/udp/4001/quic-v1"),
-        maddr("/ip4/224.0.0.1/udp/4001/quic-v1"),
-        maddr("/ip6/::1/udp/4001/quic-v1"),
-        maddr("/ip6/fc00::1/udp/4001/quic-v1"),
-        maddr("/ip6/fe80::1/udp/4001/quic-v1"),
-        maddr("/ip6/2001:db8::1/udp/4001/quic-v1"),
-        maddr("/ip6/ff02::1/udp/4001/quic-v1"),
-        // Globally routable, and a perfectly good address to dial -- but a
-        // hole punch is not a dial. Blasting random UDP at a TCP port puts
-        // traffic on one whose owner never asked for it, and no amount of it
-        // opens a path, because TCP is not the transport being punched.
-        maddr("/ip4/8.8.4.4/tcp/4001"),
-        maddr("/ip6/2606:4700:4700::1112/tcp/4001"),
-    ];
-    h.stream_data(stream, dcutr_connect_reply(&supplied), at(20));
-    drain_actions(&mut h.agent);
-    h.stream_data(stream, dcutr_sync(), at(30));
-    drain_actions(&mut h.agent);
-
-    h.agent.handle_tick(at(80));
-    let actions = drain_actions(&mut h.agent);
-    let blasted: Vec<_> = actions
-        .iter()
-        .filter_map(|action| match action {
-            NatAction::SendRandomUdp { target, .. } => Some(target.clone()),
-            _ => None,
-        })
-        .collect();
-    assert_eq!(blasted, vec![global_v4, global_v6]);
-}
-
-#[test]
-fn a_tcp_peer_can_still_be_reached_over_the_circuit_it_arrived_on() {
-    let mut h = inbound_harness(NatConfig::default());
-    let stream = StreamId::new(STOP_STREAM);
-    inbound_stop_stream(&mut h, stream, 0);
-    let target = h.target.clone();
-    h.stream_data(stream, stop_connect(&target), at(10));
-    drain_actions(&mut h.agent);
-
-    // Every address the peer offers is TCP, so there is nothing to punch.
-    // That must end as a relayed path rather than as a failure: the circuit
-    // is already carrying the connection, and DCUtR was only ever an attempt
-    // to do better than it.
-    h.stream_data(
-        stream,
-        dcutr_connect_reply(&[maddr("/ip4/8.8.4.4/tcp/4001")]),
-        at(20),
-    );
-    drain_actions(&mut h.agent);
-    h.stream_data(stream, dcutr_sync(), at(30));
-    let actions = drain_actions(&mut h.agent);
-    assert!(
-        actions
-            .iter()
-            .any(|action| matches!(action, NatAction::PromoteBridge { .. })),
-        "the relayed path still goes to the application: {actions:?}"
-    );
-    let target = h.target.clone();
-    complete_promotion(&mut h.agent, &target, &actions, at(31));
-
-    // Not one blast, ever: the punch window opens 50ms after SYNC and there
-    // was never anything in it to aim at.
-    for tick in [80u64, 180, 400] {
-        h.agent.handle_tick(at(tick));
-        assert_eq!(
-            blast_count(&drain_actions(&mut h.agent)),
-            0,
-            "there is nothing here to punch"
-        );
-    }
-}
-
-#[test]
-fn stalled_exchange_still_releases_the_bridge() {
-    let mut h = inbound_harness(NatConfig::default());
-    let stream = StreamId::new(STOP_STREAM);
-    inbound_stop_stream(&mut h, stream, 0);
-    let target = h.target.clone();
-    h.stream_data(stream, stop_connect(&target), at(10));
-    drain_actions(&mut h.agent);
-
-    // The initiator never starts DCUtR; at the exchange deadline the
-    // accepted bridge goes to the app punch-less.
-    h.agent.handle_tick(at(12_000));
-    let actions = drain_actions(&mut h.agent);
-    assert!(
-        actions
-            .iter()
-            .any(|action| matches!(action, NatAction::PromoteBridge { .. }))
-    );
-    assert_eq!(dial_count_for(&actions, &h.target), 0);
-    assert_eq!(blast_count(&actions), 0);
-    assert!(!h.agent.owns_stream(&h.relay, stream));
-    let target = h.target.clone();
-    complete_promotion(&mut h.agent, &target, &actions, at(12_001));
-    drain_events(&mut h.agent);
-    assert!(h.agent.is_idle());
-}
-
-#[test]
-fn remote_write_close_keeps_an_accepted_bridge_alive_until_handoff() {
-    let mut h = inbound_harness(NatConfig::default());
-    let stream = StreamId::new(STOP_STREAM);
-    inbound_stop_stream(&mut h, stream, 0);
-    let target = h.target.clone();
-    h.stream_data(stream, stop_connect(&target), at(10));
-    drain_actions(&mut h.agent);
-
-    h.agent.handle_event(
-        &SwarmEvent::StreamRemoteWriteClosed {
-            conn_id: minip2p_transport::ConnectionId::new(1),
-            peer_id: h.relay.clone(),
-            stream_id: stream,
-        },
-        at(20),
-    );
-    assert!(h.agent.owns_stream(&h.relay, stream));
-    assert!(!has_reset_for(&drain_actions(&mut h.agent), stream));
-
-    // The half-close does not kill the local write half; hand the accepted
-    // bridge to the app once the DCUtR exchange deadline expires.
-    h.agent.handle_tick(at(12_000));
-    let actions = drain_actions(&mut h.agent);
-    assert!(promotion_remote_write_closed(&actions));
 }
 
 #[test]
@@ -619,101 +300,4 @@ fn inbound_unserved_nat_control_streams_are_reset_owned_and_consumed() {
 
     assert!(drain_events(&mut h.agent).is_empty());
     assert!(h.agent.is_idle());
-}
-
-#[test]
-fn relay_disconnect_before_release_drops_the_circuit() {
-    let mut h = inbound_harness(NatConfig::default());
-    let stream = StreamId::new(STOP_STREAM);
-    inbound_stop_stream(&mut h, stream, 0);
-    let target = h.target.clone();
-    h.stream_data(stream, stop_connect(&target), at(10));
-    drain_actions(&mut h.agent);
-
-    h.agent.handle_event(
-        &SwarmEvent::ConnectionClosed {
-            conn_id: minip2p_transport::ConnectionId::new(1),
-            peer_id: h.relay.clone(),
-            cause: minip2p_swarm::ConnectionCloseCause::Transport,
-        },
-        at(20),
-    );
-    assert!(drain_events(&mut h.agent).is_empty());
-    assert!(!h.agent.owns_stream(&h.relay, stream));
-    assert!(h.agent.is_idle());
-}
-
-#[test]
-fn responder_reply_advertises_peer_observed_mapping() {
-    let mut h = inbound_harness(NatConfig::default());
-    // The relay's identify told us our public mapping earlier in the session.
-    let relay = h.relay.clone();
-    identify_observed(&mut h.agent, &relay, &maddr(OUR_OBSERVED_ADDR), at(0));
-
-    let stream = StreamId::new(STOP_STREAM);
-    inbound_stop_stream(&mut h, stream, 1);
-    let target = h.target.clone();
-    h.stream_data(stream, stop_connect(&target), at(10));
-    drain_actions(&mut h.agent);
-
-    h.stream_data(
-        stream,
-        dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]),
-        at(20),
-    );
-    let actions = drain_actions(&mut h.agent);
-    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
-    assert!(
-        obs.contains(&maddr(LISTEN_ADDR)),
-        "bound addresses stay in the reply"
-    );
-    assert!(
-        obs.contains(&maddr(OUR_OBSERVED_ADDR)),
-        "the reply must advertise our observed public mapping"
-    );
-}
-
-#[test]
-fn our_own_tcp_listener_is_not_offered_as_a_punch_target() {
-    let mut h = inbound_harness(NatConfig::default());
-    // A host that bound both. The direct-candidate selector accepts both,
-    // because both are dialable -- but only one of them is punchable.
-    let tcp = maddr("/ip4/198.51.100.5/tcp/4001");
-    h.agent.set_listen_addrs(&[maddr(LISTEN_ADDR), tcp.clone()]);
-    // Same for a mapping a trusted peer observed for us: the relay watching
-    // us arrive over TCP says nothing about where we can be punched.
-    let relay = h.relay.clone();
-    let observed_tcp = maddr("/ip4/203.0.113.77/tcp/45678");
-    identify_observed(&mut h.agent, &relay, &observed_tcp, at(0));
-
-    let stream = StreamId::new(STOP_STREAM);
-    inbound_stop_stream(&mut h, stream, 1);
-    let target = h.target.clone();
-    h.stream_data(stream, stop_connect(&target), at(10));
-    drain_actions(&mut h.agent);
-    h.stream_data(
-        stream,
-        dcutr_connect_reply(&[maddr(REMOTE_OBSERVED_ADDR)]),
-        at(20),
-    );
-
-    let actions = drain_actions(&mut h.agent);
-    let obs = dcutr_obs_addrs(&sent_data_on(&actions, stream));
-    assert!(
-        obs.contains(&maddr(LISTEN_ADDR)),
-        "the QUIC listener is still offered: {obs:?}"
-    );
-    assert!(
-        !obs.contains(&tcp),
-        // What goes into a CONNECT is an invitation to blast UDP at us. A
-        // `/tcp` listener cannot be punched, so offering one only spends the
-        // peer's punch window on an address that will never open -- and the
-        // peer filters it on arrival anyway, so it was never anything but
-        // noise on the wire.
-        "a TCP listener is not a punch target: {obs:?}"
-    );
-    assert!(
-        !obs.contains(&observed_tcp),
-        "nor is a TCP mapping someone observed for us: {obs:?}"
-    );
 }

--- a/crates/nat/tests/inbound.rs
+++ b/crates/nat/tests/inbound.rs
@@ -79,6 +79,13 @@ fn default_inbound_promotes_immediately_after_stop_acceptance() {
 
     let actions = drain_actions(&mut h.agent);
     assert_eq!(send_stream_count(&actions), 1, "STATUS:OK must be sent");
+    assert!(
+        !actions.iter().any(|action| matches!(
+            action,
+            NatAction::OpenStream { protocol_id, .. } if protocol_id == DCUTR_PROTOCOL_ID
+        )),
+        "DCUtR must wait until the promoted circuit is connected"
+    );
     assert!(actions.iter().any(|action| matches!(
         action,
         NatAction::PromoteBridge {

--- a/crates/nat/tests/inbound_regressions.rs
+++ b/crates/nat/tests/inbound_regressions.rs
@@ -69,6 +69,74 @@ fn open_dcutr(h: &mut Harness, conn: ConnectionId, actions: &[NatAction]) -> Str
     stream
 }
 
+#[test]
+fn silent_inbound_dcutr_exchange_times_out_and_resets_the_stream() {
+    let mut h = inbound_harness(NatConfig {
+        relay_leg_deadline_ms: 5,
+        ..NatConfig::default()
+    });
+    let (conn, actions) = drive_to_relayed(&mut h);
+    let stream = open_dcutr(&mut h, conn, &actions);
+    drain_actions(&mut h.agent);
+
+    h.agent.handle_tick(at(18));
+
+    assert!(has_reset_for(&drain_actions(&mut h.agent), stream));
+    assert!(!h.agent.owns_stream(&h.target, stream));
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn failed_inbound_dcutr_open_ends_coordination_without_losing_the_relayed_path() {
+    let mut h = inbound_harness(NatConfig::default());
+    let (_, actions) = drive_to_relayed(&mut h);
+    let token = open_stream_token(&actions);
+
+    h.agent
+        .stream_open_result(token, Err("DCUtR unavailable".into()), at(13));
+
+    assert!(drain_actions(&mut h.agent).is_empty());
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn early_closed_inbound_dcutr_exchange_resets_the_stream() {
+    let mut h = inbound_harness(NatConfig::default());
+    let (conn, actions) = drive_to_relayed(&mut h);
+    let stream = open_dcutr(&mut h, conn, &actions);
+    drain_actions(&mut h.agent);
+
+    h.agent.handle_event(
+        &SwarmEvent::StreamClosed {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: stream,
+        },
+        at(14),
+    );
+
+    assert!(has_reset_for(&drain_actions(&mut h.agent), stream));
+    assert!(!h.agent.owns_stream(&h.target, stream));
+    assert!(h.agent.is_idle());
+}
+
+#[test]
+fn oversized_inbound_dcutr_connect_keeps_the_relayed_path() {
+    let mut h = inbound_harness(NatConfig::default());
+    let addrs: Vec<_> = (1u16..=400)
+        .map(|port| maddr(&format!("/ip4/198.51.100.5/udp/{port}/quic-v1")))
+        .collect();
+    h.agent.set_listen_addrs(&addrs);
+    let (conn, actions) = drive_to_relayed(&mut h);
+    let stream = open_dcutr(&mut h, conn, &actions);
+
+    assert!(has_reset_for(&drain_actions(&mut h.agent), stream));
+    assert!(drain_events(&mut h.agent).is_empty());
+    assert!(!h.agent.owns_stream(&h.target, stream));
+    assert!(h.agent.is_idle());
+}
+
 fn answer_dcutr(h: &mut Harness, conn: ConnectionId, stream: StreamId, addrs: &[&str]) {
     let reply_addrs: Vec<_> = addrs.iter().map(|addr| maddr(addr)).collect();
     h.agent.handle_event(
@@ -179,7 +247,9 @@ fn peer_supplied_punch_targets_must_be_global_unicast_quic_ips() {
             "/ip4/8.8.4.4/tcp/4001",
         ],
     );
-    drain_actions(&mut h.agent);
+    let sync = drain_actions(&mut h.agent);
+    assert!(has_reset_for(&sync, stream));
+    assert!(!h.agent.owns_stream(&h.target, stream));
     h.agent.handle_tick(at(20));
     let targets: Vec<_> = drain_actions(&mut h.agent)
         .into_iter()

--- a/crates/nat/tests/inbound_regressions.rs
+++ b/crates/nat/tests/inbound_regressions.rs
@@ -1,0 +1,241 @@
+//! Focused inbound circuit and post-promotion DCUtR regressions.
+
+mod common;
+
+use common::*;
+
+use minip2p_core::PeerAddr;
+use minip2p_nat::{DCUTR_PROTOCOL_ID, NatAction, NatConfig, NatEvent, Path, STOP_PROTOCOL_ID};
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::{ConnectionId, StreamId};
+
+const STOP_STREAM: u64 = 40;
+const CIRCUIT_STREAM: u64 = 41;
+
+fn inbound_harness(mut config: NatConfig) -> Harness {
+    config.reservation_policy = minip2p_nat::ReservationPolicy::Never;
+    config.relays.push(
+        PeerAddr::new(maddr(RELAY_TRANSPORT_ADDR), peer(b"relay-peer"))
+            .expect("valid configured relay"),
+    );
+    Harness::without_relay(config)
+}
+
+fn inbound_stop_stream(h: &mut Harness, stream: StreamId, t: u64) {
+    h.agent.handle_event(
+        &SwarmEvent::StreamReady {
+            conn_id: ConnectionId::new(1),
+            peer_id: h.relay.clone(),
+            stream_id: stream,
+            protocol_id: STOP_PROTOCOL_ID.into(),
+            initiated_locally: false,
+        },
+        at(t),
+    );
+}
+
+fn drive_to_relayed(h: &mut Harness) -> (ConnectionId, Vec<NatAction>) {
+    let stop = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(h, stop, 0);
+    let target = h.target.clone();
+    h.stream_data(stop, stop_connect(&target), at(10));
+    let promotion = drain_actions(&mut h.agent);
+    let conn = complete_promotion(&mut h.agent, &target, &promotion, at(11));
+    let events = drain_events(&mut h.agent);
+    assert!(matches!(
+        events.as_slice(),
+        [NatEvent::InboundPathEstablished {
+            path: Path::Relayed { .. },
+            ..
+        }]
+    ));
+    (conn, drain_actions(&mut h.agent))
+}
+
+fn open_dcutr(h: &mut Harness, conn: ConnectionId, actions: &[NatAction]) -> StreamId {
+    let token = open_stream_token(actions);
+    let stream = StreamId::new(CIRCUIT_STREAM);
+    h.agent.stream_open_result(token, Ok(stream), at(12));
+    h.agent.handle_event(
+        &SwarmEvent::StreamReady {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: stream,
+            protocol_id: DCUTR_PROTOCOL_ID.into(),
+            initiated_locally: true,
+        },
+        at(13),
+    );
+    stream
+}
+
+fn answer_dcutr(h: &mut Harness, conn: ConnectionId, stream: StreamId, addrs: &[&str]) {
+    let reply_addrs: Vec<_> = addrs.iter().map(|addr| maddr(addr)).collect();
+    h.agent.handle_event(
+        &SwarmEvent::StreamData {
+            conn_id: conn,
+            peer_id: h.target.clone(),
+            stream_id: stream,
+            data: dcutr_connect_reply(&reply_addrs),
+        },
+        at(20),
+    );
+}
+
+#[test]
+fn direct_connection_before_circuit_handshake_does_not_downgrade_the_path() {
+    let mut h = inbound_harness(NatConfig::default());
+    let stop = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stop, 0);
+    let target = h.target.clone();
+    h.stream_data(stop, stop_connect(&target), at(10));
+    let promotion = drain_actions(&mut h.agent);
+    let conn = ConnectionId::new(TEST_CIRCUIT_ID);
+    h.agent
+        .promote_result(promote_token(&promotion), Ok(conn), at(11));
+
+    h.target_connected(at(12));
+    h.agent.handle_event_with_disposition_classified(
+        &SwarmEvent::ConnectionEstablished {
+            conn_id: conn,
+            peer_id: target,
+        },
+        true,
+        at(13),
+    );
+
+    let events = drain_events(&mut h.agent);
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, NatEvent::InboundDirectUpgrade { .. }))
+    );
+    assert!(!events.iter().any(|event| matches!(
+        event,
+        NatEvent::InboundPathEstablished {
+            path: Path::Relayed { .. },
+            ..
+        }
+    )));
+}
+
+#[test]
+fn blast_schedule_respects_interval_and_deadline() {
+    let mut h = inbound_harness(NatConfig {
+        responder_sync_delay_ms: 0,
+        blast_interval_ms: 100,
+        punch_deadline_ms: 250,
+        ..NatConfig::default()
+    });
+    let (conn, actions) = drive_to_relayed(&mut h);
+    let stream = open_dcutr(&mut h, conn, &actions);
+    drain_actions(&mut h.agent);
+    answer_dcutr(&mut h, conn, stream, &["/ip4/8.8.8.8/udp/4001/quic-v1"]);
+    drain_actions(&mut h.agent);
+
+    for (time, expected) in [(20, 1), (119, 0), (120, 1), (220, 1), (320, 0)] {
+        h.agent.handle_tick(at(time));
+        assert_eq!(
+            blast_count(&drain_actions(&mut h.agent)),
+            expected,
+            "t={time}"
+        );
+    }
+}
+
+#[test]
+fn zero_blast_interval_is_clamped_to_one_millisecond() {
+    let mut h = inbound_harness(NatConfig {
+        responder_sync_delay_ms: 0,
+        blast_interval_ms: 0,
+        punch_deadline_ms: 2,
+        ..NatConfig::default()
+    });
+    let (conn, actions) = drive_to_relayed(&mut h);
+    let stream = open_dcutr(&mut h, conn, &actions);
+    drain_actions(&mut h.agent);
+    answer_dcutr(&mut h, conn, stream, &["/ip4/8.8.8.8/udp/4001/quic-v1"]);
+    drain_actions(&mut h.agent);
+    h.agent.handle_tick(at(22));
+    assert_eq!(blast_count(&drain_actions(&mut h.agent)), 3);
+}
+
+#[test]
+fn peer_supplied_punch_targets_must_be_global_unicast_quic_ips() {
+    let mut h = inbound_harness(NatConfig {
+        responder_sync_delay_ms: 0,
+        ..NatConfig::default()
+    });
+    let (conn, actions) = drive_to_relayed(&mut h);
+    let stream = open_dcutr(&mut h, conn, &actions);
+    drain_actions(&mut h.agent);
+    answer_dcutr(
+        &mut h,
+        conn,
+        stream,
+        &[
+            "/ip4/10.0.0.1/udp/4001/quic-v1",
+            "/ip4/8.8.8.8/udp/4001/quic-v1",
+            "/ip4/8.8.4.4/tcp/4001",
+        ],
+    );
+    drain_actions(&mut h.agent);
+    h.agent.handle_tick(at(20));
+    let targets: Vec<_> = drain_actions(&mut h.agent)
+        .into_iter()
+        .filter_map(|action| match action {
+            NatAction::SendRandomUdp { target, .. } => Some(target),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(targets, vec![maddr("/ip4/8.8.8.8/udp/4001/quic-v1")]);
+}
+
+#[test]
+fn dcutr_connect_advertises_trusted_observation_but_not_tcp_listener() {
+    let mut h = inbound_harness(NatConfig::default());
+    h.agent
+        .set_listen_addrs(&[maddr("/ip4/192.0.2.1/tcp/4001"), maddr(LISTEN_ADDR)]);
+    let relay = h.relay.clone();
+    identify_observed(&mut h.agent, &relay, &maddr(OUR_OBSERVED_ADDR), at(0));
+    let (conn, actions) = drive_to_relayed(&mut h);
+    let stream = open_dcutr(&mut h, conn, &actions);
+    let connect = sent_data_on(&drain_actions(&mut h.agent), stream);
+    let addrs = dcutr_obs_addrs(&connect);
+    assert!(addrs.contains(&maddr(LISTEN_ADDR)));
+    assert!(addrs.contains(&maddr(OUR_OBSERVED_ADDR)));
+    assert!(!addrs.contains(&maddr("/ip4/192.0.2.1/tcp/4001")));
+}
+
+#[test]
+fn relay_disconnect_before_stop_acceptance_drops_the_circuit() {
+    let mut h = inbound_harness(NatConfig::default());
+    let stop = StreamId::new(STOP_STREAM);
+    inbound_stop_stream(&mut h, stop, 0);
+
+    h.agent.handle_event(
+        &SwarmEvent::ConnectionClosed {
+            conn_id: ConnectionId::new(1),
+            peer_id: h.relay.clone(),
+            cause: minip2p_swarm::ConnectionCloseCause::Transport,
+        },
+        at(1),
+    );
+
+    assert!(!h.agent.owns_stream(&h.relay, stop));
+    assert!(drain_events(&mut h.agent).is_empty());
+}
+
+#[test]
+fn tcp_only_source_still_gets_the_relayed_path() {
+    let mut h = inbound_harness(NatConfig::default());
+    h.agent
+        .set_listen_addrs(&[maddr("/ip4/192.0.2.1/tcp/4001")]);
+
+    let (_, actions) = drive_to_relayed(&mut h);
+
+    assert!(actions.iter().any(|action| matches!(
+        action,
+        NatAction::OpenStream { protocol_id, .. } if protocol_id == DCUTR_PROTOCOL_ID
+    )));
+}

--- a/crates/nat/tests/two_agents.rs
+++ b/crates/nat/tests/two_agents.rs
@@ -606,45 +606,26 @@ fn two_agents_punch_to_a_direct_connection() {
 }
 
 #[test]
-fn force_relay_peer_and_default_peer_still_establish_relayed_paths() {
-    let mut world = World::with_force_relay(true, false);
-    world.settle_reservation();
-    let id = world.start_connect();
+fn force_relay_on_either_peer_keeps_both_paths_relayed() {
+    for (dialer_forced, listener_forced) in [(true, false), (false, true)] {
+        let mut world = World::with_force_relay(dialer_forced, listener_forced);
+        world.settle_reservation();
+        let id = world.start_connect();
 
-    assert!(matches!(
-        drain_events(&mut world.a).as_slice(),
-        [NatEvent::PathEstablished { connect_id, path: Path::Relayed { .. }, .. }]
-            if *connect_id == id
-    ));
-    assert!(matches!(
-        drain_events(&mut world.b).as_slice(),
-        [NatEvent::InboundPathEstablished {
-            path: Path::Relayed { .. },
-            ..
-        }]
-    ));
-    assert_eq!(world.punch_dials_from_a + world.punch_dials_from_b, 0);
-}
-
-#[test]
-fn default_dialer_and_force_relay_listener_still_establish_relayed_paths() {
-    let mut world = World::with_force_relay(false, true);
-    world.settle_reservation();
-    let id = world.start_connect();
-
-    assert!(matches!(
-        drain_events(&mut world.a).as_slice(),
-        [NatEvent::PathEstablished { connect_id, path: Path::Relayed { .. }, .. }]
-            if *connect_id == id
-    ));
-    assert!(matches!(
-        drain_events(&mut world.b).as_slice(),
-        [NatEvent::InboundPathEstablished {
-            path: Path::Relayed { .. },
-            ..
-        }]
-    ));
-    assert_eq!(world.punch_dials_from_a + world.punch_dials_from_b, 0);
+        assert!(matches!(
+            drain_events(&mut world.a).as_slice(),
+            [NatEvent::PathEstablished { connect_id, path: Path::Relayed { .. }, .. }]
+                if *connect_id == id
+        ));
+        assert!(matches!(
+            drain_events(&mut world.b).as_slice(),
+            [NatEvent::InboundPathEstablished {
+                path: Path::Relayed { .. },
+                ..
+            }]
+        ));
+        assert_eq!(world.punch_dials_from_a + world.punch_dials_from_b, 0);
+    }
 }
 
 #[test]

--- a/crates/nat/tests/two_agents.rs
+++ b/crates/nat/tests/two_agents.rs
@@ -12,7 +12,9 @@ mod common;
 use common::{LISTEN_ADDR, at, drain_events, identify_observed, maddr, peer};
 
 use minip2p_core::{Multiaddr, PeerAddr, PeerId};
-use minip2p_nat::{ConnectId, NatAction, NatAgent, NatConfig, NatEvent, Path, ReservationPolicy};
+use minip2p_nat::{
+    ConnectId, DCUTR_PROTOCOL_ID, NatAction, NatAgent, NatConfig, NatEvent, Path, ReservationPolicy,
+};
 use minip2p_relay::{HOP_PROTOCOL_ID, STOP_PROTOCOL_ID};
 use minip2p_swarm::SwarmEvent;
 use minip2p_test_support::{ConnectRequestOutcome, PendingConnectId, RelayEmulator};
@@ -66,10 +68,16 @@ struct World {
     punch_dials_from_b: usize,
     punch_dial_addrs_from_a: Vec<Multiaddr>,
     punch_dial_addrs_from_b: Vec<Multiaddr>,
+    circuit_conns: [Option<ConnectionId>; 2],
+    dcutr_streams: Vec<(Side, StreamId, Side, StreamId)>,
 }
 
 impl World {
     fn new() -> Self {
+        Self::with_force_relay(false, false)
+    }
+
+    fn with_force_relay(a_force_relay: bool, b_force_relay: bool) -> Self {
         let a_id = peer(b"agent-a");
         let b_id = peer(b"agent-b");
         let relay_id = peer(b"relay-peer");
@@ -80,6 +88,7 @@ impl World {
             NatConfig {
                 relays: vec![relay_addr.clone()],
                 reservation_policy: ReservationPolicy::Never,
+                force_relay: a_force_relay,
                 ..NatConfig::default()
             },
         );
@@ -90,6 +99,7 @@ impl World {
             NatConfig {
                 relays: vec![relay_addr],
                 reservation_policy: ReservationPolicy::Always,
+                force_relay: b_force_relay,
                 ..NatConfig::default()
             },
         );
@@ -115,6 +125,15 @@ impl World {
             punch_dials_from_b: 0,
             punch_dial_addrs_from_a: Vec::new(),
             punch_dial_addrs_from_b: Vec::new(),
+            circuit_conns: [None, None],
+            dcutr_streams: Vec::new(),
+        }
+    }
+
+    fn side_index(side: Side) -> usize {
+        match side {
+            Side::A => 0,
+            Side::B => 1,
         }
     }
 
@@ -137,7 +156,7 @@ impl World {
         loop {
             let mut progressed = false;
             for side in [Side::A, Side::B] {
-                while let Some(action) = self.agent(side).poll_action() {
+                if let Some(action) = self.agent(side).poll_action() {
                     self.process(side, action);
                     progressed = true;
                 }
@@ -220,7 +239,47 @@ impl World {
                 peer,
                 protocol_id,
             } => {
-                assert_eq!(peer, self.relay_id, "agents only open streams to the relay");
+                if peer != self.relay_id {
+                    assert_eq!(protocol_id, DCUTR_PROTOCOL_ID);
+                    let remote = match side {
+                        Side::A => Side::B,
+                        Side::B => Side::A,
+                    };
+                    assert_eq!(peer, self.peer_of(remote));
+                    self.next_stream += 1;
+                    let local_stream = StreamId::new(self.next_stream);
+                    self.next_stream += 1;
+                    let remote_stream = StreamId::new(self.next_stream);
+                    self.dcutr_streams
+                        .push((side, local_stream, remote, remote_stream));
+                    let local_conn = self.circuit_conns[Self::side_index(side)].unwrap();
+                    let remote_conn = self.circuit_conns[Self::side_index(remote)].unwrap();
+                    let local_peer = self.peer_of(remote);
+                    self.agent(side)
+                        .stream_open_result(token, Ok(local_stream), now);
+                    self.agent(side).handle_event(
+                        &SwarmEvent::StreamReady {
+                            conn_id: local_conn,
+                            peer_id: local_peer,
+                            stream_id: local_stream,
+                            protocol_id: protocol_id.clone(),
+                            initiated_locally: true,
+                        },
+                        now,
+                    );
+                    let remote_peer = self.peer_of(side);
+                    self.agent(remote).handle_event(
+                        &SwarmEvent::StreamReady {
+                            conn_id: remote_conn,
+                            peer_id: remote_peer,
+                            stream_id: remote_stream,
+                            protocol_id,
+                            initiated_locally: false,
+                        },
+                        now,
+                    );
+                    return;
+                }
                 assert_eq!(protocol_id, HOP_PROTOCOL_ID);
                 self.next_stream += 1;
                 let stream = StreamId::new(self.next_stream);
@@ -241,7 +300,49 @@ impl World {
             }
             NatAction::SendStream {
                 stream_id, data, ..
-            } => self.on_relay_bytes(side, stream_id, data),
+            } => {
+                if let Some((_, _, remote, remote_stream)) = self
+                    .dcutr_streams
+                    .iter()
+                    .find(|(local, local_stream, _, _)| {
+                        *local == side && *local_stream == stream_id
+                    })
+                    .copied()
+                {
+                    let conn_id = self.circuit_conns[Self::side_index(remote)].unwrap();
+                    let peer = self.peer_of(side);
+                    self.agent(remote).handle_event(
+                        &SwarmEvent::StreamData {
+                            conn_id,
+                            peer_id: peer,
+                            stream_id: remote_stream,
+                            data,
+                        },
+                        now,
+                    );
+                } else if let Some((local, local_stream, _, _)) = self
+                    .dcutr_streams
+                    .iter()
+                    .find(|(_, _, remote, remote_stream)| {
+                        *remote == side && *remote_stream == stream_id
+                    })
+                    .copied()
+                {
+                    let conn_id = self.circuit_conns[Self::side_index(local)].unwrap();
+                    let peer = self.peer_of(side);
+                    self.agent(local).handle_event(
+                        &SwarmEvent::StreamData {
+                            conn_id,
+                            peer_id: peer,
+                            stream_id: local_stream,
+                            data,
+                        },
+                        now,
+                    );
+                } else {
+                    self.on_relay_bytes(side, stream_id, data);
+                }
+            }
             NatAction::SendRandomUdp { .. } => {
                 if side == Side::B {
                     self.blasts_from_b += 1;
@@ -252,6 +353,7 @@ impl World {
             } => {
                 self.next_conn += 1;
                 let conn_id = ConnectionId::new((1 << 63) | self.next_conn);
+                self.circuit_conns[Self::side_index(side)] = Some(conn_id);
                 let agent = self.agent(side);
                 agent.promote_result(token, Ok(conn_id), now);
                 agent.handle_event_with_disposition_classified(
@@ -501,6 +603,48 @@ fn two_agents_punch_to_a_direct_connection() {
         matches!(events.as_slice(), [NatEvent::InboundDirectUpgrade { peer }] if *peer == world.a_id),
         "B reports the inbound upgrade, got {events:?}"
     );
+}
+
+#[test]
+fn force_relay_peer_and_default_peer_still_establish_relayed_paths() {
+    let mut world = World::with_force_relay(true, false);
+    world.settle_reservation();
+    let id = world.start_connect();
+
+    assert!(matches!(
+        drain_events(&mut world.a).as_slice(),
+        [NatEvent::PathEstablished { connect_id, path: Path::Relayed { .. }, .. }]
+            if *connect_id == id
+    ));
+    assert!(matches!(
+        drain_events(&mut world.b).as_slice(),
+        [NatEvent::InboundPathEstablished {
+            path: Path::Relayed { .. },
+            ..
+        }]
+    ));
+    assert_eq!(world.punch_dials_from_a + world.punch_dials_from_b, 0);
+}
+
+#[test]
+fn default_dialer_and_force_relay_listener_still_establish_relayed_paths() {
+    let mut world = World::with_force_relay(false, true);
+    world.settle_reservation();
+    let id = world.start_connect();
+
+    assert!(matches!(
+        drain_events(&mut world.a).as_slice(),
+        [NatEvent::PathEstablished { connect_id, path: Path::Relayed { .. }, .. }]
+            if *connect_id == id
+    ));
+    assert!(matches!(
+        drain_events(&mut world.b).as_slice(),
+        [NatEvent::InboundPathEstablished {
+            path: Path::Relayed { .. },
+            ..
+        }]
+    ));
+    assert_eq!(world.punch_dials_from_a + world.punch_dials_from_b, 0);
 }
 
 #[test]


### PR DESCRIPTION
Closes #116.

Promote Circuit Relay bridges through Noise and Yamux before starting DCUtR. The reserved peer now opens the DCUtR stream as initiator, while the original circuit dialer responds and performs the direct QUIC punch.

`force_relay` still promotes the circuit but skips direct candidates, DCUtR, UDP blasts, and punch dials. A failed or missing DCUtR exchange leaves the established relayed path usable.

Verification:
- `just fmt`
- `just test`
- `just clippy`
- `just check-nostd`
- final Standards review: PASS
- final Spec review: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the relayed circuit through Noise and Yamux before starting DCUtR, so a failed or missing hole punch no longer loses the connection. Closes #116.

**Changes**
- The reserved peer opens the DCUtR stream as initiator while the original circuit dialer responds and performs the QUIC punch.
- `force_relay` keeps the promoted circuit but skips direct candidates, DCUtR, UDP blasts, and punch dials.
- Keeps relayed attempts alive until DCUtR settles and makes the exchange one-shot.
- Resets consumed control streams before releasing ownership and bounds inbound DCUtR setup so silent peers cannot hold coordination indefinitely.

<sup>Written for commit 6b981b583a8166925c877250d50f8d043362d478. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

