### PR TITLE
fix(quic): close relayed circuits on remote stream reset

### DIFF
--- a/crates/minip2p/src/std/nat.rs
+++ b/crates/minip2p/src/std/nat.rs
@@ -375,6 +375,7 @@ mod tests {
         local_addr: minip2p_core::PeerAddr,
         relay_addr: minip2p_core::PeerAddr,
         inner_conn: ConnectionId,
+        relay_conn: ConnectionId,
         stream: StreamId,
     }
 
@@ -395,6 +396,7 @@ mod tests {
 
         let deadline = Instant::now() + std::time::Duration::from_secs(5);
         let mut inner_conn = None;
+        let mut relay_conn = None;
         let mut local_ready = false;
         let mut relay_ready = false;
         while !local_ready || !relay_ready {
@@ -418,15 +420,25 @@ mod tests {
                     _ => {}
                 }
             }
-            if let Some(Event::PeerReady { peer_id, .. }) = relay
+            if let Some(event) = relay
                 .next_event(std::time::Duration::from_millis(10))
                 .expect("drive relay")
-                && peer_id == *local.peer_id()
             {
-                relay_ready = true;
+                match event {
+                    Event::ConnectionEstablished { peer_id, conn_id }
+                        if peer_id == *local.peer_id() =>
+                    {
+                        relay_conn = Some(conn_id);
+                    }
+                    Event::PeerReady { peer_id, .. } if peer_id == *local.peer_id() => {
+                        relay_ready = true;
+                    }
+                    _ => {}
+                }
             }
         }
         let inner_conn = inner_conn.expect("local connection id");
+        let relay_conn = relay_conn.expect("relay connection id");
         let stream = local
             .open_stream(relay_addr.peer_id(), HOP_PROTOCOL_ID)
             .expect("open bridge stream");
@@ -455,6 +467,7 @@ mod tests {
             local_addr,
             relay_addr,
             inner_conn,
+            relay_conn,
             stream,
         }
     }
@@ -1046,5 +1059,49 @@ mod tests {
             .expect("transport-side close");
         swept.pump(&mut swept_pair.local.swarm);
         assert!(swept.promoted.is_empty());
+    }
+
+    #[test]
+    fn remote_bridge_reset_closes_promoted_circuit() {
+        let mut pair = negotiated_bridge();
+        let key = (pair.inner_conn, pair.stream);
+        let (mut driver, action) = promotion_driver(&pair, false);
+        execute(&mut driver, action, &mut pair.local);
+        let promoted = circuit_id(&driver, key);
+
+        pair.relay
+            .swarm
+            .transport_mut()
+            .reset_stream(pair.relay_conn, pair.stream)
+            .expect("reset bridge at relay");
+
+        let deadline = Instant::now() + std::time::Duration::from_secs(2);
+        let mut circuit_failed = false;
+        while Instant::now() < deadline && !circuit_failed {
+            let _ = pair
+                .relay
+                .swarm
+                .poll_next(std::time::Duration::from_millis(10))
+                .expect("drive reset sender");
+            if let Some(event) = pair
+                .local
+                .swarm
+                .poll_next(std::time::Duration::from_millis(10))
+                .expect("drive reset receiver")
+            {
+                circuit_failed = matches!(
+                    &event,
+                    SwarmEvent::Error(error) if error.conn_id == Some(promoted)
+                );
+                driver.ingest(&event, &mut pair.local.swarm);
+            }
+        }
+
+        assert!(
+            circuit_failed,
+            "remote RESET_STREAM did not fail the promoted circuit"
+        );
+        assert!(!driver.promoted.contains_key(&key));
+        assert!(pair.local.swarm.transport().circuit_ids().is_empty());
     }
 }

--- a/transports/quic/src/connection.rs
+++ b/transports/quic/src/connection.rs
@@ -600,6 +600,10 @@ impl QuicConnection {
                         }
                     }
                     Err(quiche::Error::Done) => break,
+                    Err(quiche::Error::StreamReset(_)) => {
+                        self.note_stream_reset(stream_id, events);
+                        break;
+                    }
                     Err(e) => {
                         events.push(TransportEvent::Error {
                             id: self.id,
@@ -744,6 +748,30 @@ impl QuicConnection {
             && state.is_fully_closed()
             && !state.closed_notified
         {
+            state.closed_notified = true;
+            events.push(TransportEvent::StreamClosed {
+                id: self.id,
+                stream_id,
+            });
+        }
+    }
+
+    /// A peer reset terminates both halves and discards writes that can no
+    /// longer be delivered.
+    fn note_stream_reset(&mut self, stream_id: StreamId, events: &mut Vec<TransportEvent>) {
+        let Some(state) = self.stream_states.get_mut(&stream_id.as_u64()) else {
+            return;
+        };
+        let dropped = state
+            .pending_writes
+            .iter()
+            .map(|write| write.bytes.len().saturating_sub(write.offset))
+            .sum::<usize>();
+        state.pending_writes.clear();
+        self.pending_write_bytes = self.pending_write_bytes.saturating_sub(dropped);
+        state.local_write_closed = true;
+        state.remote_write_closed = true;
+        if !state.closed_notified {
             state.closed_notified = true;
             events.push(TransportEvent::StreamClosed {
                 id: self.id,


### PR DESCRIPTION
Closes #121

Treat a peer `RESET_STREAM` as terminal stream closure instead of a generic QUIC connection error. This preserves the stream ID so `CircuitTransport` can close the promoted relay circuit while leaving the hop connection up. Pending writes for the reset stream are discarded and released from the queue budget.

Adds a focused test that resets the adopted bridge from the relay side over a real QUIC connection and checks that the promoted circuit and NAT bookkeeping are removed.

Tests:
- `cargo test -p minip2p-rs --features nat,quic remote_bridge_reset_closes_promoted_circuit`
- `cargo test -p minip2p-quic`
- `cargo clippy -p minip2p-rs --features nat,quic --all-targets -- -D warnings`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats a peer `RESET_STREAM` as terminal stream closure instead of a generic QUIC connection error. The stream ID is preserved so `CircuitTransport` closes the promoted relay circuit while the hop connection stays up.

**Bug Fixes**

- Discards and releases pending writes for the reset stream from the queue budget.
- Adds a test that resets the adopted bridge from the relay side and verifies the promoted circuit and NAT bookkeeping are removed.

Closes #121

<sup>Written for commit 018eee03fd90d3436b55077e4ac041de299c4796. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

