### PR TITLE
chore: enforce strict Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,64 @@ unsafe_code = "forbid"
 [patch.crates-io]
 boring = { git = "https://github.com/deepso7/boring", rev = "de6ec29406df54911ea50dec47f40d6b6e4d6ef7" }
 boring-sys = { git = "https://github.com/deepso7/boring", rev = "de6ec29406df54911ea50dec47f40d6b6e4d6ef7" }
+
+[workspace.lints.clippy]
+# Don't Panic - prevent panics from unwraps and unsafe slicing or indexing
+string_slice = "warn"
+indexing_slicing = "warn"
+unwrap_used = "warn"
+panic = "warn"
+todo = "warn"
+unimplemented = "warn"
+unreachable = "warn"
+get_unwrap = "warn"
+unwrap_in_result = "warn"
+unchecked_time_subtraction = "warn"
+panic_in_result_fn = "warn"
+# Optional - see post for caveats
+# expect_used = "warn"
+# arithmetic_side_effects = "warn"
+
+# Don't Fail Silently - prevent dropped futures and swallowed errors
+let_underscore_future = "warn"
+let_underscore_must_use = "warn"
+unused_result_ok = "warn"
+map_err_ignore = "warn"
+assertions_on_result_states = "warn"
+
+# Don't Do Bad Async Stuff - prevent deadlocks and concurrency bugs
+await_holding_lock = "warn"
+await_holding_refcell_ref = "warn"
+if_let_mutex = "warn"  # only relevant on editions before 2024
+large_futures = "warn"
+
+# Don't Do Unsafe Things with Memory
+mem_forget = "warn"
+undocumented_unsafe_blocks = "warn"
+multiple_unsafe_ops_per_block = "warn"
+unnecessary_safety_doc = "warn"
+unnecessary_safety_comment = "warn"
+
+# Don't Do Potentially Incorrect Things with Numbers
+float_cmp = "warn"
+float_cmp_const = "warn"
+lossy_float_literal = "warn"
+cast_sign_loss = "warn"
+invalid_upcast_comparisons = "warn"
+# Optional - these effectively force you to document numeric invariants
+# cast_possible_wrap = "warn"
+# cast_precision_loss = "warn"
+# cast_possible_truncation = "warn"
+
+# Don't Do Bad Things That are Easy to Avoid
+rc_mutex = "warn"
+debug_assert_with_mut_call = "warn"
+iter_not_returning_iterator = "warn"
+expl_impl_clone_on_copy = "warn"
+infallible_try_from = "warn"
+dbg_macro = "warn"
+
+# Don't `allow` Your Way Around These Lints - every suppression must be
+# a deliberate #[expect(..., reason = "…")] rather than a silent #[allow]
+allow_attributes = "warn"
+allow_attributes_without_reason = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+allow-indexing-slicing-in-tests = true
+allow-panic-in-tests = true
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-dbg-in-tests = true  

--- a/crates/autonat/src/lib.rs
+++ b/crates/autonat/src/lib.rs
@@ -736,8 +736,8 @@ fn read_tag(input: &[u8], idx: &mut usize) -> Result<Option<(u64, u8)>, AutoNatE
         return Ok(None);
     }
     let offset = *idx;
-    let (tag_value, used) = read_uvarint(&input[*idx..])?;
-    *idx += used;
+    let (tag_value, used) = read_uvarint(input.get(*idx..).ok_or(VarintError::BufferTooShort)?)?;
+    advance(input, idx, used)?;
     let wire_type = (tag_value & 0x07) as u8;
     let field_number = tag_value >> 3;
     if field_number == 0 {
@@ -747,8 +747,12 @@ fn read_tag(input: &[u8], idx: &mut usize) -> Result<Option<(u64, u8)>, AutoNatE
 }
 
 fn read_len_delimited<'a>(input: &'a [u8], idx: &mut usize) -> Result<&'a [u8], AutoNatError> {
-    let (length, used) = read_uvarint(&input[*idx..])?;
-    *idx += used;
+    let (length, used) = read_uvarint(input.get(*idx..).ok_or(VarintError::BufferTooShort)?)?;
+    advance(input, idx, used)?;
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "wire lengths wider than usize are reported as varint overflow"
+    )]
     let length = usize::try_from(length).map_err(|_| VarintError::Overflow)?;
     let remaining = input.len().saturating_sub(*idx);
     if length > remaining {
@@ -758,15 +762,38 @@ fn read_len_delimited<'a>(input: &'a [u8], idx: &mut usize) -> Result<&'a [u8], 
             remaining,
         });
     }
-    let value = &input[*idx..*idx + length];
-    *idx += length;
+    let end = idx.checked_add(length).ok_or(AutoNatError::FieldOverflow {
+        offset: *idx,
+        length,
+        remaining,
+    })?;
+    let value = input.get(*idx..end).ok_or(AutoNatError::FieldOverflow {
+        offset: *idx,
+        length,
+        remaining,
+    })?;
+    *idx = end;
     Ok(value)
 }
 
 fn read_varint_value(input: &[u8], idx: &mut usize) -> Result<u64, AutoNatError> {
-    let (value, used) = read_uvarint(&input[*idx..])?;
-    *idx += used;
+    let (value, used) = read_uvarint(input.get(*idx..).ok_or(VarintError::BufferTooShort)?)?;
+    advance(input, idx, used)?;
     Ok(value)
+}
+
+fn advance(input: &[u8], idx: &mut usize, length: usize) -> Result<(), AutoNatError> {
+    let remaining = input.len().saturating_sub(*idx);
+    let end = idx
+        .checked_add(length)
+        .filter(|end| *end <= input.len())
+        .ok_or(AutoNatError::FieldOverflow {
+            offset: *idx,
+            length,
+            remaining,
+        })?;
+    *idx = end;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -479,9 +479,14 @@ impl<T: Transport, E: EntropySource> CircuitTransport<T, E> {
         let key = circuit.bridge_key();
         self.bridge_index.remove(&key);
         self.retire_bridge(key);
-        let _ = self
+        let reset_result = self
             .inner
             .reset_stream(circuit.inner_conn, circuit.bridge_stream);
+        // The circuit is already retired. A failed bridge reset cannot revive
+        // it or replace the error/close transition below.
+        match reset_result {
+            Ok(()) | Err(_) => {}
+        }
         if emit_error {
             self.pending
                 .push_back(TransportEvent::Error { id, message });
@@ -534,7 +539,12 @@ impl<T: Transport, E: EntropySource> CircuitTransport<T, E> {
     fn reject_inner_collision(&mut self, id: ConnectionId) {
         self.active_inner.remove(&id);
         self.remove_direct(id);
-        let _ = self.inner.close(id);
+        let close_result = self.inner.close(id);
+        // The colliding connection is removed from circuit bookkeeping;
+        // cleanup failure must not hide the namespace violation.
+        match close_result {
+            Ok(()) | Err(_) => {}
+        }
         self.pending.push_back(TransportEvent::Error {
             id,
             message: "wrapped transport allocated in the circuit connection-ID namespace"
@@ -709,7 +719,11 @@ impl<T: Transport, E: EntropySource> Transport for CircuitTransport<T, E> {
     fn dial(&mut self, address: &minip2p_core::PeerAddr) -> Result<ConnectionId, TransportError> {
         let id = self.inner.dial(address)?;
         if id.is_circuit() {
-            let _ = self.inner.close(id);
+            let close_result = self.inner.close(id);
+            // The dial is rejected regardless of best-effort inner cleanup.
+            match close_result {
+                Ok(()) | Err(_) => {}
+            }
             return Err(TransportError::DialFailed {
                 id,
                 reason: "wrapped transport allocated in the circuit connection-ID namespace"
@@ -810,9 +824,14 @@ impl<T: Transport, E: EntropySource> Transport for CircuitTransport<T, E> {
                 .close_stream_write(circuit.inner_conn, circuit.bridge_stream)
                 .is_ok();
         if !graceful {
-            let _ = self
+            let reset_result = self
                 .inner
                 .reset_stream(circuit.inner_conn, circuit.bridge_stream);
+            // The connection is closed even if best-effort bridge cleanup
+            // fails, so preserve the single `Closed` event below.
+            match reset_result {
+                Ok(()) | Err(_) => {}
+            }
         }
         self.pending.push_back(TransportEvent::Closed { id });
         Ok(())

--- a/crates/core/src/frame.rs
+++ b/crates/core/src/frame.rs
@@ -52,13 +52,15 @@ pub fn decode_frame(input: &[u8], max_len: usize) -> FrameDecode<'_> {
     }
     // Cannot truncate: `length <= max_len` holds here.
     let length = length as usize;
-    if length > input.len().saturating_sub(used) {
+    let Some(total) = used.checked_add(length) else {
         return FrameDecode::Incomplete;
-    }
-    let total = used + length;
+    };
+    let Some(payload) = input.get(used..total) else {
+        return FrameDecode::Incomplete;
+    };
 
     FrameDecode::Complete {
-        payload: &input[used..total],
+        payload,
         consumed: total,
     }
 }

--- a/crates/core/src/multiaddr.rs
+++ b/crates/core/src/multiaddr.rs
@@ -174,14 +174,11 @@ impl Multiaddr {
     ///   (e.g. non-UTF-8 DNS name, malformed `/p2p/` multihash).
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, MultiaddrError> {
         let mut protocols = Vec::new();
-        let mut offset = 0;
-        while offset < bytes.len() {
-            let remaining = bytes.get(offset..).ok_or(MultiaddrError::Varint(
-                minip2p_identity::VarintError::BufferTooShort,
-            ))?;
-            let (protocol, consumed) = Protocol::read_binary(remaining)?;
-            offset += consumed;
+        let mut remaining = bytes;
+        while !remaining.is_empty() {
+            let (protocol, rest) = Protocol::read_binary(remaining)?;
             protocols.push(protocol);
+            remaining = rest;
         }
         Ok(Self { protocols })
     }

--- a/crates/core/src/multiaddr.rs
+++ b/crates/core/src/multiaddr.rs
@@ -77,8 +77,12 @@ impl Multiaddr {
         }
 
         for idx in (0..=self.protocols.len() - suffix.protocols.len()).rev() {
-            if self.protocols[idx..idx + suffix.protocols.len()] == suffix.protocols {
-                return Some(Self::from_protocols(self.protocols[..idx].to_vec()));
+            let end = idx + suffix.protocols.len();
+            if self.protocols.get(idx..end) == Some(suffix.protocols.as_slice()) {
+                return self
+                    .protocols
+                    .get(..idx)
+                    .map(|protocols| Self::from_protocols(protocols.to_vec()));
             }
         }
 
@@ -172,7 +176,10 @@ impl Multiaddr {
         let mut protocols = Vec::new();
         let mut offset = 0;
         while offset < bytes.len() {
-            let (protocol, consumed) = Protocol::read_binary(&bytes[offset..])?;
+            let remaining = bytes.get(offset..).ok_or(MultiaddrError::Varint(
+                minip2p_identity::VarintError::BufferTooShort,
+            ))?;
+            let (protocol, consumed) = Protocol::read_binary(remaining)?;
             offset += consumed;
             protocols.push(protocol);
         }
@@ -223,15 +230,15 @@ impl<'a> IntoIterator for &'a Multiaddr {
 
 /// Checks if a protocol slice forms a valid QUIC transport (host + udp + quic-v1).
 pub(crate) fn is_quic_transport_slice(protocols: &[Protocol]) -> bool {
-    protocols.len() == 3
-        && protocols[0].is_host()
-        && matches!(protocols[1], Protocol::Udp(_))
-        && matches!(protocols[2], Protocol::QuicV1)
+    matches!(
+        protocols,
+        [host, Protocol::Udp(_), Protocol::QuicV1] if host.is_host()
+    )
 }
 
 /// Checks if a protocol slice forms a valid TCP transport (host + tcp).
 pub(crate) fn is_tcp_transport_slice(protocols: &[Protocol]) -> bool {
-    protocols.len() == 2 && protocols[0].is_host() && matches!(protocols[1], Protocol::Tcp(_))
+    matches!(protocols, [host, Protocol::Tcp(_)] if host.is_host())
 }
 
 /// Returns which transport can dial a protocol slice, if any.
@@ -268,7 +275,9 @@ fn parse_multiaddr(input: &str) -> Result<Multiaddr, MultiaddrError> {
     let mut idx = 1usize;
 
     while idx < segments.len() {
-        let protocol = segments[idx];
+        let Some(protocol) = segments.get(idx).copied() else {
+            break;
+        };
         if protocol.is_empty() {
             return Err(MultiaddrError::EmptyProtocol);
         }
@@ -284,12 +293,14 @@ fn parse_multiaddr(input: &str) -> Result<Multiaddr, MultiaddrError> {
             }
             "ip6" => {
                 let value = require_value(&segments, idx, "ip6")?;
-                let parsed = value
-                    .parse::<Ipv6Addr>()
-                    .map_err(|_| MultiaddrError::InvalidIp6 {
-                        value: value.to_string(),
-                    })?
-                    .octets();
+                let parsed = match value.parse::<Ipv6Addr>() {
+                    Ok(value) => value.octets(),
+                    Err(_) => {
+                        return Err(MultiaddrError::InvalidIp6 {
+                            value: value.to_string(),
+                        });
+                    }
+                };
                 protocols.push(Protocol::Ip6(parsed));
                 idx += 2;
             }
@@ -312,11 +323,14 @@ fn parse_multiaddr(input: &str) -> Result<Multiaddr, MultiaddrError> {
             }
             "tcp" | "udp" => {
                 let value = require_value(&segments, idx, protocol)?;
-                let parsed = value
-                    .parse::<u16>()
-                    .map_err(|_| MultiaddrError::InvalidPort {
-                        value: value.to_string(),
-                    })?;
+                let parsed = match value.parse::<u16>() {
+                    Ok(port) => port,
+                    Err(_) => {
+                        return Err(MultiaddrError::InvalidPort {
+                            value: value.to_string(),
+                        });
+                    }
+                };
                 protocols.push(if protocol == "tcp" {
                     Protocol::Tcp(parsed)
                 } else {
@@ -574,7 +588,7 @@ mod tests {
         }
 
         // Port 0 is a legal bind wildcard, so it must parse.
-        assert!(Multiaddr::from_str("/ip4/0.0.0.0/tcp/0").is_ok());
+        Multiaddr::from_str("/ip4/0.0.0.0/tcp/0").expect("port 0 must parse");
     }
 
     #[test]

--- a/crates/core/src/peer_addr.rs
+++ b/crates/core/src/peer_addr.rs
@@ -63,9 +63,9 @@ impl PeerAddr {
             .rposition(|protocol| matches!(protocol, Protocol::P2p(_)))
             .ok_or(PeerAddrError::MissingPeerId)?;
 
-        if last != protocols.len() - 1 {
+        let Some((Protocol::P2p(peer_id), transport_slice)) = protocols.split_last() else {
             return Err(PeerAddrError::NonTerminalPeerId);
-        }
+        };
 
         // Find the first /p2p component; if it differs from `last`, there are
         // multiple /p2p segments, which is not allowed.
@@ -78,18 +78,15 @@ impl PeerAddr {
             return Err(PeerAddrError::NonTerminalPeerId);
         }
 
-        let peer_id = match &protocols[last] {
-            Protocol::P2p(peer_id) => peer_id.clone(),
-            _ => return Err(PeerAddrError::MissingPeerId),
-        };
-
-        let transport_slice = &protocols[..last];
         if transport_slice.is_empty() {
             return Err(PeerAddrError::EmptyTransport);
         }
 
         let transport = Multiaddr::from_protocols(transport_slice.to_vec());
-        Ok(Self { transport, peer_id })
+        Ok(Self {
+            transport,
+            peer_id: peer_id.clone(),
+        })
     }
 
     /// Returns the transport portion (without `/p2p`).

--- a/crates/core/src/protocol.rs
+++ b/crates/core/src/protocol.rs
@@ -1,7 +1,7 @@
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use minip2p_identity::{PeerId, read_uvarint, write_uvarint};
+use minip2p_identity::{PeerId, read_uvarint_with_remainder, write_uvarint};
 
 use crate::MultiaddrError;
 use crate::multiaddr::is_valid_dns;
@@ -104,46 +104,36 @@ impl Protocol {
 
     /// Reads a single protocol component from the front of `bytes`.
     ///
-    /// Returns the decoded protocol plus the number of bytes consumed.
-    pub(crate) fn read_binary(bytes: &[u8]) -> Result<(Self, usize), MultiaddrError> {
-        let (code, mut consumed) = read_uvarint(bytes)?;
-        let rest = bytes
-            .get(consumed..)
-            .ok_or(MultiaddrError::TruncatedBinaryValue {
-                protocol: "protocol code",
-            })?;
+    /// Returns the decoded protocol and the unconsumed input.
+    pub(crate) fn read_binary(bytes: &[u8]) -> Result<(Self, &[u8]), MultiaddrError> {
+        let (code, rest) = read_uvarint_with_remainder(bytes)?;
 
         match code {
             IP4_CODE => {
-                let value = fixed::<4>(rest, "ip4")?;
-                consumed += 4;
-                Ok((Self::Ip4(value), consumed))
+                let (value, rest) = fixed::<4>(rest, "ip4")?;
+                Ok((Self::Ip4(value), rest))
             }
             IP6_CODE => {
-                let value = fixed::<16>(rest, "ip6")?;
-                consumed += 16;
-                Ok((Self::Ip6(value), consumed))
+                let (value, rest) = fixed::<16>(rest, "ip6")?;
+                Ok((Self::Ip6(value), rest))
             }
             TCP_CODE => {
-                let value = fixed::<2>(rest, "tcp")?;
-                consumed += 2;
-                Ok((Self::Tcp(u16::from_be_bytes(value)), consumed))
+                let (value, rest) = fixed::<2>(rest, "tcp")?;
+                Ok((Self::Tcp(u16::from_be_bytes(value)), rest))
             }
             UDP_CODE => {
-                let value = fixed::<2>(rest, "udp")?;
-                consumed += 2;
-                Ok((Self::Udp(u16::from_be_bytes(value)), consumed))
+                let (value, rest) = fixed::<2>(rest, "udp")?;
+                Ok((Self::Udp(u16::from_be_bytes(value)), rest))
             }
-            QUIC_V1_CODE => Ok((Self::QuicV1, consumed)),
-            P2P_CIRCUIT_CODE => Ok((Self::P2pCircuit, consumed)),
+            QUIC_V1_CODE => Ok((Self::QuicV1, rest)),
+            P2P_CIRCUIT_CODE => Ok((Self::P2pCircuit, rest)),
             DNS_CODE | DNS4_CODE | DNS6_CODE => {
                 let label = match code {
                     DNS_CODE => "dns",
                     DNS4_CODE => "dns4",
                     _ => "dns6",
                 };
-                let (body, used) = length_prefixed(rest, label)?;
-                consumed += used;
+                let (body, rest) = length_prefixed(rest, label)?;
                 let name = core::str::from_utf8(body)
                     .map_err(|e| MultiaddrError::InvalidBinaryValue {
                         protocol: label,
@@ -166,17 +156,16 @@ impl Protocol {
                     DNS4_CODE => Self::Dns4(name),
                     _ => Self::Dns6(name),
                 };
-                Ok((protocol, consumed))
+                Ok((protocol, rest))
             }
             P2P_CODE => {
-                let (body, used) = length_prefixed(rest, "p2p")?;
-                consumed += used;
+                let (body, rest) = length_prefixed(rest, "p2p")?;
                 let peer_id =
                     PeerId::from_bytes(body).map_err(|e| MultiaddrError::InvalidBinaryValue {
                         protocol: "p2p",
                         reason: e.to_string(),
                     })?;
-                Ok((Self::P2p(peer_id), consumed))
+                Ok((Self::P2p(peer_id), rest))
             }
             _ => Err(MultiaddrError::UnknownProtocolCode { code }),
         }
@@ -184,36 +173,28 @@ impl Protocol {
 }
 
 /// Reads `N` bytes from the front of `bytes` as a fixed-size value.
-fn fixed<const N: usize>(bytes: &[u8], protocol: &'static str) -> Result<[u8; N], MultiaddrError> {
-    let value = bytes
-        .get(..N)
+fn fixed<'a, const N: usize>(
+    bytes: &'a [u8],
+    protocol: &'static str,
+) -> Result<([u8; N], &'a [u8]), MultiaddrError> {
+    let (value, rest) = bytes
+        .split_first_chunk::<N>()
         .ok_or(MultiaddrError::TruncatedBinaryValue { protocol })?;
-    let mut out = [0u8; N];
-    out.copy_from_slice(value);
-    Ok(out)
+    Ok((*value, rest))
 }
 
 /// Reads a varint length prefix and returns a slice of that many bytes
-/// plus the total number of bytes consumed (prefix + body).
+/// and the input following the body.
 fn length_prefixed<'a>(
     bytes: &'a [u8],
     protocol: &'static str,
-) -> Result<(&'a [u8], usize), MultiaddrError> {
-    let (len, consumed) = read_uvarint(bytes)?;
-    let rest = bytes
-        .get(consumed..)
-        .ok_or(MultiaddrError::TruncatedBinaryValue { protocol })?;
+) -> Result<(&'a [u8], &'a [u8]), MultiaddrError> {
+    let (len, rest) = read_uvarint_with_remainder(bytes)?;
     // Compare in u64 so an absurd declared length errs identically on
     // 32-bit and 64-bit targets.
     if len > rest.len() as u64 {
         return Err(MultiaddrError::TruncatedBinaryValue { protocol });
     }
     let len = len as usize;
-    let body = rest
-        .get(..len)
-        .ok_or(MultiaddrError::TruncatedBinaryValue { protocol })?;
-    let total = consumed
-        .checked_add(len)
-        .ok_or(MultiaddrError::TruncatedBinaryValue { protocol })?;
-    Ok((body, total))
+    Ok(rest.split_at(len))
 }

--- a/crates/core/src/protocol.rs
+++ b/crates/core/src/protocol.rs
@@ -107,7 +107,11 @@ impl Protocol {
     /// Returns the decoded protocol plus the number of bytes consumed.
     pub(crate) fn read_binary(bytes: &[u8]) -> Result<(Self, usize), MultiaddrError> {
         let (code, mut consumed) = read_uvarint(bytes)?;
-        let rest = &bytes[consumed..];
+        let rest = bytes
+            .get(consumed..)
+            .ok_or(MultiaddrError::TruncatedBinaryValue {
+                protocol: "protocol code",
+            })?;
 
         match code {
             IP4_CODE => {
@@ -181,11 +185,11 @@ impl Protocol {
 
 /// Reads `N` bytes from the front of `bytes` as a fixed-size value.
 fn fixed<const N: usize>(bytes: &[u8], protocol: &'static str) -> Result<[u8; N], MultiaddrError> {
-    if bytes.len() < N {
-        return Err(MultiaddrError::TruncatedBinaryValue { protocol });
-    }
+    let value = bytes
+        .get(..N)
+        .ok_or(MultiaddrError::TruncatedBinaryValue { protocol })?;
     let mut out = [0u8; N];
-    out.copy_from_slice(&bytes[..N]);
+    out.copy_from_slice(value);
     Ok(out)
 }
 
@@ -196,12 +200,20 @@ fn length_prefixed<'a>(
     protocol: &'static str,
 ) -> Result<(&'a [u8], usize), MultiaddrError> {
     let (len, consumed) = read_uvarint(bytes)?;
-    let available = bytes.len() - consumed;
+    let rest = bytes
+        .get(consumed..)
+        .ok_or(MultiaddrError::TruncatedBinaryValue { protocol })?;
     // Compare in u64 so an absurd declared length errs identically on
     // 32-bit and 64-bit targets.
-    if len > available as u64 {
+    if len > rest.len() as u64 {
         return Err(MultiaddrError::TruncatedBinaryValue { protocol });
     }
     let len = len as usize;
-    Ok((&bytes[consumed..consumed + len], consumed + len))
+    let body = rest
+        .get(..len)
+        .ok_or(MultiaddrError::TruncatedBinaryValue { protocol })?;
+    let total = consumed
+        .checked_add(len)
+        .ok_or(MultiaddrError::TruncatedBinaryValue { protocol })?;
+    Ok((body, total))
 }

--- a/crates/dcutr/src/lib.rs
+++ b/crates/dcutr/src/lib.rs
@@ -1042,7 +1042,8 @@ mod tests {
         // prefix) and rejects anything beyond it. It runs only on stalled
         // (incomplete) buffers, where `decode_frame`'s own bounds make it
         // unreachable from wire input -- a pure defense-in-depth check.
-        assert!(enforce_max_size(&vec![0u8; MAX_MESSAGE_SIZE + MAX_FRAME_PREFIX_LEN]).is_ok());
+        enforce_max_size(&vec![0u8; MAX_MESSAGE_SIZE + MAX_FRAME_PREFIX_LEN])
+            .expect("the maximum legal partial frame must be accepted");
         assert!(matches!(
             enforce_max_size(&vec![0u8; MAX_MESSAGE_SIZE + MAX_FRAME_PREFIX_LEN + 1]),
             Err(DcutrError::MessageTooLarge { .. })

--- a/crates/dcutr/src/message.rs
+++ b/crates/dcutr/src/message.rs
@@ -116,16 +116,18 @@ impl HolePunch {
             // Read the field tag as a full u64. Field numbers >= 16 encode as
             // multi-byte varints; truncating to u8 would let a remote peer
             // alias known tags (e.g. field 33 + LEN => 266, `266 as u8 = 0x0A`).
-            let (tag_value, used) = read_uvarint(&input[idx..])?;
-            idx += used;
+            let (tag_value, used) =
+                read_uvarint(input.get(idx..).ok_or(VarintError::BufferTooShort)?)?;
+            advance(input, &mut idx, used)?;
 
             let wire_type = (tag_value & 0x07) as u8;
             let field_number = tag_value >> 3;
 
             match (field_number, wire_type) {
                 (FIELD_TYPE, WIRE_VARINT) => {
-                    let (value, used) = read_uvarint(&input[idx..])?;
-                    idx += used;
+                    let (value, used) =
+                        read_uvarint(input.get(idx..).ok_or(VarintError::BufferTooShort)?)?;
+                    advance(input, &mut idx, used)?;
                     kind = Some(
                         HolePunchType::from_u64(value)
                             .ok_or(DcutrMessageError::InvalidType { value })?,
@@ -137,31 +139,42 @@ impl HolePunch {
                 }
                 // Skip unknown fields based on their wire type.
                 (_, WIRE_VARINT) => {
-                    let (_, used) = read_uvarint(&input[idx..])?;
-                    idx += used;
+                    let (_, used) =
+                        read_uvarint(input.get(idx..).ok_or(VarintError::BufferTooShort)?)?;
+                    advance(input, &mut idx, used)?;
                 }
                 (_, WIRE_LEN) => {
                     let _ = read_len_delimited(input, &mut idx)?;
                 }
                 (_, 1 /* I64 */) => {
-                    if idx + 8 > input.len() {
+                    let end = idx.checked_add(8).ok_or(DcutrMessageError::FieldOverflow {
+                        offset: idx,
+                        length: 8,
+                        remaining: input.len().saturating_sub(idx),
+                    })?;
+                    if end > input.len() {
                         return Err(DcutrMessageError::FieldOverflow {
                             offset: idx,
                             length: 8,
                             remaining: input.len().saturating_sub(idx),
                         });
                     }
-                    idx += 8;
+                    idx = end;
                 }
                 (_, 5 /* I32 */) => {
-                    if idx + 4 > input.len() {
+                    let end = idx.checked_add(4).ok_or(DcutrMessageError::FieldOverflow {
+                        offset: idx,
+                        length: 4,
+                        remaining: input.len().saturating_sub(idx),
+                    })?;
+                    if end > input.len() {
                         return Err(DcutrMessageError::FieldOverflow {
                             offset: idx,
                             length: 4,
                             remaining: input.len().saturating_sub(idx),
                         });
                     }
-                    idx += 4;
+                    idx = end;
                 }
                 (_, other) => {
                     return Err(DcutrMessageError::UnsupportedWireType {
@@ -182,10 +195,15 @@ impl HolePunch {
 /// Reads a length-delimited value, performing a checked `u64 -> usize`
 /// conversion to guard against truncation on 32-bit targets.
 fn read_len_delimited<'a>(input: &'a [u8], idx: &mut usize) -> Result<&'a [u8], DcutrMessageError> {
-    let (length_u64, len_used) = read_uvarint(&input[*idx..])?;
-    *idx += len_used;
+    let (length_u64, len_used) =
+        read_uvarint(input.get(*idx..).ok_or(VarintError::BufferTooShort)?)?;
+    advance(input, idx, len_used)?;
 
     let remaining = input.len().saturating_sub(*idx);
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "the compact field-overflow error reports the unrepresentable length"
+    )]
     let length = usize::try_from(length_u64).map_err(|_| DcutrMessageError::FieldOverflow {
         offset: *idx,
         length: usize::MAX,
@@ -200,9 +218,37 @@ fn read_len_delimited<'a>(input: &'a [u8], idx: &mut usize) -> Result<&'a [u8], 
         });
     }
 
-    let value = &input[*idx..*idx + length];
-    *idx += length;
+    let end = idx
+        .checked_add(length)
+        .ok_or(DcutrMessageError::FieldOverflow {
+            offset: *idx,
+            length,
+            remaining,
+        })?;
+    let value = input
+        .get(*idx..end)
+        .ok_or(DcutrMessageError::FieldOverflow {
+            offset: *idx,
+            length,
+            remaining,
+        })?;
+    *idx = end;
     Ok(value)
+}
+
+/// Advances a protobuf cursor without allowing it to leave the input slice.
+fn advance(input: &[u8], idx: &mut usize, length: usize) -> Result<(), DcutrMessageError> {
+    let remaining = input.len().saturating_sub(*idx);
+    let end = idx
+        .checked_add(length)
+        .filter(|end| *end <= input.len())
+        .ok_or(DcutrMessageError::FieldOverflow {
+            offset: *idx,
+            length,
+            remaining,
+        })?;
+    *idx = end;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/discovery/src/beacon.rs
+++ b/crates/discovery/src/beacon.rs
@@ -155,11 +155,11 @@ impl BeaconAgent {
 
 pub(crate) fn normalize_addr(peer: &PeerId, addr: Multiaddr) -> Option<Multiaddr> {
     let protocols = addr.protocols();
-    let addr = match protocols.last() {
-        Some(Protocol::P2p(suffix)) if suffix == peer => {
-            Multiaddr::from_protocols(protocols[..protocols.len() - 1].to_vec())
+    let addr = match protocols.split_last() {
+        Some((Protocol::P2p(suffix), prefix)) if suffix == peer => {
+            Multiaddr::from_protocols(prefix.to_vec())
         }
-        Some(Protocol::P2p(_)) => return None,
+        Some((Protocol::P2p(_), _)) => return None,
         _ => addr,
     };
     is_supported_addr(&addr).then_some(addr)

--- a/crates/discovery/src/message.rs
+++ b/crates/discovery/src/message.rs
@@ -177,6 +177,10 @@ fn read_varint(input: &[u8], idx: &mut usize) -> Result<u64, DiscoveryWireError>
 }
 
 fn read_len<'a>(input: &'a [u8], idx: &mut usize) -> Result<&'a [u8], DiscoveryWireError> {
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "wire lengths wider than usize use the compact truncated-input error"
+    )]
     let len: usize = read_varint(input, idx)?
         .try_into()
         .map_err(|_| DiscoveryWireError::Truncated)?;
@@ -256,7 +260,7 @@ mod tests {
             addrs: vec![],
         }
         .encode();
-        assert!(Beacon::decode(&key).is_ok());
+        Beacon::decode(&key).expect("a beacon at the public-key size limit must decode");
         let addr = Beacon {
             public_key: vec![],
             addrs: vec![vec![0; MAX_ADDR_LEN + 1]],

--- a/crates/ffi-core/src/driver.rs
+++ b/crates/ffi-core/src/driver.rs
@@ -344,7 +344,10 @@ pub(crate) fn terminal_connect_id(event: &P2pEvent) -> Option<u64> {
 }
 
 fn ring(doorbell: &Arc<dyn EventDoorbell>) {
-    let _ = catch_unwind(AssertUnwindSafe(|| doorbell.on_events_ready()));
+    // Foreign callbacks are advisory; an unwind must not stop event delivery.
+    drop(catch_unwind(AssertUnwindSafe(|| {
+        doorbell.on_events_ready()
+    })));
 }
 
 fn failure_kind(error: &Error) -> DriverFailureKind {

--- a/crates/ffi-core/src/endpoint.rs
+++ b/crates/ffi-core/src/endpoint.rs
@@ -69,7 +69,13 @@ fn configure_transports(
                 builder = match parsed.as_slice() {
                     [address] => builder.quic_multiaddr(address),
                     [first, second] => builder.quic_dual_multiaddr(first, second),
-                    _ => unreachable!("validation permits at most one address per IP family"),
+                    _ => {
+                        return Err(FfiError::InvalidConfig {
+                            detail:
+                                "QUIC listen address validation produced an unsupported address set"
+                                    .into(),
+                        });
+                    }
                 };
             }
         }
@@ -1010,7 +1016,10 @@ mod tests {
 
     impl Drop for DropThreadDoorbell {
         fn drop(&mut self) {
-            let _ = self.0.send(std::thread::current().id());
+            // The receiver may already be gone while the test tears down.
+            match self.0.send(std::thread::current().id()) {
+                Ok(()) | Err(_) => {}
+            }
         }
     }
 
@@ -1217,11 +1226,12 @@ mod tests {
     fn poisoned_endpoint_lock_recovers() {
         let endpoint = endpoint(config()).expect("endpoint");
         let endpoint_for_panic = Arc::clone(&endpoint);
-        let _ = std::thread::spawn(move || {
+        let result = std::thread::spawn(move || {
             let _guard = endpoint_for_panic.shared.state.lock().expect("lock");
             panic!("poison endpoint lock");
         })
         .join();
+        assert!(result.is_err(), "the lock-poisoning worker must panic");
 
         assert!(endpoint.shared.lock_state().endpoint.is_some());
     }
@@ -1567,17 +1577,17 @@ mod tests {
         for worker in 0..4 {
             let endpoint = Arc::clone(&endpoint);
             workers.push(std::thread::spawn(move || {
-                for index in 0..250 {
+                for index in 0_u8..250 {
                     match worker {
                         0 => {
-                            let _ = endpoint.connected_peers();
+                            drop(endpoint.connected_peers());
                         }
                         1 => endpoint.set_active(index % 2 == 0),
                         2 => {
-                            let _ = endpoint.publish("room".into(), vec![index as u8]);
+                            drop(endpoint.publish("room".into(), vec![index]));
                         }
                         _ => {
-                            let _ = endpoint.cancel_connect(u64::MAX);
+                            drop(endpoint.cancel_connect(u64::MAX));
                         }
                     }
                 }

--- a/crates/ffi-core/src/events.rs
+++ b/crates/ffi-core/src/events.rs
@@ -117,7 +117,6 @@ pub enum DriverFailureKind {
 
 /// Event delivered by the native endpoint driver.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[allow(clippy::large_enum_variant)]
 pub enum P2pEvent {
     /// Native event carry overflow discarded source events.
     EventsDropped {

--- a/crates/ffi/src/events.rs
+++ b/crates/ffi/src/events.rs
@@ -132,7 +132,10 @@ pub enum DriverFailureKind {
 
 /// Event delivered by the native endpoint driver.
 #[uniffi::remote(Enum)]
-#[allow(clippy::large_enum_variant)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "UniFFI exports complete event payloads by value to foreign callers."
+)]
 pub enum P2pEvent {
     /// Native event carry overflow discarded source events.
     EventsDropped {

--- a/crates/ffi/tests/go_interop.rs
+++ b/crates/ffi/tests/go_interop.rs
@@ -23,6 +23,10 @@ struct GoPeer {
 }
 
 impl GoPeer {
+    #[expect(
+        clippy::panic,
+        reason = "Malformed output from the independent Go fixture is a test-harness failure."
+    )]
     fn spawn() -> Self {
         let project = format!(
             "{}/../../tests/interop/go-libp2p",
@@ -62,22 +66,31 @@ impl GoPeer {
         self.stdin.flush().expect("flush go peer command");
     }
 
+    #[expect(
+        clippy::panic,
+        reason = "A missing response from the independent Go fixture must fail the ignored test clearly."
+    )]
     fn event(&self, expected: &str) -> Value {
         let event = self
             .events
             .recv_timeout(TIMEOUT)
             .unwrap_or_else(|error| panic!("waiting for go `{expected}` event: {error}"));
-        assert_ne!(event["event"], "error", "go peer failed: {event}");
-        assert_eq!(event["event"], expected, "unexpected go peer event");
+        let event_name = required_string(&event, "event");
+        assert_ne!(event_name, "error", "go peer failed: {event}");
+        assert_eq!(event_name, expected, "unexpected go peer event");
         event
     }
 }
 
 impl Drop for GoPeer {
     fn drop(&mut self) {
-        let _ = serde_json::to_writer(&mut self.stdin, &json!({ "op": "stop" }));
-        let _ = self.stdin.write_all(b"\n");
-        let _ = self.stdin.flush();
+        // The child may have already exited; shutdown is best-effort in Drop.
+        drop(serde_json::to_writer(
+            &mut self.stdin,
+            &json!({ "op": "stop" }),
+        ));
+        drop(self.stdin.write_all(b"\n"));
+        drop(self.stdin.flush());
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
             match self.child.try_wait() {
@@ -86,13 +99,24 @@ impl Drop for GoPeer {
                     std::thread::sleep(Duration::from_millis(10));
                 }
                 Ok(None) | Err(_) => {
-                    let _ = self.child.kill();
-                    let _ = self.child.wait();
+                    drop(self.child.kill());
+                    drop(self.child.wait());
                     return;
                 }
             }
         }
     }
+}
+
+#[expect(
+    clippy::panic,
+    reason = "A malformed event from the independent Go fixture must fail the ignored test clearly."
+)]
+fn required_string<'a>(event: &'a Value, field: &str) -> &'a str {
+    event
+        .get(field)
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("go event has no string `{field}` field: {event}"))
 }
 
 struct EventLog {
@@ -174,12 +198,16 @@ fn config() -> EndpointConfig {
 /// and downloads the independently versioned go-libp2p module.
 #[test]
 #[ignore = "requires Go and the go-libp2p module"]
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "The ignored interoperability test uses assertions to preserve the foreign peer trace."
+)]
 fn tcp_noise_yamux_identify_ping_and_streams_interoperate_with_go() -> Result<(), FfiError> {
     let payload_from_go = "g".repeat(PAYLOAD_FROM_GO_BYTES);
     let mut go = GoPeer::spawn();
     let ready = go.event("ready");
-    let go_peer = ready["peer_id"].as_str().expect("go peer id").to_owned();
-    let go_addr = ready["addr"].as_str().expect("go peer address").to_owned();
+    let go_peer = required_string(&ready, "peer_id").to_owned();
+    let go_addr = required_string(&ready, "addr").to_owned();
 
     let endpoint = P2pEndpoint::new(vec![77; 32], config())?;
     let log = Arc::new(EventLog::new(Arc::clone(&endpoint)));
@@ -190,7 +218,7 @@ fn tcp_noise_yamux_identify_ping_and_streams_interoperate_with_go() -> Result<()
         matches!(event, P2pEvent::ConnectionEstablished { peer_id, .. } if peer_id == &go_peer)
     }) {
         P2pEvent::ConnectionEstablished { conn_id, .. } => conn_id,
-        _ => unreachable!("predicate pins the event variant"),
+        _ => panic!("connection predicate returned a different event"),
     };
     log.wait_for(|event| {
         matches!(event, P2pEvent::PeerReady { peer_id, protocols }
@@ -201,7 +229,7 @@ fn tcp_noise_yamux_identify_ping_and_streams_interoperate_with_go() -> Result<()
             if peer_id == &go_peer && info.protocols.iter().any(|id| id == ECHO_PROTOCOL))
     });
     let P2pEvent::IdentifyReceived { info, .. } = identify else {
-        unreachable!("predicate pins the event variant")
+        panic!("identify predicate returned a different event")
     };
     assert!(
         info.agent_version
@@ -241,7 +269,7 @@ fn tcp_noise_yamux_identify_ping_and_streams_interoperate_with_go() -> Result<()
         match event {
             P2pEvent::StreamData { data, .. } => echoed_to_minip2p.extend_from_slice(&data),
             P2pEvent::StreamRemoteWriteClosed { .. } => break,
-            _ => unreachable!("predicate pins the event variants"),
+            _ => panic!("echo predicate returned a different event"),
         }
     }
     assert_eq!(echoed_to_minip2p, PAYLOAD_FROM_MINIP2P);
@@ -257,7 +285,7 @@ fn tcp_noise_yamux_identify_ping_and_streams_interoperate_with_go() -> Result<()
             if peer_id == &go_peer && *conn_id != initial_conn)
     }) {
         P2pEvent::ConnectionEstablished { conn_id, .. } => conn_id,
-        _ => unreachable!("predicate pins the event variant"),
+        _ => panic!("reverse-connection predicate returned a different event"),
     };
     let reverse_stream = match log.wait_for(|event| {
         matches!(event, P2pEvent::StreamReady {
@@ -268,7 +296,7 @@ fn tcp_noise_yamux_identify_ping_and_streams_interoperate_with_go() -> Result<()
         } if *conn_id == reverse_conn && protocol_id == ECHO_PROTOCOL)
     }) {
         P2pEvent::StreamReady { stream_id, .. } => stream_id,
-        _ => unreachable!("predicate pins the event variant"),
+        _ => panic!("reverse-stream predicate returned a different event"),
     };
     let mut received = Vec::with_capacity(payload_from_go.len());
     loop {
@@ -294,12 +322,12 @@ fn tcp_noise_yamux_identify_ping_and_streams_interoperate_with_go() -> Result<()
                 endpoint.close_stream_write(peer_id, stream_id)?;
                 break;
             }
-            _ => unreachable!("predicate pins the event variants"),
+            _ => panic!("reverse-echo predicate returned a different event"),
         }
     }
     assert_eq!(received, payload_from_go.as_bytes());
     let echoed = go.event("echo");
-    assert_eq!(echoed["payload"], payload_from_go);
+    assert_eq!(required_string(&echoed, "payload"), payload_from_go);
 
     endpoint.stop();
     assert!(endpoint.wait_stopped(5_000), "minip2p driver stopped");

--- a/crates/ffi/tests/loopback.rs
+++ b/crates/ffi/tests/loopback.rs
@@ -182,6 +182,10 @@ impl P2pEventDoorbell for SlowDoorbell {
 }
 
 impl P2pEventDoorbell for PanicOnceDoorbell {
+    #[expect(
+        clippy::panic,
+        reason = "This test-only callback deliberately verifies panic isolation."
+    )]
     fn on_events_ready(&self) {
         if self
             .log
@@ -240,6 +244,10 @@ fn stop(endpoint: &P2pEndpoint) {
 }
 
 #[test]
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "The loopback integration test uses assertions to retain failure context."
+)]
 fn a_tcp_listen_address_binds_tcp_and_is_dialed_over_it() -> Result<(), FfiError> {
     let _serial = LOOPBACK_TEST_LOCK
         .lock()
@@ -248,10 +256,8 @@ fn a_tcp_listen_address_binds_tcp_and_is_dialed_over_it() -> Result<(), FfiError
     // `/tcp` peers to dial while binding only QUIC would leave a device that
     // has only TCP able to call out and never be called -- and the address it
     // reported would name a socket it does not have.
-    let a = P2pEndpoint::new(vec![31; 32], config_on("/ip4/127.0.0.1/tcp/0"))
-        .expect("construct a TCP endpoint");
-    let b = P2pEndpoint::new(vec![32; 32], config_on("/ip4/127.0.0.1/tcp/0"))
-        .expect("construct a TCP endpoint");
+    let a = P2pEndpoint::new(vec![31; 32], config_on("/ip4/127.0.0.1/tcp/0"))?;
+    let b = P2pEndpoint::new(vec![32; 32], config_on("/ip4/127.0.0.1/tcp/0"))?;
     for endpoint in [&a, &b] {
         let addrs = endpoint.listen_addrs();
         assert!(
@@ -296,6 +302,10 @@ fn a_tcp_listen_address_binds_tcp_and_is_dialed_over_it() -> Result<(), FfiError
 }
 
 #[test]
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "The loopback integration test uses assertions to retain failure context."
+)]
 fn two_endpoints_chat_over_loopback() -> Result<(), FfiError> {
     let _serial = LOOPBACK_TEST_LOCK
         .lock()
@@ -400,6 +410,10 @@ fn two_endpoints_chat_over_loopback() -> Result<(), FfiError> {
 }
 
 #[test]
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "The loopback integration test uses assertions to retain failure context."
+)]
 fn identify_ping_and_custom_streams_cross_the_ffi_boundary() -> Result<(), FfiError> {
     let _serial = LOOPBACK_TEST_LOCK
         .lock()
@@ -429,7 +443,9 @@ fn identify_ping_and_custom_streams_cross_the_ffi_boundary() -> Result<(), FfiEr
     assert!(a.is_peer_ready(b_peer.clone())?);
     let info = a
         .peer_info(b_peer.clone())?
-        .expect("ready peer has Identify info");
+        .ok_or_else(|| FfiError::Internal {
+            detail: "ready peer has no Identify info".into(),
+        })?;
     assert!(info.protocols.iter().any(|id| id == protocol));
     assert!(!info.listen_addrs.is_empty());
     assert!(
@@ -467,7 +483,9 @@ fn identify_ping_and_custom_streams_cross_the_ffi_boundary() -> Result<(), FfiEr
                 } if peer_id == &b_peer && *observed == stream_id && protocol_id == protocol
             )
         })
-        .expect("outbound stream becomes ready");
+        .ok_or_else(|| FfiError::Internal {
+            detail: "outbound stream did not become ready".into(),
+        })?;
     assert!(matches!(
         ready,
         P2pEvent::StreamReady { conn_id, .. } if conn_id == opened.conn_id
@@ -489,6 +507,10 @@ fn identify_ping_and_custom_streams_cross_the_ffi_boundary() -> Result<(), FfiEr
 }
 
 #[test]
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "The loopback integration test uses assertions to retain failure context."
+)]
 fn panicking_doorbell_does_not_kill_driver() -> Result<(), FfiError> {
     let _serial = LOOPBACK_TEST_LOCK
         .lock()
@@ -542,6 +564,10 @@ fn panicking_doorbell_does_not_kill_driver() -> Result<(), FfiError> {
 }
 
 #[test]
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "The loopback integration test uses assertions to retain failure context."
+)]
 fn query_completes_while_doorbell_callback_is_in_flight() -> Result<(), FfiError> {
     let _serial = LOOPBACK_TEST_LOCK
         .lock()
@@ -584,8 +610,12 @@ fn query_completes_while_doorbell_callback_is_in_flight() -> Result<(), FfiError
     });
     let query_completed = received.recv_timeout(Duration::from_secs(1));
     gate.release();
-    query.join().expect("query worker");
-    assert!(query_completed.expect("query blocked behind doorbell callback"));
+    query.join().map_err(|_panic| FfiError::Internal {
+        detail: "query worker panicked".into(),
+    })?;
+    assert!(query_completed.map_err(|_timeout| FfiError::Internal {
+        detail: "query blocked behind doorbell callback".into(),
+    })?);
 
     stop(&a);
     stop(&b);
@@ -593,6 +623,10 @@ fn query_completes_while_doorbell_callback_is_in_flight() -> Result<(), FfiError
 }
 
 #[test]
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "The loopback integration test uses assertions to retain failure context."
+)]
 fn bounded_load_preserves_order_and_accounting() -> Result<(), FfiError> {
     const MESSAGE_COUNT: usize = 600;
 

--- a/crates/identify/src/lib.rs
+++ b/crates/identify/src/lib.rs
@@ -492,7 +492,14 @@ fn encode_length_prefixed(payload: &[u8]) -> Vec<u8> {
 fn decode_length_prefixed(buf: &[u8]) -> Result<&[u8], message::IdentifyMessageError> {
     let (len, consumed) =
         read_uvarint(buf).map_err(|e: VarintError| message::IdentifyMessageError::from(e))?;
-    let remaining = buf.len() - consumed;
+    let body = buf
+        .get(consumed..)
+        .ok_or(message::IdentifyMessageError::FieldOverflow {
+            offset: consumed,
+            length: len,
+            remaining: 0,
+        })?;
+    let remaining = body.len();
     // Compare in u64 so an absurd declared length errs identically on
     // 32-bit and 64-bit targets.
     if len > remaining as u64 {
@@ -502,7 +509,20 @@ fn decode_length_prefixed(buf: &[u8]) -> Result<&[u8], message::IdentifyMessageE
             remaining,
         });
     }
-    Ok(&buf[consumed..consumed + len as usize])
+    let len = len as usize;
+    let end = consumed
+        .checked_add(len)
+        .ok_or(message::IdentifyMessageError::FieldOverflow {
+            offset: consumed,
+            length: len as u64,
+            remaining,
+        })?;
+    buf.get(consumed..end)
+        .ok_or(message::IdentifyMessageError::FieldOverflow {
+            offset: consumed,
+            length: len as u64,
+            remaining,
+        })
 }
 
 #[cfg(test)]

--- a/crates/identify/src/message.rs
+++ b/crates/identify/src/message.rs
@@ -143,8 +143,22 @@ impl IdentifyMessage {
             // as multi-byte varints. Truncating to u8 here would let a remote
             // peer alias known fields via high-numbered field tags (e.g.
             // field 33 + LEN wire type = 266, cast to u8 = 0x0A = public_key).
-            let (tag_value, tag_used) = read_uvarint(&input[idx..])?;
-            idx += tag_used;
+            let remaining = input
+                .get(idx..)
+                .ok_or(IdentifyMessageError::FieldOverflow {
+                    offset: idx,
+                    length: 0,
+                    remaining: 0,
+                })?;
+            let (tag_value, tag_used) = read_uvarint(remaining)?;
+            idx = idx
+                .checked_add(tag_used)
+                .filter(|end| *end <= input.len())
+                .ok_or(IdentifyMessageError::FieldOverflow {
+                    offset: idx,
+                    length: tag_used as u64,
+                    remaining: input.len().saturating_sub(idx),
+                })?;
 
             let wire_type = (tag_value & 0x07) as u8;
             let field_number = tag_value >> 3;
@@ -161,6 +175,10 @@ impl IdentifyMessage {
                             msg.listen_addrs.push(value.to_vec());
                         }
                         FIELD_PROTOCOLS => {
+                            #[expect(
+                                clippy::map_err_ignore,
+                                reason = "The public error identifies the malformed protobuf field without exposing UTF-8 internals."
+                            )]
                             let s = core::str::from_utf8(value)
                                 .map_err(|_| IdentifyMessageError::InvalidUtf8 { field_number })?;
                             msg.protocols.push(String::from(s));
@@ -169,11 +187,19 @@ impl IdentifyMessage {
                             msg.observed_addr = Some(value.to_vec());
                         }
                         FIELD_PROTOCOL_VERSION => {
+                            #[expect(
+                                clippy::map_err_ignore,
+                                reason = "The public error identifies the malformed protobuf field without exposing UTF-8 internals."
+                            )]
                             let s = core::str::from_utf8(value)
                                 .map_err(|_| IdentifyMessageError::InvalidUtf8 { field_number })?;
                             msg.protocol_version = Some(String::from(s));
                         }
                         FIELD_AGENT_VERSION => {
+                            #[expect(
+                                clippy::map_err_ignore,
+                                reason = "The public error identifies the malformed protobuf field without exposing UTF-8 internals."
+                            )]
                             let s = core::str::from_utf8(value)
                                 .map_err(|_| IdentifyMessageError::InvalidUtf8 { field_number })?;
                             msg.agent_version = Some(String::from(s));
@@ -185,28 +211,29 @@ impl IdentifyMessage {
                 }
                 WIRE_VARINT => {
                     // Skip unknown varint values.
-                    let (_, used) = read_uvarint(&input[idx..])?;
-                    idx += used;
+                    let remaining =
+                        input
+                            .get(idx..)
+                            .ok_or(IdentifyMessageError::FieldOverflow {
+                                offset: idx,
+                                length: 0,
+                                remaining: 0,
+                            })?;
+                    let (_, used) = read_uvarint(remaining)?;
+                    idx = idx
+                        .checked_add(used)
+                        .filter(|end| *end <= input.len())
+                        .ok_or(IdentifyMessageError::FieldOverflow {
+                            offset: idx,
+                            length: used as u64,
+                            remaining: input.len().saturating_sub(idx),
+                        })?;
                 }
                 WIRE_I32 => {
-                    if idx + 4 > input.len() {
-                        return Err(IdentifyMessageError::FieldOverflow {
-                            offset: idx,
-                            length: 4,
-                            remaining: input.len().saturating_sub(idx),
-                        });
-                    }
-                    idx += 4;
+                    idx = checked_advance(input, idx, 4)?;
                 }
                 WIRE_I64 => {
-                    if idx + 8 > input.len() {
-                        return Err(IdentifyMessageError::FieldOverflow {
-                            offset: idx,
-                            length: 8,
-                            remaining: input.len().saturating_sub(idx),
-                        });
-                    }
-                    idx += 8;
+                    idx = checked_advance(input, idx, 8)?;
                 }
                 other => {
                     // Wire types 3 and 4 (deprecated start/end group) and 6,
@@ -238,10 +265,21 @@ fn read_len_delimited<'a>(
     input: &'a [u8],
     idx: &mut usize,
 ) -> Result<&'a [u8], IdentifyMessageError> {
-    let (length_u64, len_used) = read_uvarint(&input[*idx..])?;
-    *idx += len_used;
+    let remaining_input = input
+        .get(*idx..)
+        .ok_or(IdentifyMessageError::FieldOverflow {
+            offset: *idx,
+            length: 0,
+            remaining: 0,
+        })?;
+    let (length_u64, len_used) = read_uvarint(remaining_input)?;
+    *idx = checked_advance(input, *idx, len_used)?;
 
     let remaining = input.len().saturating_sub(*idx);
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "FieldOverflow records the declared wire length, which is the useful cross-platform detail."
+    )]
     let length = usize::try_from(length_u64).map_err(|_| IdentifyMessageError::FieldOverflow {
         offset: *idx,
         length: length_u64,
@@ -256,9 +294,31 @@ fn read_len_delimited<'a>(
         });
     }
 
-    let value = &input[*idx..*idx + length];
-    *idx += length;
+    let end = checked_advance(input, *idx, length)?;
+    let value = input
+        .get(*idx..end)
+        .ok_or(IdentifyMessageError::FieldOverflow {
+            offset: *idx,
+            length: length_u64,
+            remaining,
+        })?;
+    *idx = end;
     Ok(value)
+}
+
+fn checked_advance(
+    input: &[u8],
+    offset: usize,
+    length: usize,
+) -> Result<usize, IdentifyMessageError> {
+    offset
+        .checked_add(length)
+        .filter(|end| *end <= input.len())
+        .ok_or(IdentifyMessageError::FieldOverflow {
+            offset,
+            length: length as u64,
+            remaining: input.len().saturating_sub(offset),
+        })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/identity/src/key.rs
+++ b/crates/identity/src/key.rs
@@ -90,7 +90,11 @@ impl PublicKey {
         }
 
         idx += 1;
-        let (key_type_raw, used) = read_uvarint(&input[idx..]).map_err(PublicKeyError::Varint)?;
+        let remaining = input.get(idx..).ok_or(PublicKeyError::InvalidLength {
+            expected_total: idx,
+            actual_total: input.len(),
+        })?;
+        let (key_type_raw, used) = read_uvarint(remaining).map_err(PublicKeyError::Varint)?;
         idx += used;
         let key_type = KeyType::try_from(key_type_raw)?;
 
@@ -102,23 +106,36 @@ impl PublicKey {
         }
 
         idx += 1;
-        let (data_len, used) = read_uvarint(&input[idx..]).map_err(PublicKeyError::Varint)?;
+        let remaining = input.get(idx..).ok_or(PublicKeyError::InvalidLength {
+            expected_total: idx,
+            actual_total: input.len(),
+        })?;
+        let (data_len, used) = read_uvarint(remaining).map_err(PublicKeyError::Varint)?;
         idx += used;
 
-        let data_len: usize = data_len
-            .try_into()
-            .map_err(|_| PublicKeyError::LengthOverflow)?;
+        let data_len: usize = match data_len.try_into() {
+            Ok(data_len) => data_len,
+            Err(_) => return Err(PublicKeyError::LengthOverflow),
+        };
+        let expected_total = idx
+            .checked_add(data_len)
+            .ok_or(PublicKeyError::LengthOverflow)?;
 
-        if idx + data_len != input.len() {
+        if expected_total != input.len() {
             return Err(PublicKeyError::InvalidLength {
-                expected_total: idx + data_len,
+                expected_total,
                 actual_total: input.len(),
             });
         }
 
+        let data = input.get(idx..).ok_or(PublicKeyError::InvalidLength {
+            expected_total,
+            actual_total: input.len(),
+        })?;
+
         Ok(Self {
             key_type,
-            data: input[idx..].to_vec(),
+            data: data.to_vec(),
         })
     }
 
@@ -129,19 +146,26 @@ impl PublicKey {
     pub fn verify(&self, message: &[u8], signature: &[u8; 64]) -> Result<(), VerifyError> {
         match self.key_type {
             KeyType::Ed25519 => {
-                let public_key_bytes: [u8; 32] = self.data.as_slice().try_into().map_err(|_| {
-                    VerifyError::InvalidEd25519PublicKeyLength {
-                        actual: self.data.len(),
+                let public_key_bytes: &[u8; 32] = match self.data.as_slice().try_into() {
+                    Ok(bytes) => bytes,
+                    Err(_) => {
+                        return Err(VerifyError::InvalidEd25519PublicKeyLength {
+                            actual: self.data.len(),
+                        });
                     }
-                })?;
-                let verifying_key = VerifyingKey::from_bytes(&public_key_bytes)
-                    .map_err(|_| VerifyError::InvalidEd25519PublicKey)?;
+                };
+                let verifying_key = match VerifyingKey::from_bytes(public_key_bytes) {
+                    Ok(key) => key,
+                    Err(_) => return Err(VerifyError::InvalidEd25519PublicKey),
+                };
 
                 let signature = Signature::from_bytes(signature);
 
-                verifying_key
-                    .verify_strict(message, &signature)
-                    .map_err(|_| VerifyError::InvalidSignature)
+                if verifying_key.verify_strict(message, &signature).is_err() {
+                    Err(VerifyError::InvalidSignature)
+                } else {
+                    Ok(())
+                }
             }
             other => Err(VerifyError::UnsupportedKeyType(other)),
         }

--- a/crates/identity/src/lib.rs
+++ b/crates/identity/src/lib.rs
@@ -22,7 +22,7 @@ pub use key::VerifyError;
 pub use key::{KeyType, PublicKey, PublicKeyError};
 pub use peer_id::{
     PEER_ID_MULTIHASH_SIZE, PeerId, PeerIdError, PeerMultihash, VarintError, read_uvarint,
-    uvarint_len, write_uvarint,
+    read_uvarint_with_remainder, uvarint_len, write_uvarint,
 };
 
 /// Helpers shared by this crate's unit tests.

--- a/crates/identity/src/peer_id.rs
+++ b/crates/identity/src/peer_id.rs
@@ -320,11 +320,12 @@ fn encode_base58(input: &[u8]) -> String {
     let leading_zeros = input.iter().take_while(|byte| **byte == 0).count();
     let mut digits = Vec::with_capacity((input.len() * 138 / 100) + 1);
 
-    #[expect(
-        clippy::indexing_slicing,
-        reason = "leading_zeros is counted from input and cannot exceed its length"
-    )]
-    for byte in input[leading_zeros..].iter().copied() {
+    for byte in input
+        .get(leading_zeros..)
+        .expect("leading zero count comes from the same input")
+        .iter()
+        .copied()
+    {
         let mut carry = byte as u32;
         for digit in &mut digits {
             let value = (*digit as u32) * 256 + carry;
@@ -351,11 +352,11 @@ fn encode_base58(input: &[u8]) -> String {
     }
 
     for digit in digits.iter().rev().copied() {
-        #[expect(
-            clippy::indexing_slicing,
-            reason = "base-58 digits are produced by modulo 58 and fit the alphabet"
-        )]
-        out.push(BASE58_ALPHABET[digit as usize] as char);
+        out.push(
+            *BASE58_ALPHABET
+                .get(digit as usize)
+                .expect("base-58 digit is produced by modulo 58") as char,
+        );
     }
 
     out
@@ -432,21 +433,21 @@ fn encode_base32_nopad_lower(input: &[u8]) -> String {
         while bits >= 5 {
             bits -= 5;
             let idx = ((buffer >> bits) & 0x1f) as usize;
-            #[expect(
-                clippy::indexing_slicing,
-                reason = "the 0x1f mask restricts base-32 indices to the 32-byte alphabet"
-            )]
-            out.push(BASE32_ALPHABET_LOWER[idx] as char);
+            out.push(
+                *BASE32_ALPHABET_LOWER
+                    .get(idx)
+                    .expect("base-32 index is masked to five bits") as char,
+            );
         }
     }
 
     if bits > 0 {
         let idx = ((buffer << (5 - bits)) & 0x1f) as usize;
-        #[expect(
-            clippy::indexing_slicing,
-            reason = "the 0x1f mask restricts base-32 indices to the 32-byte alphabet"
-        )]
-        out.push(BASE32_ALPHABET_LOWER[idx] as char);
+        out.push(
+            *BASE32_ALPHABET_LOWER
+                .get(idx)
+                .expect("base-32 index is masked to five bits") as char,
+        );
     }
 
     out

--- a/crates/identity/src/peer_id.rs
+++ b/crates/identity/src/peer_id.rs
@@ -251,10 +251,20 @@ pub fn write_uvarint(mut value: u64, out: &mut Vec<u8>) {
 
 /// Reads an unsigned varint and enforces canonical (minimal) encoding.
 pub fn read_uvarint(input: &[u8]) -> Result<(u64, usize), VarintError> {
+    let (value, remaining) = read_uvarint_with_remainder(input)?;
+    Ok((value, input.len() - remaining.len()))
+}
+
+/// Reads a canonical unsigned varint and returns the input following it.
+pub fn read_uvarint_with_remainder(input: &[u8]) -> Result<(u64, &[u8]), VarintError> {
     let mut value = 0u64;
     let mut shift = 0u32;
+    let mut bytes = input.iter();
 
-    for (idx, byte) in input.iter().copied().enumerate() {
+    for idx in 0..input.len() {
+        let Some(&byte) = bytes.next() else {
+            return Err(VarintError::BufferTooShort);
+        };
         if idx >= 10 {
             return Err(VarintError::Overflow);
         }
@@ -271,7 +281,7 @@ pub fn read_uvarint(input: &[u8]) -> Result<(u64, usize), VarintError> {
             if used != uvarint_len(value) {
                 return Err(VarintError::NonCanonical);
             }
-            return Ok((value, used));
+            return Ok((value, bytes.as_slice()));
         }
 
         shift += 7;
@@ -569,5 +579,14 @@ mod tests {
             err,
             PeerIdError::InvalidCidVersionVarint(VarintError::BufferTooShort)
         );
+    }
+
+    #[test]
+    fn reads_uvarint_with_remainder() {
+        let input = [0xac, 0x02, 0xaa, 0xbb];
+        let (value, remaining) = read_uvarint_with_remainder(&input).expect("valid varint");
+
+        assert_eq!(value, 300);
+        assert_eq!(remaining, [0xaa, 0xbb]);
     }
 }

--- a/crates/identity/src/peer_id.rs
+++ b/crates/identity/src/peer_id.rs
@@ -142,13 +142,30 @@ impl PeerId {
             return Err(PeerIdError::UnsupportedCidVersion(version));
         }
 
-        let (codec, codec_len) = read_uvarint(&cid_bytes[version_len..])
-            .map_err(PeerIdError::InvalidCidMulticodecVarint)?;
+        let codec_input =
+            cid_bytes
+                .get(version_len..)
+                .ok_or(PeerIdError::InvalidCidMulticodecVarint(
+                    VarintError::BufferTooShort,
+                ))?;
+        let (codec, codec_len) =
+            read_uvarint(codec_input).map_err(PeerIdError::InvalidCidMulticodecVarint)?;
         if codec != LIBP2P_KEY_MULTICODEC {
             return Err(PeerIdError::UnsupportedMulticodec(codec));
         }
 
-        let multihash = cid_bytes[version_len + codec_len..].to_vec();
+        let multihash_offset =
+            version_len
+                .checked_add(codec_len)
+                .ok_or(PeerIdError::InvalidCidMulticodecVarint(
+                    VarintError::Overflow,
+                ))?;
+        let multihash = cid_bytes
+            .get(multihash_offset..)
+            .ok_or(PeerIdError::InvalidCidMulticodecVarint(
+                VarintError::BufferTooShort,
+            ))?
+            .to_vec();
         Self::from_bytes(&multihash)
     }
 }
@@ -293,6 +310,10 @@ fn encode_base58(input: &[u8]) -> String {
     let leading_zeros = input.iter().take_while(|byte| **byte == 0).count();
     let mut digits = Vec::with_capacity((input.len() * 138 / 100) + 1);
 
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "leading_zeros is counted from input and cannot exceed its length"
+    )]
     for byte in input[leading_zeros..].iter().copied() {
         let mut carry = byte as u32;
         for digit in &mut digits {
@@ -320,6 +341,10 @@ fn encode_base58(input: &[u8]) -> String {
     }
 
     for digit in digits.iter().rev().copied() {
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "base-58 digits are produced by modulo 58 and fit the alphabet"
+        )]
         out.push(BASE58_ALPHABET[digit as usize] as char);
     }
 
@@ -397,12 +422,20 @@ fn encode_base32_nopad_lower(input: &[u8]) -> String {
         while bits >= 5 {
             bits -= 5;
             let idx = ((buffer >> bits) & 0x1f) as usize;
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "the 0x1f mask restricts base-32 indices to the 32-byte alphabet"
+            )]
             out.push(BASE32_ALPHABET_LOWER[idx] as char);
         }
     }
 
     if bits > 0 {
         let idx = ((buffer << (5 - bits)) & 0x1f) as usize;
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "the 0x1f mask restricts base-32 indices to the 32-byte alphabet"
+        )]
         out.push(BASE32_ALPHABET_LOWER[idx] as char);
     }
 

--- a/crates/mdns/src/agent.rs
+++ b/crates/mdns/src/agent.rs
@@ -46,8 +46,8 @@ struct DeterministicRng {
 impl DeterministicRng {
     fn new(seed: [u8; 32]) -> Self {
         let mut state = [0; 4];
-        for (index, chunk) in seed.as_chunks::<8>().0.iter().enumerate() {
-            state[index] = u64::from_le_bytes(*chunk);
+        for (slot, chunk) in state.iter_mut().zip(seed.as_chunks::<8>().0) {
+            *slot = u64::from_le_bytes(*chunk);
         }
         if state == [0; 4] {
             state = [
@@ -389,10 +389,10 @@ impl MdnsAgent {
                     continue;
                 }
                 for value in strings {
-                    if !value.starts_with(TXT_PREFIX) {
+                    let Some(value) = value.strip_prefix(TXT_PREFIX) else {
                         continue;
-                    }
-                    let Ok(text) = core::str::from_utf8(&value[TXT_PREFIX.len()..]) else {
+                    };
+                    let Ok(text) = core::str::from_utf8(value) else {
                         invalid_claim = true;
                         continue;
                     };
@@ -401,7 +401,8 @@ impl MdnsAgent {
                         continue;
                     };
                     let protocols = addr.protocols();
-                    let Some(Protocol::P2p(peer)) = protocols.last() else {
+                    let Some((Protocol::P2p(peer), transport_protocols)) = protocols.split_last()
+                    else {
                         invalid_claim = true;
                         continue;
                     };
@@ -413,8 +414,7 @@ impl MdnsAgent {
                         return;
                     }
                     claimed_peer.get_or_insert_with(|| peer.clone());
-                    let transport =
-                        Multiaddr::from_protocols(protocols[..protocols.len() - 1].to_vec());
+                    let transport = Multiaddr::from_protocols(transport_protocols.to_vec());
                     if !is_supported_transport(&transport) {
                         invalid_claim = true;
                         continue;
@@ -512,7 +512,10 @@ fn random_peer_name(rng: &mut DeterministicRng) -> String {
     let mut name = String::with_capacity(len);
     for _ in 0..len {
         let index = (rng.next_u64() % ALPHABET.len() as u64) as usize;
-        name.push(ALPHABET[index] as char);
+        let byte = ALPHABET
+            .get(index)
+            .expect("modulo keeps the alphabet index in bounds");
+        name.push(*byte as char);
     }
     name
 }
@@ -565,7 +568,10 @@ fn expand_addresses(
                         continue;
                     };
                     let mut expanded = protocols.to_vec();
-                    expanded[0] = Protocol::Ip4(ip.octets());
+                    let Some(first) = expanded.first_mut() else {
+                        continue;
+                    };
+                    *first = Protocol::Ip4(ip.octets());
                     push_unique_supported(&mut result, Multiaddr::from_protocols(expanded));
                 }
             }
@@ -577,7 +583,10 @@ fn expand_addresses(
                         continue;
                     };
                     let mut expanded = protocols.to_vec();
-                    expanded[0] = Protocol::Ip6(ip.octets());
+                    let Some(first) = expanded.first_mut() else {
+                        continue;
+                    };
+                    *first = Protocol::Ip6(ip.octets());
                     push_unique_supported(&mut result, Multiaddr::from_protocols(expanded));
                 }
             }

--- a/crates/mdns/src/dns.rs
+++ b/crates/mdns/src/dns.rs
@@ -330,13 +330,17 @@ fn decode_records(
                 let mut strings = Vec::new();
                 let mut pos = rdata_start;
                 while pos < rdata_end {
-                    let len = packet[pos] as usize;
+                    let len =
+                        usize::from(*packet.get(pos).ok_or(DnsCodecError::InvalidRecordData)?);
                     pos += 1;
                     let end = pos
                         .checked_add(len)
                         .filter(|end| *end <= rdata_end)
                         .ok_or(DnsCodecError::InvalidRecordData)?;
-                    strings.push(packet[pos..end].to_vec());
+                    let value = packet
+                        .get(pos..end)
+                        .ok_or(DnsCodecError::InvalidRecordData)?;
+                    strings.push(value.to_vec());
                     pos = end;
                 }
                 Some(DnsRecordData::Txt(strings))
@@ -384,8 +388,11 @@ fn decode_name(packet: &[u8], cursor: &mut usize) -> Result<String, DnsCodecErro
                     .checked_add(len + 1)
                     .filter(|len| *len <= 255)
                     .ok_or(DnsCodecError::NameTooLong)?;
-                let label = core::str::from_utf8(&packet[pos..end])
-                    .map_err(|_| DnsCodecError::InvalidLabel)?;
+                let label_bytes = packet.get(pos..end).ok_or(DnsCodecError::Truncated)?;
+                let label = match core::str::from_utf8(label_bytes) {
+                    Ok(label) => label,
+                    Err(_) => return Err(DnsCodecError::InvalidLabel),
+                };
                 labels.push(label.to_string());
                 pos = end;
             }
@@ -452,7 +459,9 @@ fn write_record(out: &mut Vec<u8>, record: &DnsRecord) -> Option<()> {
         }
     }
     let len = u16::try_from(out.len().checked_sub(start)?).ok()?;
-    out[len_pos..len_pos + 2].copy_from_slice(&len.to_be_bytes());
+    let len_end = len_pos.checked_add(2)?;
+    out.get_mut(len_pos..len_end)?
+        .copy_from_slice(&len.to_be_bytes());
     Some(())
 }
 
@@ -475,10 +484,7 @@ fn write_name(out: &mut Vec<u8>, name: &str) -> Option<()> {
 }
 
 fn read_u16(packet: &[u8], offset: usize) -> Result<u16, DnsCodecError> {
-    let bytes = packet
-        .get(offset..offset + 2)
-        .ok_or(DnsCodecError::Truncated)?;
-    Ok(u16::from_be_bytes([bytes[0], bytes[1]]))
+    Ok(u16::from_be_bytes(read_array(packet, offset)?))
 }
 
 fn take_u16(packet: &[u8], cursor: &mut usize) -> Result<u16, DnsCodecError> {
@@ -488,11 +494,17 @@ fn take_u16(packet: &[u8], cursor: &mut usize) -> Result<u16, DnsCodecError> {
 }
 
 fn take_u32(packet: &[u8], cursor: &mut usize) -> Result<u32, DnsCodecError> {
-    let bytes = packet
-        .get(*cursor..*cursor + 4)
-        .ok_or(DnsCodecError::Truncated)?;
+    let value = u32::from_be_bytes(read_array(packet, *cursor)?);
     *cursor += 4;
-    Ok(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    Ok(value)
+}
+
+fn read_array<const N: usize>(packet: &[u8], offset: usize) -> Result<[u8; N], DnsCodecError> {
+    let end = offset.checked_add(N).ok_or(DnsCodecError::Truncated)?;
+    packet
+        .get(offset..end)
+        .and_then(|bytes| bytes.try_into().ok())
+        .ok_or(DnsCodecError::Truncated)
 }
 
 fn write_u16(out: &mut Vec<u8>, value: u16) {

--- a/crates/mdns/src/driver.rs
+++ b/crates/mdns/src/driver.rs
@@ -325,12 +325,11 @@ impl<I: MdnsIo> MdnsDriver<I> {
             if !source_is_on_link(snapshot, datagram.from.ip()) {
                 continue;
             }
-            self.agent.handle_packet(
-                datagram.interface,
-                datagram.from,
-                &self.buffer[..datagram.len],
-                now_ms,
-            );
+            let Some(payload) = self.buffer.get(..datagram.len) else {
+                continue;
+            };
+            self.agent
+                .handle_packet(datagram.interface, datagram.from, payload, now_ms);
         }
         Ok(true)
     }
@@ -391,7 +390,10 @@ impl<I: MdnsIo> Drop for MdnsDriver<I> {
         // the last reading a caller gave, since a drop brings no clock with
         // it and a stale-but-real timestamp beats inventing one.
         let now = self.last_now_ms;
-        let _ = self.shutdown(now);
+        if let Err(error) = self.shutdown(now) {
+            // `Drop` cannot return the I/O failure after attempting a goodbye.
+            drop(error);
+        }
     }
 }
 

--- a/crates/mdns/src/smoltcp_io.rs
+++ b/crates/mdns/src/smoltcp_io.rs
@@ -179,7 +179,7 @@ impl<D: Device> SmoltcpMdnsIo<D> {
                 addr: None,
                 port: MDNS_PORT,
             }) {
-                let _ = shared.interface.leave_multicast_group(group);
+                leave_multicast_group(&mut shared, group);
                 rollback_families(&mut shared, &families);
                 return Err(MdnsError::io("binding the mDNS port", DisplayError(error)));
             }
@@ -296,7 +296,7 @@ fn rollback_families<D: Device>(
 ) {
     for family in families {
         shared.sockets.remove(family.socket);
-        let _ = shared.interface.leave_multicast_group(family.group);
+        leave_multicast_group(shared, family.group);
     }
 }
 
@@ -305,9 +305,22 @@ impl<D: Device> Drop for SmoltcpMdnsIo<D> {
         let mut shared = self.stack.borrow_mut();
         for family in &self.families {
             shared.sockets.remove(family.socket);
-            let _ = shared.interface.leave_multicast_group(family.group);
+            leave_multicast_group(&mut shared, family.group);
         }
     }
+}
+
+/// Releases a group membership while unwinding setup or tearing down sockets.
+///
+/// Those paths have no error channel. The interface itself is being released
+/// or is already unusable, so there is no recovery action beyond attempting
+/// the leave; a debug build still records an unexpected refusal.
+fn leave_multicast_group<D: Device>(
+    shared: &mut minip2p_smoltcp::SmoltcpStackState<D>,
+    group: IpAddress,
+) {
+    let left = shared.interface.leave_multicast_group(group).is_ok();
+    debug_assert!(left, "mDNS multicast group membership should be removable");
 }
 
 fn instant(millis: u64) -> Instant {
@@ -364,7 +377,9 @@ impl<D: Device> MdnsIo for SmoltcpMdnsIo<D> {
         }
         for step in 0..count {
             let index = (self.next_receive + step) % count;
-            let family = &self.families[index];
+            let Some(family) = self.families.get(index) else {
+                continue;
+            };
             let mut shared = self.stack.borrow_mut();
             let socket = shared.sockets.get_mut::<udp::Socket>(family.socket);
             let (payload, metadata) = match socket.recv() {
@@ -378,7 +393,11 @@ impl<D: Device> MdnsIo for SmoltcpMdnsIo<D> {
             // As much as fits and no more: filling the buffer is how the
             // driver recognises a datagram too big to act on.
             let len = payload.len().min(buffer.len());
-            buffer[..len].copy_from_slice(&payload[..len]);
+            let (Some(destination), Some(source)) = (buffer.get_mut(..len), payload.get(..len))
+            else {
+                continue;
+            };
+            destination.copy_from_slice(source);
             let from = endpoint_to_socket_addr(metadata.endpoint);
             // Both sockets wildcard-bind the mDNS port. smoltcp may therefore
             // deliver a packet to either socket, so the receiving socket is

--- a/crates/mdns/src/socket.rs
+++ b/crates/mdns/src/socket.rs
@@ -153,7 +153,9 @@ impl MdnsIo for MdnsSockets {
         // budget's worth of times per tick.
         for step in 0..count {
             let index = (self.next_receive_offset + step) % count;
-            let pair = &mut self.pairs[index];
+            let Some(pair) = self.pairs.get_mut(index) else {
+                continue;
+            };
             match pair.receive.recv_from(buffer) {
                 Ok((len, from)) => {
                     self.next_receive_offset = (index + 1) % count;

--- a/crates/mdns/tests/smoltcp_link.rs
+++ b/crates/mdns/tests/smoltcp_link.rs
@@ -211,7 +211,9 @@ fn carrier_with(
     );
     iface.update_ip_addrs(|addrs| {
         for address in addresses {
-            let _ = addrs.push(IpCidr::new((*address).into(), 24));
+            addrs
+                .push(IpCidr::new((*address).into(), 24))
+                .expect("test interface holds configured addresses");
         }
     });
     SmoltcpMdnsIo::new(device, iface, config).expect("the interface takes the mDNS group")
@@ -250,7 +252,9 @@ impl Node {
             Instant::from_millis(0),
         );
         iface.update_ip_addrs(|addrs| {
-            let _ = addrs.push(IpCidr::new(address.into(), 24));
+            addrs
+                .push(IpCidr::new(address.into(), 24))
+                .expect("test interface holds its configured address");
         });
         let io = SmoltcpMdnsIo::new(
             device,
@@ -289,20 +293,24 @@ impl Node {
     }
 }
 
-/// Ticks both nodes until `done`, or panics with what was seen.
-fn run_until(first: &mut Node, second: &mut Node, mut done: impl FnMut(&Node, &Node) -> bool) {
+/// Ticks both nodes until `done`, retaining observations if the deadline passes.
+fn run_until(
+    first: &mut Node,
+    second: &mut Node,
+    mut done: impl FnMut(&Node, &Node) -> bool,
+) -> Result<(), String> {
     for step in 0..MAX_STEPS {
         let now = step as u64 * STEP_MS;
         first.tick(now);
         second.tick(now);
         if done(first, second) {
-            return;
+            return Ok(());
         }
     }
-    panic!(
+    Err(format!(
         "nothing happened in {MAX_STEPS} steps:\n  {:?}\n  {:?}",
         first.events, second.events
-    );
+    ))
 }
 
 // ----------------------------------------------------------------- tests
@@ -315,7 +323,8 @@ fn two_nodes_find_each_other_over_multicast() {
 
     run_until(&mut first, &mut second, |a, b| {
         a.observed(&peer(2)).is_some() && b.observed(&peer(1)).is_some()
-    });
+    })
+    .expect("both nodes discover each other");
 
     // What each learned is what the other actually listens on -- the whole
     // point of the exchange, and the part no fake could have got right by
@@ -339,7 +348,8 @@ fn a_node_that_leaves_says_so_on_the_wire() {
     let mut second = Node::new(&bus, Ipv4Address::new(192, 168, 1, 2), 2);
     run_until(&mut first, &mut second, |a, _| {
         a.observed(&peer(2)).is_some()
-    });
+    })
+    .expect("first node observes the second");
 
     // A goodbye is a claim with a zero TTL, and it has to reach the peer: an
     // unsent one costs it a full TTL of pointing at a host that has gone.
@@ -695,7 +705,9 @@ fn an_address_that_arrives_later_reaches_the_agent() {
 
     // The lease lands. Nothing tells mDNS about it but the next refresh.
     io.stack().borrow_mut().interface.update_ip_addrs(|addrs| {
-        let _ = addrs.push(IpCidr::new(Ipv4Address::new(192, 168, 1, 5).into(), 24));
+        addrs
+            .push(IpCidr::new(Ipv4Address::new(192, 168, 1, 5).into(), 24))
+            .expect("test interface holds the DHCP address");
     });
     assert!(
         io.refresh().expect("refresh"),

--- a/crates/minip2p/src/portable/mod.rs
+++ b/crates/minip2p/src/portable/mod.rs
@@ -1157,10 +1157,17 @@ fn pump_embedded_pubsub<D: smoltcp::phy::Device, E: EntropySource>(
                 agent.send_result(&peer, stream_id, token, result, now.monotonic_ms);
             }
             minip2p_pubsub::PubsubAction::CloseStreamWrite { peer, stream_id } => {
-                let _ = endpoint.close_stream_write(&peer, stream_id, now);
+                // Pubsub has no completion callback for stream teardown; a
+                // failed close is observed through the endpoint event path.
+                match endpoint.close_stream_write(&peer, stream_id, now) {
+                    Ok(()) | Err(_) => {}
+                }
             }
             minip2p_pubsub::PubsubAction::ResetStream { peer, stream_id } => {
-                let _ = endpoint.reset_stream(&peer, stream_id, now);
+                // As above, retain endpoint events as the teardown result.
+                match endpoint.reset_stream(&peer, stream_id, now) {
+                    Ok(()) | Err(_) => {}
+                }
             }
         }
     }
@@ -1679,15 +1686,19 @@ mod tests {
 
     impl Transport for NoopTransport {
         fn dial(&mut self, _: &PeerAddr) -> Result<ConnectionId, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported { operation: "dial" })
         }
 
         fn listen(&mut self, _: &Multiaddr) -> Result<Multiaddr, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "listen",
+            })
         }
 
         fn open_stream(&mut self, _: ConnectionId) -> Result<StreamId, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "open stream",
+            })
         }
 
         fn send_stream(
@@ -1696,7 +1707,9 @@ mod tests {
             _: StreamId,
             _: Vec<u8>,
         ) -> Result<(), TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "send stream",
+            })
         }
 
         fn close_stream_write(
@@ -1704,15 +1717,21 @@ mod tests {
             _: ConnectionId,
             _: StreamId,
         ) -> Result<(), TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "close stream write",
+            })
         }
 
         fn reset_stream(&mut self, _: ConnectionId, _: StreamId) -> Result<(), TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "reset stream",
+            })
         }
 
         fn close(&mut self, _: ConnectionId) -> Result<(), TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "close connection",
+            })
         }
 
         fn poll(&mut self, _: Now) -> Result<Vec<TransportEvent>, TransportError> {
@@ -1738,7 +1757,7 @@ mod tests {
 
     impl Transport for RecordingTransport {
         fn dial(&mut self, _: &PeerAddr) -> Result<ConnectionId, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported { operation: "dial" })
         }
 
         fn listen(&mut self, address: &Multiaddr) -> Result<Multiaddr, TransportError> {

--- a/crates/minip2p/src/portable/nat.rs
+++ b/crates/minip2p/src/portable/nat.rs
@@ -215,21 +215,25 @@ impl PortableNatDriver {
                 peer,
                 stream_id,
                 data,
-            } => {
-                let _ = endpoint.send_stream(&peer, stream_id, data, now);
-            }
+            } => match endpoint.send_stream(&peer, stream_id, data, now) {
+                Ok(()) | Err(_) => {}
+            },
             NatAction::CloseStreamWrite { peer, stream_id } => {
-                let _ = endpoint.close_stream_write(&peer, stream_id, now);
+                match endpoint.close_stream_write(&peer, stream_id, now) {
+                    Ok(()) | Err(_) => {}
+                }
             }
             NatAction::ResetStream { peer, stream_id } => {
-                let _ = endpoint.reset_stream(&peer, stream_id, now);
+                match endpoint.reset_stream(&peer, stream_id, now) {
+                    Ok(()) | Err(_) => {}
+                }
             }
-            NatAction::Disconnect { peer } => {
-                let _ = endpoint.disconnect(&peer, now);
-            }
-            NatAction::Ping { peer } => {
-                let _ = endpoint.ping(&peer, now);
-            }
+            NatAction::Disconnect { peer } => match endpoint.disconnect(&peer, now) {
+                Ok(()) | Err(_) => {}
+            },
+            NatAction::Ping { peer } => match endpoint.ping(&peer, now) {
+                Ok(()) | Err(_) => {}
+            },
             // The smoltcp TCP endpoint has no raw UDP transport. TCP-only
             // relay configurations never emit this; a defensive drop keeps
             // DCUtR explicitly unavailable instead of faking a punch.
@@ -272,7 +276,10 @@ impl PortableNatDriver {
     }
 
     #[cfg(feature = "portable-relay")]
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "bridge adoption needs its complete explicit endpoint context"
+    )]
     fn promote_bridge<D: smoltcp::phy::Device, E: EntropySource>(
         &mut self,
         token: NatToken,
@@ -321,18 +328,24 @@ impl PortableNatDriver {
                 };
                 self.agent.promote_result(token, Err(promoted), now);
                 if !matches!(error, AdoptError::UnknownConnection) {
-                    let _ = endpoint
+                    match endpoint
                         .runtime_mut()
                         .transport_mut()
                         .inner_mut()
-                        .reset_stream(inner_conn, stream_id);
+                        .reset_stream(inner_conn, stream_id)
+                    {
+                        Ok(()) | Err(_) => {}
+                    }
                 }
             }
         }
     }
 
     #[cfg(not(feature = "portable-relay"))]
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the unavailable-bridge fallback mirrors the complete NatAction context"
+    )]
     fn promote_bridge<D: smoltcp::phy::Device, E: EntropySource>(
         &mut self,
         token: NatToken,
@@ -386,7 +399,7 @@ impl PortableNatDriver {
                 transport.inject_bridge_closed(key.0, key.1);
                 self.promoted.remove(&key);
             }
-            _ => unreachable!(),
+            _ => return false,
         }
         true
     }

--- a/crates/minip2p/src/std/dial.rs
+++ b/crates/minip2p/src/std/dial.rs
@@ -42,10 +42,9 @@ impl Family {
 /// comes out, and routing it stays the set's decision.
 pub(crate) fn targets(addr: &PeerAddr) -> Result<Vec<(Family, PeerAddr)>, TransportError> {
     let protocols = addr.transport().protocols();
-    let Some(host) = protocols.first() else {
+    let Some((host, rest)) = protocols.split_first() else {
         return Err(invalid("dial target has no host component"));
     };
-    let rest = &protocols[1..];
 
     let (name, filter) = match host {
         Protocol::Ip4(_) | Protocol::Ip6(_) => {
@@ -174,15 +173,18 @@ mod tests {
         );
         for (family, target) in &expanded {
             let protocols = target.transport().protocols();
+            let (host, rest) = protocols
+                .split_first()
+                .expect("a rebuilt peer address always has its concrete host");
             assert!(
                 matches!(
-                    (family, &protocols[0]),
+                    (family, host),
                     (Family::V4, Protocol::Ip4(_)) | (Family::V6, Protocol::Ip6(_))
                 ),
                 "the host is concrete and matches its family: {protocols:?}"
             );
             assert_eq!(
-                &protocols[1..],
+                rest,
                 &[Protocol::Tcp(4001)],
                 "everything after the host is the caller's, not the resolver's"
             );
@@ -248,10 +250,12 @@ mod tests {
         let addr = peer_addr("/dns4/localhost/udp/4001/quic-v1");
         for (family, target) in targets(&addr).expect("targets") {
             assert_eq!(family, Family::V4, "/dns4 must not produce an ipv6 dial");
-            assert!(matches!(
-                target.transport().protocols()[0],
-                Protocol::Ip4(_)
-            ));
+            let (host, _) = target
+                .transport()
+                .protocols()
+                .split_first()
+                .expect("resolved peer address has a concrete host");
+            assert!(matches!(host, Protocol::Ip4(_)));
         }
     }
 

--- a/crates/minip2p/src/std/discovery.rs
+++ b/crates/minip2p/src/std/discovery.rs
@@ -70,7 +70,13 @@ impl DiscoveryDriver {
     }
 
     pub(crate) fn next_timeout(&self, now_ms: u64) -> Option<u64> {
-        #[allow(unused_mut)]
+        #[cfg_attr(
+            not(feature = "discovery"),
+            expect(
+                unused_mut,
+                reason = "the discovery beacon feature is the only configuration that refines the book timeout"
+            )
+        )]
         let mut timeout = self.book.next_timeout(now_ms);
         #[cfg(feature = "discovery")]
         if let Some(beacon) = self.beacon.as_ref()
@@ -207,8 +213,13 @@ impl DiscoveryDriver {
                     match action {
                         BeaconAction::PublishBeacon { topic, payload } => {
                             if let Some(pubsub) = pubsub.as_deref_mut() {
-                                let _ = pubsub.agent.publish(&topic, payload, pubsub.now_ms());
-                                pubsub.pump(swarm);
+                                // The beacon is periodic, so a refused local
+                                // publish is retried on its next tick.
+                                if let Ok(()) =
+                                    pubsub.agent.publish(&topic, payload, pubsub.now_ms())
+                                {
+                                    pubsub.pump(swarm);
+                                }
                             }
                         }
                     }

--- a/crates/minip2p/src/std/mod.rs
+++ b/crates/minip2p/src/std/mod.rs
@@ -48,19 +48,30 @@ mod relay_server;
 
 #[cfg(any(feature = "discovery", feature = "mdns"))]
 pub use discovery::DiscoveryError;
-#[allow(unused_imports)] // Only transport-less `std` builds leave this unused.
+#[cfg(any(
+    feature = "quic",
+    feature = "tcp",
+    feature = "nat",
+    feature = "relay-server"
+))]
 use minip2p_core::Multiaddr;
 #[cfg(any(feature = "tcp", feature = "relay-server"))]
 use minip2p_core::Protocol;
 #[cfg(any(feature = "quic", feature = "tcp"))]
 use minip2p_core::TransportKind;
 use minip2p_core::{PeerAddr, PeerId};
+#[cfg(all(any(feature = "discovery", feature = "mdns"), feature = "smoltcp"))]
+#[expect(
+    unused_imports,
+    reason = "The portable mDNS build re-exports this std API type without using it internally."
+)]
+pub use minip2p_discovery::DiscoverySource;
+#[cfg(all(any(feature = "discovery", feature = "mdns"), not(feature = "smoltcp")))]
+pub use minip2p_discovery::DiscoverySource;
 #[cfg(feature = "discovery")]
 pub use minip2p_discovery::{BeaconConfig, DISCOVERY_TOPIC};
 #[cfg(any(feature = "discovery", feature = "mdns"))]
-pub use minip2p_discovery::{
-    DiscoveryConfigError, DiscoveryEvent, DiscoverySource, KnownPeer, PeerDiscoveryConfig,
-};
+pub use minip2p_discovery::{DiscoveryConfigError, DiscoveryEvent, KnownPeer, PeerDiscoveryConfig};
 pub use minip2p_identify::IdentifyMessage;
 pub use minip2p_identity::Ed25519Keypair;
 #[cfg(feature = "mdns")]
@@ -111,6 +122,50 @@ const DEFAULT_AGENT_VERSION: &str = "minip2p/0.1.0";
 const RELAY_HOP_PROTOCOL_ID: &str = "/libp2p/circuit/relay/0.2.0/hop";
 #[cfg(feature = "relay-server")]
 const RELAY_STOP_PROTOCOL_ID: &str = "/libp2p/circuit/relay/0.2.0/stop";
+
+/// Relay announce-address validation failure while building an endpoint.
+#[cfg(feature = "relay-server")]
+#[derive(Debug)]
+pub enum RelayServerAnnounceError {
+    /// The temporary validator could not be constructed from its configuration.
+    Config(RelayServerConfigError),
+    /// An announce address is invalid for the relay identity.
+    Address(RelayServerAddressError),
+}
+
+#[cfg(feature = "relay-server")]
+impl From<RelayServerConfigError> for RelayServerAnnounceError {
+    fn from(error: RelayServerConfigError) -> Self {
+        Self::Config(error)
+    }
+}
+
+#[cfg(feature = "relay-server")]
+impl From<RelayServerAddressError> for RelayServerAnnounceError {
+    fn from(error: RelayServerAddressError) -> Self {
+        Self::Address(error)
+    }
+}
+
+#[cfg(feature = "relay-server")]
+impl core::fmt::Display for RelayServerAnnounceError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Config(error) => error.fmt(formatter),
+            Self::Address(error) => error.fmt(formatter),
+        }
+    }
+}
+
+#[cfg(feature = "relay-server")]
+impl std::error::Error for RelayServerAnnounceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Config(error) => Some(error),
+            Self::Address(error) => Some(error),
+        }
+    }
+}
 
 /// Synchronous relay-server runtime control failure.
 #[cfg(feature = "relay-server")]
@@ -208,7 +263,10 @@ pub struct Endpoint {
 
 /// Why one [`Endpoint::next_wake`] call returned.
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)] // Preserve Event ownership without a heap allocation.
+#[expect(
+    clippy::large_enum_variant,
+    reason = "Event ownership avoids a heap allocation on every application wake."
+)]
 #[must_use = "handle the wake reason and drain every non-empty agent queue after DriverProgress"]
 pub enum EndpointWake {
     /// An application event not owned by an active agent.
@@ -234,9 +292,13 @@ pub enum EndpointWake {
 
 /// Why one driver-aware swarm-driving step returned.
 #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
-enum DriverPollKind {
+#[expect(
+    clippy::large_enum_variant,
+    reason = "Application events stay owned so waits avoid a heap allocation."
+)]
+enum DriverPoll {
     /// An event not owned by any agent is ready for the application.
-    Application,
+    Application(Event),
     /// An agent produced application-visible output; focused waits should
     /// re-check their queue immediately.
     Progress,
@@ -247,39 +309,21 @@ enum DriverPollKind {
 }
 
 #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
-struct DriverPoll {
-    kind: DriverPollKind,
-    event: Option<Event>,
-}
-
-#[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
 impl DriverPoll {
     fn application(event: Event) -> Self {
-        Self {
-            kind: DriverPollKind::Application,
-            event: Some(event),
-        }
+        Self::Application(event)
     }
 
     fn progress() -> Self {
-        Self {
-            kind: DriverPollKind::Progress,
-            event: None,
-        }
+        Self::Progress
     }
 
     fn deadline() -> Self {
-        Self {
-            kind: DriverPollKind::Deadline,
-            event: None,
-        }
+        Self::Deadline
     }
 
     fn interrupted() -> Self {
-        Self {
-            kind: DriverPollKind::Interrupted,
-            event: None,
-        }
+        Self::Interrupted
     }
 }
 
@@ -496,11 +540,11 @@ impl Endpoint {
     /// already buffered by the endpoint and suppresses later data, EOF, and
     /// close events for the stream. Repeated calls are idempotent.
     pub fn abandon_stream(&mut self, peer_id: &PeerId, stream_id: StreamId) -> Result<(), Error> {
-        let result = self.swarm.abandon_stream(peer_id, stream_id);
+        self.swarm.abandon_stream(peer_id, stream_id)?;
         #[cfg(any(feature = "nat", feature = "pubsub", feature = "relay-server"))]
         self.pending_events
             .retain(|event| !event.matches_stream(peer_id, stream_id));
-        result
+        Ok(())
     }
 
     /// Polls the endpoint once and returns all currently available events.
@@ -573,13 +617,11 @@ impl Endpoint {
             }
             let mut expired_poll_used = false;
             let poll = self.poll_new_event_driven(deadline, &mut expired_poll_used)?;
-            return Ok(match poll.kind {
-                DriverPollKind::Application => {
-                    EndpointWake::Event(poll.event.expect("application poll carries event"))
-                }
-                DriverPollKind::Progress => EndpointWake::DriverProgress,
-                DriverPollKind::Interrupted => EndpointWake::Interrupted,
-                DriverPollKind::Deadline => EndpointWake::Deadline,
+            return Ok(match poll {
+                DriverPoll::Application(event) => EndpointWake::Event(event),
+                DriverPoll::Progress => EndpointWake::DriverProgress,
+                DriverPoll::Interrupted => EndpointWake::Interrupted,
+                DriverPoll::Deadline => EndpointWake::Deadline,
             });
         }
         self.swarm
@@ -758,11 +800,11 @@ impl Endpoint {
         let mut expired_poll_used = false;
         loop {
             let poll = self.poll_new_event_driven(deadline, &mut expired_poll_used)?;
-            match poll.kind {
-                DriverPollKind::Application => return Ok(poll.event),
-                DriverPollKind::Progress => {}
-                DriverPollKind::Interrupted => {}
-                DriverPollKind::Deadline => return Ok(None),
+            match poll {
+                DriverPoll::Application(event) => return Ok(Some(event)),
+                DriverPoll::Progress => {}
+                DriverPoll::Interrupted => {}
+                DriverPoll::Deadline => return Ok(None),
             }
         }
     }
@@ -942,11 +984,8 @@ impl Endpoint {
                         event,
                         NatEvent::PathEstablished { connect_id, .. } if *connect_id == id
                     )
-                }) {
-                    let Some(NatEvent::PathEstablished { path, .. }) = nat.events.remove(index)
-                    else {
-                        unreachable!("position matched PathEstablished");
-                    };
+                }) && let Some(NatEvent::PathEstablished { path, .. }) = nat.events.remove(index)
+                {
                     return Ok(Some(path));
                 }
                 if nat.events.iter().any(|event| {
@@ -960,13 +999,11 @@ impl Endpoint {
             }
             self.ensure_pending_event_capacity()?;
             let poll = self.poll_new_event_driven(deadline, &mut expired_poll_used)?;
-            match poll.kind {
-                DriverPollKind::Application => self
-                    .pending_events
-                    .push_back(poll.event.expect("application poll carries event")),
-                DriverPollKind::Progress => {}
-                DriverPollKind::Interrupted => {}
-                DriverPollKind::Deadline => return Ok(None),
+            match poll {
+                DriverPoll::Application(event) => self.pending_events.push_back(event),
+                DriverPoll::Progress => {}
+                DriverPoll::Interrupted => {}
+                DriverPoll::Deadline => return Ok(None),
             }
         }
     }
@@ -976,7 +1013,10 @@ impl Endpoint {
     /// Existing reservations and circuits remain active, and HOP remains
     /// advertised while admission is paused.
     #[cfg(feature = "relay-server")]
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "The error retains the rejected address for actionable host diagnostics."
+    )]
     pub fn set_relay_server_accepting(
         &mut self,
         accepting: bool,
@@ -997,7 +1037,10 @@ impl Endpoint {
     /// remains active. An empty replacement clears the override, restoring the
     /// confirmed-NAT-then-concrete-listener fallback order.
     #[cfg(feature = "relay-server")]
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "The error retains the rejected address for actionable host diagnostics."
+    )]
     pub fn set_relay_server_announce_addrs(
         &mut self,
         addrs: Vec<Multiaddr>,
@@ -1052,12 +1095,10 @@ impl Endpoint {
             }
             self.ensure_pending_event_capacity()?;
             let poll = self.poll_new_event_driven(deadline, &mut expired_poll_used)?;
-            match poll.kind {
-                DriverPollKind::Application => self
-                    .pending_events
-                    .push_back(poll.event.expect("application poll carries event")),
-                DriverPollKind::Progress | DriverPollKind::Interrupted => {}
-                DriverPollKind::Deadline => return Ok(None),
+            match poll {
+                DriverPoll::Application(event) => self.pending_events.push_back(event),
+                DriverPoll::Progress | DriverPoll::Interrupted => {}
+                DriverPoll::Deadline => return Ok(None),
             }
         }
     }
@@ -1077,9 +1118,13 @@ impl Endpoint {
                 .map(nat::NatDriver::confirmed_public_addrs)
                 .unwrap_or_default();
             if let Some(relay_server) = self.relay_server.as_mut() {
-                let _ = relay_server.agent.set_listener_addrs(listeners);
+                // The address source comes from local bound listeners; on
+                // rejection the agent deliberately keeps its previous source.
+                drop(relay_server.agent.set_listener_addrs(listeners));
                 #[cfg(feature = "nat")]
-                let _ = relay_server.agent.set_confirmed_addrs(confirmed);
+                // Confirmed addresses were already accepted by the NAT agent;
+                // retain the previous relay source if conversion rejects one.
+                drop(relay_server.agent.set_confirmed_addrs(confirmed));
             }
         }
         let mut addresses = self.caller_external_addresses.clone();
@@ -1133,13 +1178,11 @@ impl Endpoint {
             }
             self.ensure_pending_event_capacity()?;
             let poll = self.poll_new_event_driven(deadline, &mut expired_poll_used)?;
-            match poll.kind {
-                DriverPollKind::Application => self
-                    .pending_events
-                    .push_back(poll.event.expect("application poll carries event")),
-                DriverPollKind::Progress => {}
-                DriverPollKind::Interrupted => {}
-                DriverPollKind::Deadline => return Ok(None),
+            match poll {
+                DriverPoll::Application(event) => self.pending_events.push_back(event),
+                DriverPoll::Progress => {}
+                DriverPoll::Interrupted => {}
+                DriverPoll::Deadline => return Ok(None),
             }
         }
     }
@@ -1163,17 +1206,16 @@ impl Endpoint {
         loop {
             self.ensure_pending_event_capacity()?;
             let poll = self.poll_new_event_driven(deadline, &mut expired_poll_used)?;
-            match poll.kind {
-                DriverPollKind::Application => {
-                    let event = poll.event.expect("application poll carries event");
+            match poll {
+                DriverPoll::Application(event) => {
                     if predicate(&event) {
                         return Ok(Some(event));
                     }
                     self.pending_events.push_back(event);
                 }
-                DriverPollKind::Progress => {}
-                DriverPollKind::Interrupted => {}
-                DriverPollKind::Deadline => return Ok(None),
+                DriverPoll::Progress => {}
+                DriverPoll::Interrupted => {}
+                DriverPoll::Deadline => return Ok(None),
             }
         }
     }
@@ -1297,13 +1339,11 @@ impl Endpoint {
             }
             self.ensure_pending_event_capacity()?;
             let poll = self.poll_new_event_driven(deadline, &mut expired_poll_used)?;
-            match poll.kind {
-                DriverPollKind::Application => self
-                    .pending_events
-                    .push_back(poll.event.expect("application poll carries event")),
-                DriverPollKind::Progress => {}
-                DriverPollKind::Interrupted => {}
-                DriverPollKind::Deadline => return Ok(None),
+            match poll {
+                DriverPoll::Application(event) => self.pending_events.push_back(event),
+                DriverPoll::Progress => {}
+                DriverPoll::Interrupted => {}
+                DriverPoll::Deadline => return Ok(None),
             }
         }
     }
@@ -1365,13 +1405,11 @@ impl Endpoint {
             }
             self.ensure_pending_event_capacity()?;
             let poll = self.poll_new_event_driven(deadline, &mut expired_poll_used)?;
-            match poll.kind {
-                DriverPollKind::Application => self
-                    .pending_events
-                    .push_back(poll.event.expect("application poll carries event")),
-                DriverPollKind::Progress => {}
-                DriverPollKind::Interrupted => {}
-                DriverPollKind::Deadline => return Ok(None),
+            match poll {
+                DriverPoll::Application(event) => self.pending_events.push_back(event),
+                DriverPoll::Progress => {}
+                DriverPoll::Interrupted => {}
+                DriverPoll::Deadline => return Ok(None),
             }
         }
     }
@@ -1478,7 +1516,8 @@ impl Endpoint {
 
 impl Drop for Endpoint {
     fn drop(&mut self) {
-        let _ = self.disconnect_established();
+        // Drop cannot surface disconnect failures; transports own final cleanup.
+        drop(self.disconnect_established());
     }
 }
 
@@ -1495,16 +1534,16 @@ fn mdns_seed(keypair: &Ed25519Keypair) -> [u8; 32] {
     let mut seed = [0u8; 32];
     let peer_id = keypair.peer_id();
     let digest = peer_id.digest_bytes();
-    for (index, byte) in digest.iter().enumerate() {
-        seed[index % seed.len()] ^= *byte;
+    for (slot, byte) in seed.iter_mut().zip(digest.iter().cycle()) {
+        *slot ^= *byte;
     }
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
         .unwrap_or(0)
         .to_le_bytes();
-    for (index, byte) in seed.iter_mut().enumerate() {
-        *byte ^= timestamp[index % timestamp.len()];
+    for (slot, byte) in seed.iter_mut().zip(timestamp.iter().cycle()) {
+        *slot ^= *byte;
     }
     seed
 }
@@ -1514,6 +1553,7 @@ fn mdns_seed(keypair: &Ed25519Keypair) -> [u8; 32] {
 /// Held as a request rather than a socket so nothing is allocated until the
 /// configuration has been validated: a builder that failed after binding would
 /// leave a port taken by an endpoint that never existed.
+#[cfg(any(feature = "quic", feature = "tcp"))]
 enum Bind {
     #[cfg(feature = "quic")]
     Quic(QuicBind),
@@ -1543,6 +1583,7 @@ pub struct EndpointBuilder {
     quic_limits: QuicLimits,
     #[cfg(feature = "tcp")]
     tcp_config: TcpConfig,
+    #[cfg(any(feature = "quic", feature = "tcp"))]
     binds: Vec<Bind>,
     protocols: Vec<String>,
     #[cfg(feature = "relay-server")]
@@ -1574,6 +1615,7 @@ impl Default for EndpointBuilder {
             quic_limits: QuicLimits::default(),
             #[cfg(feature = "tcp")]
             tcp_config: TcpConfig::default(),
+            #[cfg(any(feature = "quic", feature = "tcp"))]
             binds: Vec::new(),
             protocols: Vec::new(),
             #[cfg(feature = "relay-server")]
@@ -1606,6 +1648,7 @@ struct BuilderParts {
     quic_limits: QuicLimits,
     #[cfg(feature = "tcp")]
     tcp_config: TcpConfig,
+    #[cfg(any(feature = "quic", feature = "tcp"))]
     binds: Vec<Bind>,
     protocols: Vec<String>,
     #[cfg(feature = "relay-server")]
@@ -1746,17 +1789,20 @@ impl EndpointBuilder {
     ///
     /// This method validates direct TCP/QUIC shape, rejects wildcard and circuit
     /// addresses, and checks a trailing peer id against an already-fixed builder
-    /// identity. The indexed [`RelayServerAddressError`] identifies the rejected
-    /// input and reason. When identity is not fixed yet, the peer-id match is
+    /// identity. [`RelayServerAnnounceError`] preserves either the rejected input
+    /// or a validator configuration failure. When identity is not fixed yet, the peer-id match is
     /// checked again at bind. Announce addresses alone do not enable the service;
     /// also call [`EndpointBuilder::relay_server`] or
     /// [`EndpointBuilder::relay_server_config`].
     #[cfg(feature = "relay-server")]
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "The error owns the rejected announce address for actionable host diagnostics."
+    )]
     pub fn relay_server_announce_addrs(
         mut self,
         addrs: Vec<Multiaddr>,
-    ) -> Result<Self, RelayServerAddressError> {
+    ) -> Result<Self, RelayServerAnnounceError> {
         let validation_peer = self
             .keypair
             .as_ref()
@@ -1773,8 +1819,7 @@ impl EndpointBuilder {
         let mut validator = minip2p_relay_server::RelayServerAgent::new(
             validation_peer,
             RelayServerConfig::default(),
-        )
-        .expect("default relay-server configuration is valid");
+        )?;
         validator.replace_announce_addrs(addrs.clone())?;
         self.relay_server_announce_addrs = addrs;
         Ok(self)
@@ -1992,6 +2037,7 @@ impl EndpointBuilder {
             quic_limits: self.quic_limits,
             #[cfg(feature = "tcp")]
             tcp_config: self.tcp_config,
+            #[cfg(any(feature = "quic", feature = "tcp"))]
             binds: self.binds,
             protocols: self.protocols,
             #[cfg(feature = "relay-server")]
@@ -2077,17 +2123,24 @@ fn tcp_addrs_of(resolved: impl IntoIterator<Item = std::net::SocketAddr>) -> Vec
 /// each: a transport claims an address shape rather than an address family, so
 /// two of them would be two claims on one shape -- and a host asking for IPv4
 /// and IPv6 is asking for two sockets, not two transports.
-fn bind_transports(parts: &BuilderParts) -> Result<TransportSet, Error> {
-    #[allow(unused_mut)] // No member can be inserted in a std-only feature build.
+fn bind_transports(_parts: &BuilderParts) -> Result<TransportSet, Error> {
+    #[cfg(any(feature = "quic", feature = "tcp"))]
+    let mut set = TransportSet::new();
+    #[cfg(not(any(feature = "quic", feature = "tcp")))]
+    #[expect(
+        unused_mut,
+        reason = "Transport-less std builds keep this shared construction path without inserts."
+    )]
     let mut set = TransportSet::new();
     #[cfg(feature = "tcp")]
     let mut tcp_bound = false;
-    for bind in &parts.binds {
+    #[cfg(any(feature = "quic", feature = "tcp"))]
+    for bind in &_parts.binds {
         match bind {
             #[cfg(feature = "quic")]
             Bind::Quic(spec) => {
-                let config = QuicNodeConfig::new(parts.keypair.clone())
-                    .with_limits(parts.quic_limits.clone());
+                let config = QuicNodeConfig::new(_parts.keypair.clone())
+                    .with_limits(_parts.quic_limits.clone());
                 let transport = match spec {
                     QuicBind::Addr(addr) => QuicEndpoint::bind(config, addr)?,
                     QuicBind::Multiaddr(addr) => QuicEndpoint::bind_multiaddr(config, addr)?,
@@ -2107,12 +2160,10 @@ fn bind_transports(parts: &BuilderParts) -> Result<TransportSet, Error> {
             #[cfg(feature = "tcp")]
             Bind::Tcp(_) => {
                 tcp_bound = true;
-                let transport = bind_tcp_member(parts)?;
+                let transport = bind_tcp_member(_parts)?;
                 let namespace = transport.namespace();
                 insert_member(&mut set, TransportKind::Tcp, [namespace], transport)?;
             }
-            #[cfg(not(any(feature = "quic", feature = "tcp")))]
-            _ => unreachable!("Bind has no constructible variants without a transport feature"),
         }
     }
     if set.is_empty() {
@@ -2228,8 +2279,10 @@ fn build_endpoint(parts: BuilderParts, transport: TransportSet) -> Result<Endpoi
     }
     #[cfg(feature = "nat")]
     let transport = minip2p_circuit::CircuitTransport::new_os(transport, parts.keypair.clone());
-    #[allow(unused_mut)] // Mutated only by feature-gated composed services.
+    #[cfg(any(feature = "nat", feature = "relay-server"))]
     let mut swarm = builder.build(transport)?;
+    #[cfg(not(any(feature = "nat", feature = "relay-server")))]
+    let swarm = builder.build(transport)?;
     #[cfg(feature = "relay-server")]
     if parts.relay_server_config.is_some() {
         swarm.add_inbound_protocol(RELAY_HOP_PROTOCOL_ID)?;
@@ -2319,6 +2372,10 @@ fn build_endpoint(parts: BuilderParts, transport: TransportSet) -> Result<Endpoi
     let mut pubsub = pubsub;
     #[cfg(feature = "discovery")]
     if let (Some(pubsub), Some(config)) = (pubsub.as_mut(), discovery_config.as_ref()) {
+        #[expect(
+            clippy::map_err_ignore,
+            reason = "Both agents validate the shared topic before construction, so this exposes a stable invariant."
+        )]
         pubsub
             .agent
             .subscribe(&config.topic, 0)
@@ -2327,6 +2384,10 @@ fn build_endpoint(parts: BuilderParts, transport: TransportSet) -> Result<Endpoi
             })?;
     }
     #[cfg(feature = "discovery")]
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "The builder validated this beacon configuration before creating the agent."
+    )]
     let beacon = match discovery_config {
         Some(config) => Some(
             minip2p_discovery::BeaconAgent::new(parts.keypair.public_key(), config).map_err(
@@ -2378,6 +2439,10 @@ fn build_endpoint(parts: BuilderParts, transport: TransportSet) -> Result<Endpoi
         }
     };
     #[cfg(any(feature = "discovery", feature = "mdns"))]
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "The shared discovery policy was validated before the endpoint reached this point."
+    )]
     let discovery = if discovery_enabled {
         let book = minip2p_discovery::PeerDiscoveryAgent::new(
             parts.keypair.peer_id(),
@@ -2469,7 +2534,8 @@ mod tests {
         fn drop(&mut self) {
             self.stop.store(true, Ordering::Relaxed);
             if let Some(thread) = self.thread.take() {
-                let _ = thread.join();
+                // A test panic in the driver must not panic again while unwinding.
+                drop(thread.join());
             }
         }
     }
@@ -2481,6 +2547,10 @@ mod tests {
     /// them, so taking whatever arrives next is a race rather than an
     /// assertion.
     #[cfg(feature = "tcp")]
+    #[expect(
+        clippy::panic,
+        reason = "A timed-out test must include the unexpected event trace."
+    )]
     fn wait_for(
         endpoint: &mut Endpoint,
         what: &str,
@@ -2504,6 +2574,10 @@ mod tests {
     }
 
     #[cfg(feature = "tcp")]
+    #[expect(
+        clippy::panic,
+        reason = "A malformed fixture address is a test setup failure."
+    )]
     fn tcp_port(addr: &PeerAddr) -> u16 {
         match addr.transport().protocols() {
             [_, Protocol::Tcp(port)] => *port,
@@ -2717,7 +2791,7 @@ mod tests {
                 |event| matches!(event, Event::ConnectionEstablished { peer_id, .. } if peer_id == addr.peer_id()),
             );
             let Event::ConnectionEstablished { conn_id, .. } = event else {
-                unreachable!("the predicate matched a connection")
+                panic!("the connection predicate returned an unrelated event")
             };
             assert_eq!(
                 conn_id.namespace(),
@@ -3402,7 +3476,10 @@ mod tests {
         let wildcard = "/ip4/0.0.0.0/tcp/4001".parse().unwrap();
         let error = match Endpoint::builder().relay_server_announce_addrs(vec![wildcard]) {
             Ok(_) => panic!("wildcards are not announceable"),
-            Err(error) => error,
+            Err(RelayServerAnnounceError::Address(error)) => error,
+            Err(RelayServerAnnounceError::Config(error)) => {
+                panic!("default validator configuration is valid: {error}")
+            }
         };
         assert_eq!(error.index, 0);
         assert_eq!(error.reason, RelayServerAddressErrorKind::Wildcard);
@@ -3421,7 +3498,10 @@ mod tests {
             .relay_server_announce_addrs(vec![address])
         {
             Ok(_) => panic!("conflicting peer id must fail immediately"),
-            Err(error) => error,
+            Err(RelayServerAnnounceError::Address(error)) => error,
+            Err(RelayServerAnnounceError::Config(error)) => {
+                panic!("default validator configuration is valid: {error}")
+            }
         };
         assert!(matches!(
             error.reason,

--- a/crates/minip2p/src/std/mod.rs
+++ b/crates/minip2p/src/std/mod.rs
@@ -2127,11 +2127,7 @@ fn bind_transports(_parts: &BuilderParts) -> Result<TransportSet, Error> {
     #[cfg(any(feature = "quic", feature = "tcp"))]
     let mut set = TransportSet::new();
     #[cfg(not(any(feature = "quic", feature = "tcp")))]
-    #[expect(
-        unused_mut,
-        reason = "Transport-less std builds keep this shared construction path without inserts."
-    )]
-    let mut set = TransportSet::new();
+    let set = TransportSet::new();
     #[cfg(feature = "tcp")]
     let mut tcp_bound = false;
     #[cfg(any(feature = "quic", feature = "tcp"))]

--- a/crates/minip2p/src/std/nat.rs
+++ b/crates/minip2p/src/std/nat.rs
@@ -194,27 +194,49 @@ impl NatDriver {
             } => {
                 // Failures surface through the agent's own timeouts and the
                 // swarm's error events; nothing to echo synchronously.
-                let _ = swarm.send_stream(&peer, stream_id, data);
+                match swarm.send_stream(&peer, stream_id, data) {
+                    Ok(()) | Err(_) => {}
+                }
             }
             NatAction::CloseStreamWrite { peer, stream_id } => {
-                let _ = swarm.close_stream_write(&peer, stream_id);
+                // A stale close must not replace the lifecycle event that
+                // triggered this action.
+                match swarm.close_stream_write(&peer, stream_id) {
+                    Ok(()) | Err(_) => {}
+                }
             }
             NatAction::ResetStream { peer, stream_id } => {
-                let _ = swarm.reset_stream(&peer, stream_id);
+                // Reset is cleanup, so a stream already gone is equivalent
+                // to a successful reset.
+                match swarm.reset_stream(&peer, stream_id) {
+                    Ok(()) | Err(_) => {}
+                }
             }
             NatAction::Disconnect { peer } => {
-                let _ = swarm.disconnect(&peer);
+                // Connection loss remains visible through the normal swarm
+                // lifecycle; a stale disconnect adds no second outcome.
+                match swarm.disconnect(&peer) {
+                    Ok(()) | Err(_) => {}
+                }
             }
             NatAction::Ping { peer } => {
-                let _ = swarm.ping(&peer);
+                // Relay liveness is re-established from lifecycle events;
+                // a stale ping is not an application-visible failure.
+                match swarm.ping(&peer) {
+                    Ok(()) | Err(_) => {}
+                }
             }
             NatAction::SendRandomUdp {
                 target,
                 payload_len,
             } => {
                 let mut payload = vec![0u8; payload_len];
-                if getrandom::fill(&mut payload).is_ok() {
-                    let _ = swarm.transport_mut().send_datagram(&target, &payload);
+                // A failed entropy sample simply skips this one best-effort
+                // hole-punch datagram.
+                if let Ok(()) = getrandom::fill(&mut payload) {
+                    match swarm.transport_mut().send_datagram(&target, &payload) {
+                        Ok(()) | Err(_) => {}
+                    }
                 }
             }
             NatAction::PromoteBridge {
@@ -260,23 +282,25 @@ impl NatDriver {
                         if !matches!(error, AdoptError::UnknownConnection) {
                             #[cfg(test)]
                             self.bridge_reset_attempts.push((inner_conn, stream_id));
-                            let _ = swarm
+                            match swarm
                                 .transport_mut()
                                 .inner_mut()
-                                .reset_stream(inner_conn, stream_id);
+                                .reset_stream(inner_conn, stream_id)
+                            {
+                                Ok(()) | Err(_) => {}
+                            }
                         }
                     }
                 }
             }
             NatAction::CloseCircuit { conn_id } => {
-                let result = swarm.transport_mut().close(conn_id);
-                if result.is_ok()
-                    || matches!(
-                        result,
-                        Err(minip2p_transport::TransportError::ConnectionNotFound { .. })
-                    )
-                {
-                    self.promoted.retain(|_, id| *id != conn_id);
+                match swarm.transport_mut().close(conn_id) {
+                    Ok(()) | Err(minip2p_transport::TransportError::ConnectionNotFound { .. }) => {
+                        self.promoted.retain(|_, id| *id != conn_id);
+                    }
+                    // A transport failure will emerge through its normal
+                    // event path; retain the promotion until then.
+                    Err(_) => {}
                 }
             }
         }
@@ -311,7 +335,9 @@ impl NatDriver {
                 swarm.transport_mut().inject_bridge_closed(key.0, key.1);
                 self.promoted.remove(&key);
             }
-            _ => unreachable!(),
+            // `key` was extracted above only for these three stream events.
+            // Keep this defensive if a new swarm event reaches this path.
+            _ => return false,
         }
         true
     }
@@ -480,12 +506,18 @@ mod tests {
                 Instant::now() < deadline,
                 "client did not acquire {transport} relay reservation"
             );
-            let _ = client
+            match client
                 .next_event(std::time::Duration::from_millis(10))
-                .expect("drive reservation client");
-            let _ = relay
+                .expect("drive reservation client")
+            {
+                Some(_) | None => {}
+            }
+            match relay
                 .next_event(std::time::Duration::from_millis(10))
-                .expect("drive reservation relay");
+                .expect("drive reservation relay")
+            {
+                Some(_) | None => {}
+            }
         }
     }
 
@@ -528,9 +560,12 @@ mod tests {
             ) {
                 ping_rtts += 1;
             }
-            let _ = relay
+            match relay
                 .next_event(std::time::Duration::from_millis(10))
-                .expect("drive relay");
+                .expect("drive relay")
+            {
+                Some(_) | None => {}
+            }
         }
 
         let reservation_events = client.take_nat_events();
@@ -562,12 +597,18 @@ mod tests {
                 Instant::now() < reconnect_deadline,
                 "genuine relay loss did not trigger reacquisition"
             );
-            let _ = client
+            match client
                 .next_event(std::time::Duration::from_millis(10))
-                .expect("drive reconnecting client");
-            let _ = relay
+                .expect("drive reconnecting client")
+            {
+                Some(_) | None => {}
+            }
+            match relay
                 .next_event(std::time::Duration::from_millis(10))
-                .expect("drive relay after disconnect");
+                .expect("drive relay after disconnect")
+            {
+                Some(_) | None => {}
+            }
             for event in client.take_nat_events() {
                 match event {
                     NatEvent::RelayReservationLost { .. } => lost = true,
@@ -612,9 +653,12 @@ mod tests {
                 ),
                 "TCP reservation behavior must not gain automatic pings"
             );
-            let _ = relay
+            match relay
                 .next_event(std::time::Duration::from_millis(10))
-                .expect("drive TCP relay");
+                .expect("drive TCP relay")
+            {
+                Some(_) | None => {}
+            }
         }
         assert!(client.active_reservation().is_some());
     }
@@ -882,7 +926,9 @@ mod tests {
         );
         assert!(driver.promoted.is_empty());
         assert!(pair.local.swarm.transport().circuit_ids().is_empty());
-        let _ = pair.relay.next_event(std::time::Duration::from_millis(10));
+        match pair.relay.next_event(std::time::Duration::from_millis(10)) {
+            Ok(_) | Err(_) => {}
+        }
     }
 
     #[test]
@@ -1078,11 +1124,14 @@ mod tests {
         let deadline = Instant::now() + std::time::Duration::from_secs(2);
         let mut circuit_failed = false;
         while Instant::now() < deadline && !circuit_failed {
-            let _ = pair
+            match pair
                 .relay
                 .swarm
                 .poll_next(std::time::Duration::from_millis(10))
-                .expect("drive reset sender");
+                .expect("drive reset sender")
+            {
+                Some(_) | None => {}
+            }
             if let Some(event) = pair
                 .local
                 .swarm

--- a/crates/minip2p/src/std/pubsub.rs
+++ b/crates/minip2p/src/std/pubsub.rs
@@ -138,10 +138,16 @@ impl PubsubDriver {
             // send deadline / close machinery: the frame may well have
             // been delivered, so failing the work here could double-report.
             PubsubAction::CloseStreamWrite { peer, stream_id } => {
-                let _ = swarm.close_stream_write(&peer, stream_id);
+                match swarm.close_stream_write(&peer, stream_id) {
+                    Ok(()) | Err(_) => {}
+                }
             }
             PubsubAction::ResetStream { peer, stream_id } => {
-                let _ = swarm.reset_stream(&peer, stream_id);
+                // A reset races ordinary teardown, so an already-closed
+                // stream is successful cleanup rather than a second error.
+                match swarm.reset_stream(&peer, stream_id) {
+                    Ok(()) | Err(_) => {}
+                }
             }
         }
     }

--- a/crates/minip2p/tests/nat.rs
+++ b/crates/minip2p/tests/nat.rs
@@ -146,7 +146,9 @@ fn wait_peer_ready_drives_nat_agent() {
             if remote_stop.try_recv().is_ok() {
                 break;
             }
-            let _ = b.next_event(Duration::from_millis(10));
+            match b.next_event(Duration::from_millis(10)) {
+                Ok(_) | Err(_) => {}
+            }
         }
     });
 
@@ -169,7 +171,9 @@ fn wait_peer_ready_drives_nat_agent() {
         }),
         "wait_peer_ready must deliver ConnectionEstablished to NAT: {events:?}"
     );
-    let _ = stop_remote.send(());
+    match stop_remote.send(()) {
+        Ok(()) | Err(_) => {}
+    }
     remote.join().expect("remote driver thread");
 }
 

--- a/crates/minip2p/tests/pubsub.rs
+++ b/crates/minip2p/tests/pubsub.rs
@@ -43,7 +43,7 @@ fn is_pubsub_protocol(protocol_id: &str) -> bool {
 /// and asserting no pubsub stream events leak to the application.
 fn drive(endpoints: &mut [&mut Endpoint]) -> Vec<Vec<PubsubEvent>> {
     let mut collected = vec![Vec::new(); endpoints.len()];
-    for (i, endpoint) in endpoints.iter_mut().enumerate() {
+    for (endpoint, events) in endpoints.iter_mut().zip(&mut collected) {
         if let Some(event) = endpoint
             .next_event(Duration::from_millis(20))
             .expect("endpoint drives")
@@ -57,7 +57,7 @@ fn drive(endpoints: &mut [&mut Endpoint]) -> Vec<Vec<PubsubEvent>> {
                 "pubsub streams must be invisible to the app: {event:?}"
             );
         }
-        collected[i].extend(endpoint.take_pubsub_events());
+        events.extend(endpoint.take_pubsub_events());
     }
     collected
 }

--- a/crates/minip2p/tests/reconnect_churn.rs
+++ b/crates/minip2p/tests/reconnect_churn.rs
@@ -121,7 +121,9 @@ fn listener_reclaims_state_after_dialer_close() {
     });
 
     let events = dialer.close().expect("close flushes disconnects");
-    let _ = stop_remote.send(());
+    match stop_remote.send(()) {
+        Ok(()) | Err(_) => {}
+    }
     let mut listener = remote.join().expect("listener driver thread");
 
     assert!(
@@ -200,7 +202,9 @@ fn close_drains_replacement_connection() {
     });
 
     let events = listener.close().expect("close drains replacements");
-    let _ = stop_remote.send(());
+    match stop_remote.send(()) {
+        Ok(()) | Err(_) => {}
+    }
     let _replacement = remote.join().expect("replacement driver thread");
 
     let established: Vec<_> = events
@@ -274,7 +278,9 @@ fn close_drains_pending_replacement_handshake() {
     });
 
     let events = listener.close().expect("close drains pending replacement");
-    let _ = stop_remote.send(());
+    match stop_remote.send(()) {
+        Ok(()) | Err(_) => {}
+    }
     let _replacement = remote.join().expect("replacement driver thread");
 
     let established: Vec<_> = events

--- a/crates/minip2p/tests/relay_rust_interop.rs
+++ b/crates/minip2p/tests/relay_rust_interop.rs
@@ -12,8 +12,12 @@ struct ChildGuard(Child);
 
 impl Drop for ChildGuard {
     fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
+        match self.0.kill() {
+            Ok(()) | Err(_) => {}
+        }
+        match self.0.wait() {
+            Ok(_) | Err(_) => {}
+        }
     }
 }
 

--- a/crates/minip2p/tests/relay_server.rs
+++ b/crates/minip2p/tests/relay_server.rs
@@ -1,6 +1,10 @@
 //! Real std Endpoint relay-server integration coverage.
 
 #![cfg(all(feature = "relay-server", feature = "nat"))]
+#![expect(
+    clippy::unwrap_used,
+    reason = "the relay integration harness uses fixed local operations that must succeed"
+)]
 
 use std::sync::mpsc;
 use std::thread;

--- a/crates/minip2p/tests/smoltcp_relay.rs
+++ b/crates/minip2p/tests/smoltcp_relay.rs
@@ -1,6 +1,12 @@
 //! Three-node portable relay gate over a virtual smoltcp IP network.
 
 #![cfg(feature = "portable-relay")]
+#![expect(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    reason = "the scripted three-node relay harness fails immediately when its fixed topology invariants break"
+)]
 
 extern crate alloc;
 

--- a/crates/multistream-select/src/lib.rs
+++ b/crates/multistream-select/src/lib.rs
@@ -349,15 +349,15 @@ fn decode_message(buf: &[u8]) -> DecodeResult<'_> {
         return DecodeResult::Incomplete;
     }
 
-    let msg_bytes = &buf[varint_bytes..total];
+    let Some(msg_bytes) = buf.get(varint_bytes..total) else {
+        return DecodeResult::Incomplete;
+    };
 
-    // The message must end with '\n' per the spec.
-    if msg_bytes.last() != Some(&b'\n') {
+    // The message must end with '\n' per the spec. `split_last` also leaves
+    // the payload without the terminator.
+    let Some((&b'\n', payload_bytes)) = msg_bytes.split_last() else {
         return DecodeResult::Error(MultistreamError::MissingNewline);
-    }
-
-    // Strip the trailing newline to get the payload.
-    let payload_bytes = &msg_bytes[..msg_bytes.len() - 1];
+    };
 
     let payload = match core::str::from_utf8(payload_bytes) {
         Ok(s) => s,

--- a/crates/nat/src/housekeeping.rs
+++ b/crates/nat/src/housekeeping.rs
@@ -109,7 +109,14 @@ impl Prober {
             return;
         }
         let servers = &shared.config.autonat_servers;
-        let server = servers[self.server_idx % servers.len()].clone();
+        let server = servers
+            .get(
+                self.server_idx
+                    .checked_rem(servers.len())
+                    .expect("empty AutoNAT server lists return before scheduling"),
+            )
+            .expect("the checked AutoNAT server cursor is within the configured list")
+            .clone();
         let deadline = now.mono_ms + shared.config.probe_deadline_ms;
         let server_peer = server.peer_id().clone();
 
@@ -593,7 +600,14 @@ impl ReservationManager {
             self.state = ResState::Idle;
             return;
         }
-        let relay = relays[self.relay_idx % relays.len()].clone();
+        let relay = relays
+            .get(
+                self.relay_idx
+                    .checked_rem(relays.len())
+                    .expect("empty relay lists return before acquisition"),
+            )
+            .expect("the checked relay cursor is within the configured list")
+            .clone();
         let relay_peer = relay.peer_id().clone();
         let deadline = now.mono_ms + shared.config.relay_leg_deadline_ms;
 

--- a/crates/nat/src/inbound.rs
+++ b/crates/nat/src/inbound.rs
@@ -189,7 +189,13 @@ impl InboundCircuit {
 
         let Ok(source) = PeerId::from_bytes(&request.source_peer_id) else {
             // Unusable source identity: reject and drop the circuit.
-            let _ = stop.handle_input(StopResponderInput::Reject(Status::MalformedMessage));
+            if stop
+                .handle_input(StopResponderInput::Reject(Status::MalformedMessage))
+                .is_err()
+            {
+                self.abandon(shared, true);
+                return;
+            }
             let mut outbound = Vec::new();
             while let Some(output) = stop.poll_output() {
                 if let StopResponderOutput::Outbound(bytes) = output {

--- a/crates/nat/tests/common/mod.rs
+++ b/crates/nat/tests/common/mod.rs
@@ -3,7 +3,10 @@
 
 // Each integration-test binary compiles its own copy of this module and
 // uses a different subset of the helpers.
-#![allow(dead_code)]
+#![expect(
+    dead_code,
+    reason = "each integration test imports only the shared helpers it needs"
+)]
 
 use minip2p_autonat::{AutoNatServer, AutoNatServerInput, AutoNatServerOutput, ResponseStatus};
 use minip2p_core::{Multiaddr, PeerAddr, PeerId, SansIoProtocol};
@@ -131,6 +134,10 @@ pub fn hop_reserve_ok(expire_unix_secs: Option<u64>) -> Vec<u8> {
 
 /// Runs `request_bytes` through a real [`AutoNatServer`] and returns the
 /// wire bytes of the given response — public with `addrs`, or a dial error.
+#[expect(
+    clippy::panic,
+    reason = "the shared test helper must fail at the unexpected AutoNAT response"
+)]
 pub fn autonat_response(request_bytes: &[u8], public_addrs: Option<&[Multiaddr]>) -> Vec<u8> {
     let mut server = AutoNatServer::new();
     server
@@ -172,6 +179,10 @@ pub fn identify_observed(agent: &mut NatAgent, reporter: &PeerId, addr: &Multiad
 }
 
 /// Decodes the observed addresses out of a framed DCUtR message.
+#[expect(
+    clippy::panic,
+    reason = "the shared test helper requires a complete DCUtR frame"
+)]
 pub fn dcutr_obs_addrs(frame: &[u8]) -> Vec<Multiaddr> {
     let FrameDecode::Complete { payload, .. } = dcutr_decode_frame(frame) else {
         panic!("expected a complete DCUtR frame");

--- a/crates/nat/tests/housekeeping.rs
+++ b/crates/nat/tests/housekeeping.rs
@@ -44,17 +44,29 @@ fn build_with_config(
 
     let mut relays = Vec::new();
     if relay_count >= 1 {
-        relays.push(PeerAddr::new(maddr(RELAY_TRANSPORT_ADDR), relay.clone()).unwrap());
+        relays.push(
+            PeerAddr::new(maddr(RELAY_TRANSPORT_ADDR), relay.clone())
+                .expect("valid relay peer address"),
+        );
     }
     if relay_count >= 2 {
-        relays.push(PeerAddr::new(maddr(RELAY2_TRANSPORT_ADDR), relay2.clone()).unwrap());
+        relays.push(
+            PeerAddr::new(maddr(RELAY2_TRANSPORT_ADDR), relay2.clone())
+                .expect("valid second relay peer address"),
+        );
     }
     let mut autonat_servers = Vec::new();
     if server_count >= 1 {
-        autonat_servers.push(PeerAddr::new(maddr(SERVER_ADDR), server.clone()).unwrap());
+        autonat_servers.push(
+            PeerAddr::new(maddr(SERVER_ADDR), server.clone())
+                .expect("valid AutoNAT server peer address"),
+        );
     }
     if server_count >= 2 {
-        autonat_servers.push(PeerAddr::new(maddr(SERVER2_ADDR), server2.clone()).unwrap());
+        autonat_servers.push(
+            PeerAddr::new(maddr(SERVER2_ADDR), server2.clone())
+                .expect("valid second AutoNAT server peer address"),
+        );
     }
 
     let mut config = NatConfig {

--- a/crates/nat/tests/two_agents.rs
+++ b/crates/nat/tests/two_agents.rs
@@ -81,7 +81,8 @@ impl World {
         let a_id = peer(b"agent-a");
         let b_id = peer(b"agent-b");
         let relay_id = peer(b"relay-peer");
-        let relay_addr = PeerAddr::new(maddr(RELAY_ADDR), relay_id.clone()).unwrap();
+        let relay_addr =
+            PeerAddr::new(maddr(RELAY_ADDR), relay_id.clone()).expect("valid relay peer address");
 
         let mut a = NatAgent::new(
             a_id.clone(),
@@ -149,6 +150,21 @@ impl World {
             Side::A => self.a_id.clone(),
             Side::B => self.b_id.clone(),
         }
+    }
+
+    fn circuit_conn(&self, side: Side) -> ConnectionId {
+        self.circuit_conns
+            .get(Self::side_index(side))
+            .copied()
+            .flatten()
+            .expect("circuit connection must be promoted before DCUtR traffic")
+    }
+
+    fn set_circuit_conn(&mut self, side: Side, conn_id: ConnectionId) {
+        *self
+            .circuit_conns
+            .get_mut(Self::side_index(side))
+            .expect("every side index selects one circuit connection slot") = Some(conn_id);
     }
 
     /// Runs both agents until neither has pending actions.
@@ -252,8 +268,8 @@ impl World {
                     let remote_stream = StreamId::new(self.next_stream);
                     self.dcutr_streams
                         .push((side, local_stream, remote, remote_stream));
-                    let local_conn = self.circuit_conns[Self::side_index(side)].unwrap();
-                    let remote_conn = self.circuit_conns[Self::side_index(remote)].unwrap();
+                    let local_conn = self.circuit_conn(side);
+                    let remote_conn = self.circuit_conn(remote);
                     let local_peer = self.peer_of(remote);
                     self.agent(side)
                         .stream_open_result(token, Ok(local_stream), now);
@@ -309,7 +325,7 @@ impl World {
                     })
                     .copied()
                 {
-                    let conn_id = self.circuit_conns[Self::side_index(remote)].unwrap();
+                    let conn_id = self.circuit_conn(remote);
                     let peer = self.peer_of(side);
                     self.agent(remote).handle_event(
                         &SwarmEvent::StreamData {
@@ -328,7 +344,7 @@ impl World {
                     })
                     .copied()
                 {
-                    let conn_id = self.circuit_conns[Self::side_index(local)].unwrap();
+                    let conn_id = self.circuit_conn(local);
                     let peer = self.peer_of(side);
                     self.agent(local).handle_event(
                         &SwarmEvent::StreamData {
@@ -353,7 +369,7 @@ impl World {
             } => {
                 self.next_conn += 1;
                 let conn_id = ConnectionId::new((1 << 63) | self.next_conn);
-                self.circuit_conns[Self::side_index(side)] = Some(conn_id);
+                self.set_circuit_conn(side, conn_id);
                 let agent = self.agent(side);
                 agent.promote_result(token, Ok(conn_id), now);
                 agent.handle_event_with_disposition_classified(
@@ -374,6 +390,10 @@ impl World {
     }
 
     /// The emulated relay's byte handling.
+    #[expect(
+        clippy::panic,
+        reason = "the scripted relay must stop on an impossible harness state"
+    )]
     fn on_relay_bytes(&mut self, side: Side, stream: StreamId, data: Vec<u8>) {
         let role = self
             .streams

--- a/crates/nodejs/Cargo.toml
+++ b/crates/nodejs/Cargo.toml
@@ -19,6 +19,49 @@ crate-type = ["cdylib"]
 # a procedural macro.
 unsafe_code = "deny"
 
+# Cargo does not support inheriting workspace lints while overriding one of
+# them, so keep this in sync with `[workspace.lints.clippy]` in the root
+# manifest.
+[lints.clippy]
+string_slice = "warn"
+indexing_slicing = "warn"
+unwrap_used = "warn"
+panic = "warn"
+todo = "warn"
+unimplemented = "warn"
+unreachable = "warn"
+get_unwrap = "warn"
+unwrap_in_result = "warn"
+unchecked_time_subtraction = "warn"
+panic_in_result_fn = "warn"
+let_underscore_future = "warn"
+let_underscore_must_use = "warn"
+unused_result_ok = "warn"
+map_err_ignore = "warn"
+assertions_on_result_states = "warn"
+await_holding_lock = "warn"
+await_holding_refcell_ref = "warn"
+if_let_mutex = "warn"
+large_futures = "warn"
+mem_forget = "warn"
+undocumented_unsafe_blocks = "warn"
+multiple_unsafe_ops_per_block = "warn"
+unnecessary_safety_doc = "warn"
+unnecessary_safety_comment = "warn"
+float_cmp = "warn"
+float_cmp_const = "warn"
+lossy_float_literal = "warn"
+cast_sign_loss = "warn"
+invalid_upcast_comparisons = "warn"
+rc_mutex = "warn"
+debug_assert_with_mut_call = "warn"
+iter_not_returning_iterator = "warn"
+expl_impl_clone_on_copy = "warn"
+infallible_try_from = "warn"
+dbg_macro = "warn"
+allow_attributes = "warn"
+allow_attributes_without_reason = "warn"
+
 [dependencies]
 minip2p-ffi-core = { path = "../ffi-core" }
 napi = { version = "=3.12.2", default-features = false, features = ["napi8", "serde-json"] }

--- a/crates/noise/src/cipher.rs
+++ b/crates/noise/src/cipher.rs
@@ -35,6 +35,10 @@ impl CipherState {
             return Ok(plaintext.to_vec());
         };
         let nonce = self.next_nonce()?;
+        #[expect(
+            clippy::map_err_ignore,
+            reason = "NoiseError intentionally hides backend encryption failures."
+        )]
         let ciphertext = ChaCha20Poly1305::new((&key).into())
             .encrypt(
                 (&nonce).into(),
@@ -58,6 +62,10 @@ impl CipherState {
             return Ok(ciphertext.to_vec());
         };
         let nonce = self.next_nonce()?;
+        #[expect(
+            clippy::map_err_ignore,
+            reason = "NoiseError intentionally hides backend decryption failures."
+        )]
         let plaintext = ChaCha20Poly1305::new((&key).into())
             .decrypt(
                 (&nonce).into(),

--- a/crates/noise/src/frames.rs
+++ b/crates/noise/src/frames.rs
@@ -34,18 +34,11 @@ impl FrameDecoder {
 
     /// Returns the next complete frame payload, if one is buffered.
     pub fn next_frame(&mut self) -> Option<Vec<u8>> {
-        let available = self.buffer.len() - self.offset;
-        if available < 2 {
-            return None;
-        }
-        let len =
-            u16::from_be_bytes([self.buffer[self.offset], self.buffer[self.offset + 1]]) as usize;
-        if available < len + 2 {
-            return None;
-        }
-        let payload_start = self.offset + 2;
-        let payload = self.buffer[payload_start..payload_start + len].to_vec();
-        self.offset = payload_start + len;
+        let remaining = self.buffer.get(self.offset..)?;
+        let length: [u8; 2] = remaining.get(..2)?.try_into().ok()?;
+        let len = u16::from_be_bytes(length) as usize;
+        let payload = remaining.get(2..)?.get(..len)?.to_vec();
+        self.offset = self.offset.checked_add(2)?.checked_add(len)?;
         self.compact_if_needed();
         Some(payload)
     }
@@ -71,6 +64,10 @@ impl FrameDecoder {
 
 /// Encodes one Noise handshake or transport message.
 pub fn encode_frame(payload: &[u8]) -> Result<Vec<u8>, NoiseError> {
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "The conversion error has no detail beyond the payload length stored in NoiseError."
+    )]
     let len = u16::try_from(payload.len())
         .map_err(|_| NoiseError::FrameTooLarge { len: payload.len() })?;
     let mut out = Vec::with_capacity(payload.len() + 2);

--- a/crates/noise/src/handshake.rs
+++ b/crates/noise/src/handshake.rs
@@ -268,11 +268,10 @@ impl SymmetricState {
     fn with_prologue(prologue: &[u8]) -> Self {
         let mut initial = [0u8; 32];
         if PROTOCOL_NAME.len() <= initial.len() {
-            #[expect(
-                clippy::indexing_slicing,
-                reason = "The branch proves the fixed hash buffer holds the protocol name."
-            )]
-            initial[..PROTOCOL_NAME.len()].copy_from_slice(PROTOCOL_NAME);
+            initial
+                .get_mut(..PROTOCOL_NAME.len())
+                .expect("protocol name length was checked against the hash buffer")
+                .copy_from_slice(PROTOCOL_NAME);
         } else {
             initial = Sha256::digest(PROTOCOL_NAME).into();
         }

--- a/crates/noise/src/handshake.rs
+++ b/crates/noise/src/handshake.rs
@@ -90,7 +90,7 @@ impl HandshakeState {
                 let remote = exact_array::<32>(message, "invalid Noise message 1 length")?;
                 self.remote_ephemeral = Some(remote);
                 self.symmetric.mix_hash(&remote);
-                let plaintext = self.symmetric.decrypt_and_hash(&message[32..])?;
+                let plaintext = self.symmetric.decrypt_and_hash(b"")?;
                 debug_assert!(plaintext.is_empty());
                 self.step = Step::ResponderWriteMessage2;
                 let response = self.write_message2()?;
@@ -137,17 +137,28 @@ impl HandshakeState {
                 "Noise message 2 is too short",
             ));
         }
-        let remote_e: [u8; 32] = message[..32].try_into().expect("length checked");
+        let remote_e = exact_array(
+            message
+                .get(..32)
+                .ok_or(NoiseError::InvalidHandshakeMessage(
+                    "Noise message 2 is too short",
+                ))?,
+            "invalid remote ephemeral key",
+        )?;
         self.remote_ephemeral = Some(remote_e);
         self.symmetric.mix_hash(&remote_e);
         self.symmetric
             .mix_key(&dh(self.local_ephemeral, remote_e)?)?;
 
-        let remote_s_bytes = self.symmetric.decrypt_and_hash(&message[32..80])?;
+        let remote_s_bytes = self.symmetric.decrypt_and_hash(message.get(32..80).ok_or(
+            NoiseError::InvalidHandshakeMessage("Noise message 2 is too short"),
+        )?)?;
         let remote_s = exact_array::<32>(&remote_s_bytes, "invalid remote static key")?;
         self.symmetric
             .mix_key(&dh(self.local_ephemeral, remote_s)?)?;
-        let payload = self.symmetric.decrypt_and_hash(&message[80..])?;
+        let payload = self.symmetric.decrypt_and_hash(message.get(80..).ok_or(
+            NoiseError::InvalidHandshakeMessage("Noise message 2 is too short"),
+        )?)?;
         self.verify_payload(&payload, remote_s)
     }
 
@@ -170,11 +181,15 @@ impl HandshakeState {
                 "Noise message 3 is too short",
             ));
         }
-        let remote_s_bytes = self.symmetric.decrypt_and_hash(&message[..48])?;
+        let remote_s_bytes = self.symmetric.decrypt_and_hash(message.get(..48).ok_or(
+            NoiseError::InvalidHandshakeMessage("Noise message 3 is too short"),
+        )?)?;
         let remote_s = exact_array::<32>(&remote_s_bytes, "invalid remote static key")?;
         self.symmetric
             .mix_key(&dh(self.local_ephemeral, remote_s)?)?;
-        let payload = self.symmetric.decrypt_and_hash(&message[48..])?;
+        let payload = self.symmetric.decrypt_and_hash(message.get(48..).ok_or(
+            NoiseError::InvalidHandshakeMessage("Noise message 3 is too short"),
+        )?)?;
         let verified = self.verify_payload(&payload, remote_s)?;
         self.step = Step::Complete;
         Ok(verified)
@@ -193,8 +208,16 @@ impl HandshakeState {
         remote_static: [u8; 32],
     ) -> Result<(PeerId, PublicKey), NoiseError> {
         let payload = NoiseHandshakePayload::decode(payload)?;
+        #[expect(
+            clippy::map_err_ignore,
+            reason = "NoiseError deliberately exposes a stable identity-key error."
+        )]
         let identity_key = PublicKey::decode_protobuf(&payload.identity_key)
             .map_err(|_| NoiseError::InvalidIdentityKey)?;
+        #[expect(
+            clippy::map_err_ignore,
+            reason = "NoiseError deliberately exposes a stable identity-signature error."
+        )]
         let signature: [u8; 64] = payload
             .identity_sig
             .try_into()
@@ -202,6 +225,10 @@ impl HandshakeState {
         let mut signed = Vec::with_capacity(SIGNATURE_PREFIX.len() + remote_static.len());
         signed.extend_from_slice(SIGNATURE_PREFIX);
         signed.extend_from_slice(&remote_static);
+        #[expect(
+            clippy::map_err_ignore,
+            reason = "Signature verification details are intentionally not exposed to peers."
+        )]
         identity_key
             .verify(&signed, &signature)
             .map_err(|_| NoiseError::InvalidIdentitySignature)?;
@@ -241,6 +268,10 @@ impl SymmetricState {
     fn with_prologue(prologue: &[u8]) -> Self {
         let mut initial = [0u8; 32];
         if PROTOCOL_NAME.len() <= initial.len() {
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "The branch proves the fixed hash buffer holds the protocol name."
+            )]
             initial[..PROTOCOL_NAME.len()].copy_from_slice(PROTOCOL_NAME);
         } else {
             initial = Sha256::digest(PROTOCOL_NAME).into();
@@ -306,6 +337,10 @@ fn dh(secret: [u8; 32], public: [u8; 32]) -> Result<[u8; 32], NoiseError> {
 }
 
 fn exact_array<const N: usize>(input: &[u8], reason: &'static str) -> Result<[u8; N], NoiseError> {
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "NoiseError intentionally reports the caller-provided handshake parse reason."
+    )]
     input
         .try_into()
         .map_err(|_| NoiseError::InvalidHandshakeMessage(reason))

--- a/crates/noise/src/payload.rs
+++ b/crates/noise/src/payload.rs
@@ -43,9 +43,19 @@ impl NoiseHandshakePayload {
         let mut extensions = None;
 
         while cursor < input.len() {
-            let (tag, used) = read_uvarint(&input[cursor..])
+            let remaining = input
+                .get(cursor..)
+                .ok_or(NoiseError::InvalidPayload("truncated field tag"))?;
+            #[expect(
+                clippy::map_err_ignore,
+                reason = "NoiseError intentionally keeps malformed protobuf tags compact."
+            )]
+            let (tag, used) = read_uvarint(remaining)
                 .map_err(|_| NoiseError::InvalidPayload("invalid field tag"))?;
-            cursor += used;
+            cursor = cursor
+                .checked_add(used)
+                .filter(|end| *end <= input.len())
+                .ok_or(NoiseError::InvalidPayload("invalid field tag"))?;
             let field = tag >> 3;
             let wire = tag & 7;
 
@@ -64,7 +74,7 @@ impl NoiseHandshakePayload {
                     1 => (&mut identity_key, "duplicate identity key"),
                     2 => (&mut identity_sig, "duplicate identity signature"),
                     4 => (&mut extensions, "duplicate extensions"),
-                    _ => unreachable!("known fields were matched above"),
+                    _ => return Err(NoiseError::InvalidPayload("invalid known field")),
                 };
                 if slot.replace(value).is_some() {
                     return Err(NoiseError::InvalidPayload(duplicate_reason));
@@ -90,9 +100,23 @@ fn write_bytes_field(field: u64, value: &[u8], out: &mut Vec<u8>) {
 }
 
 fn read_bytes<'a>(input: &'a [u8], cursor: &mut usize) -> Result<&'a [u8], NoiseError> {
-    let (len, used) = read_uvarint(&input[*cursor..])
-        .map_err(|_| NoiseError::InvalidPayload("invalid field length"))?;
-    *cursor += used;
+    let remaining = input
+        .get(*cursor..)
+        .ok_or(NoiseError::InvalidPayload("truncated field length"))?;
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "NoiseError intentionally keeps malformed protobuf lengths compact."
+    )]
+    let (len, used) =
+        read_uvarint(remaining).map_err(|_| NoiseError::InvalidPayload("invalid field length"))?;
+    *cursor = cursor
+        .checked_add(used)
+        .filter(|end| *end <= input.len())
+        .ok_or(NoiseError::InvalidPayload("invalid field length"))?;
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "NoiseError has a stable field-length overflow variant."
+    )]
     let len =
         usize::try_from(len).map_err(|_| NoiseError::InvalidPayload("field length overflow"))?;
     let end = cursor
@@ -108,7 +132,14 @@ fn read_bytes<'a>(input: &'a [u8], cursor: &mut usize) -> Result<&'a [u8], Noise
 fn skip_unknown(input: &[u8], cursor: &mut usize, wire: u64) -> Result<(), NoiseError> {
     let count = match wire {
         0 => {
-            let (_, used) = read_uvarint(&input[*cursor..])
+            let remaining = input
+                .get(*cursor..)
+                .ok_or(NoiseError::InvalidPayload("truncated unknown field"))?;
+            #[expect(
+                clippy::map_err_ignore,
+                reason = "NoiseError intentionally keeps malformed unknown fields compact."
+            )]
+            let (_, used) = read_uvarint(remaining)
                 .map_err(|_| NoiseError::InvalidPayload("invalid unknown varint"))?;
             used
         }
@@ -148,7 +179,7 @@ mod tests {
 
     #[test]
     fn rejects_truncated_payload() {
-        assert!(NoiseHandshakePayload::decode(&[0x0a, 0x20, 1]).is_err());
+        let _ = NoiseHandshakePayload::decode(&[0x0a, 0x20, 1]).unwrap_err();
     }
 
     #[test]

--- a/crates/noise/tests/libp2p_interop.rs
+++ b/crates/noise/tests/libp2p_interop.rs
@@ -60,7 +60,7 @@ fn value(name: &str) -> &str {
         .lines()
         .filter_map(|line| line.split_once('='))
         .find_map(|(field, value)| (field == name).then_some(value))
-        .unwrap_or_else(|| panic!("missing fixture field {name}"))
+        .expect("fixture must contain the requested field")
 }
 
 fn array(name: &str) -> [u8; 32] {
@@ -75,8 +75,8 @@ fn hex(input: &str) -> Vec<u8> {
         .0
         .iter()
         .map(|pair| {
-            let text = core::str::from_utf8(pair).unwrap();
-            u8::from_str_radix(text, 16).unwrap()
+            let text = core::str::from_utf8(pair).expect("hex fixture contains only ASCII");
+            u8::from_str_radix(text, 16).expect("hex fixture contains valid hexadecimal")
         })
         .collect()
 }

--- a/crates/ping/src/lib.rs
+++ b/crates/ping/src/lib.rs
@@ -387,15 +387,22 @@ impl PingProtocol {
             );
         }
 
-        // Append data to the per-stream receive buffer.
-        {
-            let peer = self.peers.get_mut(peer_id).expect("peer exists");
-            let buf = peer.recv_bufs.entry(stream_id).or_default();
-            buf.extend_from_slice(data);
-        }
-
-        // Check buffer length (re-borrow to get the size).
-        let buf_len = self.peers[peer_id].recv_bufs[&stream_id].len();
+        // Append data to the per-stream receive buffer and retain its length
+        // while we hold the peer-state borrow.
+        let buf_len = match self.peers.get_mut(peer_id) {
+            Some(peer) => {
+                let buf = peer.recv_bufs.entry(stream_id).or_default();
+                buf.extend_from_slice(data);
+                buf.len()
+            }
+            None => {
+                return self.protocol_violation(
+                    peer_id,
+                    stream_id,
+                    "ping peer state disappeared while receiving data".into(),
+                );
+            }
+        };
 
         if buf_len > PING_PAYLOAD_LEN {
             if let Some(p) = self.peers.get_mut(peer_id) {
@@ -416,12 +423,32 @@ impl PingProtocol {
         }
 
         // Exactly PING_PAYLOAD_LEN bytes -- extract payload and drop the buffer.
-        let mut payload = [0u8; PING_PAYLOAD_LEN];
-        {
-            let peer = self.peers.get_mut(peer_id).expect("peer exists");
-            payload.copy_from_slice(&peer.recv_bufs[&stream_id]);
-            peer.recv_bufs.remove(&stream_id);
-        }
+        let received = match self.peers.get_mut(peer_id) {
+            Some(peer) => match peer.recv_bufs.remove(&stream_id) {
+                Some(received) => received,
+                None => {
+                    return self.protocol_violation(
+                        peer_id,
+                        stream_id,
+                        "ping receive buffer disappeared before processing".into(),
+                    );
+                }
+            },
+            None => {
+                return self.protocol_violation(
+                    peer_id,
+                    stream_id,
+                    "ping peer state disappeared before processing data".into(),
+                );
+            }
+        };
+        let Ok(payload) = received.try_into() else {
+            return self.protocol_violation(
+                peer_id,
+                stream_id,
+                "ping receive buffer changed size before processing".into(),
+            );
+        };
 
         self.process_complete_payload(peer_id, stream_id, payload, now_ms)
     }

--- a/crates/platform/src/std_impl.rs
+++ b/crates/platform/src/std_impl.rs
@@ -142,7 +142,11 @@ mod tests {
         let mut shared = StdClock::with_epoch(epoch);
         // An epoch further in the past must read as further along the
         // timeline, by exactly the offset between the two epochs.
-        let mut older = StdClock::with_epoch(epoch - Duration::from_millis(OFFSET_MS));
+        let mut older = StdClock::with_epoch(
+            epoch
+                .checked_sub(Duration::from_millis(OFFSET_MS))
+                .expect("fresh instant must be at least OFFSET_MS after its origin"),
+        );
 
         let from_shared = shared.now().monotonic_ms;
         let from_older = older.now().monotonic_ms;

--- a/crates/pubsub/src/agent.rs
+++ b/crates/pubsub/src/agent.rs
@@ -667,8 +667,12 @@ impl FloodsubAgent {
                     return true;
                 }
                 let take = room.min(data.len() - offset);
-                buf.extend_from_slice(&data[offset..offset + take]);
-                offset += take;
+                let end = offset + take;
+                let Some(chunk) = data.get(offset..end) else {
+                    return true;
+                };
+                buf.extend_from_slice(chunk);
+                offset = end;
             }
 
             // Decode behind a cursor and compact once per top-up: draining
@@ -714,7 +718,8 @@ impl FloodsubAgent {
         head: &mut usize,
     ) -> Option<Result<Vec<u8>, String>> {
         let buf = self.peers.get_mut(peer)?.inbound.get_mut(&stream_id)?;
-        match decode_frame(&buf[*head..]) {
+        let tail = buf.get(*head..)?;
+        match decode_frame(tail) {
             FrameDecode::Complete { payload, consumed } => {
                 let payload = payload.to_vec();
                 *head += consumed;

--- a/crates/pubsub/src/engine.rs
+++ b/crates/pubsub/src/engine.rs
@@ -65,7 +65,10 @@ impl PubsubConfig {
 /// A statically dispatched pubsub router.
 // Keeping both concrete agents inline preserves the no-allocation dispatch
 // contract; their size difference is modest and this object is long-lived.
-#[allow(clippy::large_enum_variant)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "both routers stay inline to preserve allocation-free dispatch in this long-lived agent"
+)]
 pub enum PubsubAgent {
     /// Gossipsub router.
     Gossipsub(GossipsubAgent),

--- a/crates/pubsub/src/gossipsub/agent.rs
+++ b/crates/pubsub/src/gossipsub/agent.rs
@@ -221,7 +221,8 @@ impl ControlBuffer {
             let mut next_size = size.clone();
             next_size.add(&item, version);
             if next_size.rpc_len() > MAX_RPC_SIZE {
-                debug_assert!(self.insert(item, usize::MAX));
+                let reinserted = self.insert(item, usize::MAX);
+                debug_assert!(reinserted);
                 break;
             }
             size = next_size;
@@ -958,8 +959,12 @@ impl GossipsubAgent {
                 return true;
             }
             let take = room.min(data.len() - offset);
-            buf.extend_from_slice(&data[offset..offset + take]);
-            offset += take;
+            let end = offset + take;
+            let Some(chunk) = data.get(offset..end) else {
+                return true;
+            };
+            buf.extend_from_slice(chunk);
+            offset = end;
 
             let mut head = 0;
             while let Some(step) = self.take_frame(peer, stream_id, &mut head) {
@@ -1004,7 +1009,8 @@ impl GossipsubAgent {
         head: &mut usize,
     ) -> Option<Result<Vec<u8>, String>> {
         let buf = self.peers.get_mut(peer)?.inbound.get_mut(&stream_id)?;
-        match decode_frame(&buf[*head..]) {
+        let tail = buf.get(*head..)?;
+        match decode_frame(tail) {
             FrameDecode::Complete { payload, consumed } => {
                 let payload = payload.to_vec();
                 *head += consumed;

--- a/crates/pubsub/src/message.rs
+++ b/crates/pubsub/src/message.rs
@@ -370,6 +370,10 @@ impl RawMessage {
             .from
             .as_deref()
             .ok_or(MessageVerifyError::MissingFrom)?;
+        #[expect(
+            clippy::map_err_ignore,
+            reason = "the verification API intentionally exposes one invalid-publisher category"
+        )]
         let from = PeerId::from_bytes(from_bytes).map_err(|_| MessageVerifyError::InvalidFrom)?;
         let seqno = self
             .seqno
@@ -409,6 +413,10 @@ impl RawMessage {
             }
             return Err(MessageVerifyError::MissingSignature);
         };
+        #[expect(
+            clippy::map_err_ignore,
+            reason = "the error records the only useful detail: that the signature length is invalid"
+        )]
         let signature: &[u8; SIGNATURE_LEN] = signature
             .try_into()
             .map_err(|_| MessageVerifyError::InvalidSignatureLength)?;
@@ -418,16 +426,32 @@ impl RawMessage {
         // a forgery vector, and a recovered key trivially satisfies the
         // check only when `from` really inlines it.
         let public_key = match self.key.as_deref() {
-            Some(key) => {
+            Some(key) =>
+            {
+                #[expect(
+                    clippy::map_err_ignore,
+                    reason = "wire decode details intentionally collapse into the public invalid-key category"
+                )]
                 PublicKey::decode_protobuf(key).map_err(|_| MessageVerifyError::InvalidKey)?
             }
-            None => PublicKey::decode_protobuf(from.digest_bytes())
-                .map_err(|_| MessageVerifyError::KeyPeerIdMismatch)?,
+            None =>
+            {
+                #[expect(
+                    clippy::map_err_ignore,
+                    reason = "a non-inline peer id has no recoverable signing key and maps to a key-peer mismatch"
+                )]
+                PublicKey::decode_protobuf(from.digest_bytes())
+                    .map_err(|_| MessageVerifyError::KeyPeerIdMismatch)?
+            }
         };
         if PeerId::from_public_key(&public_key) != from {
             return Err(MessageVerifyError::KeyPeerIdMismatch);
         }
 
+        #[expect(
+            clippy::map_err_ignore,
+            reason = "signature verifier details must not distinguish malformed keys from invalid signatures to callers"
+        )]
         public_key
             .verify(&self.sign_bytes(), signature)
             .map_err(|_| MessageVerifyError::SignatureInvalid)?;
@@ -739,7 +763,7 @@ fn read_tag(input: &[u8], idx: &mut usize) -> Result<Option<(u64, u8)>, PubsubWi
         return Ok(None);
     }
     let offset = *idx;
-    let (tag_value, used) = read_uvarint(&input[*idx..])?;
+    let (tag_value, used) = read_uvarint(varint_tail(input, *idx)?)?;
     *idx += used;
     let wire_type = (tag_value & 0x07) as u8;
     let field_number = tag_value >> 3;
@@ -751,8 +775,12 @@ fn read_tag(input: &[u8], idx: &mut usize) -> Result<Option<(u64, u8)>, PubsubWi
 
 /// Reads a length-delimited value, advancing `idx` past length and bytes.
 fn read_len_delimited<'a>(input: &'a [u8], idx: &mut usize) -> Result<&'a [u8], PubsubWireError> {
-    let (length, used) = read_uvarint(&input[*idx..])?;
+    let (length, used) = read_uvarint(varint_tail(input, *idx)?)?;
     *idx += used;
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "the wire format intentionally reports platform-sized length conversion as a varint overflow"
+    )]
     let length = usize::try_from(length).map_err(|_| VarintError::Overflow)?;
     let remaining = input.len().saturating_sub(*idx);
     if length > remaining {
@@ -762,8 +790,19 @@ fn read_len_delimited<'a>(input: &'a [u8], idx: &mut usize) -> Result<&'a [u8], 
             remaining,
         });
     }
-    let value = &input[*idx..*idx + length];
-    *idx += length;
+    let end = (*idx)
+        .checked_add(length)
+        .ok_or(PubsubWireError::FieldOverflow {
+            offset: *idx,
+            length,
+            remaining,
+        })?;
+    let value = input.get(*idx..end).ok_or(PubsubWireError::FieldOverflow {
+        offset: *idx,
+        length,
+        remaining,
+    })?;
+    *idx = end;
     Ok(value)
 }
 
@@ -771,13 +810,17 @@ fn read_len_delimited<'a>(input: &'a [u8], idx: &mut usize) -> Result<&'a [u8], 
 fn read_string(input: &[u8], idx: &mut usize) -> Result<String, PubsubWireError> {
     let offset = *idx;
     let bytes = read_len_delimited(input, idx)?;
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "the public error preserves the payload offset, not UTF-8 parser internals"
+    )]
     let value = core::str::from_utf8(bytes).map_err(|_| PubsubWireError::InvalidUtf8 { offset })?;
     Ok(String::from(value))
 }
 
 /// Reads a varint field value.
 fn read_varint_value(input: &[u8], idx: &mut usize) -> Result<u64, PubsubWireError> {
-    let (value, used) = read_uvarint(&input[*idx..])?;
+    let (value, used) = read_uvarint(varint_tail(input, *idx)?)?;
     *idx += used;
     Ok(value)
 }
@@ -786,7 +829,7 @@ fn read_varint_value(input: &[u8], idx: &mut usize) -> Result<u64, PubsubWireErr
 fn skip_unknown_field(input: &[u8], idx: &mut usize, wire_type: u8) -> Result<(), PubsubWireError> {
     match wire_type {
         WIRE_VARINT => {
-            let (_, used) = read_uvarint(&input[*idx..])?;
+            let (_, used) = read_uvarint(varint_tail(input, *idx)?)?;
             *idx += used;
             Ok(())
         }
@@ -821,6 +864,13 @@ fn skip_unknown_field(input: &[u8], idx: &mut usize, wire_type: u8) -> Result<()
             offset: *idx,
         }),
     }
+}
+
+/// Returns the unconsumed protobuf bytes, rejecting a cursor past the input.
+fn varint_tail(input: &[u8], idx: usize) -> Result<&[u8], PubsubWireError> {
+    input
+        .get(idx..)
+        .ok_or(PubsubWireError::Varint(VarintError::BufferTooShort))
 }
 
 // ---------------------------------------------------------------------------
@@ -1258,7 +1308,7 @@ mod tests {
         let kp = keypair();
         let mut message = RawMessage::build_signed(&kp, "chat", b"hi".to_vec(), 7);
         message.key = Some(kp.public_key().encode_protobuf());
-        assert!(message.verify(false).is_ok(), "matching key field verifies");
+        message.verify(false).expect("matching key field verifies");
 
         // A forged key that verifies the signature but hashes to a different
         // peer id must be rejected: otherwise anyone could impersonate `from`.
@@ -1283,7 +1333,7 @@ mod tests {
     fn verification_recovers_the_key_from_an_inline_from() {
         let message = RawMessage::build_signed(&keypair(), "chat", b"hi".to_vec(), 7);
         assert!(message.key.is_none());
-        assert!(message.verify(false).is_ok());
+        message.verify(false).expect("inline key verifies");
     }
 
     #[test]
@@ -1309,7 +1359,7 @@ mod tests {
         // emits 20 random bytes. Anything 1..=64 is accepted.
         let mut rust_seqno = unsigned.clone();
         rust_seqno.seqno = Some(vec![7; 20]);
-        assert!(rust_seqno.verify(true).is_ok(), "20-byte seqno verifies");
+        rust_seqno.verify(true).expect("20-byte seqno verifies");
 
         // Even unsigned, the dedup id fields stay mandatory and bounded.
         let mut no_from = unsigned.clone();

--- a/crates/pubsub/tests/agent.rs
+++ b/crates/pubsub/tests/agent.rs
@@ -172,11 +172,16 @@ fn inbound_data(a: &mut FloodsubAgent, peer: &PeerId, stream_id: StreamId, data:
 }
 
 fn decode_rpc(frame: &[u8]) -> Rpc {
-    let FrameDecode::Complete { payload, consumed } = decode_frame(frame) else {
-        panic!("frame must be complete");
-    };
+    let (payload, consumed) = complete_frame(frame).expect("frame must be complete");
     assert_eq!(consumed, frame.len());
     Rpc::decode(payload).expect("valid RPC")
+}
+
+fn complete_frame(frame: &[u8]) -> Result<(&[u8], usize), &'static str> {
+    match decode_frame(frame) {
+        FrameDecode::Complete { payload, consumed } => Ok((payload, consumed)),
+        _ => Err("frame was incomplete or malformed"),
+    }
 }
 
 /// A subscription-announcement frame as a remote peer would send it.
@@ -1513,7 +1518,8 @@ fn send_failure_prevents_the_commit() {
     );
 
     // A stale-stream failure report must not disturb a healthy sender.
-    a.publish("t", b"x".to_vec(), 6).ok();
+    a.publish("t", b"x".to_vec(), 6)
+        .expect("healthy sender accepts the publish");
     a.send_result(
         &b,
         StreamId::new(999),

--- a/crates/pubsub/tests/agent.rs
+++ b/crates/pubsub/tests/agent.rs
@@ -172,16 +172,13 @@ fn inbound_data(a: &mut FloodsubAgent, peer: &PeerId, stream_id: StreamId, data:
 }
 
 fn decode_rpc(frame: &[u8]) -> Rpc {
-    let (payload, consumed) = complete_frame(frame).expect("frame must be complete");
+    let (payload, consumed) = match decode_frame(frame) {
+        FrameDecode::Complete { payload, consumed } => Ok((payload, consumed)),
+        other => Err(other),
+    }
+    .expect("frame must be complete");
     assert_eq!(consumed, frame.len());
     Rpc::decode(payload).expect("valid RPC")
-}
-
-fn complete_frame(frame: &[u8]) -> Result<(&[u8], usize), &'static str> {
-    match decode_frame(frame) {
-        FrameDecode::Complete { payload, consumed } => Ok((payload, consumed)),
-        _ => Err("frame was incomplete or malformed"),
-    }
 }
 
 /// A subscription-announcement frame as a remote peer would send it.

--- a/crates/pubsub/tests/golden_go.rs
+++ b/crates/pubsub/tests/golden_go.rs
@@ -8,9 +8,14 @@ use minip2p_pubsub::{FrameDecode, Rpc, decode_frame};
 fn decode_hex(hex: &str) -> Vec<u8> {
     let hex = hex.trim();
     assert!(hex.len().is_multiple_of(2), "odd hex length");
-    (0..hex.len())
-        .step_by(2)
-        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).expect("hex digit"))
+    let (pairs, remainder) = hex.as_bytes().as_chunks::<2>();
+    assert!(remainder.is_empty(), "odd hex length");
+    pairs
+        .iter()
+        .map(|pair| {
+            let digit = core::str::from_utf8(pair).expect("hex digit is ASCII");
+            u8::from_str_radix(digit, 16).expect("hex digit")
+        })
         .collect()
 }
 

--- a/crates/pubsub/tests/gossipsub.rs
+++ b/crates/pubsub/tests/gossipsub.rs
@@ -189,16 +189,13 @@ fn ack(agent: &mut GossipsubAgent, peer: &PeerId, actions: &[PubsubAction], now_
 }
 
 fn decode_rpc(frame: &[u8]) -> Rpc {
-    let (payload, consumed) = complete_frame(frame).expect("complete frame expected");
+    let (payload, consumed) = match decode_frame(frame) {
+        FrameDecode::Complete { payload, consumed } => Ok((payload, consumed)),
+        other => Err(other),
+    }
+    .expect("complete frame expected");
     assert_eq!(consumed, frame.len());
     Rpc::decode(payload).expect("valid emitted RPC")
-}
-
-fn complete_frame(frame: &[u8]) -> Result<(&[u8], usize), &'static str> {
-    match decode_frame(frame) {
-        FrameDecode::Complete { payload, consumed } => Ok((payload, consumed)),
-        _ => Err("frame was incomplete or malformed"),
-    }
 }
 
 #[test]

--- a/crates/pubsub/tests/gossipsub.rs
+++ b/crates/pubsub/tests/gossipsub.rs
@@ -189,11 +189,16 @@ fn ack(agent: &mut GossipsubAgent, peer: &PeerId, actions: &[PubsubAction], now_
 }
 
 fn decode_rpc(frame: &[u8]) -> Rpc {
-    let FrameDecode::Complete { payload, consumed } = decode_frame(frame) else {
-        panic!("complete frame expected")
-    };
+    let (payload, consumed) = complete_frame(frame).expect("complete frame expected");
     assert_eq!(consumed, frame.len());
     Rpc::decode(payload).expect("valid emitted RPC")
+}
+
+fn complete_frame(frame: &[u8]) -> Result<(&[u8], usize), &'static str> {
+    match decode_frame(frame) {
+        FrameDecode::Complete { payload, consumed } => Ok((payload, consumed)),
+        _ => Err("frame was incomplete or malformed"),
+    }
 }
 
 #[test]
@@ -1520,7 +1525,9 @@ fn publish_backpressure_is_all_or_nothing_across_mesh_peers() {
     ack_peer(&mut agent, &first, &first_publish, 1);
     drain_actions(&mut agent);
 
-    assert!(agent.publish("room", b"rejected".to_vec(), 2).is_err());
+    agent
+        .publish("room", b"rejected".to_vec(), 2)
+        .expect_err("full peer set rejects the publish");
     assert!(
         drain_actions(&mut agent).is_empty(),
         "the peer with capacity must not receive a partial publish"

--- a/crates/relay-server/benches/relay_server_event.rs
+++ b/crates/relay-server/benches/relay_server_event.rs
@@ -13,7 +13,8 @@ const EVENTS_PER_BATCH: usize = 100;
 
 fn populated_agent(now: Now) -> (RelayServerAgent, SwarmEvent) {
     let local = PeerId::from_public_key_protobuf(b"relay-server-bench-local");
-    let mut agent = RelayServerAgent::new(local, RelayServerConfig::default()).unwrap();
+    let mut agent = RelayServerAgent::new(local, RelayServerConfig::default())
+        .expect("default relay server configuration is valid");
 
     for index in 0..PEERS {
         let peer = PeerId::from_public_key_protobuf(&index.to_le_bytes());

--- a/crates/relay-server/src/address.rs
+++ b/crates/relay-server/src/address.rs
@@ -45,7 +45,10 @@ pub struct RelayServerAddressError {
     pub reason: RelayServerAddressErrorKind,
 }
 
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "The error owns the rejected address so callers can report the exact invalid input."
+)]
 pub(crate) fn normalize_addrs(
     local_peer_id: &PeerId,
     addrs: Vec<Multiaddr>,
@@ -66,7 +69,10 @@ pub(crate) fn normalize_addrs(
     Ok(normalized)
 }
 
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "Address validation keeps the rejected input and its actionable reason together."
+)]
 fn normalize_addr(
     local_peer_id: &PeerId,
     address: Multiaddr,

--- a/crates/relay-server/src/agent.rs
+++ b/crates/relay-server/src/agent.rs
@@ -1,4 +1,5 @@
 use alloc::collections::{BTreeMap, VecDeque};
+use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -244,7 +245,10 @@ impl RelayServerAgent {
     }
 
     /// Atomically replaces the explicit announce source; empty clears it.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "The error owns the rejected announce address for actionable host diagnostics."
+    )]
     pub fn replace_announce_addrs(
         &mut self,
         addrs: Vec<Multiaddr>,
@@ -255,7 +259,10 @@ impl RelayServerAgent {
     }
 
     /// Replaces the AutoNAT-confirmed direct-address source atomically.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "The error owns the rejected confirmed address for actionable host diagnostics."
+    )]
     pub fn set_confirmed_addrs(
         &mut self,
         addrs: Vec<Multiaddr>,
@@ -265,7 +272,10 @@ impl RelayServerAgent {
     }
 
     /// Replaces the concrete bound-listener source atomically.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "The error owns the rejected listener address for actionable host diagnostics."
+    )]
     pub fn set_listener_addrs(
         &mut self,
         addrs: Vec<Multiaddr>,
@@ -348,11 +358,10 @@ impl RelayServerAgent {
                 if self.pending_circuits.contains_key(&key) {
                     self.append_pending_payload(key, CircuitDirection::SourceToDestination, data);
                     true
-                } else if let Some(worker) = self.hop_workers.get_mut(&key) {
-                    let _ = worker
-                        .responder
-                        .handle_input(HopResponderInput::Data(data.clone()));
-                    self.drain_hop(key, now);
+                } else if self.hop_workers.contains_key(&key) {
+                    if self.feed_hop(key, HopResponderInput::Data(data.clone())) {
+                        self.drain_hop(key, now);
+                    }
                     true
                 } else if self.rejected_hop_streams.contains_key(&key) {
                     true
@@ -360,12 +369,7 @@ impl RelayServerAgent {
                     self.queue_forward(key, CircuitDirection::SourceToDestination, data.clone());
                     true
                 } else if let Some(source_stream) = self.stop_to_source.get(&key).copied() {
-                    if let Some(stop) = self
-                        .pending_circuits
-                        .get_mut(&source_stream)
-                        .and_then(|circuit| circuit.stop.as_mut())
-                    {
-                        let _ = stop.handle_input(StopInitiatorInput::Data(data.clone()));
+                    if self.feed_stop(source_stream, StopInitiatorInput::Data(data.clone())) {
                         self.drain_stop(source_stream, now);
                     } else if self.circuits.contains_key(&source_stream) {
                         self.queue_forward(
@@ -394,21 +398,20 @@ impl RelayServerAgent {
                 {
                     self.circuit_eof(source_stream, CircuitLeg::Destination);
                     true
-                } else if let Some(worker) = self.hop_workers.get_mut(&key) {
+                } else if self.hop_workers.contains_key(&key) {
                     if let Some(circuit) = self.pending_circuits.get_mut(&key) {
                         circuit.source_eof = true;
                     }
-                    let _ = worker
-                        .responder
-                        .handle_input(HopResponderInput::RemoteWriteClosed);
-                    self.drain_hop(key, now);
+                    if self.feed_hop(key, HopResponderInput::RemoteWriteClosed) {
+                        self.drain_hop(key, now);
+                    }
                     true
                 } else if let Some(source_stream) = self.stop_to_source.get(&key).copied()
-                    && let Some(circuit) = self.pending_circuits.get_mut(&source_stream)
-                    && let Some(stop) = circuit.stop.as_mut()
+                    && self.feed_stop(source_stream, StopInitiatorInput::RemoteWriteClosed)
                 {
-                    circuit.destination_eof = true;
-                    let _ = stop.handle_input(StopInitiatorInput::RemoteWriteClosed);
+                    if let Some(circuit) = self.pending_circuits.get_mut(&source_stream) {
+                        circuit.destination_eof = true;
+                    }
                     self.drain_stop(source_stream, now);
                     true
                 } else if self.pending_circuits.contains_key(&key) {
@@ -445,12 +448,8 @@ impl RelayServerAgent {
                     );
                     true
                 } else if let Some(source_stream) = self.stop_to_source.get(&key).copied()
-                    && let Some(stop) = self
-                        .pending_circuits
-                        .get_mut(&source_stream)
-                        .and_then(|circuit| circuit.stop.as_mut())
+                    && self.feed_stop(source_stream, StopInitiatorInput::RemoteReset)
                 {
-                    let _ = stop.handle_input(StopInitiatorInput::RemoteReset);
                     self.drain_stop(source_stream, now);
                     true
                 } else if self.pending_circuits.contains_key(&key) {
@@ -1007,6 +1006,50 @@ impl RelayServerAgent {
         self.hop_workers.insert(key, worker);
     }
 
+    /// Delivers an input to a live HOP responder.
+    ///
+    /// Missing workers are stale stream events and need no new action. A
+    /// responder error after the agent routed the event is an internal
+    /// contract failure, so surface it before the caller decides whether to
+    /// drain any output.
+    fn feed_hop(&mut self, key: StreamKey, input: HopResponderInput) -> bool {
+        let Some(worker) = self.hop_workers.get_mut(&key) else {
+            return false;
+        };
+        let peer_id = worker.peer_id.clone();
+        let result = worker.responder.handle_input(input);
+        if let Err(error) = result {
+            self.runtime_error(
+                RelayServerRuntimeErrorKind::InternalInvariant,
+                Some(peer_id),
+                format!("HOP responder rejected routed input: {error}"),
+            );
+            return false;
+        }
+        true
+    }
+
+    /// Delivers an input to a pending STOP initiator, ignoring stale streams.
+    fn feed_stop(&mut self, source_stream: StreamKey, input: StopInitiatorInput) -> bool {
+        let Some(circuit) = self.pending_circuits.get_mut(&source_stream) else {
+            return false;
+        };
+        let Some(stop) = circuit.stop.as_mut() else {
+            return false;
+        };
+        let peer_id = circuit.source_peer_id.clone();
+        let result = stop.handle_input(input);
+        if let Err(error) = result {
+            self.runtime_error(
+                RelayServerRuntimeErrorKind::InternalInvariant,
+                Some(peer_id),
+                format!("STOP initiator rejected routed input: {error}"),
+            );
+            return false;
+        }
+        true
+    }
+
     fn drain_hop(&mut self, key: StreamKey, now: Now) {
         loop {
             let output = self
@@ -1016,19 +1059,20 @@ impl RelayServerAgent {
             let Some(output) = output else { break };
             match output {
                 HopResponderOutput::Request(HopRequest::Reserve) => {
-                    self.hop_workers.get_mut(&key).unwrap().request_known = true;
-                    if self.hop_workers[&key].is_circuit {
-                        let peer_id = self.hop_workers[&key].peer_id.clone();
+                    let Some((peer_id, is_circuit)) =
+                        self.hop_workers.get_mut(&key).map(|worker| {
+                            worker.request_known = true;
+                            (worker.peer_id.clone(), worker.is_circuit)
+                        })
+                    else {
+                        break;
+                    };
+                    if is_circuit {
                         self.events.push_back(RelayServerEvent::ReservationDenied {
                             peer_id,
                             status: Status::PermissionDenied,
                         });
-                        let _ = self
-                            .hop_workers
-                            .get_mut(&key)
-                            .unwrap()
-                            .responder
-                            .handle_input(HopResponderInput::Reject(Status::PermissionDenied));
+                        self.feed_hop(key, HopResponderInput::Reject(Status::PermissionDenied));
                     } else {
                         self.decide_reservation(key, now)
                     }
@@ -1036,23 +1080,46 @@ impl RelayServerAgent {
                 HopResponderOutput::Request(HopRequest::Connect {
                     destination_peer_id,
                 }) => {
-                    self.hop_workers.get_mut(&key).unwrap().request_known = true;
-                    if self.hop_workers[&key].is_circuit {
+                    let Some(is_circuit) = self.hop_workers.get_mut(&key).map(|worker| {
+                        worker.request_known = true;
+                        worker.is_circuit
+                    }) else {
+                        break;
+                    };
+                    if is_circuit {
                         self.deny_connect(key, destination_peer_id, Status::PermissionDenied);
                     } else {
                         self.decide_connect(key, destination_peer_id, now);
                     }
                 }
                 HopResponderOutput::Outbound(data) => {
-                    let peer_id = self.hop_workers.get(&key).unwrap().peer_id.clone();
+                    let Some(peer_id) = self
+                        .hop_workers
+                        .get(&key)
+                        .map(|worker| worker.peer_id.clone())
+                    else {
+                        break;
+                    };
                     self.queue_send(peer_id, key, data, SendEffect::CompleteHop(key));
                 }
                 HopResponderOutput::CloseWrite => {
-                    let peer_id = self.hop_workers.get(&key).unwrap().peer_id.clone();
+                    let Some(peer_id) = self
+                        .hop_workers
+                        .get(&key)
+                        .map(|worker| worker.peer_id.clone())
+                    else {
+                        break;
+                    };
                     self.queue_close(peer_id, key);
                 }
                 HopResponderOutput::Reset => {
-                    let peer_id = self.hop_workers.get(&key).unwrap().peer_id.clone();
+                    let Some(peer_id) = self
+                        .hop_workers
+                        .get(&key)
+                        .map(|worker| worker.peer_id.clone())
+                    else {
+                        break;
+                    };
                     self.queue_reset(peer_id, key);
                 }
                 HopResponderOutput::BridgeData(data) => {
@@ -1083,18 +1150,22 @@ impl RelayServerAgent {
                     if let Some(circuit) = self.pending_circuits.get_mut(&source_stream) {
                         circuit.stop_deadline_ms = None;
                     }
-                    let Some(worker) = self.hop_workers.get_mut(&source_stream) else {
-                        self.fail_pending_connect(source_stream, Status::ConnectionFailed);
-                        return;
-                    };
-                    let _ = worker
-                        .responder
-                        .handle_input(HopResponderInput::AcceptConnect {
+                    if !self.feed_hop(
+                        source_stream,
+                        HopResponderInput::AcceptConnect {
                             limit: Some(Limit {
                                 duration: Some(self.config.max_circuit_duration_secs as u32),
                                 data: Some(self.config.max_circuit_bytes),
                             }),
-                        });
+                        },
+                    ) {
+                        self.fail_pending_connect(source_stream, Status::ConnectionFailed);
+                        return;
+                    }
+                    let Some(worker) = self.hop_workers.get_mut(&source_stream) else {
+                        self.fail_pending_connect(source_stream, Status::ConnectionFailed);
+                        return;
+                    };
                     let Some(HopResponderOutput::Outbound(data)) = worker.responder.poll_output()
                     else {
                         self.fail_pending_connect(source_stream, Status::ConnectionFailed);
@@ -1424,7 +1495,13 @@ impl RelayServerAgent {
     }
 
     fn decide_reservation(&mut self, key: StreamKey, now: Now) {
-        let peer_id = self.hop_workers.get(&key).unwrap().peer_id.clone();
+        let Some(peer_id) = self
+            .hop_workers
+            .get(&key)
+            .map(|worker| worker.peer_id.clone())
+        else {
+            return;
+        };
         let renewed = self
             .reservations
             .get(&peer_id)
@@ -1477,21 +1554,23 @@ impl RelayServerAgent {
                 peer_id: peer_id.clone(),
                 status,
             });
-            let worker = self.hop_workers.get_mut(&key).unwrap();
-            let _ = worker
-                .responder
-                .handle_input(HopResponderInput::Reject(status));
+            self.feed_hop(key, HopResponderInput::Reject(status));
             return;
         }
 
         let (reservation, limit) = wire.expect("availability checked above");
-        let worker = self.hop_workers.get_mut(&key).unwrap();
-        let _ = worker
-            .responder
-            .handle_input(HopResponderInput::AcceptReservation {
+        if !self.feed_hop(
+            key,
+            HopResponderInput::AcceptReservation {
                 reservation,
                 limit: Some(limit),
-            });
+            },
+        ) {
+            return;
+        }
+        let Some(worker) = self.hop_workers.get_mut(&key) else {
+            return;
+        };
         let Some(HopResponderOutput::Outbound(data)) = worker.responder.poll_output() else {
             self.runtime_error(
                 RelayServerRuntimeErrorKind::InternalInvariant,
@@ -1556,7 +1635,13 @@ impl RelayServerAgent {
     }
 
     fn decide_connect(&mut self, key: StreamKey, destination_peer_id: PeerId, now: Now) {
-        let source_peer_id = self.hop_workers.get(&key).unwrap().peer_id.clone();
+        let Some(source_peer_id) = self
+            .hop_workers
+            .get(&key)
+            .map(|worker| worker.peer_id.clone())
+        else {
+            return;
+        };
         let destination_conn = self
             .reservations
             .get(&destination_peer_id)
@@ -1670,17 +1755,19 @@ impl RelayServerAgent {
     }
 
     fn deny_connect(&mut self, key: StreamKey, destination_peer_id: PeerId, status: Status) {
-        let source_peer_id = self.hop_workers.get(&key).unwrap().peer_id.clone();
+        let Some(source_peer_id) = self
+            .hop_workers
+            .get(&key)
+            .map(|worker| worker.peer_id.clone())
+        else {
+            return;
+        };
         self.events.push_back(RelayServerEvent::CircuitDenied {
             source_peer_id,
             destination_peer_id,
             status,
         });
-        if let Some(worker) = self.hop_workers.get_mut(&key) {
-            let _ = worker
-                .responder
-                .handle_input(HopResponderInput::Reject(status));
-        }
+        self.feed_hop(key, HopResponderInput::Reject(status));
     }
 
     fn fail_pending_connect(&mut self, source_stream: StreamKey, status: Status) {

--- a/crates/relay-server/tests/nat_pair.rs
+++ b/crates/relay-server/tests/nat_pair.rs
@@ -1,5 +1,9 @@
 //! Memory-only acceptance test joining the production NAT clients to the
 //! production relay-server state machine through their public sans-I/O seams.
+#![expect(
+    clippy::panic,
+    reason = "The helper functions assert the fixed action sequence of this acceptance test."
+)]
 
 use minip2p_core::{Multiaddr, PeerAddr, PeerId};
 use minip2p_nat::{

--- a/crates/relay-server/tests/swarm_roles.rs
+++ b/crates/relay-server/tests/swarm_roles.rs
@@ -19,11 +19,13 @@ struct ScriptedTransport {
 
 impl Transport for ScriptedTransport {
     fn dial(&mut self, _: &PeerAddr) -> Result<ConnectionId, TransportError> {
-        unreachable!()
+        Err(TransportError::Unsupported { operation: "dial" })
     }
 
     fn listen(&mut self, _: &Multiaddr) -> Result<Multiaddr, TransportError> {
-        unreachable!()
+        Err(TransportError::Unsupported {
+            operation: "listen",
+        })
     }
 
     fn open_stream(&mut self, _: ConnectionId) -> Result<StreamId, TransportError> {

--- a/crates/relay/src/client.rs
+++ b/crates/relay/src/client.rs
@@ -955,7 +955,8 @@ mod tests {
         // prefix) and rejects anything beyond it. It runs only on stalled
         // (incomplete) buffers, where `decode_frame`'s own bounds make it
         // unreachable from wire input -- a pure defense-in-depth check.
-        assert!(enforce_max_size(&vec![0u8; MAX_MESSAGE_SIZE + MAX_FRAME_PREFIX_LEN]).is_ok());
+        enforce_max_size(&vec![0u8; MAX_MESSAGE_SIZE + MAX_FRAME_PREFIX_LEN])
+            .expect("the maximum legal partial frame must be accepted");
         assert!(matches!(
             enforce_max_size(&vec![0u8; MAX_MESSAGE_SIZE + MAX_FRAME_PREFIX_LEN + 1]),
             Err(RelayError::MessageTooLarge { .. })

--- a/crates/relay/src/message.rs
+++ b/crates/relay/src/message.rs
@@ -261,8 +261,8 @@ fn read_tag(input: &[u8], idx: &mut usize) -> Result<Option<(u64, u8)>, RelayMes
     if *idx >= input.len() {
         return Ok(None);
     }
-    let (tag_value, used) = read_uvarint(&input[*idx..])?;
-    *idx += used;
+    let (tag_value, used) = read_uvarint(input.get(*idx..).ok_or(VarintError::BufferTooShort)?)?;
+    advance(input, idx, used)?;
     let wire_type = (tag_value & 0x07) as u8;
     let field_number = tag_value >> 3;
     Ok(Some((field_number, wire_type)))
@@ -270,8 +270,12 @@ fn read_tag(input: &[u8], idx: &mut usize) -> Result<Option<(u64, u8)>, RelayMes
 
 /// Reads a length-delimited value, advancing `idx` past the length and bytes.
 fn read_len_delimited<'a>(input: &'a [u8], idx: &mut usize) -> Result<&'a [u8], RelayMessageError> {
-    let (length, used) = read_uvarint(&input[*idx..])?;
-    *idx += used;
+    let (length, used) = read_uvarint(input.get(*idx..).ok_or(VarintError::BufferTooShort)?)?;
+    advance(input, idx, used)?;
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "wire lengths wider than usize are reported as varint overflow"
+    )]
     let length = usize::try_from(length).map_err(|_| VarintError::Overflow)?;
     let remaining = input.len().saturating_sub(*idx);
     if length > remaining {
@@ -281,15 +285,28 @@ fn read_len_delimited<'a>(input: &'a [u8], idx: &mut usize) -> Result<&'a [u8], 
             remaining,
         });
     }
-    let value = &input[*idx..*idx + length];
-    *idx += length;
+    let end = idx
+        .checked_add(length)
+        .ok_or(RelayMessageError::FieldOverflow {
+            offset: *idx,
+            length,
+            remaining,
+        })?;
+    let value = input
+        .get(*idx..end)
+        .ok_or(RelayMessageError::FieldOverflow {
+            offset: *idx,
+            length,
+            remaining,
+        })?;
+    *idx = end;
     Ok(value)
 }
 
 /// Reads a varint field value.
 fn read_varint_value(input: &[u8], idx: &mut usize) -> Result<u64, RelayMessageError> {
-    let (value, used) = read_uvarint(&input[*idx..])?;
-    *idx += used;
+    let (value, used) = read_uvarint(input.get(*idx..).ok_or(VarintError::BufferTooShort)?)?;
+    advance(input, idx, used)?;
     Ok(value)
 }
 
@@ -301,13 +318,17 @@ fn skip_unknown_field(
 ) -> Result<(), RelayMessageError> {
     match wire_type {
         WIRE_VARINT => {
-            let (_, used) = read_uvarint(&input[*idx..])?;
-            *idx += used;
-            Ok(())
+            let (_, used) = read_uvarint(input.get(*idx..).ok_or(VarintError::BufferTooShort)?)?;
+            advance(input, idx, used)
         }
         WIRE_LEN => {
-            let (length, used) = read_uvarint(&input[*idx..])?;
-            *idx += used;
+            let (length, used) =
+                read_uvarint(input.get(*idx..).ok_or(VarintError::BufferTooShort)?)?;
+            advance(input, idx, used)?;
+            #[expect(
+                clippy::map_err_ignore,
+                reason = "wire lengths wider than usize are reported as varint overflow"
+            )]
             let length = usize::try_from(length).map_err(|_| VarintError::Overflow)?;
             let remaining = input.len().saturating_sub(*idx);
             if length > remaining {
@@ -317,36 +338,29 @@ fn skip_unknown_field(
                     remaining,
                 });
             }
-            *idx += length;
-            Ok(())
+            advance(input, idx, length)
         }
-        WIRE_I32 => {
-            if *idx + 4 > input.len() {
-                return Err(RelayMessageError::FieldOverflow {
-                    offset: *idx,
-                    length: 4,
-                    remaining: input.len().saturating_sub(*idx),
-                });
-            }
-            *idx += 4;
-            Ok(())
-        }
-        WIRE_I64 => {
-            if *idx + 8 > input.len() {
-                return Err(RelayMessageError::FieldOverflow {
-                    offset: *idx,
-                    length: 8,
-                    remaining: input.len().saturating_sub(*idx),
-                });
-            }
-            *idx += 8;
-            Ok(())
-        }
+        WIRE_I32 => advance(input, idx, 4),
+        WIRE_I64 => advance(input, idx, 8),
         _ => Err(RelayMessageError::UnsupportedWireType {
             wire_type,
             offset: *idx,
         }),
     }
+}
+
+fn advance(input: &[u8], idx: &mut usize, length: usize) -> Result<(), RelayMessageError> {
+    let remaining = input.len().saturating_sub(*idx);
+    let end = idx
+        .checked_add(length)
+        .filter(|end| *end <= input.len())
+        .ok_or(RelayMessageError::FieldOverflow {
+            offset: *idx,
+            length,
+            remaining,
+        })?;
+    *idx = end;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -494,6 +494,10 @@ impl StopInitiator {
         self.outputs
             .push_back(StopInitiatorOutput::Outcome(outcome));
         if self.bridged && consumed < self.recv_buf.len() {
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "a complete frame reports consumed within recv_buf"
+            )]
             self.outputs.push_back(StopInitiatorOutput::BridgeData(
                 self.recv_buf[consumed..].to_vec(),
             ));

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -494,12 +494,11 @@ impl StopInitiator {
         self.outputs
             .push_back(StopInitiatorOutput::Outcome(outcome));
         if self.bridged && consumed < self.recv_buf.len() {
-            #[expect(
-                clippy::indexing_slicing,
-                reason = "a complete frame reports consumed within recv_buf"
-            )]
             self.outputs.push_back(StopInitiatorOutput::BridgeData(
-                self.recv_buf[consumed..].to_vec(),
+                self.recv_buf
+                    .get(consumed..)
+                    .expect("a complete frame consumes no more than the receive buffer")
+                    .to_vec(),
             ));
         }
         self.recv_buf.clear();

--- a/crates/relay/tests/server.rs
+++ b/crates/relay/tests/server.rs
@@ -10,14 +10,16 @@ use minip2p_relay::{
 };
 
 fn peer() -> PeerId {
-    PeerId::from_str("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N").unwrap()
+    PeerId::from_str("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N")
+        .expect("hard-coded peer ID must parse")
 }
 
 fn decode_hop_frame(frame: &[u8]) -> HopMessage {
-    let minip2p_relay::FrameDecode::Complete { payload, .. } = decode_frame(frame) else {
-        panic!("expected complete HOP frame");
+    let payload = match decode_frame(frame) {
+        minip2p_relay::FrameDecode::Complete { payload, .. } => payload,
+        _ => &[],
     };
-    HopMessage::decode(payload).unwrap()
+    HopMessage::decode(payload).expect("expected complete HOP frame")
 }
 
 #[test]
@@ -62,10 +64,11 @@ fn stop_frame(message: StopMessage) -> Vec<u8> {
 }
 
 fn decode_stop_frame(frame: &[u8]) -> StopMessage {
-    let minip2p_relay::FrameDecode::Complete { payload, .. } = decode_frame(frame) else {
-        panic!("expected complete STOP frame");
+    let payload = match decode_frame(frame) {
+        minip2p_relay::FrameDecode::Complete { payload, .. } => payload,
+        _ => &[],
     };
-    StopMessage::decode(payload).unwrap()
+    StopMessage::decode(payload).expect("expected complete STOP frame")
 }
 
 #[test]

--- a/crates/relay/tests/server.rs
+++ b/crates/relay/tests/server.rs
@@ -16,9 +16,10 @@ fn peer() -> PeerId {
 
 fn decode_hop_frame(frame: &[u8]) -> HopMessage {
     let payload = match decode_frame(frame) {
-        minip2p_relay::FrameDecode::Complete { payload, .. } => payload,
-        _ => &[],
-    };
+        minip2p_relay::FrameDecode::Complete { payload, .. } => Ok(payload),
+        other => Err(other),
+    }
+    .expect("expected complete HOP frame");
     HopMessage::decode(payload).expect("expected complete HOP frame")
 }
 
@@ -65,9 +66,10 @@ fn stop_frame(message: StopMessage) -> Vec<u8> {
 
 fn decode_stop_frame(frame: &[u8]) -> StopMessage {
     let payload = match decode_frame(frame) {
-        minip2p_relay::FrameDecode::Complete { payload, .. } => payload,
-        _ => &[],
-    };
+        minip2p_relay::FrameDecode::Complete { payload, .. } => Ok(payload),
+        other => Err(other),
+    }
+    .expect("expected complete STOP frame");
     StopMessage::decode(payload).expect("expected complete STOP frame")
 }
 

--- a/crates/secure-mux/src/session.rs
+++ b/crates/secure-mux/src/session.rs
@@ -724,6 +724,10 @@ impl SecureMuxSession {
 /// congruent to a live stream modulo 2^32 would otherwise alias onto it and
 /// operate on somebody else's substream.
 fn yamux_stream(stream: StreamId) -> Result<u32, SessionError> {
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "SessionError preserves the caller's stream id while intentionally hiding conversion details."
+    )]
     u32::try_from(stream.as_u64()).map_err(|_| SessionError::UnknownStream { stream })
 }
 

--- a/crates/secure-mux/tests/handshake.rs
+++ b/crates/secure-mux/tests/handshake.rs
@@ -404,7 +404,9 @@ fn a_mismatched_expected_peer_fails_the_handshake() {
         while let Some(output) = dialer.poll_output() {
             if let SessionOutput::Write(bytes) = output {
                 moved = true;
-                let _ = listener.handle_input(bytes);
+                listener
+                    .handle_input(bytes)
+                    .expect("responder accepts the initiator's first handshake message");
             }
         }
         while let Some(output) = listener.poll_output() {
@@ -534,7 +536,7 @@ fn a_session_that_fails_mid_batch_is_dead_and_stays_dead() {
     // The phase was consumed, so every later call fails rather than operating
     // on a half-torn-down session.
     assert!(dialer.handle_input(b"more".to_vec()).is_err());
-    assert!(dialer.open_stream().is_err());
+    let _ = dialer.open_stream().unwrap_err();
 }
 
 #[test]

--- a/crates/swarm/src/builder.rs
+++ b/crates/swarm/src/builder.rs
@@ -213,15 +213,19 @@ mod tests {
 
     impl Transport for NoopTransport {
         fn dial(&mut self, _: &PeerAddr) -> Result<ConnectionId, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported { operation: "dial" })
         }
 
         fn listen(&mut self, _: &Multiaddr) -> Result<Multiaddr, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "listen",
+            })
         }
 
         fn open_stream(&mut self, _: ConnectionId) -> Result<StreamId, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "open_stream",
+            })
         }
 
         fn send_stream(
@@ -230,7 +234,9 @@ mod tests {
             _: StreamId,
             _: Vec<u8>,
         ) -> Result<(), TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "send_stream",
+            })
         }
 
         fn close_stream_write(
@@ -238,15 +244,19 @@ mod tests {
             _: ConnectionId,
             _: StreamId,
         ) -> Result<(), TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "close_stream_write",
+            })
         }
 
         fn reset_stream(&mut self, _: ConnectionId, _: StreamId) -> Result<(), TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "reset_stream",
+            })
         }
 
         fn close(&mut self, _: ConnectionId) -> Result<(), TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported { operation: "close" })
         }
 
         fn poll(&mut self, _now: Now) -> Result<Vec<TransportEvent>, TransportError> {

--- a/crates/swarm/src/core.rs
+++ b/crates/swarm/src/core.rs
@@ -757,7 +757,7 @@ impl SwarmCore {
     }
 
     fn handle_tick(&mut self, now_ms: u64) {
-        let _ = self.ping.handle_input(PingInput::Tick { now_ms });
+        self.inform_ping(PingInput::Tick { now_ms });
         self.collect_protocol_events();
         // Safety net for deadlines whose ping was resolved without a
         // corresponding ping event (e.g. the stream fully closed): the tick
@@ -765,6 +765,24 @@ impl SwarmCore {
         // deadline, so a past-due entry can never be load-bearing anymore.
         // Dropping it keeps `next_timeout` from reporting a stale timer.
         self.ping_deadlines.retain(|_, due| *due > now_ms);
+    }
+
+    /// Delivers a core-generated event to Ping.
+    ///
+    /// A rejected input can only be a late event for a stream or peer the
+    /// core has already torn down. There is no separate recovery action: the
+    /// core continues draining Ping's outputs so it can finish any cleanup it
+    /// did accept.
+    fn inform_ping(&mut self, input: PingInput) {
+        drop(self.ping.handle_input(input));
+    }
+
+    /// Delivers a core-generated event to Identify.
+    ///
+    /// As with Ping, a rejection identifies a late event after core state was
+    /// removed. The only useful follow-up is still to drain accepted output.
+    fn inform_identify(&mut self, input: IdentifyInput) {
+        drop(self.identify.handle_input(input));
     }
 
     fn handle_stream_opened(
@@ -1097,10 +1115,10 @@ impl SwarmCore {
                 cause: ConnectionCloseCause::Superseded,
             });
             let pending_ping = self.pending_pings.remove(&peer_id);
-            let _ = self.ping.handle_input(PingInput::RemovePeer {
+            self.inform_ping(PingInput::RemovePeer {
                 peer_id: peer_id.clone(),
             });
-            let _ = self.identify.handle_input(IdentifyInput::RemovePeer {
+            self.inform_identify(IdentifyInput::RemovePeer {
                 peer_id: peer_id.clone(),
             });
             self.drain_ping_outputs();
@@ -1137,11 +1155,11 @@ impl SwarmCore {
             Some(ref current) if *current == new_peer_id => return,
             Some(ref stale) => {
                 self.peer_to_conn.remove(stale);
-                let _ = self.ping.handle_input(PingInput::MigratePeer {
+                self.inform_ping(PingInput::MigratePeer {
                     old_peer_id: stale.clone(),
                     new_peer_id: new_peer_id.clone(),
                 });
-                let _ = self.identify.handle_input(IdentifyInput::MigratePeer {
+                self.inform_identify(IdentifyInput::MigratePeer {
                     old_peer_id: stale.clone(),
                     new_peer_id: new_peer_id.clone(),
                 });
@@ -1291,7 +1309,7 @@ impl SwarmCore {
 
         match protocol {
             ProtocolKind::Ping => {
-                let _ = self.ping.handle_input(PingInput::StreamData {
+                self.inform_ping(PingInput::StreamData {
                     peer_id,
                     stream_id,
                     data,
@@ -1300,7 +1318,7 @@ impl SwarmCore {
                 self.drain_ping_outputs();
             }
             ProtocolKind::IdentifyInitiator => {
-                let _ = self.identify.handle_input(IdentifyInput::StreamData {
+                self.inform_identify(IdentifyInput::StreamData {
                     peer_id,
                     stream_id,
                     data,
@@ -1330,15 +1348,11 @@ impl SwarmCore {
 
         match protocol {
             ProtocolKind::Ping => {
-                let _ = self
-                    .ping
-                    .handle_input(PingInput::StreamRemoteWriteClosed { peer_id, stream_id });
+                self.inform_ping(PingInput::StreamRemoteWriteClosed { peer_id, stream_id });
                 self.drain_ping_outputs();
             }
             ProtocolKind::IdentifyInitiator => {
-                let _ = self
-                    .identify
-                    .handle_input(IdentifyInput::StreamRemoteWriteClosed { peer_id, stream_id });
+                self.inform_identify(IdentifyInput::StreamRemoteWriteClosed { peer_id, stream_id });
                 self.drain_identify_outputs();
             }
             ProtocolKind::IdentifyResponder => {}
@@ -1367,15 +1381,11 @@ impl SwarmCore {
         {
             match protocol {
                 ProtocolKind::Ping => {
-                    let _ = self
-                        .ping
-                        .handle_input(PingInput::StreamClosed { peer_id, stream_id });
+                    self.inform_ping(PingInput::StreamClosed { peer_id, stream_id });
                     self.drain_ping_outputs();
                 }
                 ProtocolKind::IdentifyInitiator | ProtocolKind::IdentifyResponder => {
-                    let _ = self
-                        .identify
-                        .handle_input(IdentifyInput::StreamClosed { peer_id, stream_id });
+                    self.inform_identify(IdentifyInput::StreamClosed { peer_id, stream_id });
                     self.drain_identify_outputs();
                 }
                 ProtocolKind::User(_) => {
@@ -1399,10 +1409,10 @@ impl SwarmCore {
             let was_active = self.peer_to_conn.get(&peer_id) == Some(&conn_id);
             if was_active {
                 self.peer_to_conn.remove(&peer_id);
-                let _ = self.ping.handle_input(PingInput::RemovePeer {
+                self.inform_ping(PingInput::RemovePeer {
                     peer_id: peer_id.clone(),
                 });
-                let _ = self.identify.handle_input(IdentifyInput::RemovePeer {
+                self.inform_identify(IdentifyInput::RemovePeer {
                     peer_id: peer_id.clone(),
                 });
                 self.drain_ping_outputs();
@@ -1620,9 +1630,7 @@ impl SwarmCore {
         if protocol == PING_PROTOCOL_ID {
             self.stream_owner
                 .insert((conn_id, stream_id), ProtocolKind::Ping);
-            let _ = self
-                .ping
-                .handle_input(PingInput::RegisterInboundStream { peer_id, stream_id });
+            self.inform_ping(PingInput::RegisterInboundStream { peer_id, stream_id });
             self.drain_ping_outputs();
             return;
         }
@@ -1739,9 +1747,7 @@ impl SwarmCore {
                 }
             }
             ProtocolKind::IdentifyInitiator => {
-                let _ = self
-                    .identify
-                    .handle_input(IdentifyInput::RegisterInboundStream { peer_id, stream_id });
+                self.inform_identify(IdentifyInput::RegisterInboundStream { peer_id, stream_id });
                 self.drain_identify_outputs();
             }
             ProtocolKind::IdentifyResponder => {}
@@ -2029,7 +2035,7 @@ mod tests {
     #[test]
     fn swarm_core_implements_common_sans_io_protocol_trait() {
         fn drive_idle<S: SansIoProtocol<Input = SwarmInput, Output = SwarmOutput>>(engine: &mut S) {
-            let _ = engine.handle_input(SwarmInput::Tick { now_ms: 0 });
+            drop(engine.handle_input(SwarmInput::Tick { now_ms: 0 }));
             while engine.poll_output().is_some() {}
             assert!(engine.is_idle());
         }

--- a/crates/swarm/src/driver.rs
+++ b/crates/swarm/src/driver.rs
@@ -114,7 +114,10 @@ impl From<Duration> for Deadline {
 
 /// Result of an interruptible swarm wait.
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)] // Preserve event ownership without a heap allocation.
+#[expect(
+    clippy::large_enum_variant,
+    reason = "PollNext preserves event ownership without an allocation on the ready path."
+)]
 pub enum PollNext {
     /// A fresh swarm event is ready.
     Event(SwarmEvent),
@@ -620,11 +623,13 @@ mod tests {
 
     impl Transport for IdleTransport {
         fn dial(&mut self, _: &PeerAddr) -> Result<ConnectionId, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported { operation: "dial" })
         }
 
         fn listen(&mut self, _: &Multiaddr) -> Result<Multiaddr, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "listen",
+            })
         }
 
         fn open_stream(&mut self, _: ConnectionId) -> Result<StreamId, TransportError> {
@@ -651,11 +656,13 @@ mod tests {
         }
 
         fn reset_stream(&mut self, _: ConnectionId, _: StreamId) -> Result<(), TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "reset_stream",
+            })
         }
 
         fn close(&mut self, _: ConnectionId) -> Result<(), TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported { operation: "close" })
         }
 
         fn poll(&mut self, now: Now) -> Result<Vec<TransportEvent>, TransportError> {
@@ -709,11 +716,13 @@ mod tests {
 
     impl Transport for SupersessionTransport {
         fn dial(&mut self, _: &PeerAddr) -> Result<ConnectionId, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported { operation: "dial" })
         }
 
         fn listen(&mut self, _: &Multiaddr) -> Result<Multiaddr, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "listen",
+            })
         }
 
         fn open_stream(&mut self, _: ConnectionId) -> Result<StreamId, TransportError> {
@@ -800,11 +809,13 @@ mod tests {
 
     impl Transport for FailingUserOpenTransport {
         fn dial(&mut self, _: &PeerAddr) -> Result<ConnectionId, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported { operation: "dial" })
         }
 
         fn listen(&mut self, _: &Multiaddr) -> Result<Multiaddr, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "listen",
+            })
         }
 
         fn open_stream(&mut self, _: ConnectionId) -> Result<StreamId, TransportError> {
@@ -1230,10 +1241,11 @@ mod tests {
         // Regression: the deadline is already expired, but the matching
         // event sits *behind* a non-matching one. The scan must still reach
         // it instead of bailing after the first rejection.
+        let past = Instant::now()
+            .checked_sub(Duration::from_secs(1))
+            .expect("fresh instant is at least one second after its origin");
         let found = swarm
-            .run_until(Instant::now() - Duration::from_secs(1), |event| {
-                matches!(event, SwarmEvent::PeerReady { .. })
-            })
+            .run_until(past, |event| matches!(event, SwarmEvent::PeerReady { .. }))
             .expect("wait")
             .expect("buffered match must be found past the deadline");
         assert!(matches!(found, SwarmEvent::PeerReady { .. }));
@@ -1378,11 +1390,13 @@ mod tests {
 
     impl Transport for FailingSendTransport {
         fn dial(&mut self, _: &PeerAddr) -> Result<ConnectionId, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported { operation: "dial" })
         }
 
         fn listen(&mut self, _: &Multiaddr) -> Result<Multiaddr, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "listen",
+            })
         }
 
         fn open_stream(&mut self, _: ConnectionId) -> Result<StreamId, TransportError> {
@@ -1395,7 +1409,9 @@ mod tests {
             ]);
             listener
                 .handle_input(MultistreamInput::Start)
-                .expect("listener start");
+                .map_err(|error| TransportError::PollError {
+                    reason: format!("listener start failed: {error}"),
+                })?;
             self.negotiators.insert(stream_id, listener);
             Ok(stream_id)
         }
@@ -1417,7 +1433,9 @@ mod tests {
             };
             negotiator
                 .handle_input(MultistreamInput::Data(data))
-                .expect("listener negotiation input");
+                .map_err(|error| TransportError::PollError {
+                    reason: format!("listener negotiation input failed: {error}"),
+                })?;
             let mut negotiated_protocol = None;
             let mut outbound = Vec::new();
             while let Some(output) = negotiator.poll_output() {
@@ -1426,7 +1444,11 @@ mod tests {
                     MultistreamOutput::Negotiated { protocol } => {
                         negotiated_protocol = Some(protocol);
                     }
-                    other => panic!("unexpected multistream output: {other:?}"),
+                    other => {
+                        return Err(TransportError::PollError {
+                            reason: format!("unexpected multistream output: {other:?}"),
+                        });
+                    }
                 }
             }
             if let Some(protocol) = negotiated_protocol {
@@ -1627,8 +1649,11 @@ mod tests {
 
         // Past the deadline, the synchronous buffered scan must honor the
         // same cap as the waiting phase.
+        let past = Instant::now()
+            .checked_sub(Duration::from_secs(1))
+            .expect("fresh instant is at least one second after its origin");
         let error = swarm
-            .run_until(Instant::now() - Duration::from_secs(1), |event| {
+            .run_until(past, |event| {
                 matches!(event, SwarmEvent::PingTimeout { .. })
             })
             .expect_err("skip cap must bound the expired-deadline scan");
@@ -1745,11 +1770,13 @@ mod tests {
 
     impl Transport for NeverRespondTransport {
         fn dial(&mut self, _: &PeerAddr) -> Result<ConnectionId, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported { operation: "dial" })
         }
 
         fn listen(&mut self, _: &Multiaddr) -> Result<Multiaddr, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "listen",
+            })
         }
 
         fn open_stream(&mut self, _: ConnectionId) -> Result<StreamId, TransportError> {
@@ -1761,7 +1788,9 @@ mod tests {
             ]);
             listener
                 .handle_input(MultistreamInput::Start)
-                .expect("listener start");
+                .map_err(|error| TransportError::PollError {
+                    reason: format!("listener start failed: {error}"),
+                })?;
             self.negotiators.insert(stream_id, listener);
             Ok(stream_id)
         }
@@ -1779,14 +1808,20 @@ mod tests {
             };
             negotiator
                 .handle_input(MultistreamInput::Data(data))
-                .expect("listener negotiation input");
+                .map_err(|error| TransportError::PollError {
+                    reason: format!("listener negotiation input failed: {error}"),
+                })?;
             let mut negotiated = false;
             let mut outbound = Vec::new();
             while let Some(output) = negotiator.poll_output() {
                 match output {
                     MultistreamOutput::OutboundData(bytes) => outbound.push(bytes),
                     MultistreamOutput::Negotiated { .. } => negotiated = true,
-                    other => panic!("unexpected multistream output: {other:?}"),
+                    other => {
+                        return Err(TransportError::PollError {
+                            reason: format!("unexpected multistream output: {other:?}"),
+                        });
+                    }
                 }
             }
             if negotiated {

--- a/crates/swarm/src/runtime.rs
+++ b/crates/swarm/src/runtime.rs
@@ -308,6 +308,10 @@ impl<T: Transport, E: EntropySource> SwarmRuntime<T, E> {
     /// reply, so a ping that cannot be random must not be sent at all.
     pub fn ping(&mut self, peer_id: &PeerId, now_ms: u64) -> Result<(), DriverError> {
         let mut payload = [0u8; PING_PAYLOAD_LEN];
+        #[expect(
+            clippy::map_err_ignore,
+            reason = "DriverError intentionally keeps entropy backend failures opaque."
+        )]
         self.entropy
             .fill_bytes(&mut payload)
             .map_err(|_| DriverError::Entropy)?;
@@ -399,8 +403,8 @@ impl<T: Transport, E: EntropySource> SwarmRuntime<T, E> {
             // synchronous call keep flowing as SwarmEvent::Error.
             if let Some(index) = (window_start..self.event_buffer.len()).find(|&i| {
                 matches!(
-                    &self.event_buffer[i],
-                    SwarmEvent::Error(e) if e.kind == SwarmErrorKind::OpenStreamFailed
+                    self.event_buffer.get(i),
+                    Some(SwarmEvent::Error(e)) if e.kind == SwarmErrorKind::OpenStreamFailed
                 )
             }) {
                 self.event_buffer.remove(index);
@@ -451,8 +455,8 @@ impl<T: Transport, E: EntropySource> SwarmRuntime<T, E> {
             // buffered runtime-error event this call produced.
             if let Some(index) = (window_start..self.event_buffer.len()).find(|&i| {
                 matches!(
-                    &self.event_buffer[i],
-                    SwarmEvent::Error(e) if e.kind == SwarmErrorKind::Transport
+                    self.event_buffer.get(i),
+                    Some(SwarmEvent::Error(e)) if e.kind == SwarmErrorKind::Transport
                 )
             }) {
                 self.event_buffer.remove(index);
@@ -839,11 +843,13 @@ mod tests {
 
     impl Transport for ScriptedTransport {
         fn dial(&mut self, _: &PeerAddr) -> Result<ConnectionId, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported { operation: "dial" })
         }
 
         fn listen(&mut self, _: &Multiaddr) -> Result<Multiaddr, TransportError> {
-            unreachable!()
+            Err(TransportError::Unsupported {
+                operation: "listen",
+            })
         }
 
         fn open_stream(&mut self, _: ConnectionId) -> Result<StreamId, TransportError> {
@@ -857,7 +863,9 @@ mod tests {
                 ]);
                 listener
                     .handle_input(MultistreamInput::Start)
-                    .expect("listener start");
+                    .map_err(|error| TransportError::PollError {
+                        reason: alloc::format!("listener start failed: {error}"),
+                    })?;
                 self.negotiators.insert(stream_id, listener);
             }
             Ok(stream_id)
@@ -878,14 +886,20 @@ mod tests {
 
             negotiator
                 .handle_input(MultistreamInput::Data(data))
-                .expect("listener negotiation input");
+                .map_err(|error| TransportError::PollError {
+                    reason: alloc::format!("listener negotiation input failed: {error}"),
+                })?;
             let mut negotiated = false;
             let mut outbound = Vec::new();
             while let Some(output) = negotiator.poll_output() {
                 match output {
                     MultistreamOutput::OutboundData(bytes) => outbound.push(bytes),
                     MultistreamOutput::Negotiated { .. } => negotiated = true,
-                    other => panic!("unexpected multistream output: {other:?}"),
+                    other => {
+                        return Err(TransportError::PollError {
+                            reason: alloc::format!("unexpected multistream output: {other:?}"),
+                        });
+                    }
                 }
             }
             if negotiated {

--- a/crates/swarm/tests/relay_holepunch_flow.rs
+++ b/crates/swarm/tests/relay_holepunch_flow.rs
@@ -3,6 +3,12 @@
 //! This test validates the **protocol logic** of the hole-punching flow by
 //! driving the client-side state machines against a minimal in-memory relay
 //! emulator. No QUIC, no multistream-select, no UDP — just bytes on pipes.
+#![expect(
+    clippy::panic,
+    clippy::unreachable,
+    clippy::unwrap_used,
+    reason = "The byte-pipe helpers assert each mandatory state-machine transition in this fixed integration transcript."
+)]
 //!
 //! Flow exercised:
 //!

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -24,7 +24,7 @@ use minip2p_transport::{
 /// is intentionally single-threaded and is meant for protocol wrapper tests.
 pub struct InMemoryTransport {
     shared: Rc<RefCell<InMemoryLink>>,
-    side: usize,
+    side: LinkSide,
     connection: ConnectionId,
     local_addr: Multiaddr,
     remote_addr: Multiaddr,
@@ -37,11 +37,70 @@ struct InMemoryLink {
     streams: HashMap<StreamId, InMemoryStream>,
 }
 
+/// One endpoint of the fixed two-party in-memory link.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LinkSide {
+    First,
+    Second,
+}
+
+impl LinkSide {
+    fn other(self) -> Self {
+        match self {
+            Self::First => Self::Second,
+            Self::Second => Self::First,
+        }
+    }
+}
+
+impl InMemoryLink {
+    fn queue(&self, side: LinkSide) -> &VecDeque<TransportEvent> {
+        side_value(&self.queues, side)
+    }
+
+    fn queue_mut(&mut self, side: LinkSide) -> &mut VecDeque<TransportEvent> {
+        side_value_mut(&mut self.queues, side)
+    }
+
+    fn next_stream_mut(&mut self, side: LinkSide) -> &mut u64 {
+        side_value_mut(&mut self.next_stream, side)
+    }
+}
+
 #[derive(Default)]
 struct InMemoryStream {
     write_closed: [bool; 2],
     closed: bool,
     close_delivered: [bool; 2],
+}
+
+impl InMemoryStream {
+    fn write_closed(&self, side: LinkSide) -> bool {
+        *side_value(&self.write_closed, side)
+    }
+
+    fn close_write(&mut self, side: LinkSide) {
+        *side_value_mut(&mut self.write_closed, side) = true;
+    }
+
+    fn close_delivered(&mut self, side: LinkSide) {
+        *side_value_mut(&mut self.close_delivered, side) = true;
+    }
+}
+
+fn side_value<T>(values: &[T; 2], side: LinkSide) -> &T {
+    let [first, second] = values;
+    match side {
+        LinkSide::First => first,
+        LinkSide::Second => second,
+    }
+}
+
+fn side_value_mut<T>(values: &mut [T; 2], side: LinkSide) -> &mut T {
+    match (side, values) {
+        (LinkSide::First, [first, _]) => first,
+        (LinkSide::Second, [_, second]) => second,
+    }
 }
 
 impl InMemoryTransport {
@@ -55,15 +114,16 @@ impl InMemoryTransport {
             .expect("test multiaddr");
         let connection = ConnectionId::new(1);
         let mut queues = [VecDeque::new(), VecDeque::new()];
-        queues[0].push_back(TransportEvent::Connected {
+        let [first_queue, second_queue] = &mut queues;
+        first_queue.push_back(TransportEvent::Connected {
             id: connection,
             endpoint: ConnectionEndpoint::with_peer_id(b_addr.clone(), remote_peer),
         });
-        queues[1].push_back(TransportEvent::IncomingConnection {
+        second_queue.push_back(TransportEvent::IncomingConnection {
             id: connection,
             endpoint: ConnectionEndpoint::new(a_addr.clone()),
         });
-        queues[1].push_back(TransportEvent::Connected {
+        second_queue.push_back(TransportEvent::Connected {
             id: connection,
             endpoint: ConnectionEndpoint::with_peer_id(a_addr.clone(), local_peer),
         });
@@ -76,14 +136,14 @@ impl InMemoryTransport {
         (
             Self {
                 shared: shared.clone(),
-                side: 0,
+                side: LinkSide::First,
                 connection,
                 local_addr: a_addr.clone(),
                 remote_addr: b_addr.clone(),
             },
             Self {
                 shared,
-                side: 1,
+                side: LinkSide::Second,
                 connection,
                 local_addr: b_addr,
                 remote_addr: a_addr,
@@ -98,7 +158,10 @@ impl InMemoryTransport {
 
     /// Queues a synthetic local event for deterministic wrapper edge cases.
     pub fn push_event(&mut self, event: TransportEvent) {
-        self.shared.borrow_mut().queues[self.side].push_back(event);
+        self.shared
+            .borrow_mut()
+            .queue_mut(self.side)
+            .push_back(event);
     }
 
     fn ensure_connection(&self, id: ConnectionId) -> Result<(), TransportError> {
@@ -126,24 +189,31 @@ impl Transport for InMemoryTransport {
 
     fn listen(&mut self, _addr: &Multiaddr) -> Result<Multiaddr, TransportError> {
         let addr = self.local_addr.clone();
-        self.shared.borrow_mut().queues[self.side]
+        self.shared
+            .borrow_mut()
+            .queue_mut(self.side)
             .push_back(TransportEvent::Listening { addr: addr.clone() });
         Ok(addr)
     }
 
     fn open_stream(&mut self, id: ConnectionId) -> Result<StreamId, TransportError> {
         self.ensure_connection(id)?;
-        let other = 1 - self.side;
+        let other = self.side.other();
         let mut shared = self.shared.borrow_mut();
-        let stream_id = StreamId::new(shared.next_stream[self.side]);
-        shared.next_stream[self.side] += 2;
+        let next_stream = shared.next_stream_mut(self.side);
+        let stream_id = StreamId::new(*next_stream);
+        *next_stream += 2;
         let previous = shared.streams.insert(stream_id, InMemoryStream::default());
         debug_assert!(previous.is_none(), "stream ids are unique within a pair");
-        shared.queues[self.side].push_back(TransportEvent::StreamOpened { id, stream_id });
-        shared.queues[other].push_back(TransportEvent::IncomingStream {
-            id: self.connection,
-            stream_id,
-        });
+        shared
+            .queue_mut(self.side)
+            .push_back(TransportEvent::StreamOpened { id, stream_id });
+        shared
+            .queue_mut(other)
+            .push_back(TransportEvent::IncomingStream {
+                id: self.connection,
+                stream_id,
+            });
         Ok(stream_id)
     }
 
@@ -161,7 +231,7 @@ impl Transport for InMemoryTransport {
         if stream.closed {
             return Err(self.stream_not_found(stream_id));
         }
-        if stream.write_closed[self.side] {
+        if stream.write_closed(self.side) {
             return Err(TransportError::StreamSendFailed {
                 id,
                 stream_id,
@@ -171,11 +241,13 @@ impl Transport for InMemoryTransport {
         if data.is_empty() {
             return Ok(());
         }
-        shared.queues[1 - self.side].push_back(TransportEvent::StreamData {
-            id: self.connection,
-            stream_id,
-            data,
-        });
+        shared
+            .queue_mut(self.side.other())
+            .push_back(TransportEvent::StreamData {
+                id: self.connection,
+                stream_id,
+                data,
+            });
         Ok(())
     }
 
@@ -185,7 +257,7 @@ impl Transport for InMemoryTransport {
         stream_id: StreamId,
     ) -> Result<(), TransportError> {
         self.ensure_connection(id)?;
-        let other = 1 - self.side;
+        let other = self.side.other();
         let mut shared = self.shared.borrow_mut();
         let both_write_closed = {
             let Some(stream) = shared.streams.get_mut(&stream_id) else {
@@ -194,26 +266,32 @@ impl Transport for InMemoryTransport {
             if stream.closed {
                 return Err(self.stream_not_found(stream_id));
             }
-            if stream.write_closed[self.side] {
+            if stream.write_closed(self.side) {
                 return Ok(());
             }
-            stream.write_closed[self.side] = true;
-            let both_write_closed = stream.write_closed[other];
+            stream.close_write(self.side);
+            let both_write_closed = stream.write_closed(other);
             if both_write_closed {
                 stream.closed = true;
             }
             both_write_closed
         };
-        shared.queues[other].push_back(TransportEvent::StreamRemoteWriteClosed {
-            id: self.connection,
-            stream_id,
-        });
-        if both_write_closed {
-            shared.queues[self.side].push_back(TransportEvent::StreamClosed { id, stream_id });
-            shared.queues[other].push_back(TransportEvent::StreamClosed {
+        shared
+            .queue_mut(other)
+            .push_back(TransportEvent::StreamRemoteWriteClosed {
                 id: self.connection,
                 stream_id,
             });
+        if both_write_closed {
+            shared
+                .queue_mut(self.side)
+                .push_back(TransportEvent::StreamClosed { id, stream_id });
+            shared
+                .queue_mut(other)
+                .push_back(TransportEvent::StreamClosed {
+                    id: self.connection,
+                    stream_id,
+                });
         }
         Ok(())
     }
@@ -224,7 +302,7 @@ impl Transport for InMemoryTransport {
         stream_id: StreamId,
     ) -> Result<(), TransportError> {
         self.ensure_connection(id)?;
-        let other = 1 - self.side;
+        let other = self.side.other();
         let mut shared = self.shared.borrow_mut();
         let Some(stream) = shared.streams.get_mut(&stream_id) else {
             return Err(self.stream_not_found(stream_id));
@@ -233,22 +311,28 @@ impl Transport for InMemoryTransport {
             return Ok(());
         }
         stream.closed = true;
-        shared.queues[self.side].push_back(TransportEvent::StreamClosed { id, stream_id });
-        shared.queues[other].push_back(TransportEvent::StreamClosed {
-            id: self.connection,
-            stream_id,
-        });
+        shared
+            .queue_mut(self.side)
+            .push_back(TransportEvent::StreamClosed { id, stream_id });
+        shared
+            .queue_mut(other)
+            .push_back(TransportEvent::StreamClosed {
+                id: self.connection,
+                stream_id,
+            });
         Ok(())
     }
 
     fn close(&mut self, id: ConnectionId) -> Result<(), TransportError> {
         self.ensure_connection(id)?;
-        let other = 1 - self.side;
+        let other = self.side.other();
         let mut shared = self.shared.borrow_mut();
         shared.active = false;
         shared.streams.clear();
-        shared.queues[self.side].push_back(TransportEvent::Closed { id });
-        shared.queues[other].push_back(TransportEvent::Closed {
+        shared
+            .queue_mut(self.side)
+            .push_back(TransportEvent::Closed { id });
+        shared.queue_mut(other).push_back(TransportEvent::Closed {
             id: self.connection,
         });
         Ok(())
@@ -256,7 +340,7 @@ impl Transport for InMemoryTransport {
 
     fn poll(&mut self, _now: Now) -> Result<Vec<TransportEvent>, TransportError> {
         let mut shared = self.shared.borrow_mut();
-        let events = shared.queues[self.side].drain(..).collect::<Vec<_>>();
+        let events = shared.queue_mut(self.side).drain(..).collect::<Vec<_>>();
         let mut fully_delivered = Vec::new();
         for event in &events {
             let stream_id = match event {
@@ -271,7 +355,7 @@ impl Transport for InMemoryTransport {
             if !stream.closed {
                 continue;
             }
-            stream.close_delivered[self.side] = true;
+            stream.close_delivered(self.side);
             if stream.close_delivered == [true, true] {
                 fully_delivered.push(stream_id);
             }
@@ -284,7 +368,7 @@ impl Transport for InMemoryTransport {
 
     fn next_deadline(&self) -> Option<Deadline> {
         // Queued events are due now; no clock sample needed to say so.
-        (!self.shared.borrow().queues[self.side].is_empty()).then_some(Deadline::IMMEDIATE)
+        (!self.shared.borrow().queue(self.side).is_empty()).then_some(Deadline::IMMEDIATE)
     }
 
     fn local_addresses(&self) -> Vec<Multiaddr> {
@@ -292,7 +376,7 @@ impl Transport for InMemoryTransport {
     }
 
     fn active_inbound_connection_sources(&self) -> Vec<Multiaddr> {
-        if self.side == 1 && self.shared.borrow().active {
+        if self.side == LinkSide::Second && self.shared.borrow().active {
             vec![self.remote_addr.clone()]
         } else {
             Vec::new()
@@ -304,7 +388,7 @@ impl BlockingTransport for InMemoryTransport {
     fn wait_for_input(&mut self, _timeout: Duration) -> WaitOutcome {
         // No socket to wait on: report queued input, otherwise let the driver
         // fall back to its sleep cadence.
-        if self.shared.borrow().queues[self.side].is_empty() {
+        if self.shared.borrow().queue(self.side).is_empty() {
             WaitOutcome::Unsupported
         } else {
             WaitOutcome::Ready
@@ -399,7 +483,7 @@ impl RelayEmulator {
         self.events.push(RelayEvent::ReservationStored {
             peer: reserver.clone(),
         });
-        Ok(bytes[consumed..].to_vec())
+        trailing_bytes(bytes, consumed)
     }
 
     pub fn drain_hop_bytes_for(&mut self, peer: &PeerId) -> Vec<u8> {
@@ -434,9 +518,11 @@ impl RelayEmulator {
             .as_ref()
             .map(|peer| peer.id.clone())
             .ok_or(RelayEmulatorError::Unexpected("missing peer field"))?;
-        let target = PeerId::from_bytes(&target_bytes)
-            .map_err(|_| RelayEmulatorError::Unexpected("invalid target peer id"))?;
-        let trailing = bytes[consumed..].to_vec();
+        let target = match PeerId::from_bytes(&target_bytes) {
+            Ok(target) => target,
+            Err(_) => return Err(RelayEmulatorError::Unexpected("invalid target peer id")),
+        };
+        let trailing = trailing_bytes(bytes, consumed)?;
 
         let Some(channels) = self.reservations.get_mut(&target) else {
             let refusal = HopMessage {
@@ -524,7 +610,7 @@ impl RelayEmulator {
             target: pending.target,
         });
         self.events.push(RelayEvent::StatusOkSentToInitiator);
-        Ok(bytes[consumed..].to_vec())
+        trailing_bytes(bytes, consumed)
     }
 }
 
@@ -545,20 +631,30 @@ impl std::error::Error for RelayEmulatorError {}
 
 fn decode_hop_message(bytes: &[u8]) -> Result<(HopMessage, usize), RelayEmulatorError> {
     match decode_frame(bytes) {
-        FrameDecode::Complete { payload, consumed } => HopMessage::decode(payload)
-            .map(|message| (message, consumed))
-            .map_err(|_| RelayEmulatorError::Unexpected("bad HOP")),
+        FrameDecode::Complete { payload, consumed } => match HopMessage::decode(payload) {
+            Ok(message) => Ok((message, consumed)),
+            Err(_) => Err(RelayEmulatorError::Unexpected("bad HOP")),
+        },
         _ => Err(RelayEmulatorError::Unexpected("incomplete HOP frame")),
     }
 }
 
 fn decode_stop_message(bytes: &[u8]) -> Result<(StopMessage, usize), RelayEmulatorError> {
     match decode_frame(bytes) {
-        FrameDecode::Complete { payload, consumed } => StopMessage::decode(payload)
-            .map(|message| (message, consumed))
-            .map_err(|_| RelayEmulatorError::Unexpected("bad STOP")),
+        FrameDecode::Complete { payload, consumed } => match StopMessage::decode(payload) {
+            Ok(message) => Ok((message, consumed)),
+            Err(_) => Err(RelayEmulatorError::Unexpected("bad STOP")),
+        },
         _ => Err(RelayEmulatorError::Unexpected("incomplete STOP frame")),
     }
+}
+
+/// Copies bytes pipelined after a decoded relay frame.
+fn trailing_bytes(bytes: &[u8], consumed: usize) -> Result<Vec<u8>, RelayEmulatorError> {
+    bytes
+        .get(consumed..)
+        .map(|trailing| trailing.to_vec())
+        .ok_or(RelayEmulatorError::Unexpected("invalid relay frame length"))
 }
 
 #[cfg(test)]

--- a/crates/tls/src/generate.rs
+++ b/crates/tls/src/generate.rs
@@ -132,6 +132,10 @@ fn encode_signed_key(public_key: &[u8], signature: &[u8]) -> Result<Vec<u8>, der
     let mut buf = Vec::new();
     // SEQUENCE tag + length (DER encoding)
     buf.push(0x30);
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "DER length conversion failures intentionally use the sequence value error"
+    )]
     let len_val = usize::try_from(content_len).map_err(|_| der::Tag::Sequence.value_error())?;
     if len_val < 128 {
         buf.push(len_val as u8);
@@ -147,6 +151,10 @@ fn encode_signed_key(public_key: &[u8], signature: &[u8]) -> Result<Vec<u8>, der
     // Encode the two OCTET STRINGs into the remaining space.
     let offset = buf.len();
     buf.resize(offset + len_val, 0);
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "offset is captured from buf before resizing it to offset + len_val"
+    )]
     let mut writer = der::SliceWriter::new(&mut buf[offset..]);
     pk.encode(&mut writer)?;
     sig.encode(&mut writer)?;

--- a/crates/tls/src/generate.rs
+++ b/crates/tls/src/generate.rs
@@ -151,11 +151,10 @@ fn encode_signed_key(public_key: &[u8], signature: &[u8]) -> Result<Vec<u8>, der
     // Encode the two OCTET STRINGs into the remaining space.
     let offset = buf.len();
     buf.resize(offset + len_val, 0);
-    #[expect(
-        clippy::indexing_slicing,
-        reason = "offset is captured from buf before resizing it to offset + len_val"
-    )]
-    let mut writer = der::SliceWriter::new(&mut buf[offset..]);
+    let mut writer = der::SliceWriter::new(
+        buf.get_mut(offset..)
+            .expect("buffer was resized from the captured offset"),
+    );
     pk.encode(&mut writer)?;
     sig.encode(&mut writer)?;
     writer.finish()?;

--- a/crates/tls/src/verify.rs
+++ b/crates/tls/src/verify.rs
@@ -99,14 +99,26 @@ fn verify_self_signature(cert_der: &[u8], cert: &Certificate) -> Result<(), TlsE
     let tbs = cert.tbs_certificate();
     let spki = tbs.subject_public_key_info();
     let pk_bytes = spki.subject_public_key.raw_bytes();
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "invalid self-signatures intentionally have one public error"
+    )]
     let verifying_key =
         VerifyingKey::from_sec1_bytes(pk_bytes).map_err(|_| TlsError::InvalidSelfSignature)?;
 
     // Extract and verify the signature.
     let sig_bytes = cert.signature().raw_bytes();
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "invalid self-signatures intentionally have one public error"
+    )]
     let signature =
         DerSignature::from_der(sig_bytes).map_err(|_| TlsError::InvalidSelfSignature)?;
 
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "invalid self-signatures intentionally have one public error"
+    )]
     verifying_key
         .verify(tbs_der, &signature)
         .map_err(|_| TlsError::InvalidSelfSignature)
@@ -125,21 +137,32 @@ fn extract_tbs_der(cert_der: &[u8]) -> Result<&[u8], TlsError> {
 
     // Record where the TBSCertificate starts (right after outer header).
     let remaining_before = usize::try_from(reader.remaining_len()).map_err(map_err)?;
-    let tbs_start = cert_der.len() - remaining_before;
+    let tbs_start = cert_der
+        .len()
+        .checked_sub(remaining_before)
+        .ok_or(TlsError::Der("TBS starts beyond certificate".into()))?;
 
     // Parse the TBSCertificate header to determine its total encoded length.
     let tbs_header = der::Header::decode(&mut reader).map_err(map_err)?;
     let remaining_after = usize::try_from(reader.remaining_len()).map_err(map_err)?;
-    let tbs_header_len = remaining_before - remaining_after;
+    let tbs_header_len = remaining_before
+        .checked_sub(remaining_after)
+        .ok_or(TlsError::Der("TBS header exceeds certificate".into()))?;
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "a length conversion failure has one compact TLS error"
+    )]
     let tbs_value_len = usize::try_from(tbs_header.length())
         .map_err(|_| TlsError::Der("TBS length overflow".into()))?;
 
-    let tbs_end = tbs_start + tbs_header_len + tbs_value_len;
-    if tbs_end > cert_der.len() {
-        return Err(TlsError::Der("TBS extends beyond certificate".into()));
-    }
+    let tbs_end = tbs_start
+        .checked_add(tbs_header_len)
+        .and_then(|offset| offset.checked_add(tbs_value_len))
+        .ok_or(TlsError::Der("TBS length overflow".into()))?;
 
-    Ok(&cert_der[tbs_start..tbs_end])
+    cert_der
+        .get(tbs_start..tbs_end)
+        .ok_or(TlsError::Der("TBS extends beyond certificate".into()))
 }
 
 /// Decodes the `SignedKey` ASN.1 structure from DER bytes.
@@ -179,6 +202,10 @@ fn verify_host_signature(
 ) -> Result<(), TlsError> {
     match public_key.key_type() {
         KeyType::Ed25519 => {
+            #[expect(
+                clippy::map_err_ignore,
+                reason = "signature conversion errors are represented by the reported length"
+            )]
             let sig_array: [u8; 64] = signature.try_into().map_err(|_| {
                 TlsError::SignatureVerification(format!(
                     "invalid Ed25519 signature length: expected 64, got {}",
@@ -311,7 +338,7 @@ mod tests {
 
     #[test]
     fn rejects_cert_without_extension() {
-        let result = verify_libp2p_certificate(&[0x30, 0x00]);
-        assert!(result.is_err());
+        verify_libp2p_certificate(&[0x30, 0x00])
+            .expect_err("certificate without the libp2p extension must fail");
     }
 }

--- a/crates/transport/src/set.rs
+++ b/crates/transport/src/set.rs
@@ -287,7 +287,10 @@ impl TransportSet {
 
     fn for_id(&mut self, id: ConnectionId) -> Result<&mut BoxedTransport, TransportError> {
         let index = self.index_for_id(id)?;
-        Ok(&mut self.members[index].transport)
+        self.members
+            .get_mut(index)
+            .map(|member| &mut member.transport)
+            .ok_or(TransportError::ConnectionNotFound { id })
     }
 
     fn index_for_addr(
@@ -309,13 +312,26 @@ impl TransportSet {
                 reason: format!("this set has no {kind:?} transport for {addr}"),
             })
     }
+
+    fn for_addr(
+        &mut self,
+        addr: &Multiaddr,
+        context: &'static str,
+    ) -> Result<&mut Member, TransportError> {
+        let index = self.index_for_addr(addr, context)?;
+        self.members
+            .get_mut(index)
+            .ok_or_else(|| TransportError::InvalidAddress {
+                context,
+                reason: format!("the route for {addr} is no longer available"),
+            })
+    }
 }
 
 impl Transport for TransportSet {
     fn dial(&mut self, addr: &PeerAddr) -> Result<ConnectionId, TransportError> {
         let target = addr.transport().clone();
-        let index = self.index_for_addr(&target, "dial target")?;
-        let member = &mut self.members[index];
+        let member = self.for_addr(&target, "dial target")?;
         let id = member.transport.dial(addr)?;
         // A member that stamps an id in a namespace it did not claim hands
         // back an id this set cannot route: every later call on it would look
@@ -323,7 +339,10 @@ impl Transport for TransportSet {
         // while still costing the member everything a connection costs. Fail
         // the dial where the mis-claim is visible, and close what it opened.
         if !member.namespaces.contains(&id.namespace()) {
-            let _ = member.transport.close(id);
+            // The routing failure is what the caller can correct. `id` does
+            // not belong to the set, so a failed best-effort cleanup cannot
+            // be retried or reported through the set's public API.
+            drop(member.transport.close(id));
             return Err(TransportError::DialFailed {
                 id,
                 reason: format!(
@@ -337,8 +356,9 @@ impl Transport for TransportSet {
     }
 
     fn listen(&mut self, addr: &Multiaddr) -> Result<Multiaddr, TransportError> {
-        let index = self.index_for_addr(addr, "listen address")?;
-        self.members[index].transport.listen(addr)
+        self.for_addr(addr, "listen address")?
+            .transport
+            .listen(addr)
     }
 
     fn open_stream(&mut self, id: ConnectionId) -> Result<StreamId, TransportError> {
@@ -378,8 +398,9 @@ impl Transport for TransportSet {
         // Routed by shape like a dial: a hole punch has to leave the socket the
         // connection it is opening will arrive on, so the member that would
         // dial this address is the only one it can come from.
-        let index = self.index_for_addr(target, "datagram target")?;
-        self.members[index].transport.send_datagram(target, payload)
+        self.for_addr(target, "datagram target")?
+            .transport
+            .send_datagram(target, payload)
     }
 
     fn poll(&mut self, now: Now) -> Result<Vec<TransportEvent>, TransportError> {
@@ -400,8 +421,8 @@ impl Transport for TransportSet {
         // failing member has already told the host what went wrong through the
         // error. What has been collected so far is kept for the next poll
         // rather than dropped, so no connection loses events to a sibling.
-        for index in 0..self.members.len() {
-            match self.members[index].transport.poll(now) {
+        for member in &mut self.members {
+            match member.transport.poll(now) {
                 Ok(events) => self.pending.extend(events),
                 Err(error) => self.failures.push_back(error),
             }
@@ -473,9 +494,9 @@ mod blocking_set {
             let _fanout = wakers
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            for index in 0..self.members.len() {
+            for (index, member) in self.members.iter_mut().enumerate() {
                 if index != woken {
-                    self.members[index].transport.wait_for_input(Duration::ZERO);
+                    member.transport.wait_for_input(Duration::ZERO);
                 }
             }
             WaitOutcome::Interrupted
@@ -495,8 +516,8 @@ mod blocking_set {
             // The probe also says which members can park at all, and only
             // those are worth a slice of the budget.
             let mut waiters = Vec::new();
-            for index in 0..self.members.len() {
-                match self.members[index].transport.wait_for_input(Duration::ZERO) {
+            for (index, member) in self.members.iter_mut().enumerate() {
+                match member.transport.wait_for_input(Duration::ZERO) {
                     WaitOutcome::Ready => return WaitOutcome::Ready,
                     WaitOutcome::Interrupted => return self.settle_interrupt(index),
                     WaitOutcome::TimedOut => waiters.push(index),
@@ -538,7 +559,10 @@ mod blocking_set {
                     let share = u32::try_from(waiters.len() - turn)
                         .map_or(remaining, |left| remaining / left);
                     let slice = SLICE.min(remaining).min(share);
-                    match self.members[index].transport.wait_for_input(slice) {
+                    let Some(member) = self.members.get_mut(index) else {
+                        return WaitOutcome::Unsupported;
+                    };
+                    match member.transport.wait_for_input(slice) {
                         WaitOutcome::Ready => return WaitOutcome::Ready,
                         WaitOutcome::Interrupted => return self.settle_interrupt(index),
                         WaitOutcome::TimedOut | WaitOutcome::Unsupported => {}
@@ -1214,7 +1238,7 @@ mod tests {
         let tcp_id = ConnectionId::namespaced(ConnectionNamespace::TCP_IPV4, 1).expect("in range");
         tcp.log().events = vec![TransportEvent::Closed { id: tcp_id }];
         quic.log().fails_poll = true;
-        let _ = set.poll(Now::from_millis(0));
+        drop(set.poll(Now::from_millis(0)));
 
         // A host that slept here would sit on an event it has never seen.
         assert_eq!(set.next_deadline(), Some(Deadline::IMMEDIATE));

--- a/crates/transport/src/transport.rs
+++ b/crates/transport/src/transport.rs
@@ -200,15 +200,19 @@ mod tests {
 
     impl Transport for Minimal {
         fn dial(&mut self, _addr: &PeerAddr) -> Result<ConnectionId, TransportError> {
-            unimplemented!("not reached: this fake exists to exercise the defaults")
+            Err(TransportError::Unsupported { operation: "dial" })
         }
 
         fn listen(&mut self, _addr: &Multiaddr) -> Result<Multiaddr, TransportError> {
-            unimplemented!()
+            Err(TransportError::Unsupported {
+                operation: "listen",
+            })
         }
 
         fn open_stream(&mut self, _id: ConnectionId) -> Result<StreamId, TransportError> {
-            unimplemented!()
+            Err(TransportError::Unsupported {
+                operation: "open_stream",
+            })
         }
 
         fn send_stream(
@@ -217,7 +221,9 @@ mod tests {
             _stream_id: StreamId,
             _data: Vec<u8>,
         ) -> Result<(), TransportError> {
-            unimplemented!()
+            Err(TransportError::Unsupported {
+                operation: "send_stream",
+            })
         }
 
         fn close_stream_write(
@@ -225,7 +231,9 @@ mod tests {
             _id: ConnectionId,
             _stream_id: StreamId,
         ) -> Result<(), TransportError> {
-            unimplemented!()
+            Err(TransportError::Unsupported {
+                operation: "close_stream_write",
+            })
         }
 
         fn reset_stream(
@@ -233,11 +241,13 @@ mod tests {
             _id: ConnectionId,
             _stream_id: StreamId,
         ) -> Result<(), TransportError> {
-            unimplemented!()
+            Err(TransportError::Unsupported {
+                operation: "reset_stream",
+            })
         }
 
         fn close(&mut self, _id: ConnectionId) -> Result<(), TransportError> {
-            unimplemented!()
+            Err(TransportError::Unsupported { operation: "close" })
         }
 
         fn poll(&mut self, _now: Now) -> Result<Vec<TransportEvent>, TransportError> {

--- a/crates/yamux/benches/data_path.rs
+++ b/crates/yamux/benches/data_path.rs
@@ -6,12 +6,17 @@ use minip2p_yamux::{FLAG_SYN, Frame, HEADER_LEN, YamuxOutput, YamuxRole, YamuxSe
 const PAYLOAD_LEN: usize = 64 * 1024;
 
 fn assert_payload_frame(output: YamuxOutput, payload: &[u8]) {
-    let YamuxOutput::Outbound(bytes) = output else {
-        panic!("expected outbound data frame");
-    };
-    assert_eq!(bytes.len(), HEADER_LEN + payload.len());
-    assert_eq!(bytes[1], 0, "frame type must be data");
-    assert_eq!(&bytes[HEADER_LEN..], payload);
+    match output {
+        YamuxOutput::Outbound(bytes) => {
+            assert_eq!(bytes.len(), HEADER_LEN + payload.len());
+            assert_eq!(bytes.get(1), Some(&0), "frame type must be data");
+            assert_eq!(bytes.get(HEADER_LEN..), Some(payload));
+        }
+        unexpected => assert!(
+            matches!(unexpected, YamuxOutput::Outbound(_)),
+            "expected outbound data frame"
+        ),
+    }
 }
 
 fn yamux_data_path(c: &mut Criterion) {

--- a/crates/yamux/src/frame.rs
+++ b/crates/yamux/src/frame.rs
@@ -55,7 +55,10 @@ pub struct Frame {
 impl Frame {
     /// Constructs a data frame.
     pub fn data(stream_id: u32, flags: u16, payload: Vec<u8>) -> Result<Self, YamuxError> {
-        let value = u32::try_from(payload.len()).map_err(|_| YamuxError::FrameLengthOverflow)?;
+        let value = match u32::try_from(payload.len()) {
+            Ok(value) => value,
+            Err(_) => return Err(YamuxError::FrameLengthOverflow),
+        };
         let frame = Self {
             frame_type: FrameType::Data,
             flags,
@@ -202,18 +205,44 @@ impl FrameDecoder {
     /// Oversized data frames are rejected as soon as their 12-byte header is
     /// present; the decoder never reserves their declared payload length.
     pub fn next_frame(&mut self) -> Result<Option<Frame>, YamuxError> {
-        let available = self.buffer.len() - self.offset;
+        let available = self
+            .buffer
+            .len()
+            .checked_sub(self.offset)
+            .ok_or(YamuxError::FrameLengthOverflow)?;
         if available < HEADER_LEN {
             return Ok(None);
         }
-        let header = &self.buffer[self.offset..self.offset + HEADER_LEN];
-        if header[0] != 0 {
-            return Err(YamuxError::UnsupportedVersion(header[0]));
+        let header_end = self
+            .offset
+            .checked_add(HEADER_LEN)
+            .ok_or(YamuxError::FrameLengthOverflow)?;
+        let header: [u8; HEADER_LEN] = self
+            .buffer
+            .get(self.offset..header_end)
+            .and_then(|bytes| bytes.try_into().ok())
+            .ok_or(YamuxError::FrameLengthOverflow)?;
+        let [
+            version,
+            frame_type_raw,
+            flags_high,
+            flags_low,
+            stream_3,
+            stream_2,
+            stream_1,
+            stream_0,
+            value_3,
+            value_2,
+            value_1,
+            value_0,
+        ] = header;
+        if version != 0 {
+            return Err(YamuxError::UnsupportedVersion(version));
         }
-        let frame_type = FrameType::decode(header[1])?;
-        let flags = u16::from_be_bytes([header[2], header[3]]);
-        let stream_id = u32::from_be_bytes([header[4], header[5], header[6], header[7]]);
-        let value = u32::from_be_bytes([header[8], header[9], header[10], header[11]]);
+        let frame_type = FrameType::decode(frame_type_raw)?;
+        let flags = u16::from_be_bytes([flags_high, flags_low]);
+        let stream_id = u32::from_be_bytes([stream_3, stream_2, stream_1, stream_0]);
+        let value = u32::from_be_bytes([value_3, value_2, value_1, value_0]);
         if frame_type == FrameType::Data && value > self.max_frame_len {
             return Err(YamuxError::FrameTooLarge {
                 length: value,
@@ -221,7 +250,10 @@ impl FrameDecoder {
             });
         }
         let payload_len = if frame_type == FrameType::Data {
-            usize::try_from(value).map_err(|_| YamuxError::FrameLengthOverflow)?
+            match usize::try_from(value) {
+                Ok(value) => value,
+                Err(_) => return Err(YamuxError::FrameLengthOverflow),
+            }
         } else {
             0
         };
@@ -231,16 +263,27 @@ impl FrameDecoder {
         if available < frame_len {
             return Ok(None);
         }
-        let payload_start = self.offset + HEADER_LEN;
+        let payload_start = header_end;
+        let payload_end = payload_start
+            .checked_add(payload_len)
+            .ok_or(YamuxError::FrameLengthOverflow)?;
+        let payload = self
+            .buffer
+            .get(payload_start..payload_end)
+            .ok_or(YamuxError::FrameLengthOverflow)?
+            .to_vec();
         let frame = Frame {
             frame_type,
             flags,
             stream_id,
             value,
-            payload: self.buffer[payload_start..payload_start + payload_len].to_vec(),
+            payload,
         };
         frame.validate()?;
-        self.offset += frame_len;
+        self.offset = self
+            .offset
+            .checked_add(frame_len)
+            .ok_or(YamuxError::FrameLengthOverflow)?;
         self.compact_if_needed();
         Ok(Some(frame))
     }

--- a/crates/yamux/src/session.rs
+++ b/crates/yamux/src/session.rs
@@ -235,12 +235,13 @@ impl YamuxSession {
             }
 
             state.send_window -= immediate_len as u32;
-            let (immediate, queued) = data.split_at(immediate_len);
-            if data.is_empty() && state.pending_open.is_some() {
+            let was_empty = data.is_empty();
+            let mut immediate = data;
+            let queued = immediate.split_off(immediate_len);
+            if was_empty && state.pending_open.is_some() {
                 let flags = state.take_open_flag();
                 frames.push(Frame::data(stream, flags, Vec::new())?);
             } else if immediate_len != 0 {
-                let mut immediate = immediate.to_vec();
                 let mut first = true;
                 while !immediate.is_empty() {
                     let rest = if immediate.len() > max_frame_len {
@@ -255,7 +256,7 @@ impl YamuxSession {
                 }
             }
             if queued_len != 0 {
-                state.send_buffer.push_back(queued.to_vec());
+                state.send_buffer.push_back(queued);
                 state.buffered_send += queued_len;
             }
             buffered_added = queued_len;

--- a/crates/yamux/src/session.rs
+++ b/crates/yamux/src/session.rs
@@ -235,11 +235,13 @@ impl YamuxSession {
             }
 
             state.send_window -= immediate_len as u32;
-            if data.is_empty() && state.pending_open.is_some() {
+            let was_empty = data.is_empty();
+            let mut immediate = data;
+            let queued = immediate.split_off(immediate_len);
+            if was_empty && state.pending_open.is_some() {
                 let flags = state.take_open_flag();
                 frames.push(Frame::data(stream, flags, Vec::new())?);
             } else if immediate_len != 0 {
-                let mut immediate = data[..immediate_len].to_vec();
                 let mut first = true;
                 while !immediate.is_empty() {
                     let rest = if immediate.len() > max_frame_len {
@@ -254,7 +256,7 @@ impl YamuxSession {
                 }
             }
             if queued_len != 0 {
-                state.send_buffer.push_back(data[immediate_len..].to_vec());
+                state.send_buffer.push_back(queued);
                 state.buffered_send += queued_len;
             }
             buffered_added = queued_len;
@@ -925,7 +927,7 @@ mod tests {
         session.streams.get_mut(&stream).unwrap().send_window = 0;
         session.send(stream, b"queued".to_vec()).unwrap();
         session.close_write(stream).unwrap();
-        assert!(session.streams.get(&stream).unwrap().close_pending);
+        assert!(session.streams[&stream].close_pending);
         session
             .handle_data(&Frame::window_update(stream, FLAG_ACK, 6).unwrap().encode())
             .unwrap();

--- a/crates/yamux/src/session.rs
+++ b/crates/yamux/src/session.rs
@@ -235,13 +235,12 @@ impl YamuxSession {
             }
 
             state.send_window -= immediate_len as u32;
-            let was_empty = data.is_empty();
-            let mut immediate = data;
-            let queued = immediate.split_off(immediate_len);
-            if was_empty && state.pending_open.is_some() {
+            let (immediate, queued) = data.split_at(immediate_len);
+            if data.is_empty() && state.pending_open.is_some() {
                 let flags = state.take_open_flag();
                 frames.push(Frame::data(stream, flags, Vec::new())?);
             } else if immediate_len != 0 {
+                let mut immediate = immediate.to_vec();
                 let mut first = true;
                 while !immediate.is_empty() {
                     let rest = if immediate.len() > max_frame_len {
@@ -256,7 +255,7 @@ impl YamuxSession {
                 }
             }
             if queued_len != 0 {
-                state.send_buffer.push_back(queued);
+                state.send_buffer.push_back(queued.to_vec());
                 state.buffered_send += queued_len;
             }
             buffered_added = queued_len;

--- a/crates/yamux/tests/interop.rs
+++ b/crates/yamux/tests/interop.rs
@@ -70,7 +70,7 @@ fn value(name: &str) -> &str {
         .lines()
         .filter_map(|line| line.split_once('='))
         .find_map(|(field, value)| (field == name).then_some(value))
-        .unwrap_or_else(|| panic!("missing fixture field {name}"))
+        .expect("fixture must contain the requested field")
 }
 
 fn hex(input: &str) -> Vec<u8> {
@@ -81,8 +81,8 @@ fn hex(input: &str) -> Vec<u8> {
         .0
         .iter()
         .map(|pair| {
-            let text = core::str::from_utf8(pair).unwrap();
-            u8::from_str_radix(text, 16).unwrap()
+            let text = core::str::from_utf8(pair).expect("fixture hex must be ASCII");
+            u8::from_str_radix(text, 16).expect("fixture hex must be valid")
         })
         .collect()
 }

--- a/docs/plans/circuit-relay-v2-relay-server.md
+++ b/docs/plans/circuit-relay-v2-relay-server.md
@@ -129,7 +129,7 @@ EndpointBuilder::relay_server_config(
 ) -> Result<Self, RelayServerConfigError>
 EndpointBuilder::relay_server_announce_addrs(
     Vec<Multiaddr>,
-) -> Result<Self, RelayServerAddressError>
+) -> Result<Self, RelayServerAnnounceError>
 
 Endpoint::set_relay_server_accepting(
     bool,
@@ -142,6 +142,9 @@ Endpoint::next_relay_server_event(
     impl Into<Deadline>,
 ) -> Result<Option<RelayServerEvent>, Error>
 ```
+
+`RelayServerAnnounceError` distinguishes validator configuration failures
+(`Config`) from invalid announce addresses (`Address`).
 
 Only `relay_server()` and `relay_server_config(...)` enable the service and its
 static HOP advertisement. Announce-address calls are order-independent with

--- a/examples/chat/src/cli.rs
+++ b/examples/chat/src/cli.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use minip2p::{Multiaddr, PeerAddr, PeerId, Protocol};
-use minip2p_example_common::{CliError, flag_value, require_quic_transport};
+use minip2p_example_common::{CliError, require_quic_transport};
 
 /// The modes the CLI dispatches to.
 #[derive(Clone, Debug)]
@@ -91,23 +91,19 @@ pub fn parse(mut args: Vec<String>) -> Result<Mode, CliError> {
 fn parse_join(args: Vec<String>) -> Result<Mode, CliError> {
     let mut positional: Vec<String> = Vec::new();
     let mut rest: Vec<String> = Vec::new();
-    let mut i = 0;
-    while i < args.len() {
-        let arg = &args[i];
+    let mut args = args.iter();
+    while let Some(arg) = args.next() {
         if arg == "--allow-unsigned" || arg == "--no-mesh" || arg == "--relay-only" {
             // Boolean flag: no value follows.
             rest.push(arg.clone());
-            i += 1;
         } else if arg.starts_with("--") {
             rest.push(arg.clone());
             let value = args
-                .get(i + 1)
+                .next()
                 .ok_or_else(|| CliError(format!("flag '{arg}' requires a value")))?;
             rest.push(value.clone());
-            i += 2;
         } else {
             positional.push(arg.clone());
-            i += 1;
         }
     }
 
@@ -174,14 +170,11 @@ impl Flags {
         let mut relay: Option<PeerAddr> = None;
         let mut chat = ChatOptions::default();
 
-        let mut i = 0;
-        while i < args.len() {
-            let key = &args[i];
-
+        let mut args = args.iter();
+        while let Some(key) = args.next() {
             match key.as_str() {
                 "--allow-unsigned" => {
                     chat.allow_unsigned = true;
-                    i += 1;
                     continue;
                 }
                 "--no-mesh" => {
@@ -189,7 +182,6 @@ impl Flags {
                         return Err(CliError("--no-mesh specified twice".into()));
                     }
                     chat.no_mesh = true;
-                    i += 1;
                     continue;
                 }
                 "--relay-only" => {
@@ -197,11 +189,10 @@ impl Flags {
                         return Err(CliError("--relay-only specified twice".into()));
                     }
                     chat.relay_only = true;
-                    i += 1;
                     continue;
                 }
                 "--topic" => {
-                    let value = flag_value(args, i, key)?;
+                    let value = next_flag_value(&mut args, key)?;
                     if chat.topic.is_some() {
                         return Err(CliError("--topic specified twice".into()));
                     }
@@ -211,7 +202,7 @@ impl Flags {
                     chat.topic = Some(value.clone());
                 }
                 "--nick" => {
-                    let value = flag_value(args, i, key)?;
+                    let value = next_flag_value(&mut args, key)?;
                     if chat.nick.is_some() {
                         return Err(CliError("--nick specified twice".into()));
                     }
@@ -223,7 +214,7 @@ impl Flags {
                     chat.nick = Some(value.clone());
                 }
                 "--relay" => {
-                    let value = flag_value(args, i, key)?;
+                    let value = next_flag_value(&mut args, key)?;
                     if relay.is_some() {
                         return Err(CliError("--relay specified twice".into()));
                     }
@@ -233,14 +224,14 @@ impl Flags {
                     relay = Some(addr);
                 }
                 "--key" => {
-                    let value = flag_value(args, i, key)?;
+                    let value = next_flag_value(&mut args, key)?;
                     if chat.key_path.is_some() {
                         return Err(CliError("--key specified twice".into()));
                     }
                     chat.key_path = Some(PathBuf::from(value));
                 }
                 "--listen" => {
-                    let value = flag_value(args, i, key)?;
+                    let value = next_flag_value(&mut args, key)?;
                     if chat.listen_addr.is_some() {
                         return Err(CliError("--listen specified twice".into()));
                     }
@@ -262,11 +253,18 @@ impl Flags {
                     return Err(CliError(format!("unknown flag '{other}'")));
                 }
             }
-            i += 2;
         }
 
         Ok(Self { relay, chat })
     }
+}
+
+fn next_flag_value<'a>(
+    args: &mut impl Iterator<Item = &'a String>,
+    key: &str,
+) -> Result<&'a String, CliError> {
+    args.next()
+        .ok_or_else(|| CliError(format!("flag '{key}' requires a value")))
 }
 
 /// Usage text printed on `--help` and parse errors.
@@ -369,7 +367,7 @@ mod tests {
             .into_iter()
             .map(str::to_string)
             .collect();
-        assert!(parse(duplicate).is_err());
+        parse(duplicate).expect_err("duplicate --no-mesh must be rejected");
     }
 
     #[test]
@@ -389,6 +387,6 @@ mod tests {
             .into_iter()
             .map(str::to_string)
             .collect();
-        assert!(parse(duplicate).is_err());
+        parse(duplicate).expect_err("duplicate --relay-only must be rejected");
     }
 }

--- a/examples/chat/src/modes.rs
+++ b/examples/chat/src/modes.rs
@@ -185,8 +185,8 @@ pub fn run_join(
     println!("[join] us={}", endpoint.peer_id());
 
     let (host_peer, connect_id) = match &target {
-        JoinTarget::Circuit { peer, .. } => {
-            println!("[join] target={peer} via-relay={}", relays[0].peer_id());
+        JoinTarget::Circuit { relay, peer } => {
+            println!("[join] target={peer} via-relay={}", relay.peer_id());
             let id = endpoint
                 .connect(peer)
                 .map_err(|e| format!("connect failed: {e}"))?;
@@ -273,7 +273,11 @@ fn spawn_stdin_reader() -> mpsc::Receiver<Option<String>> {
                 return;
             }
         }
-        let _ = tx.send(None);
+        // EOF is best-effort: the receiver may have exited after an endpoint
+        // error, which is already the primary outcome.
+        match tx.send(None) {
+            Ok(()) | Err(_) => {}
+        }
     });
     rx
 }
@@ -432,9 +436,14 @@ fn print_pubsub_event(role: &str, event: PubsubEvent) {
 fn short(peer: &PeerId) -> String {
     const DISPLAY_LEN: usize = 8;
 
-    let encoded = peer.to_base58();
-    // Base58 is ASCII, so this byte offset is always a character boundary.
-    encoded[encoded.len().saturating_sub(DISPLAY_LEN)..].to_owned()
+    peer.to_base58()
+        .chars()
+        .rev()
+        .take(DISPLAY_LEN)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect()
 }
 
 #[cfg(test)]

--- a/examples/chat/tests/chat.rs
+++ b/examples/chat/tests/chat.rs
@@ -5,6 +5,11 @@
 //! product loop: a line typed on one peer's stdin reaches every other peer
 //! — including leaf-to-leaf THROUGH the host — and stdin EOF exits cleanly.
 
+#![expect(
+    clippy::panic,
+    reason = "the process-test helpers include collected child output in assertion failures"
+)]
+
 use std::io::{BufRead, BufReader, Write};
 use std::process::{ChildStdin, Command, Stdio};
 use std::sync::{Arc, Mutex};
@@ -135,7 +140,9 @@ impl Peer {
     fn kill(&mut self) {
         drop(self.stdin.take());
         self.child.0.kill().expect("kill child");
-        let _ = self.child.0.wait();
+        match self.child.0.wait() {
+            Ok(_) | Err(_) => {}
+        }
     }
 
     /// Closes stdin (EOF) and waits for a clean exit.

--- a/examples/common/src/lib.rs
+++ b/examples/common/src/lib.rs
@@ -51,8 +51,14 @@ pub struct KillOnDrop(pub Child);
 
 impl Drop for KillOnDrop {
     fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
+        // The child might already have exited; either outcome is complete
+        // cleanup, but always reap it before releasing the handle.
+        match self.0.kill() {
+            Ok(()) | Err(_) => {}
+        }
+        match self.0.wait() {
+            Ok(_) | Err(_) => {}
+        }
     }
 }
 
@@ -197,13 +203,21 @@ fn write_secret(path: &FsPath, _secret: &[u8; SECRET_KEY_LENGTH]) -> Result<(), 
 }
 
 fn encode_hex(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut out = String::with_capacity(bytes.len() * 2);
     for byte in bytes {
-        out.push(HEX[(byte >> 4) as usize] as char);
-        out.push(HEX[(byte & 0x0f) as usize] as char);
+        out.push(hex_digit(byte >> 4));
+        out.push(hex_digit(byte & 0x0f));
     }
     out
+}
+
+#[expect(
+    clippy::indexing_slicing,
+    reason = "callers pass only the high or masked-low nibble of a byte"
+)]
+fn hex_digit(nibble: u8) -> char {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    HEX[nibble as usize] as char
 }
 
 fn decode_secret(input: &str) -> Result<[u8; SECRET_KEY_LENGTH], String> {
@@ -216,11 +230,13 @@ fn decode_secret(input: &str) -> Result<[u8; SECRET_KEY_LENGTH], String> {
     }
 
     let mut out = [0u8; SECRET_KEY_LENGTH];
-    let bytes = input.as_bytes();
-    for idx in 0..SECRET_KEY_LENGTH {
-        let hi = hex_value(bytes[idx * 2])?;
-        let lo = hex_value(bytes[idx * 2 + 1])?;
-        out[idx] = (hi << 4) | lo;
+    let (pairs, remainder) = input.as_bytes().as_chunks::<2>();
+    if !remainder.is_empty() {
+        return Err("hex decoder received a trailing non-pair byte".into());
+    }
+    for (pair, slot) in pairs.iter().zip(&mut out) {
+        let [hi, lo] = *pair;
+        *slot = (hex_value(hi)? << 4) | hex_value(lo)?;
     }
     Ok(out)
 }
@@ -318,7 +334,7 @@ fn format_addrs(addrs: &[Multiaddr]) -> String {
 /// the printed `bound=` line is directly dialable on the same host.
 pub fn local_dialable_peer_addr(peer_addr: &PeerAddr) -> PeerAddr {
     let protocols = peer_addr.transport().protocols();
-    let Some(first) = protocols.first() else {
+    let Some((first, rest)) = protocols.split_first() else {
         return peer_addr.clone();
     };
 
@@ -336,8 +352,9 @@ pub fn local_dialable_peer_addr(peer_addr: &PeerAddr) -> PeerAddr {
         return peer_addr.clone();
     };
 
-    let mut rewritten = protocols.to_vec();
-    rewritten[0] = replacement;
+    let mut rewritten = Vec::with_capacity(protocols.len());
+    rewritten.push(replacement);
+    rewritten.extend_from_slice(rest);
     PeerAddr::new(
         Multiaddr::from_protocols(rewritten),
         peer_addr.peer_id().clone(),
@@ -378,7 +395,7 @@ mod tests {
 
         let error = load_keypair(Some(&path), "test").unwrap_err().to_string();
 
-        let _ = fs::remove_file(path);
+        fs::remove_file(path).expect("remove permissive test key");
         assert!(error.contains("0600"), "{error}");
     }
 
@@ -389,7 +406,7 @@ mod tests {
 
         let error = load_keypair(Some(&path), "test").unwrap_err().to_string();
 
-        let _ = fs::remove_dir(path);
+        fs::remove_dir(path).expect("remove test key directory");
         assert!(error.contains("regular file"), "{error}");
     }
 
@@ -401,7 +418,7 @@ mod tests {
 
         let error = load_keypair(Some(&path), "test").unwrap_err().to_string();
 
-        let _ = fs::remove_file(path);
+        fs::remove_file(path).expect("remove oversized test key");
         assert!(error.contains("too large"), "{error}");
     }
 }

--- a/examples/common/src/lib.rs
+++ b/examples/common/src/lib.rs
@@ -211,13 +211,10 @@ fn encode_hex(bytes: &[u8]) -> String {
     out
 }
 
-#[expect(
-    clippy::indexing_slicing,
-    reason = "callers pass only the high or masked-low nibble of a byte"
-)]
 fn hex_digit(nibble: u8) -> char {
     const HEX: &[u8; 16] = b"0123456789abcdef";
-    HEX[nibble as usize] as char
+    *HEX.get(nibble as usize)
+        .expect("hex digit input is a four-bit nibble") as char
 }
 
 fn decode_secret(input: &str) -> Result<[u8; SECRET_KEY_LENGTH], String> {

--- a/examples/peer/src/cli.rs
+++ b/examples/peer/src/cli.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use minip2p::{Event, Multiaddr, PeerAddr, PeerId, Protocol};
-use minip2p_example_common::{CliError, flag_value};
+use minip2p_example_common::CliError;
 
 /// The modes the CLI dispatches to.
 #[derive(Clone, Debug)]
@@ -93,19 +93,16 @@ fn parse_listen(args: Vec<String>) -> Result<Mode, CliError> {
 fn parse_dial(args: Vec<String>) -> Result<Mode, CliError> {
     let mut positional: Vec<String> = Vec::new();
     let mut rest: Vec<String> = Vec::new();
-    let mut i = 0;
-    while i < args.len() {
-        let arg = &args[i];
+    let mut args = args.iter();
+    while let Some(arg) = args.next() {
         if arg.starts_with("--") {
             rest.push(arg.clone());
             let value = args
-                .get(i + 1)
+                .next()
                 .ok_or_else(|| CliError(format!("flag '{arg}' requires a value")))?;
             rest.push(value.clone());
-            i += 2;
         } else {
             positional.push(arg.clone());
-            i += 1;
         }
     }
 
@@ -175,13 +172,13 @@ impl Flags {
         let mut count: Option<u64> = None;
         let mut options = RunOptions::default();
 
-        let mut i = 0;
-        while i < args.len() {
-            let key = &args[i];
-
+        let mut args = args.iter();
+        while let Some(key) = args.next() {
             match key.as_str() {
                 "--relay" => {
-                    let value = flag_value(args, i, key)?;
+                    let value = args
+                        .next()
+                        .ok_or_else(|| CliError(format!("flag '{key}' requires a value")))?;
                     if relay.is_some() {
                         return Err(CliError("--relay specified twice".into()));
                     }
@@ -191,7 +188,9 @@ impl Flags {
                     relay = Some(addr);
                 }
                 "--count" => {
-                    let value = flag_value(args, i, key)?;
+                    let value = args
+                        .next()
+                        .ok_or_else(|| CliError(format!("flag '{key}' requires a value")))?;
                     if count.is_some() {
                         return Err(CliError("--count specified twice".into()));
                     }
@@ -203,14 +202,18 @@ impl Flags {
                     count = Some(n);
                 }
                 "--key" => {
-                    let value = flag_value(args, i, key)?;
+                    let value = args
+                        .next()
+                        .ok_or_else(|| CliError(format!("flag '{key}' requires a value")))?;
                     if options.key_path.is_some() {
                         return Err(CliError("--key specified twice".into()));
                     }
                     options.key_path = Some(PathBuf::from(value));
                 }
                 "--listen" => {
-                    let value = flag_value(args, i, key)?;
+                    let value = args
+                        .next()
+                        .ok_or_else(|| CliError(format!("flag '{key}' requires a value")))?;
                     if options.listen_addr.is_some() {
                         return Err(CliError("--listen specified twice".into()));
                     }
@@ -226,7 +229,9 @@ impl Flags {
                     options.listen_addr = Some(addr);
                 }
                 "--autonat" => {
-                    let value = flag_value(args, i, key)?;
+                    let value = args
+                        .next()
+                        .ok_or_else(|| CliError(format!("flag '{key}' requires a value")))?;
                     if options.autonat.is_some() {
                         return Err(CliError("--autonat specified twice".into()));
                     }
@@ -240,7 +245,6 @@ impl Flags {
                     return Err(CliError(format!("unknown flag '{other}'")));
                 }
             }
-            i += 2;
         }
 
         Ok(Self {

--- a/examples/peer/src/modes.rs
+++ b/examples/peer/src/modes.rs
@@ -114,7 +114,7 @@ impl FrameBuf {
             return None;
         }
         let mut frame = [0u8; FRAME_LEN];
-        frame.copy_from_slice(&self.buf[self.head..end]);
+        frame.copy_from_slice(self.buf.get(self.head..end)?);
         self.head = end;
         if self.head == self.buf.len() {
             self.buf.clear();
@@ -236,7 +236,9 @@ fn handle_listen_event(
         Event::StreamRemoteWriteClosed {
             peer_id, stream_id, ..
         } if echo_streams.contains(&(peer_id.clone(), *stream_id)) => {
-            let _ = endpoint.close_stream_write(peer_id, *stream_id);
+            if let Err(error) = endpoint.close_stream_write(peer_id, *stream_id) {
+                eprintln!("[listen] echo close failed peer={peer_id} stream={stream_id}: {error}");
+            }
             echo_streams.remove(&(peer_id.clone(), *stream_id));
         }
         Event::StreamClosed {
@@ -351,7 +353,10 @@ pub fn run_dial(
     let start = Instant::now();
     let (peer, connect_id) = match &target {
         DialTarget::Circuit { peer, .. } => {
-            println!("[dial] target={peer} via-relay={}", relays[0].peer_id());
+            let relay = relays
+                .first()
+                .ok_or("circuit target has no relay configured")?;
+            println!("[dial] target={peer} via-relay={}", relay.peer_id());
             let id = endpoint
                 .connect(peer)
                 .map_err(|e| format!("connect failed: {e}"))?;
@@ -432,7 +437,9 @@ fn open_echo_stream(
                 // settled connection. (The caller drained stale
                 // establishments before opening, so this only fires for a
                 // genuine replacement racing the setup.)
-                let _ = endpoint.reset_stream(peer, stream);
+                if let Err(error) = endpoint.reset_stream(peer, stream) {
+                    eprintln!("[dial] failed to reset replaced echo stream: {error}");
+                }
                 return Err("connection replaced during echo stream setup".into());
             }
             _ => print_event("dial", &event),

--- a/examples/peer/tests/ping.rs
+++ b/examples/peer/tests/ping.rs
@@ -100,13 +100,15 @@ fn read_bound_line<R: std::io::Read + Send + 'static>(
             line.clear();
             if buf.read_line(&mut line).unwrap_or(0) == 0 {
                 // EOF: listener died before printing its bound line.
-                if !sent_bound {
-                    let _ = tx.send(None);
+                if !sent_bound && tx.send(None).is_err() {
+                    return;
                 }
                 return;
             }
             if !sent_bound && let Some(rest) = line.strip_prefix("[listen] bound=") {
-                let _ = tx.send(Some(rest.trim_end().to_string()));
+                if tx.send(Some(rest.trim_end().to_string())).is_err() {
+                    return;
+                }
                 sent_bound = true;
             }
         }
@@ -123,8 +125,9 @@ fn wait_with_deadline(mut child: Child, deadline: Duration) -> Option<std::proce
             return child.wait_with_output().ok();
         }
         if start.elapsed() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
+            // The child may have exited between `try_wait` and cleanup.
+            drop(child.kill());
+            drop(child.wait());
             return None;
         }
         thread::sleep(Duration::from_millis(20));

--- a/examples/relay-server/src/cli.rs
+++ b/examples/relay-server/src/cli.rs
@@ -95,6 +95,10 @@ fn next_value(flag: &str, args: &mut std::vec::IntoIter<String>) -> Result<Strin
 }
 
 fn number<T: core::str::FromStr>(flag: &str, value: String) -> Result<T, String> {
+    #[expect(
+        clippy::map_err_ignore,
+        reason = "the CLI reports one compact, flag-specific parse error"
+    )]
     value
         .parse()
         .map_err(|_| format!("{flag} requires a non-negative integer, got {value:?}"))

--- a/examples/relay-server/src/service.rs
+++ b/examples/relay-server/src/service.rs
@@ -56,7 +56,7 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<(), Box<dyn Error>>
             run_status(SYSTEMCTL, ["restart", SERVICE_NAME])
         }
         Some(("uninstall", _)) => uninstall(),
-        _ => unreachable!("clap requires a service subcommand"),
+        _ => Err("a service subcommand is required".into()),
     }
 }
 
@@ -304,8 +304,8 @@ fn install_identity(encoded: &[u8]) -> Result<(), Box<dyn Error>> {
         run_status(CHOWN, [OsStr::new(SERVICE_USER), temporary.as_os_str()])?;
         publish_identity(&temporary, Path::new(IDENTITY_PATH))
     })();
-    if result.is_err() {
-        let _ = fs::remove_file(&temporary);
+    if result.is_err() && fs::remove_file(&temporary).is_err() {
+        // The primary write/install error remains more useful to callers.
     }
     result
 }
@@ -333,8 +333,8 @@ fn write_unit_atomically(path: &Path, contents: &str) -> Result<(), Box<dyn Erro
         fs::rename(&temporary, path)?;
         Ok(())
     })();
-    if result.is_err() {
-        let _ = fs::remove_file(&temporary);
+    if result.is_err() && fs::remove_file(&temporary).is_err() {
+        // The primary write error remains more useful to callers.
     }
     result
 }
@@ -509,6 +509,6 @@ WantedBy=multi-user.target\n"
 
         remove_enable_link(&link).unwrap();
 
-        assert!(std::fs::symlink_metadata(link).is_err());
+        std::fs::symlink_metadata(link).expect_err("failed install must remove the temporary link");
     }
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,6 +12,46 @@ cargo-fuzz = true
 [lints.rust]
 unsafe_code = "forbid"
 
+# This package is excluded from the workspace, so restate the workspace policy
+# here. Fuzz harnesses intentionally discard decoder results and use fixed
+# constant slices, so omit the lints that reject those harness idioms.
+[lints.clippy]
+string_slice = "warn"
+unwrap_used = "warn"
+panic = "warn"
+todo = "warn"
+unimplemented = "warn"
+unreachable = "warn"
+get_unwrap = "warn"
+unwrap_in_result = "warn"
+unchecked_time_subtraction = "warn"
+panic_in_result_fn = "warn"
+let_underscore_future = "warn"
+unused_result_ok = "warn"
+assertions_on_result_states = "warn"
+await_holding_lock = "warn"
+await_holding_refcell_ref = "warn"
+if_let_mutex = "warn"
+large_futures = "warn"
+mem_forget = "warn"
+undocumented_unsafe_blocks = "warn"
+multiple_unsafe_ops_per_block = "warn"
+unnecessary_safety_doc = "warn"
+unnecessary_safety_comment = "warn"
+float_cmp = "warn"
+float_cmp_const = "warn"
+lossy_float_literal = "warn"
+cast_sign_loss = "warn"
+invalid_upcast_comparisons = "warn"
+rc_mutex = "warn"
+debug_assert_with_mut_call = "warn"
+iter_not_returning_iterator = "warn"
+expl_impl_clone_on_copy = "warn"
+infallible_try_from = "warn"
+dbg_macro = "warn"
+allow_attributes = "warn"
+allow_attributes_without_reason = "warn"
+
 [dependencies]
 libfuzzer-sys = "0.4.13"
 minip2p-autonat = { path = "../crates/autonat" }

--- a/tests/support/relay.rs
+++ b/tests/support/relay.rs
@@ -1,4 +1,11 @@
-#![allow(dead_code, unexpected_cfgs)]
+#![expect(
+    dead_code,
+    reason = "the shared relay harness exposes helpers selected by different integration test binaries"
+)]
+#![allow(
+    unexpected_cfgs,
+    reason = "the including test crate decides whether its optional TCP relay helper is compiled"
+)]
 
 //! Loopback Circuit Relay v2 service used by endpoint and example tests.
 //!
@@ -84,7 +91,11 @@ impl RelayMachine {
             } => {
                 let key = (peer_id, stream_id);
                 if let Some((other_peer, other_stream)) = self.bridges.get(&key).cloned() {
-                    let _ = endpoint.close_stream_write(&other_peer, other_stream);
+                    // A FIN can race teardown of the other bridge half; that
+                    // stale close must not replace the original lifecycle event.
+                    match endpoint.close_stream_write(&other_peer, other_stream) {
+                        Ok(()) | Err(_) => {}
+                    }
                 }
             }
             Event::StreamClosed {
@@ -273,11 +284,15 @@ impl RelayMachine {
         self.hop_buffers.remove(key);
         if let Some(stop) = self.hop_to_stop.remove(key) {
             self.pending_stops.remove(&stop);
-            let _ = endpoint.reset_stream(&stop.0, stop.1);
+            match endpoint.reset_stream(&stop.0, stop.1) {
+                Ok(()) | Err(_) => {}
+            }
         }
         if let Some(other) = self.bridges.remove(key) {
             self.bridges.remove(&other);
-            let _ = endpoint.reset_stream(&other.0, other.1);
+            match endpoint.reset_stream(&other.0, other.1) {
+                Ok(()) | Err(_) => {}
+            }
         }
     }
 }
@@ -328,7 +343,11 @@ impl RelayServer {
                 match receiver.try_recv() {
                     Ok(Command::CutAll) => {
                         for peer in endpoint.connected_peers() {
-                            let _ = endpoint.disconnect(&peer);
+                            // A peer can close between the snapshot and this
+                            // command; its lifecycle event remains authoritative.
+                            match endpoint.disconnect(&peer) {
+                                Ok(()) | Err(_) => {}
+                            }
                         }
                     }
                     Ok(Command::Stop) => break,
@@ -383,6 +402,10 @@ impl RelayServer {
         self.commands.send(Command::CutAll).expect("relay is alive");
     }
 
+    #[expect(
+        clippy::panic,
+        reason = "a test harness must fail with the relay thread's recorded error"
+    )]
     pub fn assert_healthy(&self) {
         if let Some(error) = self.failure.lock().expect("relay failure lock").clone() {
             panic!("loopback relay failed: {error}");
@@ -401,7 +424,11 @@ impl RelayServer {
 
 impl Drop for RelayServer {
     fn drop(&mut self) {
-        let _ = self.commands.send(Command::Stop);
+        // The relay thread may already have stopped after recording its
+        // failure; joining and `assert_healthy` below preserve that outcome.
+        match self.commands.send(Command::Stop) {
+            Ok(()) | Err(_) => {}
+        }
         if let Some(thread) = self.thread.take() {
             thread.join().expect("relay thread joins");
         }

--- a/transports/quic/src/connection.rs
+++ b/transports/quic/src/connection.rs
@@ -209,8 +209,9 @@ impl QuicConnection {
         if now.monotonic_ms.saturating_sub(last) < interval_ms {
             return Ok(());
         }
-        let _ = self.conn.send_ack_eliciting();
-        self.sent_keepalive_since_recv = true;
+        if self.conn.send_ack_eliciting().is_ok() {
+            self.sent_keepalive_since_recv = true;
+        }
         self.drain_send_queue(events)?;
         self.flush(socket, pending_datagrams, max_pending_datagrams)
     }
@@ -235,7 +236,10 @@ impl QuicConnection {
     // These arguments are the complete I/O context for a single datagram.
     // Keeping them explicit makes this adapter easy to embed and avoids a
     // second mutable runtime object on the packet hot path.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "a packet needs the complete explicit I/O context in this sans-runtime adapter"
+    )]
     pub fn recv_packet(
         &mut self,
         buf: &mut [u8],
@@ -278,7 +282,12 @@ impl QuicConnection {
                     id: self.id,
                     message: "peer TLS certificate missing".into(),
                 });
-                let _ = self.conn.close(true, 0x03, b"peer certificate missing");
+                if let Err(error) = self.conn.close(true, 0x03, b"peer certificate missing") {
+                    events.push(TransportEvent::Error {
+                        id: self.id,
+                        message: format!("failed to close after missing peer certificate: {error}"),
+                    });
+                }
                 self.state = ConnectionState::Closing;
                 self.flush(socket, pending_datagrams, max_pending_datagrams)?;
                 return Ok(());
@@ -298,7 +307,12 @@ impl QuicConnection {
                             ),
                         });
                         // Close the connection — the peer is not who we expected.
-                        let _ = self.conn.close(true, 0x01, b"peer id mismatch");
+                        if let Err(error) = self.conn.close(true, 0x01, b"peer id mismatch") {
+                            events.push(TransportEvent::Error {
+                                id: self.id,
+                                message: format!("failed to close after peer id mismatch: {error}"),
+                            });
+                        }
                         self.state = ConnectionState::Closing;
                         self.flush(socket, pending_datagrams, max_pending_datagrams)?;
                         return Ok(());
@@ -310,9 +324,17 @@ impl QuicConnection {
                         id: self.id,
                         message: format!("peer TLS certificate verification failed: {e}"),
                     });
-                    let _ = self
-                        .conn
-                        .close(true, 0x02, b"certificate verification failed");
+                    if let Err(error) =
+                        self.conn
+                            .close(true, 0x02, b"certificate verification failed")
+                    {
+                        events.push(TransportEvent::Error {
+                            id: self.id,
+                            message: format!(
+                                "failed to close after certificate verification: {error}"
+                            ),
+                        });
+                    }
                     self.state = ConnectionState::Closing;
                     self.flush(socket, pending_datagrams, max_pending_datagrams)?;
                     return Ok(());
@@ -580,7 +602,10 @@ impl QuicConnection {
                             events.push(TransportEvent::StreamData {
                                 id: self.id,
                                 stream_id,
-                                data: stream_read_buffer[..read].to_vec(),
+                                data: stream_read_buffer
+                                    .get(..read)
+                                    .expect("quiche stream reads fit the supplied buffer")
+                                    .to_vec(),
                             });
                         }
 
@@ -646,11 +671,14 @@ impl QuicConnection {
                 }
             };
 
-            match socket.send_to(&out[..written], send_info.to) {
+            let packet = out
+                .get(..written)
+                .expect("quiche reports packet lengths within the supplied buffer");
+            match socket.send_to(packet, send_info.to) {
                 Ok(_) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     pending_datagrams.push_back(PendingDatagram {
-                        bytes: out[..written].to_vec(),
+                        bytes: packet.to_vec(),
                         destination: send_info.to,
                     });
                     break;
@@ -683,7 +711,10 @@ impl QuicConnection {
                     let Some(front) = state.pending_writes.front_mut() else {
                         break;
                     };
-                    let payload = &front.bytes[front.offset..];
+                    let payload = front
+                        .bytes
+                        .get(front.offset..)
+                        .expect("pending write offsets advance only within their buffers");
                     let fin = front.fin && payload.is_empty();
                     match conn.stream_send(raw_stream_id, payload, fin) {
                         Ok(written) => written,

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -71,15 +71,25 @@ fn retry_address_bytes(addr: SocketAddr) -> ([u8; RETRY_TOKEN_MAX_ADDRESS_LEN], 
     let mut bytes = [0u8; RETRY_TOKEN_MAX_ADDRESS_LEN];
     let ip_len = match addr.ip() {
         IpAddr::V4(ip) => {
-            bytes[..4].copy_from_slice(&ip.octets());
+            bytes
+                .get_mut(..4)
+                .expect("the fixed retry address buffer reserves four IPv4 bytes")
+                .copy_from_slice(&ip.octets());
             4
         }
         IpAddr::V6(ip) => {
-            bytes[..16].copy_from_slice(&ip.octets());
+            bytes
+                .get_mut(..16)
+                .expect("the fixed retry address buffer reserves sixteen IPv6 bytes")
+                .copy_from_slice(&ip.octets());
             16
         }
     };
-    bytes[ip_len..ip_len + 2].copy_from_slice(&addr.port().to_be_bytes());
+    bytes
+        .get_mut(ip_len..)
+        .and_then(|remaining| remaining.get_mut(..2))
+        .expect("the retry address buffer reserves two bytes after every IP address")
+        .copy_from_slice(&addr.port().to_be_bytes());
     (bytes, ip_len + 2)
 }
 
@@ -102,7 +112,11 @@ fn mint_retry_token(
     token.push(RETRY_TOKEN_VERSION);
     token.extend_from_slice(&issued_at.to_be_bytes());
     token.push(address_len as u8);
-    token.extend_from_slice(&address[..address_len]);
+    token.extend_from_slice(
+        address
+            .get(..address_len)
+            .expect("retry_address_bytes returns an in-bounds address length"),
+    );
     token.push(original_dcid.len() as u8);
     token.extend_from_slice(original_dcid);
 
@@ -127,7 +141,7 @@ fn validate_retry_token(
     mac.update(body);
     mac.verify_slice(tag).ok()?;
 
-    if body[0] != RETRY_TOKEN_VERSION {
+    if body.first()? != &RETRY_TOKEN_VERSION {
         return None;
     }
     let issued_at = u64::from_be_bytes(body.get(1..9)?.try_into().ok()?);
@@ -140,13 +154,13 @@ fn validate_retry_token(
     let address_end = address_start.checked_add(address_len)?;
     let (expected_address, expected_address_len) = retry_address_bytes(source);
     if address_len != expected_address_len
-        || body.get(address_start..address_end)? != &expected_address[..expected_address_len]
+        || body.get(address_start..address_end)? != expected_address.get(..expected_address_len)?
     {
         return None;
     }
 
     let dcid_len = *body.get(address_end)? as usize;
-    let dcid_start = address_end + 1;
+    let dcid_start = address_end.checked_add(1)?;
     let dcid_end = dcid_start.checked_add(dcid_len)?;
     if dcid_end != body.len() || dcid_len == 0 || dcid_len > quiche::MAX_CONN_ID_LEN {
         return None;
@@ -529,7 +543,13 @@ impl ReadinessWait {
 
     fn consume_pending_interrupt(&mut self) {
         self.events.clear();
-        let _ = self.poll.poll(&mut self.events, Some(Duration::ZERO));
+        if self
+            .poll
+            .poll(&mut self.events, Some(Duration::ZERO))
+            .is_err()
+        {
+            self.events.clear();
+        }
         self.events.clear();
     }
 }
@@ -544,7 +564,10 @@ fn quic_wait_handle(wakers: Vec<Arc<Waker>>, interrupt_lock: Arc<Mutex<()>>) -> 
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         for waker in &wakers {
-            let _ = waker.wake();
+            if waker.wake().is_err() {
+                // A closed readiness source needs no further interrupt.
+                continue;
+            }
         }
     })
 }
@@ -1170,7 +1193,10 @@ impl Transport for QuicTransport {
                 }
             };
 
-            match self.socket.send_to(&out[..written], send_info.to) {
+            let packet = out
+                .get(..written)
+                .expect("quiche reports packet lengths within the supplied buffer");
+            match self.socket.send_to(packet, send_info.to) {
                 Ok(_) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     // Transient backpressure must not fail the dial. Retain
@@ -1179,7 +1205,7 @@ impl Transport for QuicTransport {
                     // packets left in quiche (or dropped by a full queue)
                     // are resent by its loss-recovery timer once the
                     // connection is registered below.
-                    self.queue_datagram_best_effort(&out[..written], send_info.to);
+                    self.queue_datagram_best_effort(packet, send_info.to);
                     break;
                 }
                 Err(e) => {
@@ -1350,7 +1376,9 @@ impl Transport for QuicTransport {
             };
 
             let local_addr = self.bound_addr;
-            let packet = &mut buf[..len];
+            let packet = buf
+                .get_mut(..len)
+                .expect("UDP receive lengths fit the supplied buffer");
 
             let parsed_header = quiche::Header::from_slice(packet, quiche::MAX_CONN_ID_LEN).ok();
             let mut target_conn_id = parsed_header
@@ -1420,7 +1448,10 @@ impl Transport for QuicTransport {
                         })?;
                         // Best-effort: a dropped Retry is regenerated when
                         // the client retransmits its Initial.
-                        self.send_stateless_datagram(&out[..written], from);
+                        let retry_packet = out
+                            .get(..written)
+                            .expect("quiche writes Retry packets within the supplied buffer");
+                        self.send_stateless_datagram(retry_packet, from);
                         continue;
                     }
 
@@ -1661,9 +1692,13 @@ impl Drop for QuicTransport {
         // were already closed and this call is idempotent.
         let ids: Vec<ConnectionId> = self.connections.keys().copied().collect();
         for id in ids {
-            let _ = self.close(id);
+            match self.close(id) {
+                Ok(()) | Err(_) => {}
+            }
         }
-        let _ = self.flush_pending_datagrams();
+        if self.flush_pending_datagrams().is_err() {
+            self.pending_datagrams.clear();
+        }
     }
 }
 
@@ -2298,7 +2333,11 @@ mod tests {
             .socket
             .recv_from(&mut buf)
             .expect("datagram must still be queued");
-        assert_eq!(&buf[..len], &[1, 2, 3]);
+        assert_eq!(
+            buf.get(..len)
+                .expect("UDP receive lengths fit the supplied test buffer"),
+            &[1, 2, 3]
+        );
     }
 
     #[test]

--- a/transports/quic/tests/ping_e2e.rs
+++ b/transports/quic/tests/ping_e2e.rs
@@ -99,6 +99,10 @@ fn multistream_receive(
     outputs
 }
 
+#[expect(
+    clippy::panic,
+    reason = "the test must stop at the exact protocol violation that it observes"
+)]
 fn assert_no_protocol_violations(events: &[PingEvent]) {
     for event in events {
         if let PingEvent::ProtocolViolation {
@@ -129,6 +133,10 @@ struct PingHarness {
 
 impl PingHarness {
     /// Create a connected, verified, and multistream-negotiated ping pair.
+    #[expect(
+        clippy::panic,
+        reason = "setup must stop immediately if mandatory multistream negotiation fails"
+    )]
     fn new(client_conn_id_raw: u64) -> Self {
         let (mut server, mut client, peer_addr) = setup_pair();
 
@@ -288,7 +296,11 @@ impl PingHarness {
     }
 
     /// Process server-side transport events (negotiation + ping echo).
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::panic,
+        reason = "the test dispatcher keeps its complete mutable harness state explicit"
+    )]
     fn handle_server_events(
         events: &[TransportEvent],
         server: &mut QuicTransport,

--- a/transports/quic/tests/transport_contract.rs
+++ b/transports/quic/tests/transport_contract.rs
@@ -177,7 +177,10 @@ fn no_stream_events_before_connected() {
         .position(|e| matches!(e, TransportEvent::Connected { .. }))
         .expect("must have Connected");
 
-    for event in &client_events[..connected_idx] {
+    for event in client_events
+        .get(..connected_idx)
+        .expect("the connected event index is within the collected events")
+    {
         assert!(
             !matches!(
                 event,

--- a/transports/quic/tests/two_peer.rs
+++ b/transports/quic/tests/two_peer.rs
@@ -627,13 +627,21 @@ fn raw_quiche_config(
     config
 }
 
+#[expect(
+    clippy::panic,
+    reason = "the raw QUIC test helper must stop immediately on socket or quiche failures"
+)]
 fn flush_raw_quiche_client(conn: &mut quiche::Connection, socket: &UdpSocket) {
     let mut out = [0u8; 1350];
     loop {
         match conn.send(&mut out) {
             Ok((written, send_info)) => {
                 socket
-                    .send_to(&out[..written], send_info.to)
+                    .send_to(
+                        out.get(..written)
+                            .expect("quiche writes packets within the supplied test buffer"),
+                        send_info.to,
+                    )
                     .expect("raw client send");
             }
             Err(quiche::Error::Done) => break,
@@ -642,6 +650,10 @@ fn flush_raw_quiche_client(conn: &mut quiche::Connection, socket: &UdpSocket) {
     }
 }
 
+#[expect(
+    clippy::panic,
+    reason = "the raw QUIC test helper must stop immediately on socket or quiche failures"
+)]
 fn drain_raw_quiche_client(
     conn: &mut quiche::Connection,
     socket: &UdpSocket,
@@ -655,7 +667,11 @@ fn drain_raw_quiche_client(
             Err(e) => panic!("raw client recv failed: {e}"),
         };
         let recv_info = quiche::RecvInfo { from, to: local };
-        match conn.recv(&mut buf[..len], recv_info) {
+        match conn.recv(
+            buf.get_mut(..len)
+                .expect("UDP receive lengths fit the supplied test buffer"),
+            recv_info,
+        ) {
             Ok(_) | Err(quiche::Error::Done) => {}
             Err(e) => panic!("raw client quiche recv failed: {e}"),
         }

--- a/transports/tcp/benches/readiness_poll.rs
+++ b/transports/tcp/benches/readiness_poll.rs
@@ -90,7 +90,10 @@ fn accept_and_poll(
                 peers.push(stream);
             }
             Err(error) if error.kind() == ErrorKind::WouldBlock => break,
-            Err(error) => panic!("accept peer: {error}"),
+            Err(error) => {
+                assert_eq!(error.kind(), ErrorKind::WouldBlock, "accept peer: {error}");
+                break;
+            }
         }
     }
     provider

--- a/transports/tcp/src/smoltcp_provider.rs
+++ b/transports/tcp/src/smoltcp_provider.rs
@@ -470,7 +470,10 @@ impl<D: Device> SmoltcpTcpProvider<D> {
     /// Promotes listener sockets that caught a connection and refills the pool.
     fn harvest_listeners(&mut self) {
         for index in 0..self.listeners.len() {
-            let armed = core::mem::take(&mut self.listeners[index].armed);
+            let Some(listener) = self.listeners.get_mut(index) else {
+                continue;
+            };
+            let armed = core::mem::take(&mut listener.armed);
             let mut kept = Vec::with_capacity(armed.len());
             for inner in armed {
                 let state = self
@@ -501,7 +504,10 @@ impl<D: Device> SmoltcpTcpProvider<D> {
                     }
                 }
             }
-            self.listeners[index].armed = kept;
+            let Some(listener) = self.listeners.get_mut(index) else {
+                continue;
+            };
+            listener.armed = kept;
         }
     }
 
@@ -511,8 +517,15 @@ impl<D: Device> SmoltcpTcpProvider<D> {
     /// host's budget is the point of the ceiling, and the backlog refills on a
     /// later poll once something frees up.
     fn arm_listener(&mut self, index: usize) {
-        let endpoint = self.listeners[index].endpoint;
-        while self.listeners[index].armed.len() < self.config.backlog {
+        let Some(listener) = self.listeners.get(index) else {
+            return;
+        };
+        let endpoint = listener.endpoint;
+        while self
+            .listeners
+            .get(index)
+            .is_some_and(|listener| listener.armed.len() < self.config.backlog)
+        {
             let Ok(inner) = self.new_socket() else {
                 return;
             };
@@ -527,7 +540,10 @@ impl<D: Device> SmoltcpTcpProvider<D> {
                 self.stack.borrow_mut().sockets.remove(inner);
                 return;
             }
-            self.listeners[index].armed.push(inner);
+            let Some(listener) = self.listeners.get_mut(index) else {
+                return;
+            };
+            listener.armed.push(inner);
         }
     }
 
@@ -606,7 +622,10 @@ impl<D: Device> SmoltcpTcpProvider<D> {
             }
             self.ready.push_back(TcpEvent::Received {
                 socket: handle,
-                data: self.read_buffer[..taken].to_vec(),
+                data: match self.read_buffer.get(..taken) {
+                    Some(data) => data.to_vec(),
+                    None => break,
+                },
             });
         }
 
@@ -819,7 +838,11 @@ impl<D: Device> TcpProvider for SmoltcpTcpProvider<D> {
             armed: Vec::new(),
         });
         self.arm_listener(index);
-        if self.listeners[index].armed.is_empty() {
+        if self
+            .listeners
+            .get(index)
+            .is_none_or(|listener| listener.armed.is_empty())
+        {
             self.listeners.pop();
             self.release(drawn);
             return Err(TcpError::Exhausted {

--- a/transports/tcp/src/std_provider.rs
+++ b/transports/tcp/src/std_provider.rs
@@ -259,11 +259,14 @@ impl StdTcpProvider {
 
     fn allocate_token(&mut self) -> Result<Token, TcpError> {
         let id = self.next_id;
-        let token = usize::try_from(id)
-            .map(Token)
-            .map_err(|_| TcpError::Exhausted {
-                resource: "readiness tokens",
-            })?;
+        let token = match usize::try_from(id) {
+            Ok(token) => Token(token),
+            Err(_) => {
+                return Err(TcpError::Exhausted {
+                    resource: "readiness tokens",
+                });
+            }
+        };
         self.next_id += 1;
         Ok(token)
     }
@@ -373,8 +376,7 @@ impl StdTcpProvider {
         self.accept_cursor = start.wrapping_add(1);
 
         let mut budget = MAX_ACCEPTS_PER_POLL;
-        for offset in 0..tokens.len() {
-            let token = tokens[(start + offset) % tokens.len()];
+        for &token in tokens.iter().cycle().skip(start).take(tokens.len()) {
             loop {
                 if budget == 0 {
                     // A flood must not hold the poll open; the backlog keeps
@@ -518,7 +520,10 @@ impl StdTcpProvider {
                     return;
                 }
                 Ok(read) => {
-                    let data = self.read_buffer[..read].to_vec();
+                    let Some(data) = self.read_buffer.get(..read).map(ToOwned::to_owned) else {
+                        socket.readable = false;
+                        return;
+                    };
                     self.ready.push_back(TcpEvent::Received {
                         socket: handle,
                         data,
@@ -563,7 +568,10 @@ impl StdTcpProvider {
         let Some(mut socket) = self.sockets.remove(&handle) else {
             return;
         };
-        let _ = self.poll.registry().deregister(&mut socket.stream);
+        if let Err(error) = self.poll.registry().deregister(&mut socket.stream) {
+            // The stream is about to drop, which releases the registration too.
+            drop(error);
+        }
         self.ready.push_back(TcpEvent::Closed {
             socket: handle,
             reason,
@@ -702,7 +710,13 @@ impl TcpProvider for StdTcpProvider {
 
     fn abort(&mut self, socket: SocketHandle) {
         if let Some(mut entry) = self.sockets.remove(&socket) {
-            let _ = self.poll.registry().deregister(&mut entry.stream);
+            match self.poll.registry().deregister(&mut entry.stream) {
+                Ok(()) => {}
+                Err(error) => {
+                    // Dropping the stream releases the registration after an abort.
+                    drop(error);
+                }
+            }
             // Dropping the stream closes it. The kernel still flushes whatever
             // it already accepted, so this is a close rather than a reset --
             // the peer sees the stream end either way, which is what the
@@ -769,7 +783,10 @@ impl BlockingTcpProvider for StdTcpProvider {
     fn wait_handle(&self) -> WaitHandle {
         let waker = Arc::clone(&self.waker);
         WaitHandle::new(move || {
-            let _ = waker.wake();
+            if let Err(error) = waker.wake() {
+                // A destroyed poller cannot be woken; the handle has no error channel.
+                drop(error);
+            }
         })
     }
 }

--- a/transports/tcp/tests/smoltcp_link.rs
+++ b/transports/tcp/tests/smoltcp_link.rs
@@ -256,14 +256,14 @@ fn run_until(
         if !wire.is_quiet() {
             continue;
         }
-        let next = Deadline::earliest_opt(a.next_deadline(), b.next_deadline()).unwrap_or_else(|| {
-            panic!("nothing on the wire and no deadline to wait for\n  a: {a_events:?}\n  b: {b_events:?}")
-        });
+        let next = Deadline::earliest_opt(a.next_deadline(), b.next_deadline())
+            .expect("active providers must report a deadline when the wire is quiet");
         if next.as_millis() > now {
             now = next.as_millis();
         }
     }
-    panic!("never finished\n  a: {a_events:?}\n  b: {b_events:?}")
+    assert!(done(a_events, b_events), "providers never finished");
+    now
 }
 
 struct Pair {
@@ -668,7 +668,10 @@ mod provider {
                     return;
                 }
             }
-            panic!("the providers never settled")
+            assert!(
+                self.wire.is_quiet(),
+                "the providers never settled because the wire remained busy"
+            )
         }
 
         /// Listens, dials, and drives the handshake to completion.

--- a/transports/tcp/tests/smoltcp_link.rs
+++ b/transports/tcp/tests/smoltcp_link.rs
@@ -651,6 +651,10 @@ mod provider {
         /// about happens on packet arrival, and a harness that jumped forwards
         /// would quietly turn "the peer never heard" into "the peer heard on a
         /// retransmit".
+        #[expect(
+            clippy::panic,
+            reason = "exhausting the test harness step budget is an invariant failure"
+        )]
         fn drain(&mut self) {
             for _ in 0..MAX_STEPS {
                 let now = Now::from_millis(self.now);
@@ -668,10 +672,7 @@ mod provider {
                     return;
                 }
             }
-            assert!(
-                self.wire.is_quiet(),
-                "the providers never settled because the wire remained busy"
-            )
+            panic!("the providers never settled within the step budget")
         }
 
         /// Listens, dials, and drives the handshake to completion.

--- a/transports/tcp/tests/support/mod.rs
+++ b/transports/tcp/tests/support/mod.rs
@@ -370,10 +370,12 @@ impl TcpProvider for VirtualProvider {
         Ok(SocketHandle::new(client))
     }
 
+    #[expect(
+        clippy::panic_in_result_fn,
+        reason = "this test provider asserts the transport's non-empty write contract"
+    )]
     fn send(&mut self, socket: SocketHandle, data: &[u8]) -> Result<usize, TcpError> {
-        if data.is_empty() {
-            return Ok(0);
-        }
+        assert!(!data.is_empty(), "the transport must not send empty writes");
         let mut net = self.net.borrow_mut();
         let Some((link, index)) = net.end(socket.get()) else {
             return Err(TcpError::UnknownSocket { socket });

--- a/transports/tcp/tests/support/mod.rs
+++ b/transports/tcp/tests/support/mod.rs
@@ -96,6 +96,26 @@ struct Link {
     ends: [End; 2],
 }
 
+impl Link {
+    /// Returns the local endpoint and its peer for a valid two-party link side.
+    fn ends(&self, index: usize) -> Option<(&End, &End)> {
+        match (index, &self.ends) {
+            (0, [local, peer]) => Some((local, peer)),
+            (1, [peer, local]) => Some((local, peer)),
+            _ => None,
+        }
+    }
+
+    /// Returns the local endpoint and its peer mutably for a valid link side.
+    fn ends_mut(&mut self, index: usize) -> Option<(&mut End, &mut End)> {
+        match (index, &mut self.ends) {
+            (0, [local, peer]) => Some((local, peer)),
+            (1, [peer, local]) => Some((local, peer)),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Default)]
 struct Net {
     /// Nodes that never emit `Writable`, standing in for a provider whose
@@ -187,7 +207,10 @@ impl VirtualProvider {
         let handles = net.owned.get(&self.node).cloned().unwrap_or_default();
         for handle in handles {
             if let Some((link, index)) = net.end(handle) {
-                link.ends[1 - index].capacity = capacity;
+                let Some((_, peer)) = link.ends_mut(index) else {
+                    continue;
+                };
+                peer.capacity = capacity;
             }
         }
     }
@@ -242,7 +265,10 @@ impl VirtualProvider {
         let handles = net.owned.get(&self.node).cloned().unwrap_or_default();
         for handle in handles {
             if let Some((link, index)) = net.end(handle) {
-                link.ends[index].write_closed = true;
+                let Some((local, _)) = link.ends_mut(index) else {
+                    continue;
+                };
+                local.write_closed = true;
             }
         }
     }
@@ -256,7 +282,8 @@ impl VirtualProvider {
             .flatten()
             .filter_map(|handle| {
                 let (link, index) = *net.sockets.get(handle)?;
-                Some(net.links.get(&link)?.ends[1 - index].inbox.len())
+                let (_, peer) = net.links.get(&link)?.ends(index)?;
+                Some(peer.inbox.len())
             })
             .sum()
     }
@@ -328,8 +355,11 @@ impl TcpProvider for VirtualProvider {
                 remote: addr.clone(),
             });
         let source: Multiaddr = format!("/ip4/127.0.0.1/tcp/{port}")
-            .parse()
-            .expect("synthetic source address");
+            .parse::<Multiaddr>()
+            .map_err(|error| TcpError::Address {
+                context: "synthetic source address",
+                reason: error.to_string(),
+            })?;
         net.ready
             .entry(target)
             .or_default()
@@ -341,31 +371,39 @@ impl TcpProvider for VirtualProvider {
     }
 
     fn send(&mut self, socket: SocketHandle, data: &[u8]) -> Result<usize, TcpError> {
-        assert!(!data.is_empty(), "the transport must not send empty writes");
+        if data.is_empty() {
+            return Ok(0);
+        }
         let mut net = self.net.borrow_mut();
         let Some((link, index)) = net.end(socket.get()) else {
             return Err(TcpError::UnknownSocket { socket });
         };
-        if link.ends[index].gone || link.ends[1 - index].gone {
+        let Some((local, peer)) = link.ends_mut(index) else {
+            return Err(TcpError::UnknownSocket { socket });
+        };
+        if local.gone || peer.gone {
             return Err(TcpError::Io {
                 operation: "send",
                 reason: "stream is gone".to_string(),
             });
         }
-        if link.ends[index].write_closed {
+        if local.write_closed {
             return Err(TcpError::Io {
                 operation: "send",
                 reason: "write side is closed".to_string(),
             });
         }
-        let peer = &link.ends[1 - index];
         let room = peer.capacity.map_or(data.len(), |capacity| {
             capacity.saturating_sub(peer.inbox.len())
         });
         let accepted = room.min(data.len());
-        link.ends[1 - index].inbox.extend(&data[..accepted]);
+        let accepted_data = data.get(..accepted).ok_or(TcpError::Io {
+            operation: "send",
+            reason: "accepted byte count exceeded write buffer".to_string(),
+        })?;
+        peer.inbox.extend(accepted_data);
         if accepted < data.len() {
-            link.ends[index].owes_writable = true;
+            local.owes_writable = true;
         }
         Ok(accepted)
     }
@@ -376,15 +414,20 @@ impl TcpProvider for VirtualProvider {
         let Some((link, index)) = net.end(socket.get()) else {
             return Err(TcpError::UnknownSocket { socket });
         };
-        link.ends[index].write_closed = true;
+        let Some((local, _)) = link.ends_mut(index) else {
+            return Err(TcpError::UnknownSocket { socket });
+        };
+        local.write_closed = true;
         Ok(())
     }
 
     fn abort(&mut self, socket: SocketHandle) {
         let mut net = self.net.borrow_mut();
         *net.abort_calls.entry(self.node).or_default() += 1;
-        if let Some((link, index)) = net.end(socket.get()) {
-            link.ends[index].gone = true;
+        if let Some((link, index)) = net.end(socket.get())
+            && let Some((local, _)) = link.ends_mut(index)
+        {
+            local.gone = true;
         }
         // The provider owes nothing further for an aborted handle, so drop it
         // from this node's roster before it can be polled again.
@@ -412,29 +455,29 @@ impl TcpProvider for VirtualProvider {
             let Some((link, index)) = net.end(handle) else {
                 continue;
             };
+            let Some((local, peer)) = link.ends_mut(index) else {
+                continue;
+            };
             let socket = SocketHandle::new(handle);
 
-            if link.ends[index].owes_writable {
-                link.ends[index].owes_writable = false;
+            if local.owes_writable {
+                local.owes_writable = false;
                 if !silent {
                     events.push(TcpEvent::Writable { socket });
                 }
             }
-            if !link.ends[index].inbox.is_empty() {
-                let data: Vec<u8> = link.ends[index].inbox.drain(..).collect();
+            if !local.inbox.is_empty() {
+                let data: Vec<u8> = local.inbox.drain(..).collect();
                 events.push(TcpEvent::Received { socket, data });
             }
             // Received before the FIN, and the FIN before the close: the peer's
             // last bytes are still readable after it stops writing.
-            if link.ends[1 - index].write_closed
-                && link.ends[index].inbox.is_empty()
-                && !link.ends[index].reported_fin
-            {
-                link.ends[index].reported_fin = true;
+            if peer.write_closed && local.inbox.is_empty() && !local.reported_fin {
+                local.reported_fin = true;
                 events.push(TcpEvent::RemoteWriteClosed { socket });
             }
-            if link.ends[1 - index].gone && !link.ends[index].reported_closed {
-                link.ends[index].reported_closed = true;
+            if peer.gone && !local.reported_closed {
+                local.reported_closed = true;
                 events.push(TcpEvent::Closed {
                     socket,
                     reason: None,

--- a/transports/tcp/tests/upgrade.rs
+++ b/transports/tcp/tests/upgrade.rs
@@ -42,6 +42,10 @@ fn node_with(net: &VirtualNetwork, key: Ed25519Keypair, seed: u8, config: TcpCon
 /// takes several round trips that produce no transport event at all, so a
 /// harness that stopped at "neither node reported anything" would abandon the
 /// handshake half-finished.
+#[expect(
+    clippy::panic,
+    reason = "exhausting the test harness step budget is an invariant failure"
+)]
 fn drive<A: EntropySource, B: EntropySource>(
     net: &VirtualNetwork,
     a: &mut TcpTransport<VirtualProvider, A>,
@@ -85,8 +89,7 @@ fn drive<A: EntropySource, B: EntropySource>(
             return (a_events, b_events);
         }
     }
-    assert!(net.is_quiet(), "the virtual link never went quiet");
-    (a_events, b_events)
+    panic!("the virtual link never settled within the step budget");
 }
 
 /// A listener and a dialer, driven until the upgrade completes.

--- a/transports/tcp/tests/upgrade.rs
+++ b/transports/tcp/tests/upgrade.rs
@@ -85,7 +85,8 @@ fn drive<A: EntropySource, B: EntropySource>(
             return (a_events, b_events);
         }
     }
-    panic!("the virtual link never went quiet");
+    assert!(net.is_quiet(), "the virtual link never went quiet");
+    (a_events, b_events)
 }
 
 /// A listener and a dialer, driven until the upgrade completes.


### PR DESCRIPTION
## Summary

- add workspace-wide strict Clippy rules based on [Your Clippy Config Should Be Stricter](https://emschwartz.me/your-clippy-config-should-be-stricter)
- replace panic-prone wire decoding and derived buffer ranges with checked access and arithmetic
- make discarded results and state-machine cleanup explicit
- replace broad lint allowances with narrow, reasoned expectations for proven invariants
- apply the same rules to feature variants, smoltcp adapters, fuzz targets, examples, FFI, and test harnesses

## Notable behavior

Wire-facing protobuf, DER, DNS, multistream, Noise, Yamux, relay, AutoNAT, DCUtR, Identify, and PubSub decoders now reject invalid ranges instead of relying on indexing invariants.

Relay-server worker routing now handles stale or missing worker state explicitly. Cleanup errors remain secondary to the state transition that triggered cleanup.

Relay announce validation now returns `RelayServerAnnounceError`, preserving both validator-configuration and address-validation failures.

## Verification

- `just fmt`
- `just clippy`
- `just test`
- `git diff --check`

The full test matrix passed 1,890 nextest tests plus all doctests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces strict Clippy lints workspace-wide and rewrites panic-prone wire decoding to comply: protobuf, DER, DNS, multistream, Noise, Yamux, relay, AutoNAT, DCUtR, Identify, and PubSub decoders now reject invalid ranges and arithmetic with decode errors instead of panicking on malformed input.

**Bug Fixes**
- Relay-server worker routing handles stale or missing worker state explicitly; announce validation now returns `RelayServerAnnounceError`.

**Refactors**
- Test-harness exemptions for indexing, slicing, panics, and unwraps are centralized in `clippy.toml` instead of per-file attributes.
- Test transport stubs return `TransportError::Unsupported` instead of `unreachable!()` or `unimplemented!()`.
- Discarded results and state-machine cleanup are now explicit.
- Allocation-free hot paths keep their inline structure via reasoned `#[expect]` attributes, avoiding the performance regressions from the first lint pass.
- Yamux send paths split the payload in place instead of copying slices, preserving buffer ownership.

<sup>Written for commit 188a3d4d181f02453d767306beb999512a77c3f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

