### PR TITLE
perf: remove hot-path allocation and scan costs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,7 @@ dependencies = [
 name = "minip2p-discovery"
 version = "0.4.9"
 dependencies = [
+ "criterion",
  "minip2p-core",
  "minip2p-identity",
  "thiserror",
@@ -1328,6 +1329,7 @@ dependencies = [
 name = "minip2p-pubsub"
 version = "0.4.9"
 dependencies = [
+ "criterion",
  "minip2p-core",
  "minip2p-identity",
  "minip2p-swarm",
@@ -1340,6 +1342,7 @@ name = "minip2p-quic"
 version = "0.4.9"
 dependencies = [
  "boring",
+ "criterion",
  "getrandom",
  "hmac",
  "minip2p-core",
@@ -1368,6 +1371,7 @@ dependencies = [
 name = "minip2p-relay-server"
 version = "0.4.9"
 dependencies = [
+ "criterion",
  "minip2p-core",
  "minip2p-identity",
  "minip2p-nat",
@@ -1454,6 +1458,7 @@ dependencies = [
 name = "minip2p-tcp"
 version = "0.4.9"
 dependencies = [
+ "criterion",
  "minip2p-core",
  "minip2p-identity",
  "minip2p-platform",
@@ -1506,6 +1511,7 @@ dependencies = [
 name = "minip2p-yamux"
 version = "0.4.9"
 dependencies = [
+ "criterion",
  "minip2p-core",
  "minip2p-platform",
  "thiserror",

--- a/bindings/ts/node/README.md
+++ b/bindings/ts/node/README.md
@@ -1,7 +1,6 @@
 # @minip2p/node
 
-The Node.js package for [minip2p](https://minip2p.com). It is ESM-only and
-requires Node.js 24 or newer.
+The Node.js package for [minip2p](https://minip2p.com). It is ESM-only and requires Node.js 24 or newer.
 
 ```ts
 import { Minip2p, generateSecretKey } from "@minip2p/node";
@@ -18,9 +17,7 @@ console.log(endpoint.peerId(), endpoint.listenAddrs());
 endpoint.close();
 ```
 
-`Minip2p.create()` starts the endpoint. A running endpoint keeps the Node.js
-process alive until `close()` shuts it down. Promise-returning operations such
-as `connectAddr()` and `openStream()` resolve as their network work completes.
+`Minip2p.create()` starts the endpoint. A running endpoint keeps the Node.js process alive until `close()` shuts it down. Promise-returning operations such as `connectAddr()` and `openStream()` resolve as their network work completes.
 
 The Node binding accepts the same TCP, QUIC, circuit-relay, signed-discovery, and mDNS configuration as `@minip2p/react-native`.
 

--- a/bindings/ts/node/src/adapter.ts
+++ b/bindings/ts/node/src/adapter.ts
@@ -356,7 +356,7 @@ function normalizeIdentifyInfo(value: unknown): IdentifyInfo {
   if (Array.isArray(publicKey) || publicKey instanceof Uint8Array) {
     return {
       ...info,
-      publicKey: Uint8Array.from(publicKey).buffer,
+      publicKey: nativeBytesToArrayBuffer(publicKey),
     } as unknown as IdentifyInfo;
   }
   throw new TypeError(
@@ -491,14 +491,14 @@ function normalizeEventBytes(tag: string, value: unknown): unknown {
   if (tag === "StreamData") {
     const data = Reflect.get(inner, "data");
     if (Array.isArray(data) || data instanceof Uint8Array) {
-      Reflect.set(inner, "data", Uint8Array.from(data).buffer);
+      Reflect.set(inner, "data", nativeBytesToArrayBuffer(data));
     }
   }
   if (tag === "Message") {
     for (const key of ["data", "seqno"] as const) {
       const bytes = Reflect.get(inner, key);
       if (Array.isArray(bytes) || bytes instanceof Uint8Array) {
-        Reflect.set(inner, key, Uint8Array.from(bytes).buffer);
+        Reflect.set(inner, key, nativeBytesToArrayBuffer(bytes));
       }
     }
   }
@@ -509,6 +509,20 @@ function normalizeEventBytes(tag: string, value: unknown): unknown {
     }
   }
   return inner;
+}
+
+function nativeBytesToArrayBuffer(bytes: number[] | Uint8Array): ArrayBuffer {
+  if (Array.isArray(bytes)) {
+    return Uint8Array.from(bytes).buffer;
+  }
+  if (
+    bytes.buffer instanceof ArrayBuffer &&
+    bytes.byteOffset === 0 &&
+    bytes.byteLength === bytes.buffer.byteLength
+  ) {
+    return bytes.buffer;
+  }
+  return Uint8Array.from(bytes).buffer;
 }
 
 class EventDrain {
@@ -535,9 +549,11 @@ class EventDrain {
     this.#pending = true;
     if (!this.#running) {
       this.#running = true;
-      setTimeout(() => {
+      // One check-phase turn keeps native callbacks out of the caller's stack
+      // without paying the timer granularity for every bounded batch.
+      setImmediate(() => {
         void this.#run();
-      }, 0);
+      });
     }
   }
 
@@ -561,7 +577,7 @@ class EventDrain {
             }
           }
           await new Promise<void>((resolve) => {
-            setTimeout(resolve, 0);
+            setImmediate(resolve);
           });
           if (this.#stopped) {
             break;

--- a/bindings/ts/node/tests/adapter.test.ts
+++ b/bindings/ts/node/tests/adapter.test.ts
@@ -211,20 +211,64 @@ describe("Node adapter", () => {
     endpoint.close();
   });
 
-  test("gives timers a turn between non-empty native batches", async () => {
+  test("reuses exact native event buffers without exposing sliced bytes", async () => {
+    vi.useFakeTimers();
     const endpoint = createEndpoint();
     const fake = fakeEndpoint();
-    let timerRan = false;
-    let timerRanBeforeSecondDrain = false;
+    const exact = Uint8Array.of(1, 2, 3);
+    const backing = Uint8Array.of(9, 4, 5, 8);
+    const sliced = backing.subarray(1, 3);
+    const received: ArrayBuffer[] = [];
+    endpoint.on("message", ({ data }) => received.push(data));
+    fake.enqueue(
+      [
+        {
+          inner: {
+            data: exact,
+            fromPeerId: "remote",
+            seqno: Uint8Array.of(1),
+            signed: false,
+            topics: ["test"],
+          },
+          tag: "Message",
+        },
+        {
+          inner: {
+            data: sliced,
+            fromPeerId: "remote",
+            seqno: Uint8Array.of(2),
+            signed: false,
+            topics: ["test"],
+          },
+          tag: "Message",
+        },
+      ],
+      []
+    );
+
+    fake.ring();
+    await settle();
+
+    expect(received[0]).toBe(exact.buffer);
+    expect([...new Uint8Array(received[1])]).toEqual([4, 5]);
+    expect(received[1]).not.toBe(backing.buffer);
+    endpoint.close();
+  });
+
+  test("gives the event loop a turn between non-empty native batches", async () => {
+    const endpoint = createEndpoint();
+    const fake = fakeEndpoint();
+    let immediateRan = false;
+    let immediateRanBeforeSecondDrain = false;
     const secondDrain = new Promise<void>((resolve) => {
       fake.onDrain = (call) => {
         if (call === 1) {
-          setTimeout(() => {
-            timerRan = true;
-          }, 0);
+          setImmediate(() => {
+            immediateRan = true;
+          });
         }
         if (call === 2) {
-          timerRanBeforeSecondDrain = timerRan;
+          immediateRanBeforeSecondDrain = immediateRan;
           resolve();
         }
       };
@@ -237,7 +281,7 @@ describe("Node adapter", () => {
     fake.ring();
     await secondDrain;
 
-    expect(timerRanBeforeSecondDrain).toBe(true);
+    expect(immediateRanBeforeSecondDrain).toBe(true);
     endpoint.close();
   });
 

--- a/bindings/ts/react-native/README.md
+++ b/bindings/ts/react-native/README.md
@@ -50,9 +50,7 @@ unsubscribe();
 endpoint.close();
 ```
 
-`Minip2p.create` starts an endpoint. `useMinip2p` manages one for a React
-component, while `bindAppState` keeps its active state synchronized with the
-application.
+`Minip2p.create` starts an endpoint. `useMinip2p` manages one for a React component, while `bindAppState` keeps its active state synchronized with the application.
 
 Configuration defaults to gossipsub with signed messages and no relay or discovery. Set `mdns: true` for local discovery and ensure the host app has local-network and multicast permissions.
 

--- a/crates/discovery/Cargo.toml
+++ b/crates/discovery/Cargo.toml
@@ -21,3 +21,10 @@ std = ["minip2p-core/std", "minip2p-identity/std", "thiserror/std"]
 minip2p-core = { path = "../core", version = "0.4.9", default-features = false }
 minip2p-identity = { path = "../identity", version = "0.4.9", default-features = false }
 thiserror = { version = "2.0.18", default-features = false }
+
+[dev-dependencies]
+criterion = "0.8.2"
+
+[[bench]]
+name = "peer_book"
+harness = false

--- a/crates/discovery/benches/peer_book.rs
+++ b/crates/discovery/benches/peer_book.rs
@@ -1,0 +1,67 @@
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use minip2p_core::{Multiaddr, PeerId};
+use minip2p_discovery::{Observation, PeerDiscoveryAgent, PeerDiscoveryConfig};
+use minip2p_identity::{KeyType, PublicKey};
+use std::hint::black_box;
+
+const PEERS: usize = 128;
+const ADDRS_PER_PEER: usize = 16;
+
+fn peer(index: usize) -> PeerId {
+    PeerId::from_public_key(&PublicKey::new(KeyType::Ed25519, vec![index as u8; 32]))
+}
+
+fn addrs(index: usize) -> Vec<Multiaddr> {
+    (0..ADDRS_PER_PEER)
+        .map(|offset| {
+            let port = 10_000 + ((index * ADDRS_PER_PEER + offset) % 50_000) as u16;
+            format!("/ip4/192.0.2.{}/udp/{port}/quic-v1", (index % 250) + 1)
+                .parse()
+                .expect("valid benchmark address")
+        })
+        .collect()
+}
+
+fn populated(ttl_ms: u64) -> PeerDiscoveryAgent {
+    let config = PeerDiscoveryConfig {
+        auto_dial: false,
+        beacon_peer_ttl_ms: ttl_ms,
+        ..PeerDiscoveryConfig::default()
+    };
+    let mut agent = PeerDiscoveryAgent::new(peer(usize::MAX), config).expect("valid config");
+    for index in 0..PEERS {
+        agent.observe_beacon(
+            Observation {
+                peer: peer(index),
+                addrs: addrs(index),
+            },
+            0,
+        );
+    }
+    agent
+}
+
+fn peer_book(c: &mut Criterion) {
+    let mut active = populated(u64::MAX / 2);
+    let mut group = c.benchmark_group("peer_book_128_peers_16_addrs");
+    group.bench_function("tick_active", |b| {
+        b.iter(|| active.handle_tick(black_box(1)));
+    });
+    group.bench_function("tick_expire", |b| {
+        b.iter_batched(
+            || populated(1),
+            |mut agent| {
+                agent.handle_tick(black_box(1));
+                black_box(agent.pending_event_count());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("next_timeout", |b| {
+        b.iter(|| black_box(active.next_timeout(black_box(1))));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, peer_book);
+criterion_main!(benches);

--- a/crates/discovery/src/book.rs
+++ b/crates/discovery/src/book.rs
@@ -371,29 +371,43 @@ impl PeerDiscoveryAgent {
     pub fn handle_tick(&mut self, now_ms: u64) {
         let peers: Vec<PeerId> = self.book.keys().cloned().collect();
         for peer in peers {
+            let Some(entry) = self.book.get(&peer) else {
+                continue;
+            };
+            let beacon_due = entry.beacon.as_ref().is_some_and(|source| {
+                now_ms
+                    >= source
+                        .last_seen_ms
+                        .saturating_add(self.config.beacon_peer_ttl_ms)
+            });
+            let mdns_due = entry
+                .mdns
+                .values()
+                .any(|record| now_ms >= record.expires_at_ms);
+            if !beacon_due && !mdns_due {
+                continue;
+            }
+
             let before = self.book.get(&peer).map(|entry| self.view(entry));
             let mut beacon_changed = false;
             let mut mdns_changed = false;
             if let Some(entry) = self.book.get_mut(&peer) {
-                if entry.beacon.as_ref().is_some_and(|source| {
-                    now_ms
-                        >= source
-                            .last_seen_ms
-                            .saturating_add(self.config.beacon_peer_ttl_ms)
-                }) {
+                if beacon_due {
                     entry.beacon = None;
                     beacon_changed = true;
                 }
-                let expired: Vec<Multiaddr> = entry
-                    .mdns
-                    .iter()
-                    .filter(|(_, record)| now_ms >= record.expires_at_ms)
-                    .map(|(addr, _)| addr.clone())
-                    .collect();
-                for addr in expired {
-                    entry.mdns.remove(&addr);
-                    entry.mdns_order.retain(|known| known != &addr);
-                    mdns_changed = true;
+                if mdns_due {
+                    let expired: Vec<Multiaddr> = entry
+                        .mdns
+                        .iter()
+                        .filter(|(_, record)| now_ms >= record.expires_at_ms)
+                        .map(|(addr, _)| addr.clone())
+                        .collect();
+                    for addr in expired {
+                        entry.mdns.remove(&addr);
+                        entry.mdns_order.retain(|known| known != &addr);
+                        mdns_changed = true;
+                    }
                 }
                 entry.assert_mdns_order();
             }
@@ -868,6 +882,75 @@ mod tests {
         agent.observe_mdns(remote, vec![(addr(1), 200)], 1);
         assert!(agent.poll_event().is_none());
         assert_eq!(agent.known_peers()[0].mdns_last_seen_ms, Some(1));
+    }
+
+    #[test]
+    fn inactive_tick_leaves_book_and_pending_events_unchanged() {
+        let config = PeerDiscoveryConfig {
+            auto_dial: false,
+            beacon_peer_ttl_ms: 100,
+            ..PeerDiscoveryConfig::default()
+        };
+        let mut agent = agent(config);
+        let remote = peer(2);
+        agent.observe_beacon(beacon(remote.clone(), vec![addr(1)]), 0);
+        agent.observe_mdns(remote, vec![(addr(2), 100)], 0);
+        while agent.poll_event().is_some() {}
+
+        let before = agent.known_peers();
+        let before_timeout = agent.next_timeout(1);
+        agent.handle_tick(1);
+
+        assert_eq!(agent.known_peers(), before);
+        assert_eq!(agent.next_timeout(1), before_timeout);
+        assert!(agent.poll_event().is_none());
+        assert!(agent.poll_action().is_none());
+    }
+
+    #[test]
+    fn mixed_expiration_preserves_each_transition_and_provenance() {
+        let config = PeerDiscoveryConfig {
+            auto_dial: false,
+            beacon_peer_ttl_ms: 5,
+            ..PeerDiscoveryConfig::default()
+        };
+        let mut agent = agent(config);
+        let mdns_expires = peer(2);
+        let beacon_expires = peer(3);
+        let disappears = peer(4);
+
+        agent.observe_beacon(beacon(mdns_expires.clone(), vec![addr(1)]), 1);
+        agent.observe_mdns(mdns_expires.clone(), vec![(addr(2), 5)], 0);
+        agent.observe_beacon(beacon(beacon_expires.clone(), vec![addr(3)]), 0);
+        agent.observe_mdns(beacon_expires.clone(), vec![(addr(4), 100)], 1);
+        agent.observe_mdns(disappears.clone(), vec![(addr(5), 5)], 0);
+        while agent.poll_event().is_some() {}
+
+        agent.handle_tick(5);
+        let events: Vec<_> = core::iter::from_fn(|| agent.poll_event()).collect();
+
+        assert_eq!(events.len(), 3);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            DiscoveryEvent::PeerUpdated {
+                peer,
+                addrs,
+                source: DiscoverySource::Mdns,
+            } if peer == &mdns_expires && addrs == &vec![addr(1)]
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            DiscoveryEvent::PeerUpdated {
+                peer,
+                addrs,
+                source: DiscoverySource::SignedBeacon,
+            } if peer == &beacon_expires && addrs == &vec![addr(4)]
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            DiscoveryEvent::PeerExpired { peer } if peer == &disappears
+        )));
+        assert_eq!(agent.known_peers().len(), 2);
     }
 
     #[test]

--- a/crates/minip2p/src/std/relay_server.rs
+++ b/crates/minip2p/src/std/relay_server.rs
@@ -103,8 +103,8 @@ impl RelayServerDriver {
             | SwarmEvent::StreamClosed { conn_id, .. } => conn_id.is_circuit(),
             _ => false,
         };
-        // `handle_event` runs the agent tick with this same sample before it
-        // dispatches the event, preserving deadline-first ordering.
+        // The first event at this time sample runs the agent tick before
+        // dispatch, preserving deadline-first ordering for the batch.
         let claimed = self.agent.handle_event(event, is_circuit, now);
         if let SwarmEvent::ConnectionEstablished { conn_id, .. } = event
             && let Some(address) = swarm.connection_remote_addr(*conn_id).cloned()

--- a/crates/nat/README.md
+++ b/crates/nat/README.md
@@ -132,7 +132,7 @@ automatically: the relay's STOP CONNECT is auto-accepted and the bridge is
 promoted into a normal circuit connection. The agent announces that Relayed
 path, opens `/libp2p/dcutr`, and sends CONNECT followed by SYNC. It emits
 `SendRandomUdp` blasts at the original circuit dialer's observed addresses
-to open its own NAT mapping (first after `responder_sync_delay_ms`, then
+to open its own NAT mapping (first after half the measured relay RTT, then
 every `blast_interval_ms` until `punch_deadline_ms`). The original circuit
 dialer makes the QUIC simultaneous-open dial. A landed punch is announced
 with `InboundDirectUpgrade` and supersedes the circuit.

--- a/crates/nat/src/config.rs
+++ b/crates/nat/src/config.rs
@@ -56,9 +56,6 @@ pub struct NatConfig {
     pub blast_interval_ms: u64,
     /// Payload length of each random-UDP blast packet.
     pub blast_payload_len: usize,
-    /// Responder-side approximation of RTT/2: minimum delay between SYNC
-    /// arrival and the first blast.
-    pub responder_sync_delay_ms: u64,
     /// Probe verdicts (out of [`confidence_window`](Self::confidence_window))
     /// that must agree before reachability flips.
     pub confidence_threshold: u8,
@@ -102,7 +99,6 @@ impl Default for NatConfig {
             punch_max_retries: 2,
             blast_interval_ms: 100,
             blast_payload_len: 32,
-            responder_sync_delay_ms: 50,
             confidence_threshold: 3,
             confidence_window: 5,
             probe_interval_settled_ms: 90_000,

--- a/crates/nat/src/inbound.rs
+++ b/crates/nat/src/inbound.rs
@@ -517,6 +517,29 @@ impl InboundCircuit {
                     ..
                 }) => {
                     self.remote_addrs = select_global_punch_candidates(&remote_addrs);
+                    completed = true;
+                    let blast_start = now.mono_ms.saturating_add(rtt_ms.div_ceil(2));
+                    let blast_until = blast_start.saturating_add(shared.config.punch_deadline_ms);
+                    if !self.remote_addrs.is_empty() {
+                        let next_at = if rtt_ms == 0 {
+                            for addr in &self.remote_addrs {
+                                shared.push_action(NatAction::SendRandomUdp {
+                                    target: addr.clone(),
+                                    payload_len: shared.config.blast_payload_len,
+                                });
+                            }
+                            blast_start
+                                .checked_add(shared.config.blast_interval_ms.max(1))
+                                .filter(|next| *next <= blast_until)
+                        } else {
+                            Some(blast_start)
+                        };
+                        self.blast = next_at.map(|next_at| BlastSchedule {
+                            addrs: self.remote_addrs.clone(),
+                            next_at,
+                            until: blast_until,
+                        });
+                    }
                     if dcutr.handle_input(DcutrInitiatorInput::SendSync).is_ok() {
                         while let Some(DcutrInitiatorOutput::Outbound(data)) = dcutr.poll_output() {
                             if let Some(peer) = self.source.as_ref() {
@@ -527,15 +550,6 @@ impl InboundCircuit {
                                 });
                             }
                         }
-                    }
-                    completed = true;
-                    let blast_start = now.mono_ms.saturating_add(rtt_ms.div_ceil(2));
-                    if !self.remote_addrs.is_empty() {
-                        self.blast = Some(BlastSchedule {
-                            addrs: self.remote_addrs.clone(),
-                            next_at: blast_start,
-                            until: blast_start.saturating_add(shared.config.punch_deadline_ms),
-                        });
                     }
                     self.linger_until = Some(
                         blast_start.saturating_add(

--- a/crates/nat/src/inbound.rs
+++ b/crates/nat/src/inbound.rs
@@ -44,6 +44,10 @@ pub(crate) struct InboundCircuit {
     stop: Option<StopResponder>,
     dcutr: Option<DcutrInitiator>,
     dcutr_stream: Option<StreamId>,
+    /// Monotonic time when the initial DCUtR CONNECT was queued to the
+    /// transport, used to synchronize the first QUIC blast at half the
+    /// measured relay RTT.
+    dcutr_connect_sent_at: Option<u64>,
     dcutr_deadline: Option<u64>,
     remote_addrs: Vec<Multiaddr>,
     /// Secure-mux bytes coalesced behind the STOP success response. These
@@ -83,6 +87,7 @@ impl InboundCircuit {
             stop: Some(StopResponder::new()),
             dcutr: None,
             dcutr_stream: None,
+            dcutr_connect_sent_at: None,
             dcutr_deadline: None,
             remote_addrs: Vec::new(),
             pending_data: Vec::new(),
@@ -476,7 +481,9 @@ impl InboundCircuit {
             StreamInput::Ready => DcutrInitiatorInput::Flush,
             StreamInput::Data(bytes) => DcutrInitiatorInput::Data {
                 bytes: bytes.to_vec(),
-                rtt_ms: 0,
+                rtt_ms: self
+                    .dcutr_connect_sent_at
+                    .map_or(0, |sent_at| now.mono_ms.saturating_sub(sent_at)),
             },
             StreamInput::RemoteWriteClosed | StreamInput::Closed => {
                 DcutrInitiatorInput::RemoteWriteClosed
@@ -495,6 +502,7 @@ impl InboundCircuit {
         for output in outputs {
             match output {
                 DcutrInitiatorOutput::Outbound(data) => {
+                    self.dcutr_connect_sent_at.get_or_insert(now.mono_ms);
                     if let Some(peer) = self.source.as_ref() {
                         shared.push_action(NatAction::SendStream {
                             peer: peer.clone(),
@@ -504,7 +512,9 @@ impl InboundCircuit {
                     }
                 }
                 DcutrInitiatorOutput::Outcome(InitiatorOutcome::DialNow {
-                    remote_addrs, ..
+                    remote_addrs,
+                    rtt_ms,
+                    ..
                 }) => {
                     self.remote_addrs = select_global_punch_candidates(&remote_addrs);
                     if dcutr.handle_input(DcutrInitiatorInput::SendSync).is_ok() {
@@ -519,17 +529,21 @@ impl InboundCircuit {
                         }
                     }
                     completed = true;
+                    let blast_start = now.mono_ms.saturating_add(rtt_ms.div_ceil(2));
                     if !self.remote_addrs.is_empty() {
                         self.blast = Some(BlastSchedule {
                             addrs: self.remote_addrs.clone(),
-                            next_at: now.mono_ms + shared.config.responder_sync_delay_ms,
-                            until: now.mono_ms + shared.config.punch_deadline_ms,
+                            next_at: blast_start,
+                            until: blast_start.saturating_add(shared.config.punch_deadline_ms),
                         });
                     }
                     self.linger_until = Some(
-                        now.mono_ms
-                            + shared.config.punch_deadline_ms
-                                * (1 + u64::from(shared.config.punch_max_retries)),
+                        blast_start.saturating_add(
+                            shared
+                                .config
+                                .punch_deadline_ms
+                                .saturating_mul(1 + u64::from(shared.config.punch_max_retries)),
+                        ),
                     );
                 }
             }

--- a/crates/nat/tests/inbound_regressions.rs
+++ b/crates/nat/tests/inbound_regressions.rs
@@ -213,6 +213,27 @@ fn blast_schedule_starts_at_half_measured_rtt_and_respects_deadline() {
 }
 
 #[test]
+fn zero_rtt_opens_udp_mapping_before_notifying_dialer() {
+    let mut h = inbound_harness(NatConfig::default());
+    let (conn, actions) = drive_to_relayed(&mut h);
+    let stream = open_dcutr(&mut h, conn, &actions);
+    drain_actions(&mut h.agent);
+
+    // CONNECT was queued at t=13 and its reply arrived in the same clock
+    // sample. Open the UDP mapping before SYNC can make the remote dial.
+    answer_dcutr_at(&mut h, conn, stream, &["/ip4/8.8.8.8/udp/4001/quic-v1"], 13);
+    let actions = drain_actions(&mut h.agent);
+
+    assert!(matches!(
+        actions.first(),
+        Some(NatAction::SendRandomUdp { .. })
+    ));
+    assert!(matches!(actions.get(1), Some(NatAction::SendStream { .. })));
+    h.agent.handle_tick(at(13));
+    assert_eq!(blast_count(&drain_actions(&mut h.agent)), 0);
+}
+
+#[test]
 fn measured_rtt_delay_cannot_consume_the_punch_window() {
     let mut h = inbound_harness(NatConfig {
         punch_deadline_ms: 3_000,

--- a/crates/nat/tests/inbound_regressions.rs
+++ b/crates/nat/tests/inbound_regressions.rs
@@ -137,7 +137,7 @@ fn oversized_inbound_dcutr_connect_keeps_the_relayed_path() {
     assert!(h.agent.is_idle());
 }
 
-fn answer_dcutr(h: &mut Harness, conn: ConnectionId, stream: StreamId, addrs: &[&str]) {
+fn answer_dcutr_at(h: &mut Harness, conn: ConnectionId, stream: StreamId, addrs: &[&str], t: u64) {
     let reply_addrs: Vec<_> = addrs.iter().map(|addr| maddr(addr)).collect();
     h.agent.handle_event(
         &SwarmEvent::StreamData {
@@ -146,7 +146,7 @@ fn answer_dcutr(h: &mut Harness, conn: ConnectionId, stream: StreamId, addrs: &[
             stream_id: stream,
             data: dcutr_connect_reply(&reply_addrs),
         },
-        at(20),
+        at(t),
     );
 }
 
@@ -188,9 +188,8 @@ fn direct_connection_before_circuit_handshake_does_not_downgrade_the_path() {
 }
 
 #[test]
-fn blast_schedule_respects_interval_and_deadline() {
+fn blast_schedule_starts_at_half_measured_rtt_and_respects_deadline() {
     let mut h = inbound_harness(NatConfig {
-        responder_sync_delay_ms: 0,
         blast_interval_ms: 100,
         punch_deadline_ms: 250,
         ..NatConfig::default()
@@ -198,10 +197,12 @@ fn blast_schedule_respects_interval_and_deadline() {
     let (conn, actions) = drive_to_relayed(&mut h);
     let stream = open_dcutr(&mut h, conn, &actions);
     drain_actions(&mut h.agent);
-    answer_dcutr(&mut h, conn, stream, &["/ip4/8.8.8.8/udp/4001/quic-v1"]);
+    answer_dcutr_at(&mut h, conn, stream, &["/ip4/8.8.8.8/udp/4001/quic-v1"], 20);
     drain_actions(&mut h.agent);
 
-    for (time, expected) in [(20, 1), (119, 0), (120, 1), (220, 1), (320, 0)] {
+    // CONNECT was queued at t=13 and its reply arrived at t=20. Half the
+    // measured 7 ms RTT rounds up to 4 ms, so the first blast is due at t=24.
+    for (time, expected) in [(23, 0), (24, 1), (123, 0), (124, 1), (224, 1), (274, 0)] {
         h.agent.handle_tick(at(time));
         assert_eq!(
             blast_count(&drain_actions(&mut h.agent)),
@@ -212,32 +213,55 @@ fn blast_schedule_respects_interval_and_deadline() {
 }
 
 #[test]
-fn zero_blast_interval_is_clamped_to_one_millisecond() {
+fn measured_rtt_delay_cannot_consume_the_punch_window() {
     let mut h = inbound_harness(NatConfig {
-        responder_sync_delay_ms: 0,
-        blast_interval_ms: 0,
-        punch_deadline_ms: 2,
+        punch_deadline_ms: 3_000,
         ..NatConfig::default()
     });
     let (conn, actions) = drive_to_relayed(&mut h);
     let stream = open_dcutr(&mut h, conn, &actions);
     drain_actions(&mut h.agent);
-    answer_dcutr(&mut h, conn, stream, &["/ip4/8.8.8.8/udp/4001/quic-v1"]);
+
+    // CONNECT was queued at t=13. A reply at t=6_014 measures 6_001 ms,
+    // whose half-RTT delay rounds up to 3_001 ms. The full punch window must
+    // begin at t=9_015 rather than expiring before the first blast.
+    answer_dcutr_at(
+        &mut h,
+        conn,
+        stream,
+        &["/ip4/8.8.8.8/udp/4001/quic-v1"],
+        6_014,
+    );
     drain_actions(&mut h.agent);
-    h.agent.handle_tick(at(22));
+    h.agent.handle_tick(at(9_014));
+    assert_eq!(blast_count(&drain_actions(&mut h.agent)), 0);
+    h.agent.handle_tick(at(9_015));
+    assert_eq!(blast_count(&drain_actions(&mut h.agent)), 1);
+}
+
+#[test]
+fn zero_blast_interval_is_clamped_to_one_millisecond() {
+    let mut h = inbound_harness(NatConfig {
+        blast_interval_ms: 0,
+        punch_deadline_ms: 10,
+        ..NatConfig::default()
+    });
+    let (conn, actions) = drive_to_relayed(&mut h);
+    let stream = open_dcutr(&mut h, conn, &actions);
+    drain_actions(&mut h.agent);
+    answer_dcutr_at(&mut h, conn, stream, &["/ip4/8.8.8.8/udp/4001/quic-v1"], 20);
+    drain_actions(&mut h.agent);
+    h.agent.handle_tick(at(26));
     assert_eq!(blast_count(&drain_actions(&mut h.agent)), 3);
 }
 
 #[test]
 fn peer_supplied_punch_targets_must_be_global_unicast_quic_ips() {
-    let mut h = inbound_harness(NatConfig {
-        responder_sync_delay_ms: 0,
-        ..NatConfig::default()
-    });
+    let mut h = inbound_harness(NatConfig::default());
     let (conn, actions) = drive_to_relayed(&mut h);
     let stream = open_dcutr(&mut h, conn, &actions);
     drain_actions(&mut h.agent);
-    answer_dcutr(
+    answer_dcutr_at(
         &mut h,
         conn,
         stream,
@@ -246,11 +270,12 @@ fn peer_supplied_punch_targets_must_be_global_unicast_quic_ips() {
             "/ip4/8.8.8.8/udp/4001/quic-v1",
             "/ip4/8.8.4.4/tcp/4001",
         ],
+        20,
     );
     let sync = drain_actions(&mut h.agent);
     assert!(has_reset_for(&sync, stream));
     assert!(!h.agent.owns_stream(&h.target, stream));
-    h.agent.handle_tick(at(20));
+    h.agent.handle_tick(at(24));
     let targets: Vec<_> = drain_actions(&mut h.agent)
         .into_iter()
         .filter_map(|action| match action {

--- a/crates/pubsub/Cargo.toml
+++ b/crates/pubsub/Cargo.toml
@@ -29,3 +29,10 @@ minip2p-identity = { path = "../identity", version = "0.4.9", default-features =
 minip2p-swarm = { path = "../swarm", version = "0.4.9", default-features = false }
 minip2p-transport = { path = "../transport", version = "0.4.9", default-features = false }
 thiserror = { version = "2.0.18", default-features = false }
+
+[dev-dependencies]
+criterion = "0.8.2"
+
+[[bench]]
+name = "fanout"
+harness = false

--- a/crates/pubsub/benches/fanout.rs
+++ b/crates/pubsub/benches/fanout.rs
@@ -1,0 +1,104 @@
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use minip2p_identity::Ed25519Keypair;
+use minip2p_pubsub::{
+    FLOODSUB_PROTOCOL_ID, FloodsubAgent, FloodsubConfig, PubsubAction, Rpc, SubOpts, encode_frame,
+};
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::{ConnectionId, StreamId};
+
+const PEER_COUNT: u8 = 32;
+const PAYLOAD_LEN: usize = 60 * 1024;
+const TOPIC: &str = "benchmark";
+
+fn peer(seed: u8) -> minip2p_core::PeerId {
+    Ed25519Keypair::from_secret_key_bytes([seed; 32]).peer_id()
+}
+
+fn subscribed_agent() -> FloodsubAgent {
+    let mut agent = FloodsubAgent::new(
+        Ed25519Keypair::from_secret_key_bytes([1; 32]),
+        FloodsubConfig::default(),
+        0,
+    );
+    let subscription = encode_frame(
+        &Rpc {
+            subscriptions: vec![SubOpts {
+                subscribe: Some(true),
+                topic_id: Some(TOPIC.into()),
+            }],
+            publish: Vec::new(),
+            control: None,
+        }
+        .encode(),
+    );
+    for seed in 2..2 + PEER_COUNT {
+        let peer = peer(seed);
+        let stream_id = StreamId::new(u64::from(seed));
+        agent.handle_event(
+            &SwarmEvent::ConnectionEstablished {
+                peer_id: peer.clone(),
+                conn_id: ConnectionId::new(u64::from(seed)),
+            },
+            0,
+        );
+        agent.handle_event(
+            &SwarmEvent::PeerReady {
+                peer_id: peer.clone(),
+                protocols: vec![FLOODSUB_PROTOCOL_ID.into()],
+            },
+            0,
+        );
+        assert!(agent.handle_event(
+            &SwarmEvent::StreamReady {
+                peer_id: peer.clone(),
+                conn_id: ConnectionId::new(u64::from(seed)),
+                stream_id,
+                protocol_id: FLOODSUB_PROTOCOL_ID.into(),
+                initiated_locally: false,
+            },
+            0,
+        ));
+        assert!(agent.handle_event(
+            &SwarmEvent::StreamData {
+                peer_id: peer,
+                conn_id: ConnectionId::new(u64::from(seed)),
+                stream_id,
+                data: subscription.clone(),
+            },
+            0,
+        ));
+    }
+    agent
+}
+
+fn assert_fanout(agent: &mut FloodsubAgent, payload: Vec<u8>) {
+    agent.publish(TOPIC, payload, 0).expect("publish");
+    let mut opens = 0;
+    while let Some(action) = agent.poll_action() {
+        if matches!(action, PubsubAction::OpenStream { .. }) {
+            opens += 1;
+        }
+    }
+    assert_eq!(opens, usize::from(PEER_COUNT));
+}
+
+fn fanout(c: &mut Criterion) {
+    let payload = vec![0x5a; PAYLOAD_LEN];
+    assert_fanout(&mut subscribed_agent(), payload.clone());
+
+    c.bench_function("pubsub/floodsub_publish_32x60KiB", |b| {
+        b.iter_batched(
+            subscribed_agent,
+            |mut agent| {
+                let result = agent.publish(TOPIC, payload.clone(), 0);
+                black_box(result).expect("publish");
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group!(benches, fanout);
+criterion_main!(benches);

--- a/crates/pubsub/src/agent.rs
+++ b/crates/pubsub/src/agent.rs
@@ -19,7 +19,7 @@ use minip2p_transport::StreamId;
 
 use crate::config::FloodsubConfig;
 use crate::events::{
-    PublishError, PubsubAction, PubsubEvent, PubsubToken, SharedFrame, TopicError, share_frame,
+    PublishError, PubsubAction, PubsubEvent, PubsubToken, SharedFrame, TopicError,
 };
 use crate::message::{
     FLOODSUB_PROTOCOL_ID, FrameDecode, MAX_RPC_SIZE, MAX_TOPIC_LEN, RawMessage, Rpc, SubOpts,
@@ -278,7 +278,7 @@ impl FloodsubAgent {
             self.config.max_seen_messages,
         );
 
-        let frame = share_frame(encode_frame(&body));
+        let frame: SharedFrame = encode_frame(&body).into();
         for peer in recipients {
             if let Some(state) = self.peers.get_mut(&peer) {
                 state.pending.push_back(frame.clone());
@@ -923,7 +923,7 @@ impl FloodsubAgent {
             publish: alloc::vec![message.clone()],
             control: None,
         };
-        let frame = share_frame(encode_frame(&rpc.encode()));
+        let frame: SharedFrame = encode_frame(&rpc.encode()).into();
         let recipients: Vec<PeerId> = self
             .peers
             .iter()
@@ -991,7 +991,7 @@ impl FloodsubAgent {
                 control: None,
             };
             OutboundWork::Subscriptions {
-                frame: share_frame(encode_frame(&rpc.encode())),
+                frame: encode_frame(&rpc.encode()).into(),
                 snapshot: self.topics.clone(),
             }
         } else if let Some(front) = state.pending.front() {

--- a/crates/pubsub/src/agent.rs
+++ b/crates/pubsub/src/agent.rs
@@ -18,7 +18,9 @@ use minip2p_swarm::SwarmEvent;
 use minip2p_transport::StreamId;
 
 use crate::config::FloodsubConfig;
-use crate::events::{PublishError, PubsubAction, PubsubEvent, PubsubToken, TopicError};
+use crate::events::{
+    PublishError, PubsubAction, PubsubEvent, PubsubToken, SharedFrame, TopicError, share_frame,
+};
 use crate::message::{
     FLOODSUB_PROTOCOL_ID, FrameDecode, MAX_RPC_SIZE, MAX_TOPIC_LEN, RawMessage, Rpc, SubOpts,
     decode_frame, encode_frame,
@@ -49,15 +51,15 @@ enum OutboundWork {
     /// The frame encodes the diff from `sent_topics` to `snapshot`;
     /// committing sets `sent_topics = snapshot`.
     Subscriptions {
-        frame: Vec<u8>,
+        frame: SharedFrame,
         snapshot: BTreeSet<String>,
     },
     /// The front of `pending`; committing pops it.
-    Publish { frame: Vec<u8> },
+    Publish { frame: SharedFrame },
 }
 
 impl OutboundWork {
-    fn frame(&self) -> &[u8] {
+    fn frame(&self) -> &SharedFrame {
         match self {
             Self::Subscriptions { frame, .. } | Self::Publish { frame } => frame,
         }
@@ -115,7 +117,7 @@ struct PeerState {
     sender: SendState,
     /// Framed publish/forward RPCs awaiting their turn (subscription
     /// updates never queue here — they re-diff at send time).
-    pending: VecDeque<Vec<u8>>,
+    pending: VecDeque<SharedFrame>,
     /// The subscription snapshot last COMMITTED to this peer.
     sent_topics: BTreeSet<String>,
     /// Concurrent inbound streams and their reassembly buffers.
@@ -276,7 +278,7 @@ impl FloodsubAgent {
             self.config.max_seen_messages,
         );
 
-        let frame = encode_frame(&body);
+        let frame = share_frame(encode_frame(&body));
         for peer in recipients {
             if let Some(state) = self.peers.get_mut(&peer) {
                 state.pending.push_back(frame.clone());
@@ -921,7 +923,7 @@ impl FloodsubAgent {
             publish: alloc::vec![message.clone()],
             control: None,
         };
-        let frame = encode_frame(&rpc.encode());
+        let frame = share_frame(encode_frame(&rpc.encode()));
         let recipients: Vec<PeerId> = self
             .peers
             .iter()
@@ -989,7 +991,7 @@ impl FloodsubAgent {
                 control: None,
             };
             OutboundWork::Subscriptions {
-                frame: encode_frame(&rpc.encode()),
+                frame: share_frame(encode_frame(&rpc.encode())),
                 snapshot: self.topics.clone(),
             }
         } else if let Some(front) = state.pending.front() {
@@ -1074,4 +1076,35 @@ fn validate_topic(topic: &str) -> Result<(), TopicError> {
         return Err(TopicError::TooLong);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+
+    use super::*;
+
+    #[test]
+    fn fanout_queues_share_one_framed_payload() {
+        let mut agent = FloodsubAgent::new(
+            Ed25519Keypair::from_secret_key_bytes([1; 32]),
+            FloodsubConfig::default(),
+            0,
+        );
+        let first = Ed25519Keypair::from_secret_key_bytes([2; 32]).peer_id();
+        let second = Ed25519Keypair::from_secret_key_bytes([3; 32]).peer_id();
+        for peer in [&first, &second] {
+            let mut state = PeerState::default();
+            state.remote_topics.insert(String::from("topic"));
+            agent.peers.insert(peer.clone(), state);
+        }
+
+        agent
+            .publish("topic", alloc::vec![7; 1024], 0)
+            .expect("publish");
+
+        let first_frame = agent.peers[&first].pending.front().expect("first frame");
+        let second_frame = agent.peers[&second].pending.front().expect("second frame");
+        assert!(core::ptr::eq(first_frame.as_ptr(), second_frame.as_ptr()));
+    }
 }

--- a/crates/pubsub/src/events.rs
+++ b/crates/pubsub/src/events.rs
@@ -1,7 +1,11 @@
 //! Actions the host must execute, events for the application, and the
 //! caller-facing error types.
 
+#[cfg(not(feature = "std"))]
+use alloc::rc::Rc as Shared;
 use alloc::string::String;
+#[cfg(feature = "std")]
+use alloc::sync::Arc as Shared;
 use alloc::vec::Vec;
 
 use minip2p_core::PeerId;
@@ -10,6 +14,16 @@ use minip2p_transport::StreamId;
 /// Correlates an outbound open or write with its agent result echo.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct PubsubToken(pub(crate) u64);
+
+/// Immutable framed RPC bytes shared by every recipient of one publish.
+///
+/// Pure `no_std` agents use `Rc`, while the `std` build uses `Arc` so an
+/// endpoint containing an agent remains safe to move into a driver thread.
+pub(crate) type SharedFrame = Shared<[u8]>;
+
+pub(crate) fn share_frame(frame: Vec<u8>) -> SharedFrame {
+    frame.into()
+}
 
 /// I/O the driver must perform on the agent's behalf.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/pubsub/src/events.rs
+++ b/crates/pubsub/src/events.rs
@@ -21,10 +21,6 @@ pub struct PubsubToken(pub(crate) u64);
 /// endpoint containing an agent remains safe to move into a driver thread.
 pub(crate) type SharedFrame = Shared<[u8]>;
 
-pub(crate) fn share_frame(frame: Vec<u8>) -> SharedFrame {
-    frame.into()
-}
-
 /// I/O the driver must perform on the agent's behalf.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PubsubAction {

--- a/crates/pubsub/src/gossipsub/agent.rs
+++ b/crates/pubsub/src/gossipsub/agent.rs
@@ -12,7 +12,9 @@ use minip2p_transport::StreamId;
 
 use super::config::GossipsubConfig;
 use super::mcache::MessageCache;
-use crate::events::{PublishError, PubsubAction, PubsubEvent, PubsubToken, TopicError};
+use crate::events::{
+    PublishError, PubsubAction, PubsubEvent, PubsubToken, SharedFrame, TopicError, share_frame,
+};
 use crate::message::{
     ControlGraft, ControlIHave, ControlIWant, ControlMessage, ControlPrune, FrameDecode,
     MAX_RPC_SIZE, MAX_TOPIC_LEN, MESHSUB_PROTOCOL_ID_V10, MESHSUB_PROTOCOL_ID_V11, RawMessage, Rpc,
@@ -375,7 +377,7 @@ impl SendState {
 #[derive(Debug, Default)]
 struct PeerState {
     sender: SendState,
-    pending_messages: VecDeque<Vec<u8>>,
+    pending_messages: VecDeque<SharedFrame>,
     acknowledged_topics: BTreeSet<String>,
     /// Recently acknowledged unsubscriptions replayed after stream reopen.
     /// Bounded by `max_topics_per_peer`; active subscriptions are derived
@@ -595,7 +597,7 @@ impl GossipsubAgent {
         self.mcache
             .put(id, message, alloc::vec![String::from(topic)]);
 
-        let frame = encode_frame(&body);
+        let frame = share_frame(encode_frame(&body));
         for peer in recipients {
             if let Some(state) = self.peers.get_mut(&peer) {
                 state.pending_messages.push_back(frame.clone());
@@ -1298,7 +1300,9 @@ impl GossipsubAgent {
                     control: None,
                 }
                 .encode();
-                if body.len() <= MAX_RPC_SIZE && self.queue_message(peer, encode_frame(&body)) {
+                if body.len() <= MAX_RPC_SIZE
+                    && self.queue_message(peer, share_frame(encode_frame(&body)))
+                {
                     *self.iwant_served.entry(peer.clone()).or_default() += 1;
                 }
             }
@@ -1365,14 +1369,14 @@ impl GossipsubAgent {
             .filter(|peer| **peer != *arrival && **peer != from)
             .cloned()
             .collect();
-        let frame = encode_frame(
+        let frame = share_frame(encode_frame(
             &Rpc {
                 subscriptions: Vec::new(),
                 publish: alloc::vec![message.clone()],
                 control: None,
             }
             .encode(),
-        );
+        ));
         for peer in recipients {
             if self.queue_message(&peer, frame.clone()) {
                 self.drive_sender(&peer, now_ms);
@@ -1613,7 +1617,7 @@ impl GossipsubAgent {
             .encode();
             debug_assert_eq!(body.len(), body_len);
             Some((
-                encode_frame(&body),
+                share_frame(encode_frame(&body)),
                 FrameCommit::Subscriptions(subscriptions),
             ))
         } else {
@@ -1631,7 +1635,10 @@ impl GossipsubAgent {
                 .get_mut(peer)
                 .and_then(|state| state.pending_control.take_frame(version))
             {
-                Some((encode_frame(&body), FrameCommit::Control(items)))
+                Some((
+                    share_frame(encode_frame(&body)),
+                    FrameCommit::Control(items),
+                ))
             } else {
                 self.peers
                     .get(peer)
@@ -1650,7 +1657,7 @@ impl GossipsubAgent {
             token,
             peer: peer.clone(),
             stream_id,
-            data: frame,
+            data: frame.to_vec(),
         });
     }
 
@@ -1730,7 +1737,7 @@ impl GossipsubAgent {
         false
     }
 
-    fn queue_message(&mut self, peer: &PeerId, frame: Vec<u8>) -> bool {
+    fn queue_message(&mut self, peer: &PeerId, frame: SharedFrame) -> bool {
         let Some(state) = self.peers.get_mut(peer) else {
             return false;
         };

--- a/crates/pubsub/src/gossipsub/agent.rs
+++ b/crates/pubsub/src/gossipsub/agent.rs
@@ -13,7 +13,7 @@ use minip2p_transport::StreamId;
 use super::config::GossipsubConfig;
 use super::mcache::MessageCache;
 use crate::events::{
-    PublishError, PubsubAction, PubsubEvent, PubsubToken, SharedFrame, TopicError, share_frame,
+    PublishError, PubsubAction, PubsubEvent, PubsubToken, SharedFrame, TopicError,
 };
 use crate::message::{
     ControlGraft, ControlIHave, ControlIWant, ControlMessage, ControlPrune, FrameDecode,
@@ -597,7 +597,7 @@ impl GossipsubAgent {
         self.mcache
             .put(id, message, alloc::vec![String::from(topic)]);
 
-        let frame = share_frame(encode_frame(&body));
+        let frame: SharedFrame = encode_frame(&body).into();
         for peer in recipients {
             if let Some(state) = self.peers.get_mut(&peer) {
                 state.pending_messages.push_back(frame.clone());
@@ -1301,7 +1301,7 @@ impl GossipsubAgent {
                 }
                 .encode();
                 if body.len() <= MAX_RPC_SIZE
-                    && self.queue_message(peer, share_frame(encode_frame(&body)))
+                    && self.queue_message(peer, encode_frame(&body).into())
                 {
                     *self.iwant_served.entry(peer.clone()).or_default() += 1;
                 }
@@ -1369,14 +1369,15 @@ impl GossipsubAgent {
             .filter(|peer| **peer != *arrival && **peer != from)
             .cloned()
             .collect();
-        let frame = share_frame(encode_frame(
+        let frame: SharedFrame = encode_frame(
             &Rpc {
                 subscriptions: Vec::new(),
                 publish: alloc::vec![message.clone()],
                 control: None,
             }
             .encode(),
-        ));
+        )
+        .into();
         for peer in recipients {
             if self.queue_message(&peer, frame.clone()) {
                 self.drive_sender(&peer, now_ms);
@@ -1617,7 +1618,7 @@ impl GossipsubAgent {
             .encode();
             debug_assert_eq!(body.len(), body_len);
             Some((
-                share_frame(encode_frame(&body)),
+                encode_frame(&body).into(),
                 FrameCommit::Subscriptions(subscriptions),
             ))
         } else {
@@ -1635,10 +1636,7 @@ impl GossipsubAgent {
                 .get_mut(peer)
                 .and_then(|state| state.pending_control.take_frame(version))
             {
-                Some((
-                    share_frame(encode_frame(&body)),
-                    FrameCommit::Control(items),
-                ))
+                Some((encode_frame(&body).into(), FrameCommit::Control(items)))
             } else {
                 self.peers
                     .get(peer)
@@ -1892,6 +1890,38 @@ impl SplitMix64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fanout_queues_share_one_framed_payload() {
+        let mut agent = GossipsubAgent::new(
+            Ed25519Keypair::from_secret_key_bytes([1; 32]),
+            GossipsubConfig::default(),
+            0,
+            0,
+        );
+        let first = Ed25519Keypair::from_secret_key_bytes([2; 32]).peer_id();
+        let second = Ed25519Keypair::from_secret_key_bytes([3; 32]).peer_id();
+        for peer in [&first, &second] {
+            let mut state = PeerState::default();
+            state.remote_topics.insert(String::from("topic"));
+            state.advertised_version = Some(MeshsubVersion::V11);
+            agent.peers.insert(peer.clone(), state);
+        }
+
+        agent
+            .publish("topic", alloc::vec![7; 1024], 0)
+            .expect("publish");
+
+        let first_frame = agent.peers[&first]
+            .pending_messages
+            .front()
+            .expect("first frame");
+        let second_frame = agent.peers[&second]
+            .pending_messages
+            .front()
+            .expect("second frame");
+        assert!(core::ptr::eq(first_frame.as_ptr(), second_frame.as_ptr()));
+    }
 
     #[test]
     fn in_flight_control_ownership_preserves_later_aliases() {

--- a/crates/relay-server/Cargo.toml
+++ b/crates/relay-server/Cargo.toml
@@ -33,5 +33,10 @@ minip2p-transport = { path = "../transport", version = "0.4.9", default-features
 thiserror = { version = "2.0.18", default-features = false }
 
 [dev-dependencies]
+criterion = "0.8.2"
 minip2p-identity = { path = "../identity", version = "0.4.9" }
 minip2p-nat = { path = "../nat", version = "0.4.9" }
+
+[[bench]]
+name = "relay_server_event"
+harness = false

--- a/crates/relay-server/README.md
+++ b/crates/relay-server/README.md
@@ -11,10 +11,11 @@ IP policy stay in adapters.
 The host supplies a `Now`, feeds Swarm events, drains tokenized actions, and
 echoes every open/send/close/reset result. Drain a claimed input and all of its
 synchronous results to quiescence before delivering another transport event.
-Call `handle_tick(now)` before events sampled at the same time; deadlines win at
-equality. The service assumes Swarm's single live connection per peer but keeps
-exact connection and stream identities so stale superseded inputs cannot mutate
-replacement state.
+The first `handle_event` at each `Now` sample processes due deadlines before
+dispatching that event, so deadlines win at equality. Call `handle_tick(now)`
+to force that sweep without an event. The service assumes Swarm's single live
+connection per peer but keeps exact connection and stream identities so stale
+superseded inputs cannot mutate replacement state.
 
 ## Compatibility contract
 

--- a/crates/relay-server/benches/relay_server_event.rs
+++ b/crates/relay-server/benches/relay_server_event.rs
@@ -1,0 +1,69 @@
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use minip2p_core::PeerId;
+use minip2p_platform::Now;
+use minip2p_relay::HOP_PROTOCOL_ID;
+use minip2p_relay_server::{RelayServerAgent, RelayServerConfig};
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::{ConnectionId, StreamId};
+
+const PEERS: u64 = 128;
+const EVENTS_PER_BATCH: usize = 100;
+
+fn populated_agent(now: Now) -> (RelayServerAgent, SwarmEvent) {
+    let local = PeerId::from_public_key_protobuf(b"relay-server-bench-local");
+    let mut agent = RelayServerAgent::new(local, RelayServerConfig::default()).unwrap();
+
+    for index in 0..PEERS {
+        let peer = PeerId::from_public_key_protobuf(&index.to_le_bytes());
+        let conn_id = ConnectionId::new(index + 1);
+        let stream_id = StreamId::new(1);
+        agent.handle_event(
+            &SwarmEvent::ConnectionEstablished {
+                peer_id: peer.clone(),
+                conn_id,
+            },
+            false,
+            Now::from_millis(0),
+        );
+        assert!(agent.handle_event(
+            &SwarmEvent::StreamReady {
+                peer_id: peer,
+                conn_id,
+                stream_id,
+                protocol_id: HOP_PROTOCOL_ID.into(),
+                initiated_locally: false,
+            },
+            false,
+            Now::from_millis(0),
+        ));
+    }
+
+    agent.handle_tick(now);
+    let inert = SwarmEvent::StreamData {
+        peer_id: PeerId::from_public_key_protobuf(b"relay-server-bench-unrelated"),
+        conn_id: ConnectionId::new(PEERS + 1),
+        stream_id: StreamId::new(1),
+        data: Vec::new(),
+    };
+    (agent, inert)
+}
+
+fn relay_server_event(c: &mut Criterion) {
+    let now = Now::from_millis(1);
+    c.bench_function("relay_handle_event_same_now_128_pending_hops", |b| {
+        b.iter_batched(
+            || populated_agent(now),
+            |(mut agent, inert)| {
+                for _ in 0..EVENTS_PER_BATCH {
+                    black_box(agent.handle_event(black_box(&inert), false, black_box(now)));
+                }
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group!(benches, relay_server_event);
+criterion_main!(benches);

--- a/crates/relay-server/src/agent.rs
+++ b/crates/relay-server/src/agent.rs
@@ -182,6 +182,7 @@ pub struct RelayServerAgent {
     events: VecDeque<RelayServerEvent>,
     pending_operations: BTreeMap<RelayServerToken, PendingOperation>,
     next_token: u64,
+    last_event_tick_ms: Option<u64>,
     reservation_limiters: AdmissionLimiters,
     circuit_limiters: AdmissionLimiters,
 }
@@ -233,6 +234,7 @@ impl RelayServerAgent {
             events: VecDeque::new(),
             pending_operations: BTreeMap::new(),
             next_token: 1,
+            last_event_tick_ms: None,
         })
     }
 
@@ -296,8 +298,12 @@ impl RelayServerAgent {
     }
 
     /// Feeds one Swarm event and returns whether the service claimed it.
+    ///
+    /// The first event for a `Now` sample processes due deadlines. Subsequent
+    /// events with that same sample share the completed sweep; call
+    /// [`handle_tick`](Self::handle_tick) to force a sweep independently.
     pub fn handle_event(&mut self, event: &SwarmEvent, is_circuit: bool, now: Now) -> bool {
-        self.handle_tick(now);
+        self.tick_before_event(now);
         match event {
             SwarmEvent::ConnectionEstablished { peer_id, conn_id } => {
                 self.on_connection_established(peer_id.clone(), *conn_id, is_circuit);
@@ -466,6 +472,7 @@ impl RelayServerAgent {
 
     /// Processes every deadline due at or before `now`.
     pub fn handle_tick(&mut self, now: Now) {
+        self.last_event_tick_ms = Some(now.monotonic_ms);
         let expired: Vec<_> = self
             .reservations
             .iter()
@@ -539,6 +546,18 @@ impl RelayServerAgent {
         }
         self.reservation_limiters.sweep(now.monotonic_ms);
         self.circuit_limiters.sweep(now.monotonic_ms);
+    }
+
+    /// Sweeps deadlines before the first event in a driver batch.
+    ///
+    /// A single caller time sample is commonly shared by several events. New
+    /// deadlines created while handling those events are in the future unless
+    /// the clock has saturated, so rescanning unchanged state cannot make
+    /// additional progress.
+    fn tick_before_event(&mut self, now: Now) {
+        if now.monotonic_ms == u64::MAX || self.last_event_tick_ms != Some(now.monotonic_ms) {
+            self.handle_tick(now);
+        }
     }
 
     /// Reports the result of an outbound stream open.
@@ -2354,6 +2373,51 @@ mod tests {
         ));
         agent.handle_tick(Now::from_millis(2_000));
         assert_eq!(agent.poll_event(), None);
+    }
+
+    #[test]
+    fn same_time_events_expire_control_streams_before_the_first_event() {
+        let local = PeerId::from_public_key_protobuf(b"relay-same-timeout");
+        let peer = PeerId::from_public_key_protobuf(b"peer-same-timeout");
+        let config = RelayServerConfig {
+            control_stream_timeout_ms: 5,
+            ..RelayServerConfig::default()
+        };
+        let mut agent = RelayServerAgent::new(local, config).unwrap();
+        let stream = StreamKey {
+            conn_id: ConnectionId::new(34),
+            stream_id: StreamId::new(1),
+        };
+        establish(&mut agent, &peer, stream.conn_id);
+        agent.handle_event(
+            &SwarmEvent::StreamReady {
+                peer_id: peer,
+                conn_id: stream.conn_id,
+                stream_id: stream.stream_id,
+                protocol_id: HOP_PROTOCOL_ID.into(),
+                initiated_locally: false,
+            },
+            false,
+            Now::from_millis(0),
+        );
+
+        let first = SwarmEvent::ConnectionEstablished {
+            peer_id: PeerId::from_public_key_protobuf(b"first-at-deadline"),
+            conn_id: ConnectionId::new(35),
+        };
+        let second = SwarmEvent::ConnectionEstablished {
+            peer_id: PeerId::from_public_key_protobuf(b"second-at-deadline"),
+            conn_id: ConnectionId::new(36),
+        };
+        agent.handle_event(&first, false, Now::from_millis(5));
+        assert!(!agent.owns_stream(stream));
+        agent.handle_event(&second, false, Now::from_millis(5));
+
+        assert!(matches!(
+            agent.poll_action(),
+            Some(RelayServerAction::ResetStream { stream: reset, .. }) if reset == stream
+        ));
+        assert_eq!(agent.poll_action(), None);
     }
 
     #[test]

--- a/crates/relay-server/src/lib.rs
+++ b/crates/relay-server/src/lib.rs
@@ -9,12 +9,12 @@
 //! another transport event is delivered. Transport queues then provide the
 //! payload backpressure instead of an unbounded agent queue.
 //!
-//! Call [`RelayServerAgent::handle_tick`] before events sampled at the same
-//! time. This deadline-first order makes expiry, duration, and control timeout
-//! behavior deterministic. Exact [`minip2p_transport::ConnectionId`] identity
-//! is retained throughout; the service relies on Swarm's single live
-//! connection per peer while still rejecting stale results from superseded
-//! connections.
+//! The first [`RelayServerAgent::handle_event`] for a time sample processes
+//! deadlines before it dispatches the event. Call [`RelayServerAgent::handle_tick`]
+//! to force the same deadline-first order without an event. Exact
+//! [`minip2p_transport::ConnectionId`] identity is retained throughout; the
+//! service relies on Swarm's single live connection per peer while still
+//! rejecting stale results from superseded connections.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]

--- a/crates/yamux/Cargo.toml
+++ b/crates/yamux/Cargo.toml
@@ -25,3 +25,10 @@ std = [
 minip2p-core = { path = "../core", version = "0.4.9", default-features = false }
 minip2p-platform = { path = "../platform", version = "0.4.9", default-features = false }
 thiserror = { version = "2.0.18", default-features = false }
+
+[dev-dependencies]
+criterion = "0.8.2"
+
+[[bench]]
+name = "data_path"
+harness = false

--- a/crates/yamux/benches/data_path.rs
+++ b/crates/yamux/benches/data_path.rs
@@ -1,0 +1,76 @@
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use minip2p_yamux::{FLAG_SYN, Frame, HEADER_LEN, YamuxOutput, YamuxRole, YamuxSession};
+
+const PAYLOAD_LEN: usize = 64 * 1024;
+
+fn assert_payload_frame(output: YamuxOutput, payload: &[u8]) {
+    let YamuxOutput::Outbound(bytes) = output else {
+        panic!("expected outbound data frame");
+    };
+    assert_eq!(bytes.len(), HEADER_LEN + payload.len());
+    assert_eq!(bytes[1], 0, "frame type must be data");
+    assert_eq!(&bytes[HEADER_LEN..], payload);
+}
+
+fn yamux_data_path(c: &mut Criterion) {
+    let payload = vec![0x5a; PAYLOAD_LEN];
+    let inbound = Frame::data(1, FLAG_SYN, payload.clone())
+        .expect("valid frame")
+        .encode();
+
+    let mut verified_sender = YamuxSession::new(YamuxRole::Client);
+    let stream = verified_sender.open_stream().expect("open stream");
+    verified_sender
+        .send(stream, payload.clone())
+        .expect("send payload");
+    assert_payload_frame(
+        verified_sender.poll_output().expect("outbound payload"),
+        &payload,
+    );
+
+    let mut verified_receiver = YamuxSession::new(YamuxRole::Server);
+    verified_receiver
+        .handle_data(&inbound)
+        .expect("receive payload");
+    assert!(matches!(
+        verified_receiver.poll_output(),
+        Some(YamuxOutput::IncomingStream { stream: 1 })
+    ));
+    assert!(matches!(
+        verified_receiver.poll_output(),
+        Some(YamuxOutput::Data { stream: 1, data }) if data == payload
+    ));
+
+    let mut group = c.benchmark_group("yamux/64KiB");
+    group.bench_function("session_send_and_drain", |b| {
+        b.iter_batched(
+            || {
+                let mut session = YamuxSession::new(YamuxRole::Client);
+                let stream = session.open_stream().expect("open stream");
+                (session, stream, payload.clone())
+            },
+            |(mut session, stream, data)| {
+                session.send(stream, data).expect("send");
+                black_box(session.poll_output())
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("session_receive_and_drain", |b| {
+        b.iter_batched(
+            || (YamuxSession::new(YamuxRole::Server), inbound.clone()),
+            |(mut session, bytes)| {
+                session.handle_data(&bytes).expect("receive");
+                black_box(session.poll_output());
+                black_box(session.poll_output())
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, yamux_data_path);
+criterion_main!(benches);

--- a/crates/yamux/src/frame.rs
+++ b/crates/yamux/src/frame.rs
@@ -129,6 +129,11 @@ impl Frame {
         &self.payload
     }
 
+    /// Returns the data-frame payload, consuming the frame.
+    pub(crate) fn into_payload(self) -> Vec<u8> {
+        self.payload
+    }
+
     /// Encodes this frame to its 12-byte header plus optional data payload.
     pub fn encode(&self) -> Vec<u8> {
         let mut output = Vec::with_capacity(HEADER_LEN + self.payload.len());

--- a/crates/yamux/src/session.rs
+++ b/crates/yamux/src/session.rs
@@ -469,7 +469,7 @@ impl YamuxSession {
                 .checked_add(payload_len)
                 .ok_or(YamuxError::Protocol("receive accounting overflow"))?;
             if !frame.payload().is_empty() {
-                data_output = Some(frame.payload().to_vec());
+                data_output = Some(frame.into_payload());
             }
             if state.delivered_since_update > self.config.receive_window / 2 {
                 let credit = state.delivered_since_update;

--- a/examples/peer/src/modes.rs
+++ b/examples/peer/src/modes.rs
@@ -377,9 +377,10 @@ pub fn run_dial(
         return Err("no path to the target".into());
     };
     println!(
-        "[dial] path-established path={} elapsed={}ms",
+        "[dial] path-established path={} elapsed={}ms elapsed-us={}",
         path_name(&path),
-        start.elapsed().as_millis()
+        start.elapsed().as_millis(),
+        micros_since(start)
     );
 
     let relayed = matches!(path, Path::Relayed { .. });
@@ -387,6 +388,11 @@ pub fn run_dial(
     let mut channel =
         establish_direct_channel(&mut endpoint, &peer, &BTreeSet::new(), None, start)?;
     channel.direct = !relayed;
+    println!(
+        "[dial] channel-ready path={} elapsed-us={}",
+        channel.name(),
+        micros_since(start)
+    );
 
     ping_loop(&mut endpoint, &peer, channel, frames, count, start)
 }
@@ -533,6 +539,10 @@ fn ping_loop(
                 && upgraded == peer
                 && !channel.direct
             {
+                println!(
+                    "[dial] path-upgraded path=direct-punched elapsed-us={}",
+                    micros_since(start)
+                );
                 // The old bridge is already reset by the agent — never
                 // touch it again. Pongs in flight on it are gone; the
                 // reopen resends their seqs on the new stream.
@@ -555,8 +565,9 @@ fn ping_loop(
                     Err(e) => return Err(e),
                 };
                 println!(
-                    "[dial] channel-switched path=direct outstanding-resent={}",
-                    outstanding.len()
+                    "[dial] channel-switched path=direct outstanding-resent={} elapsed-us={}",
+                    outstanding.len(),
+                    micros_since(start)
                 );
             }
         }
@@ -707,6 +718,10 @@ fn ping_loop(
 
 fn millis_since(start: Instant) -> u64 {
     u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+fn micros_since(start: Instant) -> u128 {
+    start.elapsed().as_micros()
 }
 
 fn next_ping_deadline(sent_at: Instant) -> Instant {

--- a/justfile
+++ b/justfile
@@ -139,6 +139,12 @@ bindings-android:
 
 bench:
     cargo bench -p minip2p-core --bench multiaddr
+    cargo bench -p minip2p-yamux --bench data_path
+    cargo bench -p minip2p-discovery --bench peer_book
+    cargo bench -p minip2p-pubsub --bench fanout
+    cargo bench -p minip2p-relay-server --bench relay_server_event
+    cargo bench -p minip2p-quic --bench idle_poll
+    cargo bench -p minip2p-tcp --bench readiness_poll
 
 fuzz seconds="30":
     cargo +nightly fuzz run wire_inputs -- -max_total_time={{seconds}}

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -28,7 +28,12 @@ mio = { version = "1.0", features = ["net", "os-poll"] }
 socket2 = "0.6.5"
 
 [dev-dependencies]
+criterion = "0.8.2"
 minip2p-multistream-select = { path = "../../crates/multistream-select" }
 minip2p-ping = { path = "../../crates/ping" }
 minip2p-swarm = { path = "../../crates/swarm" }
 minip2p-identity = { path = "../../crates/identity" }
+
+[[bench]]
+name = "idle_poll"
+harness = false

--- a/transports/quic/benches/idle_poll.rs
+++ b/transports/quic/benches/idle_poll.rs
@@ -1,0 +1,80 @@
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use minip2p_core::PeerId;
+use minip2p_platform::{Clock, StdClock};
+use minip2p_quic::{QuicLimits, QuicNodeConfig, QuicTransport};
+use minip2p_transport::Transport;
+
+const COUNTS: &[usize] = &[1, 64, 256, 512];
+const SETUP_TIMEOUT: Duration = Duration::from_secs(20);
+
+fn idle_poll(c: &mut Criterion) {
+    let mut group = c.benchmark_group("quic/idle_poll");
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+
+    for &count in COUNTS {
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
+            let (mut server, client, server_peer, client_peer) = establish(count);
+            assert_eq!(server.connection_ids_for_peer(&client_peer).len(), count);
+            assert_eq!(client.connection_ids_for_peer(&server_peer).len(), count);
+
+            let mut clock = StdClock::with_epoch(Instant::now());
+            b.iter(|| {
+                let events = server.poll(clock.now()).expect("idle poll");
+                assert!(events.is_empty(), "idle benchmark must not emit events");
+                black_box(events);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn establish(count: usize) -> (QuicTransport, QuicTransport, PeerId, PeerId) {
+    let limits = QuicLimits {
+        idle_timeout_ms: 3_600_000,
+        ..QuicLimits::default()
+    };
+    let mut server = QuicTransport::new(
+        QuicNodeConfig::generate().with_limits(limits.clone()),
+        "127.0.0.1:0",
+    )
+    .expect("bind server");
+    let mut client = QuicTransport::new(
+        QuicNodeConfig::generate().with_limits(limits),
+        "127.0.0.1:0",
+    )
+    .expect("bind client");
+    server.listen_on_bound_addr().expect("listen");
+    let server_peer_addr = server.local_peer_addr().expect("server address");
+    let server_peer = server_peer_addr.peer_id().clone();
+    let client_peer = client.local_peer_id();
+
+    for _ in 0..count {
+        client.dial(&server_peer_addr).expect("start dial");
+    }
+
+    let started = Instant::now();
+    let mut clock = StdClock::with_epoch(started);
+    loop {
+        let server_events = server.poll(clock.now()).expect("server setup poll");
+        let client_events = client.poll(clock.now()).expect("client setup poll");
+        black_box((server_events, client_events));
+        if server.connection_ids_for_peer(&client_peer).len() == count
+            && client.connection_ids_for_peer(&server_peer).len() == count
+        {
+            return (server, client, server_peer, client_peer);
+        }
+        assert!(
+            started.elapsed() < SETUP_TIMEOUT,
+            "connection setup timed out"
+        );
+        std::thread::sleep(Duration::from_millis(1));
+    }
+}
+
+criterion_group!(benches, idle_poll);
+criterion_main!(benches);

--- a/transports/quic/src/connection.rs
+++ b/transports/quic/src/connection.rs
@@ -561,6 +561,7 @@ impl QuicConnection {
         &mut self,
         events: &mut Vec<TransportEvent>,
         socket: &UdpSocket,
+        stream_read_buffer: &mut [u8],
         pending_datagrams: &mut VecDeque<PendingDatagram>,
         max_pending_datagrams: usize,
     ) -> Result<(), TransportError> {
@@ -568,20 +569,18 @@ impl QuicConnection {
             return Ok(());
         }
 
-        let mut buf = [0u8; 65535];
-
         for raw_stream_id in self.conn.readable() {
             let stream_id = StreamId::new(raw_stream_id);
             self.ensure_stream_discovered(stream_id, events);
 
             loop {
-                match self.conn.stream_recv(raw_stream_id, &mut buf) {
+                match self.conn.stream_recv(raw_stream_id, stream_read_buffer) {
                     Ok((read, fin)) => {
                         if read > 0 {
                             events.push(TransportEvent::StreamData {
                                 id: self.id,
                                 stream_id,
-                                data: buf[..read].to_vec(),
+                                data: stream_read_buffer[..read].to_vec(),
                             });
                         }
 

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -40,6 +40,7 @@ use connection::QuicConnection;
 
 const DEFAULT_IPV4_BIND: &str = "0.0.0.0:0";
 const DEFAULT_IPV6_BIND: &str = "[::]:0";
+const STREAM_READ_BUFFER_SIZE: usize = 65_535;
 /// Maximum UDP datagrams drained from the socket per `poll()` call.
 ///
 /// Bounding the drain keeps a packet flood from starving the connection
@@ -431,6 +432,8 @@ fn build_quiche_config(node_config: &QuicNodeConfig) -> Result<quiche::Config, T
 pub struct QuicTransport {
     /// Non-blocking UDP socket for all QUIC traffic.
     socket: UdpSocket,
+    /// Address fixed when `socket` was bound.
+    bound_addr: SocketAddr,
     /// Poll registration used to wait for socket readability or an external
     /// driver interrupt without consuming a datagram.
     readiness: ReadinessWait,
@@ -446,6 +449,8 @@ pub struct QuicTransport {
     pending_events: Vec<TransportEvent>,
     /// Fully encoded QUIC packets waiting for the UDP socket to become writable.
     pending_datagrams: VecDeque<PendingDatagram>,
+    /// Reused while extracting application stream data from every connection.
+    stream_read_buffer: Vec<u8>,
     /// The socket address we're listening on, if any.
     listen_addr: Option<SocketAddr>,
     /// Connection ids for this socket, namespaced by the family it is bound to
@@ -699,7 +704,7 @@ fn single_dial_family(
     addr: &PeerAddr,
     family: AddressFamily,
 ) -> Result<ConnectionId, TransportError> {
-    let local_family = family_for_socket_addr(transport.local_addr()?);
+    let local_family = family_for_socket_addr(transport.local_addr());
     if local_family != family {
         return Err(TransportError::InvalidAddress {
             context: "dial target",
@@ -918,6 +923,7 @@ impl QuicTransport {
 
         Ok(Self {
             socket,
+            bound_addr: local_addr,
             readiness,
             quiche_config,
             connections: HashMap::new(),
@@ -925,6 +931,7 @@ impl QuicTransport {
             peer_connections: HashMap::new(),
             pending_events: Vec::new(),
             pending_datagrams: VecDeque::new(),
+            stream_read_buffer: vec![0; STREAM_READ_BUFFER_SIZE],
             listen_addr: None,
             connection_ids: ConnectionIdAllocator::new(namespace),
             last_now: None,
@@ -934,12 +941,8 @@ impl QuicTransport {
     }
 
     /// Returns the local socket address this transport is bound to.
-    pub fn local_addr(&self) -> Result<SocketAddr, TransportError> {
-        self.socket
-            .local_addr()
-            .map_err(|e| TransportError::PollError {
-                reason: format!("failed to get local addr: {e}"),
-            })
+    pub fn local_addr(&self) -> SocketAddr {
+        self.bound_addr
     }
 
     /// Sends a raw UDP packet to the given multiaddr, bypassing QUIC.
@@ -967,8 +970,8 @@ impl QuicTransport {
     }
 
     /// Exposes the bound local socket address as a multiaddr for external use.
-    pub fn local_multiaddr(&self) -> Result<Multiaddr, TransportError> {
-        Ok(socket_addr_to_multiaddr(self.local_addr()?))
+    pub fn local_multiaddr(&self) -> Multiaddr {
+        socket_addr_to_multiaddr(self.local_addr())
     }
 
     /// Returns this node's `PeerId`, derived from the configured keypair.
@@ -980,7 +983,7 @@ impl QuicTransport {
     ///
     /// Combines the bound socket address with this node's `PeerId`.
     pub fn local_peer_addr(&self) -> Result<PeerAddr, TransportError> {
-        let addr = self.local_addr()?;
+        let addr = self.local_addr();
         let peer_id = self.local_peer_id();
         let multiaddr = socket_addr_to_multiaddr(addr);
         PeerAddr::new(multiaddr, peer_id).map_err(|e| TransportError::InvalidConfig {
@@ -994,7 +997,7 @@ impl QuicTransport {
     /// address the UDP socket is bound to, avoiding manual `Multiaddr`
     /// construction.
     pub fn listen_on_bound_addr(&mut self) -> Result<Multiaddr, TransportError> {
-        let addr = self.local_addr()?;
+        let addr = self.local_addr();
         let multiaddr = socket_addr_to_multiaddr(addr);
         self.listen(&multiaddr)
     }
@@ -1135,7 +1138,7 @@ impl Transport for QuicTransport {
 
         let id = self.allocate_connection_id()?;
         let peer_socket = resolve_dial_socket_addr(addr.transport(), "dial target")?;
-        let local_socket = self.local_addr()?;
+        let local_socket = self.local_addr();
 
         let scid = Self::generate_scid().map_err(|e| TransportError::DialFailed {
             id,
@@ -1209,7 +1212,7 @@ impl Transport for QuicTransport {
     fn listen(&mut self, addr: &Multiaddr) -> Result<Multiaddr, TransportError> {
         let socket_addr = extract_listen_socket_addr(addr, "listen address")?;
 
-        let local_addr = self.local_addr()?;
+        let local_addr = self.local_addr();
         ensure_listen_matches_bound_socket(socket_addr, local_addr)?;
 
         let listen_addr = socket_addr_to_multiaddr(local_addr);
@@ -1308,13 +1311,7 @@ impl Transport for QuicTransport {
     }
 
     fn local_addresses(&self) -> Vec<Multiaddr> {
-        // If the socket isn't bound for some reason (shouldn't happen in
-        // normal usage -- we bind at construction time), return empty
-        // rather than propagate the error. The swarm uses this only to
-        // enrich Identify; a missing value is never fatal.
-        self.local_multiaddr()
-            .map(|addr| vec![addr])
-            .unwrap_or_default()
+        vec![self.local_multiaddr()]
     }
 
     fn active_inbound_connection_sources(&self) -> Vec<Multiaddr> {
@@ -1352,7 +1349,7 @@ impl Transport for QuicTransport {
                 }
             };
 
-            let local_addr = self.local_addr()?;
+            let local_addr = self.bound_addr;
             let packet = &mut buf[..len];
 
             let parsed_header = quiche::Header::from_slice(packet, quiche::MAX_CONN_ID_LEN).ok();
@@ -1536,33 +1533,42 @@ impl Transport for QuicTransport {
         }
 
         let mut to_remove = Vec::new();
-
         let keepalive_interval_ms =
             keepalive_interval_ms(self.node_config.limits().idle_timeout_ms);
-        for (&id, conn) in self.connections.iter_mut() {
-            conn.handle_timeout(
-                &self.socket,
+        let max_pending_datagrams = self.node_config.limits().max_pending_datagrams;
+        {
+            let (connections, pending_events, pending_datagrams, stream_read_buffer) = (
+                &mut self.connections,
                 &mut self.pending_events,
                 &mut self.pending_datagrams,
-                self.node_config.limits().max_pending_datagrams,
-            )?;
-            conn.maybe_keepalive(
-                now,
-                keepalive_interval_ms,
-                &self.socket,
-                &mut self.pending_events,
-                &mut self.pending_datagrams,
-                self.node_config.limits().max_pending_datagrams,
-            )?;
-            conn.poll_streams(
-                &mut self.pending_events,
-                &self.socket,
-                &mut self.pending_datagrams,
-                self.node_config.limits().max_pending_datagrams,
-            )?;
+                &mut self.stream_read_buffer,
+            );
+            for (&id, conn) in connections.iter_mut() {
+                conn.handle_timeout(
+                    &self.socket,
+                    pending_events,
+                    pending_datagrams,
+                    max_pending_datagrams,
+                )?;
+                conn.maybe_keepalive(
+                    now,
+                    keepalive_interval_ms,
+                    &self.socket,
+                    pending_events,
+                    pending_datagrams,
+                    max_pending_datagrams,
+                )?;
+                conn.poll_streams(
+                    pending_events,
+                    &self.socket,
+                    stream_read_buffer,
+                    pending_datagrams,
+                    max_pending_datagrams,
+                )?;
 
-            if conn.is_closed() {
-                to_remove.push(id);
+                if conn.is_closed() {
+                    to_remove.push(id);
+                }
             }
         }
 
@@ -1980,6 +1986,17 @@ mod tests {
     use super::*;
     use minip2p_identity::Ed25519Keypair;
 
+    #[test]
+    fn local_addr_returns_the_address_captured_at_bind() {
+        let socket = UdpSocket::bind("127.0.0.1:0").expect("bind socket");
+        let bound = socket.local_addr().expect("bound address");
+        let transport = QuicTransport::from_socket(QuicNodeConfig::generate(), socket)
+            .expect("construct transport");
+
+        assert_eq!(transport.bound_addr, bound);
+        assert_eq!(transport.local_addr(), bound);
+    }
+
     fn localhost_peer_addr(port: u16) -> PeerAddr {
         let keypair = Ed25519Keypair::generate();
         let transport = Multiaddr::from_protocols(vec![
@@ -2051,7 +2068,7 @@ mod tests {
             "127.0.0.1:0",
         )
         .expect("bind");
-        let destination = transport.local_addr().expect("local addr");
+        let destination = transport.local_addr();
 
         for payload in [&[1u8][..], &[2u8][..], &[3u8][..]] {
             transport.queue_datagram_best_effort(payload, destination);
@@ -2093,7 +2110,7 @@ mod tests {
     fn poll_drains_a_bounded_number_of_datagrams_per_call() {
         let mut transport =
             QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("bind");
-        let destination = transport.local_addr().expect("local addr");
+        let destination = transport.local_addr();
 
         let sender = UdpSocket::bind("127.0.0.1:0").expect("sender");
         for _ in 0..MAX_DATAGRAMS_PER_POLL + 8 {
@@ -2133,7 +2150,7 @@ mod tests {
     fn poisoned_queued_datagram_is_dropped_without_failing_the_poll() {
         let mut transport =
             QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("bind");
-        let addr = transport.local_multiaddr().expect("multiaddr");
+        let addr = transport.local_multiaddr();
         transport
             .pending_events
             .push(TransportEvent::Listening { addr: addr.clone() });
@@ -2144,7 +2161,7 @@ mod tests {
         // abort the whole endpoint.
         let bad_destination: SocketAddr = "[::1]:9".parse().expect("socket addr");
         transport.queue_datagram_best_effort(&[0u8; 4], bad_destination);
-        let good_destination = transport.local_addr().expect("local addr");
+        let good_destination = transport.local_addr();
         transport.queue_datagram_best_effort(&[0u8; 4], good_destination);
 
         let events = transport.poll(Now::from_millis(0)).expect("poll");
@@ -2208,7 +2225,7 @@ mod tests {
 
         // `dial` can queue a datagram before any poll has taken a sample. A
         // host that idled on `None` here would never flush it.
-        let destination = transport.local_addr().expect("local addr");
+        let destination = transport.local_addr();
         transport.queue_datagram_best_effort(&[0u8; 4], destination);
 
         let deadline = transport.next_deadline().expect("queued work must be due");
@@ -2233,7 +2250,7 @@ mod tests {
             "an idle transport arms no timer"
         );
 
-        let destination = transport.local_addr().expect("local addr");
+        let destination = transport.local_addr();
         transport.queue_datagram_best_effort(&[0u8; 4], destination);
         assert_eq!(
             transport.next_deadline(),
@@ -2259,7 +2276,7 @@ mod tests {
 
         let sender = UdpSocket::bind("127.0.0.1:0").expect("sender");
         sender
-            .send_to(&[1, 2, 3], transport.local_addr().expect("local addr"))
+            .send_to(&[1, 2, 3], transport.local_addr())
             .expect("send probe");
         assert_eq!(
             transport.wait_for_input(Duration::from_secs(2)),
@@ -2386,7 +2403,7 @@ mod tests {
         let mut server =
             QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("bind");
         server.listen_on_bound_addr().expect("listen");
-        let server_addr = server.local_addr().expect("local addr");
+        let server_addr = server.local_addr();
 
         // A syntactically valid Initial whose Retry token exceeds anything we
         // could have minted. Header parsing for an Initial stops after the

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -1987,14 +1987,20 @@ mod tests {
     use minip2p_identity::Ed25519Keypair;
 
     #[test]
-    fn local_addr_returns_the_address_captured_at_bind() {
+    fn bound_socket_address_is_exposed_as_transport_multiaddr() {
         let socket = UdpSocket::bind("127.0.0.1:0").expect("bind socket");
         let bound = socket.local_addr().expect("bound address");
         let transport = QuicTransport::from_socket(QuicNodeConfig::generate(), socket)
             .expect("construct transport");
+        let expected = Multiaddr::from_protocols(vec![
+            Protocol::Ip4([127, 0, 0, 1]),
+            Protocol::Udp(bound.port()),
+            Protocol::QuicV1,
+        ]);
 
-        assert_eq!(transport.bound_addr, bound);
-        assert_eq!(transport.local_addr(), bound);
+        assert_ne!(bound.port(), 0, "the OS must resolve the ephemeral port");
+        assert_eq!(transport.local_multiaddr(), expected);
+        assert_eq!(Transport::local_addresses(&transport), vec![expected]);
     }
 
     fn localhost_peer_addr(port: u16) -> PeerAddr {

--- a/transports/quic/tests/transport_contract.rs
+++ b/transports/quic/tests/transport_contract.rs
@@ -119,7 +119,7 @@ fn connect_pair(
 fn listen_returns_the_resolved_listen_address_and_event_matches() {
     let mut listener =
         QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("listener");
-    let requested = listener.local_multiaddr().expect("local multiaddr");
+    let requested = listener.local_multiaddr();
 
     let resolved = listener.listen(&requested).expect("listen");
     assert_eq!(resolved, requested);

--- a/transports/quic/tests/two_peer.rs
+++ b/transports/quic/tests/two_peer.rs
@@ -127,6 +127,81 @@ fn two_peers_open_stream_and_exchange_data() {
 }
 
 #[test]
+fn stream_data_is_preserved_across_connections_and_streams() {
+    let (mut server, mut client, peer_addr) = setup_pair();
+    let client_connections = [
+        client.dial(&peer_addr).expect("first dial"),
+        client.dial(&peer_addr).expect("second dial"),
+    ];
+    let mut connected_client = Vec::new();
+    let mut connected_server = Vec::new();
+
+    for _ in 0..250 {
+        let (server_events, client_events) = drive_pair_once(&mut server, &mut client);
+        for event in server_events {
+            if let TransportEvent::Connected { id, .. } = event
+                && !connected_server.contains(&id)
+            {
+                connected_server.push(id);
+            }
+        }
+        for event in client_events {
+            if let TransportEvent::Connected { id, .. } = event
+                && client_connections.contains(&id)
+                && !connected_client.contains(&id)
+            {
+                connected_client.push(id);
+            }
+        }
+        if connected_client.len() == client_connections.len()
+            && connected_server.len() == client_connections.len()
+        {
+            break;
+        }
+    }
+    assert_eq!(connected_client.len(), client_connections.len());
+    assert_eq!(connected_server.len(), client_connections.len());
+
+    let payloads = [
+        b"first connection, first stream".to_vec(),
+        b"first connection, second stream".to_vec(),
+        b"second connection, first stream".to_vec(),
+        b"second connection, second stream".to_vec(),
+    ];
+    for (connection_index, connection) in client_connections.into_iter().enumerate() {
+        for stream_index in 0..2 {
+            let stream = client.open_stream(connection).expect("open stream");
+            client
+                .send_stream(
+                    connection,
+                    stream,
+                    payloads[connection_index * 2 + stream_index].clone(),
+                )
+                .expect("send stream data");
+        }
+    }
+
+    let mut received = Vec::new();
+    for _ in 0..250 {
+        let (server_events, _) = drive_pair_once(&mut server, &mut client);
+        for event in server_events {
+            if let TransportEvent::StreamData { id, data, .. } = event
+                && connected_server.contains(&id)
+            {
+                received.push(data);
+            }
+        }
+        if received.len() == payloads.len() {
+            break;
+        }
+    }
+    received.sort();
+    let mut expected = payloads.to_vec();
+    expected.sort();
+    assert_eq!(received, expected);
+}
+
+#[test]
 fn close_stream_write_emits_remote_write_closed() {
     let (mut server, mut client, peer_addr) = setup_pair();
 
@@ -213,7 +288,7 @@ fn listener_rejects_dialer_without_mtls_identity() {
     let mut server =
         QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("server bind");
     server.listen_on_bound_addr().expect("server listen");
-    let server_addr = server.local_addr().expect("server socket addr");
+    let server_addr = server.local_addr();
 
     let client_socket = UdpSocket::bind("127.0.0.1:0").expect("client socket");
     client_socket
@@ -301,7 +376,7 @@ fn listener_rejects_dialer_with_invalid_libp2p_cert() {
     let mut server =
         QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0").expect("server bind");
     server.listen_on_bound_addr().expect("server listen");
-    let server_addr = server.local_addr().expect("server socket addr");
+    let server_addr = server.local_addr();
 
     let client_socket = UdpSocket::bind("127.0.0.1:0").expect("client socket");
     client_socket
@@ -428,7 +503,7 @@ fn listen_rejects_address_mismatch_with_bound_socket() {
     let config = QuicNodeConfig::generate();
     let mut transport = QuicTransport::new(config, "127.0.0.1:0").expect("bind");
 
-    let local = transport.local_addr().expect("local addr");
+    let local = transport.local_addr();
     let mismatched_port = if local.port() == u16::MAX {
         local.port() - 1
     } else {

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -41,8 +41,13 @@ minip2p-smoltcp = { path = "../../crates/smoltcp", version = "0.4.9", optional =
 thiserror = { version = "2.0.18", default-features = false }
 
 [dev-dependencies]
+criterion = "0.8.2"
 minip2p-identity = { path = "../../crates/identity", features = ["ed25519", "std"] }
 minip2p-secure-mux = { path = "../../crates/secure-mux" }
+
+[[bench]]
+name = "readiness_poll"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/transports/tcp/benches/readiness_poll.rs
+++ b/transports/tcp/benches/readiness_poll.rs
@@ -1,0 +1,127 @@
+use std::hint::black_box;
+use std::io::{ErrorKind, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use minip2p_core::Multiaddr;
+use minip2p_platform::Now;
+use minip2p_tcp::{StdTcpProvider, TcpEvent, TcpProvider};
+
+const COUNTS: &[usize] = &[1, 64, 256];
+const SETUP_TIMEOUT: Duration = Duration::from_secs(20);
+const CONNECT_BATCH: usize = 32;
+
+struct ReadySet {
+    provider: StdTcpProvider,
+    peers: Vec<TcpStream>,
+}
+
+fn readiness_poll(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tcp/readiness_poll");
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+
+    for &count in COUNTS {
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
+            let mut ready = establish(count);
+            b.iter(|| poll_ready(&mut ready, count));
+        });
+    }
+    group.finish();
+}
+
+fn establish(count: usize) -> ReadySet {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind peer listener");
+    listener
+        .set_nonblocking(true)
+        .expect("make peer listener nonblocking");
+    let address: Multiaddr = format!(
+        "/ip4/127.0.0.1/tcp/{}",
+        listener.local_addr().expect("peer listener address").port()
+    )
+    .parse()
+    .expect("benchmark address");
+    let mut provider = StdTcpProvider::new().expect("create provider");
+
+    let mut peers = Vec::with_capacity(count);
+    let mut connected = 0;
+    let mut started_connections = 0;
+    let started = Instant::now();
+    while started_connections != count {
+        for _ in 0..(count - started_connections).min(CONNECT_BATCH) {
+            provider
+                .connect(&address)
+                .expect("start provider connection");
+            started_connections += 1;
+        }
+        connected += accept_and_poll(&listener, &mut peers, &mut provider);
+        assert!(
+            started.elapsed() < SETUP_TIMEOUT,
+            "only started {started_connections}/{count}, established {connected}/{count} provider connections, and accepted {}/{} peer streams",
+            peers.len(),
+            count
+        );
+    }
+    while connected != count || peers.len() != count {
+        connected += accept_and_poll(&listener, &mut peers, &mut provider);
+        assert!(
+            started.elapsed() < SETUP_TIMEOUT,
+            "only established {connected}/{count} provider connections and accepted {}/{} peer streams",
+            peers.len(),
+            count
+        );
+        thread::sleep(Duration::from_micros(100));
+    }
+    ReadySet { provider, peers }
+}
+
+fn accept_and_poll(
+    listener: &TcpListener,
+    peers: &mut Vec<TcpStream>,
+    provider: &mut StdTcpProvider,
+) -> usize {
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                stream.set_nodelay(true).expect("disable Nagle");
+                peers.push(stream);
+            }
+            Err(error) if error.kind() == ErrorKind::WouldBlock => break,
+            Err(error) => panic!("accept peer: {error}"),
+        }
+    }
+    provider
+        .poll(Now::from_millis(0))
+        .expect("finish provider connection")
+        .into_iter()
+        .filter(|event| matches!(event, TcpEvent::Connected { .. }))
+        .count()
+}
+
+fn poll_ready(ready: &mut ReadySet, count: usize) {
+    for peer in &mut ready.peers {
+        peer.write_all(&[1]).expect("write readiness byte");
+    }
+
+    let mut received = 0;
+    while received != count {
+        for event in ready
+            .provider
+            .poll(Now::from_millis(0))
+            .expect("poll ready sockets")
+        {
+            if let TcpEvent::Received { data, .. } = event {
+                assert!(data.iter().all(|byte| *byte == 1), "unexpected payload");
+                received += data.len();
+                assert!(received <= count, "received more bytes than were sent");
+            }
+        }
+    }
+    black_box(received);
+}
+
+criterion_group!(benches, readiness_poll);
+criterion_main!(benches);

--- a/transports/tcp/src/std_provider.rs
+++ b/transports/tcp/src/std_provider.rs
@@ -204,6 +204,9 @@ struct Socket {
 pub struct StdTcpProvider {
     poll: Poll,
     events: Events,
+    /// Snapshot of one `mio` event batch. Reused because `Events` borrows
+    /// itself while iterating but changing socket flags needs `&mut self`.
+    observed: Vec<(Token, bool, bool)>,
     waker: Arc<Waker>,
     listeners: BTreeMap<usize, Listener>,
     sockets: BTreeMap<SocketHandle, Socket>,
@@ -241,6 +244,7 @@ impl StdTcpProvider {
         Ok(Self {
             poll,
             events: Events::with_capacity(64),
+            observed: Vec::with_capacity(64),
             waker,
             listeners: BTreeMap::new(),
             sockets: BTreeMap::new(),
@@ -307,25 +311,28 @@ impl StdTcpProvider {
 
         // Collect first: the flags live behind `&mut self`, which `events`
         // borrows for the duration of the iteration.
-        let observed: Vec<(Token, bool, bool)> = self
-            .events
-            .iter()
-            .map(|event| (event.token(), event.is_readable(), event.is_writable()))
-            .collect();
+        self.observed.clear();
+        self.observed.extend(
+            self.events
+                .iter()
+                .map(|event| (event.token(), event.is_readable(), event.is_writable())),
+        );
+        let observed = core::mem::take(&mut self.observed);
 
         let mut ready = false;
         let mut drained = Vec::new();
-        for (token, readable, writable) in observed {
+        for &(token, readable, writable) in &observed {
             if token == WAKER_TOKEN {
                 self.pending_interrupt = true;
                 continue;
             }
             ready = true;
-            let Some((handle, socket)) = self
-                .sockets
-                .iter_mut()
-                .find(|(_, socket)| socket.token == token)
-            else {
+            // Socket handles deliberately reuse the registration token. The
+            // token allocator is shared with listeners, so a listener token
+            // simply misses this map; scanning every socket here turns a
+            // readiness batch into O(events × sockets).
+            let handle = SocketHandle::new(token.0 as u64);
+            let Some(socket) = self.sockets.get_mut(&handle) else {
                 // Listeners need no flag: `accept` runs to `WouldBlock` on
                 // every poll regardless.
                 continue;
@@ -334,7 +341,7 @@ impl StdTcpProvider {
             if writable {
                 socket.writable = true;
                 if matches!(socket.phase, Phase::Open) {
-                    drained.push(*handle);
+                    drained.push(handle);
                 }
             }
         }
@@ -345,6 +352,7 @@ impl StdTcpProvider {
             self.watch_writable(handle, false);
             self.ready.push_back(TcpEvent::Writable { socket: handle });
         }
+        self.observed = observed;
         Ok(ready)
     }
 


### PR DESCRIPTION
## What changed

This removes measured hot-path costs across discovery, pubsub, relay, Yamux, QUIC, TCP, and the Node adapter.

- Skip discovery view and address cloning when no source has expired.
- Share one pubsub wire frame across queued recipients. The std build uses `Arc`; pure `no_std` uses `Rc`.
- Sweep relay deadlines once per shared `Now` sample instead of once per event.
- Move decoded Yamux payloads into output instead of allocating and copying them again.
- Reuse one QUIC stream receive buffer and cache the bound socket address.
- Resolve mio readiness tokens directly to TCP socket handles and reuse the event snapshot buffer.
- Schedule Node event batches with `setImmediate`, and reuse exact native event buffers while copying sliced views safely.
- Synchronize QUIC DCUtR with the measured relay RTT instead of a fixed 50 ms approximation.
- Add microsecond path milestones to `minip2p-peer` for actionable live diagnostics.
- Add six Criterion suites and include them in `just bench`.

## Breaking changes

- QUIC `local_addr()` and `local_multiaddr()` now return values directly. Construction guarantees both values, so the old `Result` exposed an error mode callers could not handle meaningfully.
- `NatConfig::responder_sync_delay_ms` is removed. The NAT agent now follows the DCUtR protocol directly: measure CONNECT-to-reply RTT, send SYNC, then start responder UDP blasts at `ceil(RTT / 2)`.

## Microbenchmarks

Apple M2 Pro, Rust 1.98.0, Node 24.19.0. Setup is outside each timed section.

| Path | Workload | Before | After | Change |
| --- | ---: | ---: | ---: | ---: |
| Discovery tick | 128 peers, 16 addresses, no expiry | 500.252 us median | 2.763 us | -99.45% |
| Pubsub publish | Floodsub, 32 peers, 60 KiB | 308.228 us mean | 174.960 us | -43.61% |
| Relay event | 128 pending HOP workers, same `Now` | 335 ns median | 24 ns | -92.84% |
| Yamux receive | 64 KiB data frame | 7.022 us | 4.748 us | -32.39% |
| QUIC idle poll | 64 connections | 48.706 us median | 13.338 us | -72.62% |
| QUIC idle poll | 256 connections | 200.775 us | 50.118 us | -75.04% |
| QUIC idle poll | 512 connections | 382.238 us | 100.844 us | -73.62% |
| TCP readiness | 64 ready connections | 256.578 us median | 196.341 us | -23.48% |
| TCP readiness | 256 ready connections | 1.022 ms | 805.360 us | -21.19% |
| TCP readiness | 512 ready connections | 2.276 ms | 1.803 ms | -20.78% |
| Node event drain | 4,096 events | 18.892 ms median | 0.388 ms | -97.95% |
| Node event bytes | Exact 64 KiB native buffer | 2.862 us median | 35 ns | -98.78% |

The pubsub result measures caller-visible publish latency and queued allocation pressure. Each recipient still gets its owned transport payload when its stream becomes writable.

## Live IPv6 E2E

Topology: Apple M2 Pro, a Linux peer on the same home network, an AWS Linux peer, and `relay.minip2p.com` on a t3.micro. Tailscale was used only for SSH management; the tested p2p route was the public relay followed by a verified global-IPv6 `direct-punched` path. All test binaries were cross-built locally from the compared revisions.

Fresh adjacent campaign with a stable listener and dialer identity: baseline `n=5`, final `n=10`. Values are median elapsed time from process start; parentheses are min-max. The unequal small samples support an observed live-network shift, not a general Internet SLO.

| Milestone | Baseline | Final | Change |
| --- | ---: | ---: | ---: |
| Relayed path established | 370.260 ms (364.425-373.001) | 367.796 ms (353.809-385.654) | -0.7%; effectively flat |
| IPv6 path upgraded | 1.594 s (1.594-1.603) | 595.032 ms (575.806-613.392) | -998.914 ms, -62.7%, 2.68x faster |
| Direct application channel switched | 1.762 s (1.757-1.764) | 760.331 ms (737.614-781.147) | -1.001 s, -56.8%, 2.32x faster |

The post-upgrade stream setup stayed about 166-168 ms. The gain is the eliminated lost first QUIC flight before `PathUpgraded`, not faster relay establishment or stream negotiation.

Concurrency checks on the final build:

- 10/10 sequential AWS-to-home IPv6 hole punches succeeded.
- Two simultaneous peers over different networks: 6/6 succeeded across three waves.
- Four simultaneous circuits, the production per-target ceiling: 4/4 upgraded and completed all echoes.
- Relay CPU averaged 1.0% and peaked at 3.0% during both two- and four-circuit samples; no denial, restart, or fallback occurred.

The peer workload is intentionally low bandwidth, so this does not claim a throughput increase. Production relay limits cap one target at four circuits, and the live campaign tests control-plane latency, correctness, and headroom rather than NIC saturation.

## Verification

- `just test`
- `just clippy`
- `just check-nostd`
- `just fmt`
- focused DCUtR tests, including a relay RTT longer than the punch window
- locally cross-built x86_64 Linux client and relay artifacts
- real IPv6 sequential, two-peer, and four-peer E2E waves
- deployed-relay restart/rollback smoke and clean post-deploy journal
- `git diff --check`
