### PR TITLE
Move keepalive into the transport layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,6 +1420,7 @@ dependencies = [
  "minip2p-identity",
  "minip2p-multistream-select",
  "minip2p-noise",
+ "minip2p-platform",
  "minip2p-transport",
  "minip2p-yamux",
  "thiserror",
@@ -1506,6 +1507,7 @@ name = "minip2p-yamux"
 version = "0.4.8"
 dependencies = [
  "minip2p-core",
+ "minip2p-platform",
  "thiserror",
 ]
 

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -825,17 +825,36 @@ impl<T: Transport, E: EntropySource> Transport for CircuitTransport<T, E> {
         for event in self.inner.poll(now)? {
             self.handle_inner_event(event);
         }
+        for id in self.circuits.keys().copied().collect::<Vec<_>>() {
+            if !self
+                .circuits
+                .get(&id)
+                .is_some_and(|circuit| circuit.session.is_established())
+            {
+                continue;
+            }
+            let result = self.with_circuit(id, |this, circuit| {
+                circuit.session.poll(now)?;
+                this.pump(circuit)
+            });
+            if let Err(teardown) = result {
+                self.fail_circuit(id, teardown.message, !teardown.graceful);
+            }
+        }
         Ok(self.drain_pending_events())
     }
 
     fn next_deadline(&self) -> Option<Deadline> {
-        if self.pending.is_empty() {
-            self.inner.next_deadline()
-        } else {
+        if !self.pending.is_empty() {
             // Buffered circuit events are due regardless of what the host's
             // clock reads, so this needs no retained time sample.
-            Some(Deadline::IMMEDIATE)
+            return Some(Deadline::IMMEDIATE);
         }
+        let mut deadline = self.inner.next_deadline();
+        for circuit in self.circuits.values() {
+            deadline = Deadline::earliest_opt(deadline, circuit.session.next_deadline());
+        }
+        deadline
     }
 
     fn local_addresses(&self) -> Vec<Multiaddr> {
@@ -907,6 +926,7 @@ mod tests {
     use minip2p_noise::{
         NOISE_PROTOCOL_ID, NoiseConfig, NoiseInput, NoiseOutput, NoiseRole, NoiseSession,
     };
+    use minip2p_secure_mux::KEEPALIVE_INTERVAL_MS;
     use minip2p_test_support::InMemoryTransport;
 
     #[derive(Clone, Debug)]
@@ -1318,6 +1338,49 @@ mod tests {
             }
         }
         panic!("circuit handshake did not complete");
+    }
+
+    #[test]
+    fn a_quiet_circuit_keeps_alive_without_opening_a_stream() {
+        let (mut a, mut b, circuit_id, _bridge, a_peer, b_peer) = setup_pair();
+        complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
+
+        let _ = a.poll(Now::from_millis(0)).expect("stamp initiator");
+        let _ = b.poll(Now::from_millis(0)).expect("stamp responder");
+        assert_eq!(
+            a.next_deadline(),
+            Some(Deadline::from_millis(KEEPALIVE_INTERVAL_MS))
+        );
+
+        let ping = a
+            .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
+            .expect("initiator keepalive");
+        assert!(
+            ping.iter()
+                .all(|event| !matches!(event, TransportEvent::StreamData { .. })),
+            "a yamux ping is not stream data: {ping:?}"
+        );
+
+        let pong = b
+            .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
+            .expect("responder answers");
+        assert!(
+            pong.iter()
+                .all(|event| !matches!(event, TransportEvent::StreamData { .. })),
+            "answering a yamux ping must not surface as stream data: {pong:?}"
+        );
+
+        let ack = a
+            .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
+            .expect("initiator sees the pong");
+        assert!(
+            ack.is_empty(),
+            "a keepalive pong is session traffic: {ack:?}"
+        );
+        assert!(
+            a.circuit_ids().contains(&circuit_id),
+            "keepalive must not tear the circuit down"
+        );
     }
 
     #[test]

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -852,7 +852,18 @@ impl<T: Transport, E: EntropySource> Transport for CircuitTransport<T, E> {
         }
         let mut deadline = self.inner.next_deadline();
         for circuit in self.circuits.values() {
-            deadline = Deadline::earliest_opt(deadline, circuit.session.next_deadline());
+            let session_deadline = circuit.session.next_deadline().or_else(|| {
+                // An externally injected bridge read can complete the upgrade
+                // while `Connected` is pending. The pending-event fast path
+                // then returns before `session.poll` gets a time sample, so
+                // keepalive is not armed yet. Wake once more immediately to
+                // stamp the newly established Yamux session.
+                circuit
+                    .session
+                    .is_established()
+                    .then_some(Deadline::IMMEDIATE)
+            });
+            deadline = Deadline::earliest_opt(deadline, session_deadline);
         }
         deadline
     }
@@ -952,6 +963,7 @@ mod tests {
         inner: T,
         fail_close_write: bool,
         fail_send: bool,
+        send_calls: usize,
         close_write_calls: usize,
         reset_calls: usize,
     }
@@ -1059,6 +1071,7 @@ mod tests {
                 inner,
                 fail_close_write: false,
                 fail_send: false,
+                send_calls: 0,
                 close_write_calls: 0,
                 reset_calls: 0,
             }
@@ -1087,6 +1100,7 @@ mod tests {
             stream_id: StreamId,
             data: Vec<u8>,
         ) -> Result<(), TransportError> {
+            self.send_calls += 1;
             if self.fail_send {
                 return Err(TransportError::StreamSendFailed {
                     id,
@@ -1342,15 +1356,21 @@ mod tests {
 
     #[test]
     fn a_quiet_circuit_keeps_alive_without_opening_a_stream() {
-        let (mut a, mut b, circuit_id, _bridge, a_peer, b_peer) = setup_pair();
+        let (mut a, mut b, circuit_id, bridge, a_peer, b_peer) = setup_close_observed_pair();
         complete_handshake(&mut a, &mut b, circuit_id, &a_peer, &b_peer);
+        let inner_conn = a
+            .circuits
+            .get(&circuit_id)
+            .expect("initiator circuit")
+            .inner_conn;
 
-        let _ = a.poll(Now::from_millis(0)).expect("stamp initiator");
-        let _ = b.poll(Now::from_millis(0)).expect("stamp responder");
         assert_eq!(
             a.next_deadline(),
-            Some(Deadline::from_millis(KEEPALIVE_INTERVAL_MS))
+            Some(Deadline::from_millis(KEEPALIVE_INTERVAL_MS)),
+            "Connected must arm keepalive without another poll"
         );
+
+        let a_sends = a.inner().send_calls;
 
         let ping = a
             .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
@@ -1360,15 +1380,41 @@ mod tests {
                 .all(|event| !matches!(event, TransportEvent::StreamData { .. })),
             "a yamux ping is not stream data: {ping:?}"
         );
-
-        let pong = b
-            .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
-            .expect("responder answers");
-        assert!(
-            pong.iter()
-                .all(|event| !matches!(event, TransportEvent::StreamData { .. })),
-            "answering a yamux ping must not surface as stream data: {pong:?}"
+        assert_eq!(
+            a.inner().send_calls,
+            a_sends + 1,
+            "the keepalive deadline must write a Yamux ping to the bridge"
         );
+
+        let ping_wire = b
+            .inner_mut()
+            .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
+            .expect("read ping from bridge");
+        let ping_bytes = ping_wire
+            .into_iter()
+            .find_map(|event| match event {
+                TransportEvent::StreamData {
+                    stream_id, data, ..
+                } if stream_id == bridge => Some(data),
+                _ => None,
+            })
+            .expect("Yamux ping bytes crossed the bridge");
+        b.inject_bridge_data(inner_conn, bridge, ping_bytes);
+
+        let pong_wire = a
+            .inner_mut()
+            .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
+            .expect("read pong from bridge");
+        let pong_bytes = pong_wire
+            .into_iter()
+            .find_map(|event| match event {
+                TransportEvent::StreamData {
+                    stream_id, data, ..
+                } if stream_id == bridge => Some(data),
+                _ => None,
+            })
+            .expect("Yamux pong bytes crossed the bridge");
+        a.inject_bridge_data(inner_conn, bridge, pong_bytes);
 
         let ack = a
             .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
@@ -1880,6 +1926,11 @@ mod tests {
             .expect("initiator circuit")
             .inner_conn;
         a.inject_bridge_data(inner_conn, bridge, coalesced);
+        assert_eq!(
+            a.next_deadline(),
+            Some(Deadline::IMMEDIATE),
+            "an injected handshake completion must schedule keepalive arming"
+        );
 
         let events = a
             .poll(Now::from_millis(0))
@@ -1892,6 +1943,20 @@ mod tests {
             TransportEvent::IncomingStream { id, stream_id }
                 if *id == circuit_id && *stream_id == opened
         )));
+        assert_eq!(
+            a.next_deadline(),
+            Some(Deadline::IMMEDIATE),
+            "draining pending events must leave an immediate wakeup"
+        );
+        assert!(
+            a.poll(Now::from_millis(0))
+                .expect("arm keepalive")
+                .is_empty()
+        );
+        assert_eq!(
+            a.next_deadline(),
+            Some(Deadline::from_millis(KEEPALIVE_INTERVAL_MS))
+        );
     }
 
     fn assert_pre_ready_bridge_failure(events: &[TransportEvent], circuit_id: ConnectionId) {

--- a/crates/ffi-core/src/driver.rs
+++ b/crates/ffi-core/src/driver.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use minip2p::{EndpointWake, Error, NatEvent};
 
@@ -14,7 +14,6 @@ use crate::{DriverFailureKind, EventDoorbell, P2pEvent};
 
 const DRIVER_POLL: Duration = Duration::from_millis(25);
 const DRIVER_IDLE_POLL: Duration = Duration::from_millis(500);
-const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 const MAX_CARRY_EVENTS: usize = 4096;
 
 /// Rust-side instrumentation for the background driver.
@@ -184,9 +183,7 @@ pub(crate) fn run(shared: Arc<Shared>, doorbell: Arc<dyn EventDoorbell>) {
 }
 
 fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
-    let mut next_keepalive_at = Instant::now() + KEEPALIVE_INTERVAL;
     loop {
-        service_keepalive(&guard.shared, &mut next_keepalive_at);
         let mut state = guard.shared.lock_state();
         if state.lifecycle != Lifecycle::Running {
             return Ok(());
@@ -268,46 +265,6 @@ fn pump(guard: &mut ExitGuard) -> Result<(), Error> {
             ring(guard.doorbell.as_ref().expect("doorbell exists"));
         }
     }
-}
-
-fn service_keepalive(shared: &Shared, next_at: &mut Instant) {
-    let now = Instant::now();
-    if now < *next_at {
-        return;
-    }
-    advance_keepalive_deadline(next_at, now);
-    let peers = {
-        let state = shared.lock_state();
-        if state.lifecycle != Lifecycle::Running {
-            return;
-        }
-        let Some(endpoint) = state.endpoint.as_ref() else {
-            return;
-        };
-        endpoint.connected_peers()
-    };
-    for peer in keepalive_targets(&peers) {
-        let mut state = shared.lock_state();
-        if state.lifecycle != Lifecycle::Running {
-            return;
-        }
-        let Some(endpoint) = state.endpoint.as_mut() else {
-            return;
-        };
-        // A peer may disconnect between the snapshot and ping. Its
-        // close/timeout event is the authoritative signal.
-        let _ = endpoint.ping(peer);
-    }
-}
-
-fn advance_keepalive_deadline(deadline: &mut Instant, now: Instant) {
-    while *deadline <= now {
-        *deadline += KEEPALIVE_INTERVAL;
-    }
-}
-
-fn keepalive_targets<T>(peers: &[T]) -> &[T] {
-    peers
 }
 
 fn ingest(
@@ -608,25 +565,5 @@ mod tests {
             path: crate::PathKind::DirectDialed,
         };
         assert_eq!(p2p_connect_id(&extracted), Some(7));
-    }
-
-    #[test]
-    fn keepalive_deadline_advances_from_its_previous_schedule() {
-        let start = Instant::now();
-        let mut deadline = start + KEEPALIVE_INTERVAL;
-
-        advance_keepalive_deadline(
-            &mut deadline,
-            start + KEEPALIVE_INTERVAL + Duration::from_secs(25),
-        );
-
-        assert_eq!(deadline, start + Duration::from_secs(40));
-    }
-
-    #[test]
-    fn keepalive_targets_include_every_connected_peer() {
-        let peers: Vec<_> = (0..32).collect();
-
-        assert_eq!(keepalive_targets(&peers), peers);
     }
 }

--- a/crates/ffi/tests/relayed.rs
+++ b/crates/ffi/tests/relayed.rs
@@ -200,8 +200,9 @@ fn relayed_chat_and_reservation_loss() {
 
     drop(relay);
     // Stopping the relay cannot signal an immediate close over UDP. The
-    // endpoint detects the dead relay through QUIC's 30-second idle timeout.
-    // The wider bound covers the keepalive/idle phase and slower CI scheduling.
+    // endpoint detects the dead relay through QUIC's 30-second idle timeout
+    // once keepalive pings go unanswered. The wider bound covers that wait
+    // and slower CI scheduling.
     b_log.wait_for_with_timeout(RELAY_LOSS_TIMEOUT, |event| {
         matches!(
             event,

--- a/crates/minip2p/tests/smoltcp_relay.rs
+++ b/crates/minip2p/tests/smoltcp_relay.rs
@@ -302,6 +302,16 @@ impl RelayService {
                     .send_stream(&self.a, self.a_bridge.unwrap(), data, now)
                     .unwrap();
             }
+            SwarmEvent::StreamClosed {
+                peer_id, stream_id, ..
+            } if (peer_id == self.a && Some(stream_id) == self.a_bridge)
+                || (peer_id == self.b && Some(stream_id) == self.b_stop) =>
+            {
+                self.bridged = false;
+                self.a_bridge = None;
+                self.b_stop = None;
+                self.pending = None;
+            }
             _ => {}
         }
     }

--- a/crates/secure-mux/Cargo.toml
+++ b/crates/secure-mux/Cargo.toml
@@ -20,6 +20,7 @@ std = [
     "minip2p-identity/std",
     "minip2p-multistream-select/std",
     "minip2p-noise/std",
+    "minip2p-platform/std",
     "minip2p-transport/std",
     "minip2p-yamux/std",
     "thiserror/std",
@@ -30,6 +31,7 @@ minip2p-core = { path = "../core", version = "0.4.8", default-features = false }
 minip2p-identity = { path = "../identity", version = "0.4.8", default-features = false, features = ["ed25519"] }
 minip2p-multistream-select = { path = "../multistream-select", version = "0.4.8", default-features = false }
 minip2p-noise = { path = "../noise", version = "0.4.8", default-features = false }
+minip2p-platform = { path = "../platform", version = "0.4.8", default-features = false }
 minip2p-transport = { path = "../transport", version = "0.4.8", default-features = false }
 minip2p-yamux = { path = "../yamux", version = "0.4.8", default-features = false }
 thiserror = { version = "2.0.18", default-features = false }

--- a/crates/secure-mux/README.md
+++ b/crates/secure-mux/README.md
@@ -16,7 +16,7 @@ Relay circuits and TCP connections differ only in what the byte stream *is* — 
 
 ## Usage
 
-The session owns no socket, no clock, and no executor. Feed it bytes read from the underlying stream, then drain outputs and write every `Write` back to that stream:
+The session owns no socket, no clock, and no executor. Feed it bytes read from the underlying stream, then drain outputs and write every `Write` back to that stream. After the upgrade, `poll(now)` / `next_deadline()` drive Yamux keepalive from the host's time sample:
 
 ```rust
 use minip2p_secure_mux::{SecureMuxSession, SessionConfig, SessionOutput, SessionRole, YamuxConfig};

--- a/crates/secure-mux/src/lib.rs
+++ b/crates/secure-mux/src/lib.rs
@@ -14,7 +14,9 @@
 //! bytes read from the underlying stream with [`SecureMuxSession::handle_input`]
 //! and drain [`SessionOutput`] values with
 //! [`SecureMuxSession::poll_output`], writing every
-//! [`SessionOutput::Write`] back to that stream. `no_std + alloc`.
+//! [`SessionOutput::Write`] back to that stream. After the upgrade,
+//! [`SecureMuxSession::poll`] / [`SecureMuxSession::next_deadline`] drive
+//! Yamux keepalive from the host's time sample. `no_std + alloc`.
 //!
 //! Relay circuits and TCP connections differ only in what the byte stream is,
 //! so both drive this same component rather than duplicating the state
@@ -35,6 +37,6 @@ extern crate alloc;
 mod session;
 
 pub use session::{
-    SecureMuxSession, SessionConfig, SessionError, SessionOutput, SessionRole, YamuxConfig,
-    YamuxError,
+    KEEPALIVE_INTERVAL_MS, SecureMuxSession, SessionConfig, SessionError, SessionOutput,
+    SessionRole, YamuxConfig, YamuxError,
 };

--- a/crates/secure-mux/src/session.rs
+++ b/crates/secure-mux/src/session.rs
@@ -9,11 +9,12 @@ use minip2p_multistream_select::{MultistreamInput, MultistreamOutput, Multistrea
 use minip2p_noise::{
     NOISE_PROTOCOL_ID, NoiseConfig, NoiseInput, NoiseOutput, NoiseRole, NoiseSession,
 };
+use minip2p_platform::{Deadline, Now};
 use minip2p_transport::StreamId;
 use minip2p_yamux::{YAMUX_PROTOCOL_ID, YamuxInput, YamuxOutput, YamuxRole, YamuxSession};
 use thiserror::Error;
 
-pub use minip2p_yamux::{YamuxConfig, YamuxError};
+pub use minip2p_yamux::{KEEPALIVE_INTERVAL_MS, YamuxConfig, YamuxError};
 
 /// Which end of the session opened the underlying byte stream.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -224,6 +225,28 @@ impl SecureMuxSession {
     /// Returns whether the upgrade has completed.
     pub fn is_established(&self) -> bool {
         matches!(self.phase, Some(Phase::Ready { .. }))
+    }
+
+    /// Advances Yamux keepalive using the host's time sample.
+    ///
+    /// A no-op until the upgrade has finished: there is no Yamux session to
+    /// ping during negotiation. After that, quiet sessions emit a ping as
+    /// [`SessionOutput::Write`].
+    pub fn poll(&mut self, now: Now) -> Result<(), SessionError> {
+        match self.with_yamux(|yamux| yamux.poll(now)) {
+            Ok(()) | Err(SessionError::NotEstablished) => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// When this session next wants a [`poll`](Self::poll) for keepalive.
+    ///
+    /// `None` until Yamux is up, and once the session has failed or gone away.
+    pub fn next_deadline(&self) -> Option<Deadline> {
+        match self.phase.as_ref()? {
+            Phase::Ready { yamux, .. } => yamux.next_deadline(),
+            _ => None,
+        }
     }
 
     /// Returns the authenticated peer, once Noise has verified it.

--- a/crates/secure-mux/tests/handshake.rs
+++ b/crates/secure-mux/tests/handshake.rs
@@ -6,8 +6,10 @@
 //! clock, or executor anywhere.
 
 use minip2p_identity::{Ed25519Keypair, PeerId};
+use minip2p_platform::{Deadline, Now};
 use minip2p_secure_mux::{
-    SecureMuxSession, SessionConfig, SessionError, SessionOutput, SessionRole, YamuxConfig,
+    KEEPALIVE_INTERVAL_MS, SecureMuxSession, SessionConfig, SessionError, SessionOutput,
+    SessionRole, YamuxConfig,
 };
 use minip2p_transport::StreamId;
 
@@ -533,4 +535,48 @@ fn a_session_that_fails_mid_batch_is_dead_and_stays_dead() {
     // on a half-torn-down session.
     assert!(dialer.handle_input(b"more".to_vec()).is_err());
     assert!(dialer.open_stream().is_err());
+}
+
+#[test]
+fn quiet_established_session_emits_a_keepalive_ping() {
+    let (mut dialer, mut listener, _, _) = upgraded_pair();
+
+    dialer.poll(Now::from_millis(0)).expect("stamp dialer");
+    listener.poll(Now::from_millis(0)).expect("stamp listener");
+    assert_eq!(
+        dialer.next_deadline(),
+        Some(Deadline::from_millis(KEEPALIVE_INTERVAL_MS))
+    );
+    assert!(take_writes(&mut dialer).is_empty(), "nothing is due at t=0");
+
+    dialer
+        .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
+        .expect("keepalive is due");
+    let ping = take_writes(&mut dialer);
+    assert!(
+        !ping.is_empty(),
+        "a quiet session must emit ciphertext for the yamux ping"
+    );
+
+    listener
+        .handle_input(ping)
+        .expect("listener accepts the ping");
+    let pong = take_writes(&mut listener);
+    assert!(
+        !pong.is_empty(),
+        "the listener already answers pings; that write is the pong"
+    );
+
+    let events = {
+        dialer.handle_input(pong).expect("dialer accepts the pong");
+        let mut events = Vec::new();
+        while let Some(output) = dialer.poll_output() {
+            events.push(output);
+        }
+        events
+    };
+    assert!(
+        events.is_empty(),
+        "a keepalive pong is session traffic, not a substream event: {events:?}"
+    );
 }

--- a/crates/yamux/Cargo.toml
+++ b/crates/yamux/Cargo.toml
@@ -17,9 +17,11 @@ workspace = true
 default = ["std"]
 std = [
     "minip2p-core/std",
+    "minip2p-platform/std",
     "thiserror/std",
 ]
 
 [dependencies]
 minip2p-core = { path = "../core", version = "0.4.8", default-features = false }
+minip2p-platform = { path = "../platform", version = "0.4.8", default-features = false }
 thiserror = { version = "2.0.18", default-features = false }

--- a/crates/yamux/README.md
+++ b/crates/yamux/README.md
@@ -2,7 +2,9 @@
 
 `minip2p-yamux` is a small, caller-driven, Sans-I/O implementation of the
 libp2p Yamux stream multiplexer (`/yamux/1.0.0`). It runs with `no_std + alloc`
-and leaves sockets, clocks, and task scheduling to its caller.
+and leaves sockets, clocks, and task scheduling to its caller. A quiet session
+emits a keepalive ping every 30 seconds when the host drives
+`YamuxSession::poll` with a time sample; the session never reads a clock.
 
 The session bounds inbound frame lengths, stream count, per-stream queued
 sends, and aggregate queued sends. Receive windows are replenished as data is

--- a/crates/yamux/src/lib.rs
+++ b/crates/yamux/src/lib.rs
@@ -1,8 +1,9 @@
 //! Bounded Sans-I/O implementation of the libp2p Yamux stream multiplexer.
 //!
 //! [`YamuxSession`] accepts ordered connection bytes and emits encoded Yamux
-//! frames plus stream lifecycle events. It performs no I/O, owns no clock, and
-//! remains fully caller-driven.
+//! frames plus stream lifecycle events. It performs no I/O and never reads a
+//! clock: the host supplies [`minip2p_platform::Now`] samples so a quiet
+//! session can emit keepalive pings on a deadline.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
@@ -24,6 +25,13 @@ pub use session::YamuxSession;
 
 /// Multistream-select protocol identifier for libp2p Yamux.
 pub const YAMUX_PROTOCOL_ID: &str = "/yamux/1.0.0";
+
+/// How long a session may stay quiet before it sends a keepalive ping.
+///
+/// The host drives this through [`YamuxSession::poll`] / [`YamuxSession::next_deadline`];
+/// the session never reads a clock of its own. 30 seconds matches go-libp2p
+/// yamux's default `KeepAliveInterval`.
+pub const KEEPALIVE_INTERVAL_MS: u64 = 30_000;
 
 /// Yamux's specification-defined initial stream window (256 KiB).
 pub const DEFAULT_RECEIVE_WINDOW: u32 = 256 * 1024;

--- a/crates/yamux/src/session.rs
+++ b/crates/yamux/src/session.rs
@@ -1,9 +1,11 @@
 use alloc::collections::{BTreeMap, VecDeque};
 use alloc::vec::Vec;
 
+use minip2p_platform::{Deadline, Now};
+
 use crate::{
     DEFAULT_RECEIVE_WINDOW, FLAG_ACK, FLAG_FIN, FLAG_RST, FLAG_SYN, Frame, FrameDecoder, FrameType,
-    YamuxConfig, YamuxError, YamuxOutput, YamuxRole,
+    KEEPALIVE_INTERVAL_MS, YamuxConfig, YamuxError, YamuxOutput, YamuxRole,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -91,6 +93,14 @@ pub struct YamuxSession {
     failed: bool,
     local_go_away: bool,
     remote_go_away: bool,
+    /// Monotonic milliseconds of the last poll that observed traffic, or the
+    /// first poll if none has arrived yet. `None` until the host supplies a
+    /// time sample.
+    last_activity_ms: Option<u64>,
+    /// A frame was queued or consumed since `last_activity_ms` was stamped.
+    dirty: bool,
+    /// Nonce for the next locally originated keepalive ping.
+    next_ping_nonce: u32,
 }
 
 impl YamuxSession {
@@ -132,7 +142,45 @@ impl YamuxSession {
             failed: false,
             local_go_away: false,
             remote_go_away: false,
+            last_activity_ms: None,
+            dirty: false,
+            next_ping_nonce: 1,
         }
+    }
+
+    /// Advances keepalive using the host's time sample.
+    ///
+    /// A quiet session queues a ping once [`KEEPALIVE_INTERVAL_MS`] has elapsed
+    /// since the last inbound or outbound frame. Traffic observed since the
+    /// previous sample restamps the timer, so a busy session never pings.
+    pub fn poll(&mut self, now: Now) -> Result<(), YamuxError> {
+        self.ensure_active()?;
+        if self.dirty || self.last_activity_ms.is_none() {
+            self.last_activity_ms = Some(now.monotonic_ms);
+            self.dirty = false;
+        }
+        let last = self.last_activity_ms.expect("stamped above");
+        if now.monotonic_ms.saturating_sub(last) >= KEEPALIVE_INTERVAL_MS {
+            let nonce = self.next_ping_nonce;
+            self.next_ping_nonce = self.next_ping_nonce.wrapping_add(1);
+            self.queue_frame(Frame::ping(FLAG_SYN, nonce)?);
+            self.last_activity_ms = Some(now.monotonic_ms);
+            self.dirty = false;
+        }
+        Ok(())
+    }
+
+    /// When this session next wants a [`poll`](Self::poll) for keepalive.
+    ///
+    /// `None` until the first poll supplies a timeline, and once the session
+    /// has failed or gone away.
+    pub fn next_deadline(&self) -> Option<Deadline> {
+        if self.failed || self.local_go_away || self.remote_go_away {
+            return None;
+        }
+        Some(Deadline::from_millis(
+            self.last_activity_ms?.saturating_add(KEEPALIVE_INTERVAL_MS),
+        ))
     }
 
     /// Opens a local stream and returns its role-partitioned identifier.
@@ -292,6 +340,7 @@ impl YamuxSession {
             if let Err(error) = self.process_frame(frame) {
                 return self.fail_protocol(error);
             }
+            self.dirty = true;
             if self.remote_go_away {
                 self.decoder.clear();
                 return Ok(());
@@ -608,6 +657,7 @@ impl YamuxSession {
     }
 
     fn queue_frame(&mut self, frame: Frame) {
+        self.dirty = true;
         self.pending
             .push_back(YamuxOutput::Outbound(frame.encode()));
     }
@@ -662,6 +712,8 @@ impl YamuxSession {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::KEEPALIVE_INTERVAL_MS;
+    use minip2p_platform::{Deadline, Now};
 
     fn outbound(session: &mut YamuxSession) -> Vec<u8> {
         match session.poll_output().expect("outbound Yamux frame") {
@@ -1037,6 +1089,118 @@ mod tests {
             Some(YamuxOutput::StreamClosed { stream })
         );
         assert_eq!(session.open_stream(), Err(YamuxError::SessionClosed));
+    }
+
+    #[test]
+    fn quiet_session_sends_ping_after_keepalive_interval() {
+        let mut session = YamuxSession::new(YamuxRole::Client);
+        session.poll(Now::from_millis(0)).unwrap();
+        assert_eq!(session.poll_output(), None, "nothing is due at t=0");
+
+        session
+            .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS - 1))
+            .unwrap();
+        assert_eq!(
+            session.poll_output(),
+            None,
+            "a ping one millisecond early would be early"
+        );
+
+        session
+            .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
+            .unwrap();
+        let ping = decode(&outbound(&mut session));
+        assert_eq!(ping.frame_type(), FrameType::Ping);
+        assert_eq!(ping.flags(), FLAG_SYN);
+        assert_ne!(ping.value(), 0, "the nonce is an opaque non-zero value");
+        assert_eq!(session.poll_output(), None);
+    }
+
+    #[test]
+    fn inbound_traffic_defers_the_keepalive_ping() {
+        let mut session = YamuxSession::new(YamuxRole::Server);
+        session.poll(Now::from_millis(0)).unwrap();
+
+        session
+            .handle_data(&Frame::ping(FLAG_SYN, 7).unwrap().encode())
+            .unwrap();
+        let pong = decode(&outbound(&mut session));
+        assert_eq!(pong.flags(), FLAG_ACK);
+        assert_eq!(pong.value(), 7);
+
+        session
+            .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
+            .unwrap();
+        assert_eq!(
+            session.poll_output(),
+            None,
+            "the echoed ping was traffic; the next keepalive is another interval out"
+        );
+
+        session
+            .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS * 2))
+            .unwrap();
+        let ping = decode(&outbound(&mut session));
+        assert_eq!(ping.frame_type(), FrameType::Ping);
+        assert_eq!(ping.flags(), FLAG_SYN);
+    }
+
+    #[test]
+    fn outbound_traffic_defers_the_keepalive_ping() {
+        let mut session = YamuxSession::new(YamuxRole::Client);
+        session.poll(Now::from_millis(0)).unwrap();
+        let stream = session.open_stream().unwrap();
+        session.send(stream, b"hello".to_vec()).unwrap();
+        assert_eq!(decode(&outbound(&mut session)).payload(), b"hello");
+
+        session
+            .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
+            .unwrap();
+        assert_eq!(
+            session.poll_output(),
+            None,
+            "sending on a stream is traffic; keepalive waits another interval"
+        );
+    }
+
+    #[test]
+    fn next_deadline_is_the_keepalive_interval_after_the_first_poll() {
+        let mut session = YamuxSession::new(YamuxRole::Client);
+        assert_eq!(
+            session.next_deadline(),
+            None,
+            "no sample yet means no timeline to answer on"
+        );
+
+        session.poll(Now::from_millis(10)).unwrap();
+        assert_eq!(
+            session.next_deadline(),
+            Some(Deadline::from_millis(10 + KEEPALIVE_INTERVAL_MS))
+        );
+
+        session
+            .poll(Now::from_millis(10 + KEEPALIVE_INTERVAL_MS))
+            .unwrap();
+        let _ = outbound(&mut session);
+        assert_eq!(
+            session.next_deadline(),
+            Some(Deadline::from_millis(10 + KEEPALIVE_INTERVAL_MS * 2))
+        );
+    }
+
+    #[test]
+    fn a_closed_session_does_not_keepalive() {
+        let mut session = YamuxSession::new(YamuxRole::Client);
+        session.poll(Now::from_millis(0)).unwrap();
+        session.go_away(0);
+        let _ = outbound(&mut session);
+
+        assert_eq!(
+            session.poll(Now::from_millis(KEEPALIVE_INTERVAL_MS)),
+            Err(YamuxError::SessionClosed)
+        );
+        assert_eq!(session.poll_output(), None);
+        assert_eq!(session.next_deadline(), None);
     }
 
     #[test]

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -77,10 +77,10 @@ minip2p, go-libp2p gossipsub, and signed rust-libp2p gossipsub currently emit
 8-byte big-endian counters, while this implementation accepts any 1..=64-byte
 value.
 
-A quiet room generates no traffic, and the QUIC transport drops
-connections after 30 s of silence — the chat loop pings every connected
-peer on a 10 s cadence to keep the room (and any relay reservation
-connection) alive through idle spells.
+A quiet room generates no application traffic. QUIC sends an ack-eliciting
+keepalive halfway through its idle timeout, while TCP and relay circuits use
+Yamux pings. The chat loop does not open ping-protocol streams just to keep
+connections alive.
 
 ## Live-test recipes
 

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -116,7 +116,8 @@ Two deployment details surfaced during live validation:
 4. **Manual rust-libp2p interop check (not covered by CI)**: configure a
    rust-libp2p gossipsub peer with `MessageAuthenticity::Signed` and strict
    validation, then verify messages travel in both directions. The rust peer
-   must include a `ping` behaviour (to answer this side's keepalives) or raise
-   its `idle_connection_timeout` — by default rust-libp2p closes a connection
-   after 10 s when no behaviour keeps it alive, which reads as an instant
-   disconnect here.
+   must include a `ping` behaviour or raise its `idle_connection_timeout` —
+   by default rust-libp2p closes a connection after 10 s when no behaviour
+   keeps it alive, which reads as an instant disconnect here. Transport-level
+   keepalives (QUIC PING / Yamux ping) keep the path up on this side; they
+   do not count as "in use" for rust-libp2p's swarm idle timeout.

--- a/examples/chat/src/modes.rs
+++ b/examples/chat/src/modes.rs
@@ -295,21 +295,7 @@ fn run_chat(
     // under a stdin flood.
     const MAX_LINES_PER_TICK: usize = 32;
 
-    // QUIC drops a connection after 30 s of silence (the transport's idle
-    // timeout), and a quiet room generates no traffic of its own — ping
-    // every connected peer well inside that window.
-    const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
-    let mut last_keepalive = Instant::now();
     loop {
-        if last_keepalive.elapsed() >= KEEPALIVE_INTERVAL {
-            last_keepalive = Instant::now();
-            for peer in endpoint.connected_peers() {
-                // A peer mid-disconnect can fail the ping; the close event
-                // will surface it.
-                let _ = endpoint.ping(&peer);
-            }
-        }
-
         for _ in 0..MAX_LINES_PER_TICK {
             match input.try_recv() {
                 Ok(Some(line)) => {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "minip2p-identity",
  "minip2p-multistream-select",
  "minip2p-noise",
+ "minip2p-platform",
  "minip2p-transport",
  "minip2p-yamux",
  "thiserror",
@@ -448,6 +449,7 @@ name = "minip2p-yamux"
 version = "0.4.8"
 dependencies = [
  "minip2p-core",
+ "minip2p-platform",
  "thiserror",
 ]
 

--- a/transports/quic/README.md
+++ b/transports/quic/README.md
@@ -27,6 +27,10 @@ No async runtime required. The host drives the transport by calling `poll(now)` 
   events are already buffered, so calls made between polls -- `listen`,
   `open_stream`, and the stream operations -- never leave a host asleep on an
   undelivered event.
+- Quiet connections send an ack-eliciting packet at half `idle_timeout_ms`
+  (15 s by default) so NAT bindings and the peer's idle timer stay warm
+  without an application ping. Dead paths still idle-timeout: only one ping
+  is sent per receive.
 - Stateless Retry authenticates source addresses before inbound connection
   allocation. Configurable limits bound connections, streams, queued stream
   bytes, queued UDP datagrams, and idle time.

--- a/transports/quic/src/config.rs
+++ b/transports/quic/src/config.rs
@@ -22,6 +22,9 @@ pub struct QuicLimits {
     /// QUIC idle timeout advertised to peers, in milliseconds. Must be
     /// greater than zero: quiche interprets zero as "no timeout", so
     /// transport construction rejects it.
+    ///
+    /// Quiet connections send an ack-eliciting packet at half this value so
+    /// the idle timer does not fire on a live but silent path.
     pub idle_timeout_ms: u64,
     /// Require a stateless Retry before allocating an inbound connection.
     pub require_address_validation: bool,

--- a/transports/quic/src/connection.rs
+++ b/transports/quic/src/connection.rs
@@ -7,6 +7,7 @@ use std::collections::{HashMap, VecDeque};
 use std::net::{SocketAddr, UdpSocket};
 use std::time::Duration;
 
+use minip2p_platform::{Deadline, Now};
 use minip2p_transport::{
     ConnectionEndpoint, ConnectionId, ConnectionState, StreamId, TransportError, TransportEvent,
 };
@@ -95,6 +96,14 @@ pub struct QuicConnection {
     /// Source CIDs the transport has entered into its routing table, so
     /// reindexing and unindexing never scan the whole table.
     indexed_cids: Vec<Vec<u8>>,
+    /// Host time of the last packet this connection received.
+    last_recv_ms: Option<u64>,
+    /// An ack-eliciting keepalive has been sent since `last_recv_ms`.
+    ///
+    /// Further pings would restart the idle timer without evidence the peer
+    /// is still there, so one unanswered ping is enough; idle timeout then
+    /// closes a dead path.
+    sent_keepalive_since_recv: bool,
 }
 
 impl QuicConnection {
@@ -121,6 +130,8 @@ impl QuicConnection {
             pending_write_bytes: 0,
             max_pending_write_bytes,
             indexed_cids: Vec::new(),
+            last_recv_ms: None,
+            sent_keepalive_since_recv: false,
         }
     }
 
@@ -168,6 +179,42 @@ impl QuicConnection {
         self.conn.timeout()
     }
 
+    /// When this connection next wants a keepalive poll, if it is quiet.
+    pub(crate) fn keepalive_deadline(&self, interval_ms: u64) -> Option<Deadline> {
+        if self.state != ConnectionState::Connected || self.sent_keepalive_since_recv {
+            return None;
+        }
+        Some(Deadline::from_millis(
+            self.last_recv_ms?.saturating_add(interval_ms),
+        ))
+    }
+
+    /// Sends an ack-eliciting packet if the connection has been quiet long
+    /// enough. One ping per receive; a dead peer is then left to idle-timeout.
+    pub fn maybe_keepalive(
+        &mut self,
+        now: Now,
+        interval_ms: u64,
+        socket: &UdpSocket,
+        events: &mut Vec<TransportEvent>,
+        pending_datagrams: &mut VecDeque<PendingDatagram>,
+        max_pending_datagrams: usize,
+    ) -> Result<(), TransportError> {
+        if self.state != ConnectionState::Connected || self.sent_keepalive_since_recv {
+            return Ok(());
+        }
+        let Some(last) = self.last_recv_ms else {
+            return Ok(());
+        };
+        if now.monotonic_ms.saturating_sub(last) < interval_ms {
+            return Ok(());
+        }
+        let _ = self.conn.send_ack_eliciting();
+        self.sent_keepalive_since_recv = true;
+        self.drain_send_queue(events)?;
+        self.flush(socket, pending_datagrams, max_pending_datagrams)
+    }
+
     /// Advances quiche's loss-recovery and idle timers when they are due.
     pub fn handle_timeout(
         &mut self,
@@ -194,6 +241,7 @@ impl QuicConnection {
         buf: &mut [u8],
         from: SocketAddr,
         local: SocketAddr,
+        now: Now,
         socket: &UdpSocket,
         events: &mut Vec<TransportEvent>,
         pending_datagrams: &mut VecDeque<PendingDatagram>,
@@ -202,8 +250,14 @@ impl QuicConnection {
         let recv_info = quiche::RecvInfo { from, to: local };
 
         match self.conn.recv(buf, recv_info) {
-            Ok(_) => {}
-            Err(quiche::Error::Done) => {}
+            Ok(_) => {
+                self.last_recv_ms = Some(now.monotonic_ms);
+                self.sent_keepalive_since_recv = false;
+            }
+            Err(quiche::Error::Done) => {
+                self.last_recv_ms = Some(now.monotonic_ms);
+                self.sent_keepalive_since_recv = false;
+            }
             Err(e) => {
                 events.push(TransportEvent::Error {
                     id: self.id,

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -1497,6 +1497,7 @@ impl Transport for QuicTransport {
                         packet,
                         from,
                         local_addr,
+                        now,
                         &self.socket,
                         &mut self.pending_events,
                         &mut self.pending_datagrams,
@@ -1536,8 +1537,18 @@ impl Transport for QuicTransport {
 
         let mut to_remove = Vec::new();
 
+        let keepalive_interval_ms =
+            keepalive_interval_ms(self.node_config.limits().idle_timeout_ms);
         for (&id, conn) in self.connections.iter_mut() {
             conn.handle_timeout(
+                &self.socket,
+                &mut self.pending_events,
+                &mut self.pending_datagrams,
+                self.node_config.limits().max_pending_datagrams,
+            )?;
+            conn.maybe_keepalive(
+                now,
+                keepalive_interval_ms,
                 &self.socket,
                 &mut self.pending_events,
                 &mut self.pending_datagrams,
@@ -1600,9 +1611,21 @@ impl Transport for QuicTransport {
             .connections
             .values()
             .filter_map(QuicConnection::timeout)
-            .min()?;
-        Some(deadline_for_timeout(now, timeout))
+            .min();
+        let quiche = timeout.map(|timeout| deadline_for_timeout(now, timeout));
+        let keepalive_interval_ms =
+            keepalive_interval_ms(self.node_config.limits().idle_timeout_ms);
+        let keepalive = self.connections.values().fold(None, |earliest, conn| {
+            Deadline::earliest_opt(earliest, conn.keepalive_deadline(keepalive_interval_ms))
+        });
+        Deadline::earliest_opt(quiche, keepalive)
     }
+}
+
+/// Quiet connections send an ack-eliciting packet at half the idle timeout,
+/// matching rust-libp2p / quic-go's "keep-alive at idle/2" rule.
+fn keepalive_interval_ms(idle_timeout_ms: u64) -> u64 {
+    idle_timeout_ms.max(2) / 2
 }
 
 /// Converts a quiche timeout into a deadline on the host's timeline.

--- a/transports/quic/tests/transport_contract.rs
+++ b/transports/quic/tests/transport_contract.rs
@@ -5,7 +5,7 @@
 //! transport implementation.
 
 use minip2p_core::{PeerAddr, Protocol};
-use minip2p_platform::Now;
+use minip2p_platform::{Deadline, Now};
 use minip2p_quic::{QuicEndpoint, QuicLimits, QuicNodeConfig, QuicTransport};
 use minip2p_transport::{
     BlockingTransport, ConnectionId, StreamId, Transport, TransportError, TransportEvent,
@@ -462,6 +462,45 @@ fn quic_deadline_is_exposed_and_driven_without_socket_input() {
         }
     }
     assert!(closed, "QUIC timeout must close a silent dial");
+}
+
+#[test]
+fn quiet_pair_stays_up_past_idle_timeout() {
+    let limits = QuicLimits {
+        idle_timeout_ms: 80,
+        ..QuicLimits::default()
+    };
+    let (mut server, mut client, peer_addr) = setup_pair_with_client_limits(limits);
+    let (server_id, client_id, _, _) = connect_pair(&mut server, &mut client, &peer_addr);
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(250);
+    let mut closed = false;
+    while std::time::Instant::now() < deadline {
+        closed |= server
+            .poll(common::now())
+            .expect("server poll")
+            .into_iter()
+            .any(|event| matches!(event, TransportEvent::Closed { id, .. } if id == server_id));
+        closed |= client
+            .poll(common::now())
+            .expect("client poll")
+            .into_iter()
+            .any(|event| matches!(event, TransportEvent::Closed { id, .. } if id == client_id));
+        if closed {
+            break;
+        }
+        let sleep = Deadline::earliest_opt(server.next_deadline(), client.next_deadline())
+            .map(|deadline| std::time::Duration::from_millis(deadline.millis_until(common::now())))
+            .unwrap_or(std::time::Duration::from_millis(5))
+            .min(std::time::Duration::from_millis(10));
+        if !sleep.is_zero() {
+            std::thread::sleep(sleep);
+        }
+    }
+    assert!(
+        !closed,
+        "ack-eliciting keepalive must keep a quiet pair past the idle timeout"
+    );
 }
 
 #[test]

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -42,6 +42,7 @@ thiserror = { version = "2.0.18", default-features = false }
 
 [dev-dependencies]
 minip2p-identity = { path = "../../crates/identity", features = ["ed25519", "std"] }
+minip2p-secure-mux = { path = "../../crates/secure-mux" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -44,6 +44,8 @@
 //! the peer stayed silent. Two limits bound the damage --
 //! [`TcpConfig::max_buffered_send`] on how much may queue, and
 //! [`TcpConfig::send_stall_timeout_ms`] on how long it may sit there.
+//! Established connections also fold in Yamux's 30 s keepalive deadline so a
+//! quiet TCP or relayed path stays up without an application ping.
 //!
 //! # Limits
 //!

--- a/transports/tcp/src/transport.rs
+++ b/transports/tcp/src/transport.rs
@@ -728,18 +728,6 @@ impl<P: TcpProvider, E: EntropySource> Transport for TcpTransport<P, E> {
             }
         }
 
-        // Yamux keepalive: only when the socket can take the ping. A stalled
-        // backlog would just queue another frame behind bytes that are not
-        // moving.
-        for id in self.connections.keys().copied().collect::<Vec<_>>() {
-            let should_keepalive = self.connections.get(&id).is_some_and(|connection| {
-                connection.session.is_established() && connection.outbound.is_empty()
-            });
-            if should_keepalive {
-                self.drive_connection(id, |session| session.poll(now));
-            }
-        }
-
         // Retry buffered writes even without a `Writable` event, so a provider
         // that only reports readiness coarsely still drains.
         let timeout = self.config.send_stall_timeout_ms;
@@ -784,6 +772,18 @@ impl<P: TcpProvider, E: EntropySource> Transport for TcpTransport<P, E> {
                     format!("socket accepted nothing for {stalled_for}ms; peer is not reading"),
                     true,
                 );
+            }
+        }
+
+        // Yamux keepalive: only when the socket can take the ping. Run this
+        // after retrying writes so an established session whose final upgrade
+        // bytes drained above gets its first keepalive deadline in this poll.
+        for id in self.connections.keys().copied().collect::<Vec<_>>() {
+            let should_keepalive = self.connections.get(&id).is_some_and(|connection| {
+                connection.session.is_established() && connection.outbound.is_empty()
+            });
+            if should_keepalive {
+                self.drive_connection(id, |session| session.poll(now));
             }
         }
         Ok(self.drain_pending_events())

--- a/transports/tcp/src/transport.rs
+++ b/transports/tcp/src/transport.rs
@@ -728,6 +728,18 @@ impl<P: TcpProvider, E: EntropySource> Transport for TcpTransport<P, E> {
             }
         }
 
+        // Yamux keepalive: only when the socket can take the ping. A stalled
+        // backlog would just queue another frame behind bytes that are not
+        // moving.
+        for id in self.connections.keys().copied().collect::<Vec<_>>() {
+            let should_keepalive = self.connections.get(&id).is_some_and(|connection| {
+                connection.session.is_established() && connection.outbound.is_empty()
+            });
+            if should_keepalive {
+                self.drive_connection(id, |session| session.poll(now));
+            }
+        }
+
         // Retry buffered writes even without a `Writable` event, so a provider
         // that only reports readiness coarsely still drains.
         let timeout = self.config.send_stall_timeout_ms;
@@ -793,6 +805,11 @@ impl<P: TcpProvider, E: EntropySource> Transport for TcpTransport<P, E> {
                     Some(stall.map_or(deadline, |earliest| Deadline::earliest(earliest, deadline)));
             }
             if connection.outbound.is_empty() {
+                if let Some(deadline) = connection.session.next_deadline() {
+                    stall = Some(
+                        stall.map_or(deadline, |earliest| Deadline::earliest(earliest, deadline)),
+                    );
+                }
                 continue;
             }
             let Some(since) = connection.stalled_since else {

--- a/transports/tcp/tests/upgrade.rs
+++ b/transports/tcp/tests/upgrade.rs
@@ -9,6 +9,7 @@ mod support;
 use minip2p_core::{Multiaddr, PeerAddr};
 use minip2p_identity::{Ed25519Keypair, PeerId};
 use minip2p_platform::{Deadline, EntropySource, Now};
+use minip2p_secure_mux::KEEPALIVE_INTERVAL_MS;
 use minip2p_tcp::{TcpConfig, TcpTransport};
 use minip2p_transport::{
     ConnectionId, ConnectionNamespace, StreamId, Transport, TransportError, TransportEvent,
@@ -53,14 +54,34 @@ fn drive<A: EntropySource, B: EntropySource>(
     for _ in 0..2048 {
         let from_a = a.poll(Now::from_millis(0)).expect("drive a");
         let from_b = b.poll(Now::from_millis(0)).expect("drive b");
-        let quiet = from_a.is_empty()
-            && from_b.is_empty()
+        a_events.extend(from_a.iter().cloned());
+        b_events.extend(from_b.iter().cloned());
+        // `IMMEDIATE` is real work. A future stall is too — the peer has to
+        // be polled so it can read and unstick the writer. A future keepalive
+        // is not: the session is idle until that timer. One extra pair of
+        // polls lets a stalled writer observe the peer's read before we
+        // decide the link is quiet.
+        let due_now = |deadline: Option<Deadline>| {
+            deadline.is_some_and(|deadline| deadline.is_expired_at(Now::from_millis(0)))
+        };
+        if !from_a.is_empty()
+            || !from_b.is_empty()
+            || !net.is_quiet()
+            || due_now(a.next_deadline())
+            || due_now(b.next_deadline())
+        {
+            continue;
+        }
+        let extra_a = a.poll(Now::from_millis(0)).expect("drive a extra");
+        let extra_b = b.poll(Now::from_millis(0)).expect("drive b extra");
+        a_events.extend(extra_a.iter().cloned());
+        b_events.extend(extra_b.iter().cloned());
+        if extra_a.is_empty()
+            && extra_b.is_empty()
             && net.is_quiet()
-            && a.next_deadline().is_none()
-            && b.next_deadline().is_none();
-        a_events.extend(from_a);
-        b_events.extend(from_b);
-        if quiet {
+            && !due_now(a.next_deadline())
+            && !due_now(b.next_deadline())
+        {
             return (a_events, b_events);
         }
     }
@@ -452,7 +473,11 @@ fn a_full_socket_buffers_and_drains_as_the_peer_reads() {
         "every byte must arrive exactly once, in order"
     );
     assert_eq!(dialer.provider().bytes_in_flight_to_peer(), 0);
-    assert_eq!(dialer.next_deadline(), None, "nothing is left buffered");
+    assert_eq!(
+        dialer.next_deadline(),
+        Some(Deadline::from_millis(KEEPALIVE_INTERVAL_MS)),
+        "nothing is left buffered; the yamux keepalive is the remaining deadline"
+    );
 }
 
 #[test]
@@ -569,7 +594,11 @@ fn a_stalled_socket_stops_claiming_urgency_and_recovers() {
         })
         .sum();
     assert_eq!(delivered, 1024, "the queued payload must survive the stall");
-    assert_eq!(pair.dialer.next_deadline(), None);
+    assert_eq!(
+        pair.dialer.next_deadline(),
+        Some(Deadline::from_millis(KEEPALIVE_INTERVAL_MS)),
+        "once the stall clears, only yamux keepalive remains"
+    );
 }
 
 #[test]
@@ -990,8 +1019,8 @@ fn an_idle_transport_reports_no_deadline_of_its_own() {
     let pair = upgraded_pair();
     assert_eq!(
         pair.dialer.next_deadline(),
-        None,
-        "a drained connection has nothing pending"
+        Some(Deadline::from_millis(KEEPALIVE_INTERVAL_MS)),
+        "a drained connection's only outstanding work is the yamux keepalive"
     );
 }
 
@@ -1064,7 +1093,11 @@ fn an_inbound_connection_past_the_ceiling_is_refused_without_a_word() {
         announced.extend(listener.poll(Now::from_millis(0)).expect("poll listener"));
         let _ = first.poll(Now::from_millis(0)).expect("poll first");
         let _ = second.poll(Now::from_millis(0)).expect("poll second");
-        if net.is_quiet() && listener.next_deadline().is_none() {
+        if net.is_quiet()
+            && !listener
+                .next_deadline()
+                .is_some_and(|deadline| deadline.is_expired_at(Now::from_millis(0)))
+        {
             break;
         }
     }
@@ -1151,7 +1184,48 @@ fn an_established_connection_is_no_longer_on_the_handshake_clock() {
     // an idle host to do it.
     assert_eq!(
         pair.dialer.next_deadline(),
-        None,
-        "an authenticated connection has nothing outstanding"
+        Some(Deadline::from_millis(KEEPALIVE_INTERVAL_MS)),
+        "an authenticated connection is off the handshake clock; keepalive is 30s, not 5s"
+    );
+}
+
+#[test]
+fn a_quiet_connection_keeps_alive_without_opening_a_stream() {
+    let mut pair = upgraded_pair();
+    assert_eq!(
+        pair.dialer.next_deadline(),
+        Some(Deadline::from_millis(KEEPALIVE_INTERVAL_MS))
+    );
+
+    let dialer_events = pair
+        .dialer
+        .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
+        .expect("dialer keepalive");
+    assert!(
+        dialer_events.is_empty(),
+        "a yamux ping is not a transport event: {dialer_events:?}"
+    );
+
+    let listener_events = pair
+        .listener
+        .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
+        .expect("listener sees the ping");
+    assert!(
+        listener_events.is_empty(),
+        "answering a yamux ping must not surface as stream data: {listener_events:?}"
+    );
+
+    let ack = pair
+        .dialer
+        .poll(Now::from_millis(KEEPALIVE_INTERVAL_MS))
+        .expect("dialer sees the pong");
+    assert!(
+        ack.is_empty(),
+        "a keepalive pong is session traffic: {ack:?}"
+    );
+    assert_eq!(
+        pair.dialer.connection_ids().len(),
+        1,
+        "keepalive must not tear the connection down"
     );
 }

--- a/transports/tcp/tests/upgrade.rs
+++ b/transports/tcp/tests/upgrade.rs
@@ -1205,6 +1205,10 @@ fn a_quiet_connection_keeps_alive_without_opening_a_stream() {
         dialer_events.is_empty(),
         "a yamux ping is not a transport event: {dialer_events:?}"
     );
+    assert!(
+        pair.dialer.provider().bytes_in_flight_to_peer() > 0,
+        "the keepalive deadline must write a Yamux ping to the socket"
+    );
 
     let listener_events = pair
         .listener
@@ -1228,4 +1232,59 @@ fn a_quiet_connection_keeps_alive_without_opening_a_stream() {
         1,
         "keepalive must not tear the connection down"
     );
+}
+
+#[test]
+fn completing_an_upgrade_arms_the_keepalive_deadline() {
+    let net = VirtualNetwork::new();
+    let listener_key = identity(2);
+    let listener_peer = listener_key.peer_id();
+    let mut dialer = node(&net, identity(1), 10);
+    let mut listener = node(&net, listener_key, 20);
+    dialer.provider_mut().suppress_writable();
+    listener.listen(&addr(LISTEN_ADDR)).expect("listener binds");
+    let target = PeerAddr::new(addr(LISTEN_ADDR), listener_peer).expect("dial target");
+    dialer.dial(&target).expect("dial starts");
+
+    for _ in 0..128 {
+        dialer.provider_mut().set_in_flight_capacity(Some(0));
+        let dialer_events = dialer.poll(Now::from_millis(0)).expect("drive dialer");
+        if dialer_events
+            .iter()
+            .any(|event| matches!(event, TransportEvent::Connected { .. }))
+        {
+            dialer.provider_mut().set_in_flight_capacity(None);
+            dialer
+                .poll(Now::from_millis(0))
+                .expect("drain the final upgrade bytes");
+            assert_eq!(
+                dialer.next_deadline(),
+                Some(Deadline::from_millis(KEEPALIVE_INTERVAL_MS)),
+                "the poll that completes and flushes the upgrade must arm keepalive"
+            );
+            return;
+        }
+        dialer.provider_mut().set_in_flight_capacity(None);
+        dialer.poll(Now::from_millis(0)).expect("flush dialer");
+        listener.provider_mut().set_in_flight_capacity(Some(0));
+        let listener_events = listener.poll(Now::from_millis(0)).expect("drive listener");
+        if listener_events
+            .iter()
+            .any(|event| matches!(event, TransportEvent::Connected { .. }))
+        {
+            listener.provider_mut().set_in_flight_capacity(None);
+            listener
+                .poll(Now::from_millis(0))
+                .expect("drain the final upgrade bytes");
+            assert_eq!(
+                listener.next_deadline(),
+                Some(Deadline::from_millis(KEEPALIVE_INTERVAL_MS)),
+                "the poll that completes and flushes the upgrade must arm keepalive"
+            );
+            return;
+        }
+        listener.provider_mut().set_in_flight_capacity(None);
+        listener.poll(Now::from_millis(0)).expect("flush listener");
+    }
+    panic!("the upgrade did not complete");
 }


### PR DESCRIPTION
Closes #119

## What changed

- Send ack-eliciting QUIC packets halfway through the configured idle timeout, with one unanswered keepalive before normal idle-timeout teardown.
- Add caller-driven Yamux keepalive deadlines for TCP and relayed paths.
- Remove the FFI driver and chat example ping-all loops. Application `ping()` remains an RTT service.
- Cover quiet QUIC, TCP, secure-mux, and circuit sessions, including portable relay teardown after late keepalive traffic.

## Validation

- `just fmt`
- `just clippy`
- `just check-nostd`
- `just test` feature matrix. The initial run exposed a portable relay emulator lifecycle bug; after fixing it, the failing variant passed in full.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #119 by moving keepalive into the transport layer so quiet connections no longer rely on application-level ping loops.

- QUIC sends one ack-eliciting packet at half the idle timeout and tears down after one unanswered keepalive.
- Yamux sessions emit a 30-second ping when the host drives `poll(now)` / `next_deadline()`; frame traffic restamps the timer.
- Circuit, TCP, and relayed paths fold in the Yamux keepalive deadline, arming it immediately when an upgrade completes — including handshakes finalized through injected bridge reads.
- The FFI driver and chat example drop their ping-all loops; application `ping()` remains an RTT service.

<sup>Written for commit fe863889b8879b15c9bc8eb01c855ebd179dccf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

