### PR TITLE
Bench measure: suites, results schema, and comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # Docker linux cross-compile output (examples deployed to test boxes).
 /target-linux
 .DS_Store
+__pycache__/
 /tmp
 /bindings/ts/node/*.node
 /bindings/ts/node/npm/*/*.node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode-next"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6626829353ae29293be5c86f42de5f0468bc758af074b0c7d08f07e538ccbc"
+dependencies = [
+ "pastey",
+ "rapidhash",
+ "serde",
+ "unty-next",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +622,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +697,16 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "either-or-both"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717164c227120ba9ddf3e2b32305fc0122741d3ee41a54968eae7573ee01933"
+dependencies = [
+ "indexmap",
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -928,6 +971,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "gungraun"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9300d38d30facf6870c15bc9e243edcc47e5ddc270c9d2c1ae824a00b1faea79"
+dependencies = [
+ "bincode-next",
+ "derive_more",
+ "gungraun-macros",
+ "gungraun-runner",
+]
+
+[[package]]
+name = "gungraun-macros"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f3214bae6cfd6739f4f29edb262bae439c6393a7b7b12c4eeb96417c2e50df"
+dependencies = [
+ "derive_more",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "gungraun-runner"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c68c92812da579a2510a2cc702d5aa3251992b9662d4a98502ca46e0cbe16e"
+dependencies = [
+ "either-or-both",
+ "serde",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1246,7 @@ name = "minip2p-core"
 version = "0.4.11"
 dependencies = [
  "criterion",
+ "gungraun",
  "minip2p-identity",
  "thiserror",
 ]
@@ -1182,6 +1264,7 @@ name = "minip2p-discovery"
 version = "0.4.11"
 dependencies = [
  "criterion",
+ "gungraun",
  "minip2p-core",
  "minip2p-identity",
  "thiserror",
@@ -1330,6 +1413,7 @@ name = "minip2p-pubsub"
 version = "0.4.11"
 dependencies = [
  "criterion",
+ "gungraun",
  "minip2p-core",
  "minip2p-identity",
  "minip2p-swarm",
@@ -1372,6 +1456,7 @@ name = "minip2p-relay-server"
 version = "0.4.11"
 dependencies = [
  "criterion",
+ "gungraun",
  "minip2p-core",
  "minip2p-identity",
  "minip2p-nat",
@@ -1396,6 +1481,7 @@ dependencies = [
 name = "minip2p-rs"
 version = "0.4.11"
 dependencies = [
+ "criterion",
  "getrandom",
  "minip2p-circuit",
  "minip2p-core",
@@ -1512,6 +1598,7 @@ name = "minip2p-yamux"
 version = "0.4.11"
 dependencies = [
  "criterion",
+ "gungraun",
  "minip2p-core",
  "minip2p-platform",
  "thiserror",
@@ -1676,6 +1763,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,6 +1871,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr3"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e564d14133360e1ae169ffde5da25881b5fa47261665b8e5713c212c27799da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0d4471b3436c22106b21913b1dda531558918ae9b7ec55d58aa84b43552233"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,6 +1943,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "rayon"
@@ -2449,6 +2573,12 @@ name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
+name = "unty-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16062d030850f35054e37746427b9febb74a2f24c9c6dd6fa2d0c13c5f53221e"
 
 [[package]]
 name = "walkdir"

--- a/bench/fixtures/baseline.json
+++ b/bench/fixtures/baseline.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "git_sha": "baseline",
+  "rows": [
+    { "tier": "rust-micro", "name": "micro/noise", "metric": "Ir", "value": 1000 },
+    { "tier": "rust-micro", "name": "micro/boundary", "metric": "Ir", "value": 1000 },
+    { "tier": "rust-wall", "name": "wall/changed", "metric": "median_ns", "value": 100 }
+  ]
+}

--- a/bench/fixtures/current.json
+++ b/bench/fixtures/current.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "git_sha": "current",
+  "rows": [
+    { "tier": "rust-micro", "name": "micro/noise", "metric": "Ir", "value": 1009 },
+    { "tier": "rust-micro", "name": "micro/boundary", "metric": "Ir", "value": 1020 },
+    { "tier": "rust-wall", "name": "wall/changed", "metric": "median_ns", "value": 120 },
+    { "tier": "node-ffi", "name": "node/missing", "metric": "median_ns", "value": 50 }
+  ]
+}

--- a/bench/pins.json
+++ b/bench/pins.json
@@ -1,0 +1,6 @@
+{
+  "rust": "1.98.0",
+  "profile": "release",
+  "gungraun": "0.19.4",
+  "valgrind": "3.27.1"
+}

--- a/bench/test_bench_results.py
+++ b/bench/test_bench_results.py
@@ -60,6 +60,12 @@ class BenchResultsTest(unittest.TestCase):
                 subprocess.run(["git", "add", "."], cwd=repository, check=True)
                 subprocess.run(["git", "commit", "-qm", "baseline"], cwd=repository, check=True)
                 baseline = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repository, text=True).strip()
+                previous = Path.cwd()
+                try:
+                    os.chdir(repository)
+                    self.assertEqual(bench_results.ir_compatible(baseline, baseline), (True, None))
+                finally:
+                    os.chdir(previous)
                 if isinstance(change, str):
                     (repository / path).write_text(change)
                 else:
@@ -140,7 +146,7 @@ class BenchResultsTest(unittest.TestCase):
                 estimate.parent.mkdir(parents=True)
                 estimate.write_text(json.dumps({"median": {"point_estimate": 10}}))
             bench_results.collect_criterion(root, output, "sha", marker)
-            self.assertEqual(len(json.loads(output.read_text())["rows"]), 28)
+            self.assertEqual(len(json.loads(output.read_text())["rows"]), len(bench_results.EXPECTED_CRITERION))
 
             missing = next(iter(bench_results.EXPECTED_CRITERION))
             root.joinpath(*missing.split("/"), "new", "estimates.json").unlink()

--- a/bench/test_bench_results.py
+++ b/bench/test_bench_results.py
@@ -142,8 +142,9 @@ class BenchResultsTest(unittest.TestCase):
             stale = root / "removed/benchmark/new/estimates.json"
             stale.parent.mkdir(parents=True)
             stale.write_text(json.dumps({"median": {"point_estimate": 1}}))
-            os.utime(stale, ns=(1, 1))
             marker.touch()
+            marker_time = marker.stat().st_mtime_ns
+            os.utime(stale, ns=(marker_time, marker_time))
             for name in bench_results.EXPECTED_CRITERION:
                 estimate = root.joinpath(*name.split("/"), "new", "estimates.json")
                 estimate.parent.mkdir(parents=True)
@@ -165,10 +166,10 @@ class BenchResultsTest(unittest.TestCase):
         self.assertNotIn("`micro/noise`", markdown)
 
     def test_renderer_escapes_benchmark_names(self):
-        current = {**self.current, "rows": [{**self.current["rows"][0], "name": "bad|`name\nrow"}]}
+        current = {**self.current, "rows": [{**self.current["rows"][0], "name": "bad\\|`name\rrow\nnext"}]}
         rows = bench_results.compare_rows(current, None, None)
         markdown = bench_results.render(current, None, rows, False)
-        self.assertIn("`bad\\|&#96;name<br>row`", markdown)
+        self.assertIn("`bad&#92;&#124;&#96;name<br>row<br>next`", markdown)
 
 
 if __name__ == "__main__":

--- a/bench/test_bench_results.py
+++ b/bench/test_bench_results.py
@@ -1,0 +1,61 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+SPEC = importlib.util.spec_from_file_location("bench_results", ROOT / "scripts/bench_results.py")
+bench_results = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = bench_results
+SPEC.loader.exec_module(bench_results)
+
+
+class BenchResultsTest(unittest.TestCase):
+    def setUp(self):
+        self.current = bench_results.validate(bench_results.load_json(ROOT / "bench/fixtures/current.json"))
+        self.baseline = bench_results.validate(bench_results.load_json(ROOT / "bench/fixtures/baseline.json"))
+
+    def test_locked_boundaries_and_missing_row(self):
+        rows = bench_results.compare_rows(self.current, self.baseline, None)
+        by_name = {row.name: row for row in rows}
+        self.assertEqual(by_name["micro/noise"].classification, "noise")
+        self.assertEqual(by_name["micro/boundary"].classification, "notable")
+        self.assertEqual(by_name["wall/changed"].classification, "changed")
+        self.assertEqual(by_name["node/missing"].classification, "unclassified")
+        self.assertEqual(by_name["node/missing"].reason, "missing baseline row")
+
+    def test_no_baseline(self):
+        rows = bench_results.compare_rows(self.current, None, None)
+        self.assertTrue(all(row.classification == "unclassified" for row in rows))
+        self.assertTrue(all(row.reason == "no baseline" for row in rows))
+
+    def test_incompatible_ir_does_not_affect_wall_clock(self):
+        rows = bench_results.compare_rows(self.current, self.baseline, "incompatible Ir pins: Valgrind differs")
+        self.assertTrue(all(row.classification == "unclassified" for row in rows if row.tier == "rust-micro"))
+        self.assertEqual(next(row for row in rows if row.tier == "rust-wall").classification, "changed")
+
+    def test_merge_writes_valid_schema(self):
+        with tempfile.TemporaryDirectory() as directory:
+            first = Path(directory) / "first.json"
+            second = Path(directory) / "second.json"
+            output = Path(directory) / "results.json"
+            first.write_text(json.dumps({"schema_version": 1, "git_sha": "sha", "rows": self.current["rows"][:2]}))
+            second.write_text(json.dumps({"schema_version": 1, "git_sha": "sha", "rows": self.current["rows"][2:]}))
+            bench_results.merge([first, second], output, None)
+            merged = bench_results.validate(json.loads(output.read_text()))
+            self.assertEqual(len(merged["rows"]), 4)
+
+    def test_renderer_has_locked_layout(self):
+        rows = bench_results.compare_rows(self.current, self.baseline, None)
+        markdown = bench_results.render(self.current, self.baseline, rows, True)
+        self.assertIn("Baseline: `baseline`", markdown)
+        self.assertIn("Baseline is stale", markdown)
+        self.assertIn("| tier | noise | changed | notable | unclassified |", markdown)
+        self.assertNotIn("`micro/noise`", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/test_bench_results.py
+++ b/bench/test_bench_results.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -37,6 +38,14 @@ class BenchResultsTest(unittest.TestCase):
         self.assertTrue(all(row.classification == "unclassified" for row in rows if row.tier == "rust-micro"))
         self.assertEqual(next(row for row in rows if row.tier == "rust-wall").classification, "changed")
 
+    def test_missing_current_row_is_unclassified(self):
+        current = {**self.current, "rows": self.current["rows"][:-1]}
+        baseline = {**self.baseline, "rows": [*self.baseline["rows"], self.current["rows"][-1]]}
+        row = next(row for row in bench_results.compare_rows(current, baseline, None) if row.name == "node/missing")
+        self.assertIsNone(row.current)
+        self.assertEqual(row.classification, "unclassified")
+        self.assertEqual(row.reason, "missing current row")
+
     def test_merge_writes_valid_schema(self):
         with tempfile.TemporaryDirectory() as directory:
             first = Path(directory) / "first.json"
@@ -47,6 +56,28 @@ class BenchResultsTest(unittest.TestCase):
             bench_results.merge([first, second], output, None)
             merged = bench_results.validate(json.loads(output.read_text()))
             self.assertEqual(len(merged["rows"]), 4)
+
+    def test_criterion_collector_requires_fresh_complete_manifest(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "criterion"
+            marker = Path(directory) / "started"
+            output = Path(directory) / "results.json"
+            stale = root / "removed/benchmark/new/estimates.json"
+            stale.parent.mkdir(parents=True)
+            stale.write_text(json.dumps({"median": {"point_estimate": 1}}))
+            os.utime(stale, ns=(1, 1))
+            marker.touch()
+            for name in bench_results.EXPECTED_CRITERION:
+                estimate = root.joinpath(*name.split("/"), "new", "estimates.json")
+                estimate.parent.mkdir(parents=True)
+                estimate.write_text(json.dumps({"median": {"point_estimate": 10}}))
+            bench_results.collect_criterion(root, output, "sha", marker)
+            self.assertEqual(len(json.loads(output.read_text())["rows"]), 28)
+
+            missing = next(iter(bench_results.EXPECTED_CRITERION))
+            root.joinpath(*missing.split("/"), "new", "estimates.json").unlink()
+            with self.assertRaisesRegex(bench_results.BenchError, "row set mismatch"):
+                bench_results.collect_criterion(root, output, "sha", marker)
 
     def test_renderer_has_locked_layout(self):
         rows = bench_results.compare_rows(self.current, self.baseline, None)

--- a/bench/test_bench_results.py
+++ b/bench/test_bench_results.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -38,6 +39,44 @@ class BenchResultsTest(unittest.TestCase):
         self.assertTrue(all(row.classification == "unclassified" for row in rows if row.tier == "rust-micro"))
         self.assertEqual(next(row for row in rows if row.tier == "rust-wall").classification, "changed")
 
+    def test_ir_compatibility_checks_each_git_pin(self):
+        changes = {
+            "Cargo.lock": ("Cargo.lock", "lock changed\n", "Cargo.lock differs"),
+            **{
+                key: ("bench/pins.json", {key: "changed"}, f"{label} differs")
+                for key, label in bench_results.IR_PINS.items()
+            },
+        }
+        for name, (path, change, expected) in changes.items():
+            with self.subTest(pin=name), tempfile.TemporaryDirectory() as directory:
+                repository = Path(directory)
+                subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+                subprocess.run(["git", "config", "user.email", "bench@example.invalid"], cwd=repository, check=True)
+                subprocess.run(["git", "config", "user.name", "Bench Test"], cwd=repository, check=True)
+                (repository / "bench").mkdir()
+                (repository / "Cargo.lock").write_text("lock\n")
+                pins = {key: "same" for key in bench_results.IR_PINS}
+                (repository / "bench/pins.json").write_text(json.dumps(pins))
+                subprocess.run(["git", "add", "."], cwd=repository, check=True)
+                subprocess.run(["git", "commit", "-qm", "baseline"], cwd=repository, check=True)
+                baseline = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repository, text=True).strip()
+                if isinstance(change, str):
+                    (repository / path).write_text(change)
+                else:
+                    pins.update(change)
+                    (repository / path).write_text(json.dumps(pins))
+                subprocess.run(["git", "add", "."], cwd=repository, check=True)
+                subprocess.run(["git", "commit", "-qm", "current"], cwd=repository, check=True)
+                current = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repository, text=True).strip()
+                previous = Path.cwd()
+                try:
+                    os.chdir(repository)
+                    compatible, reason = bench_results.ir_compatible(baseline, current)
+                finally:
+                    os.chdir(previous)
+                self.assertFalse(compatible)
+                self.assertIn(expected, reason)
+
     def test_missing_current_row_is_unclassified(self):
         current = {**self.current, "rows": self.current["rows"][:-1]}
         baseline = {**self.baseline, "rows": [*self.baseline["rows"], self.current["rows"][-1]]}
@@ -56,6 +95,35 @@ class BenchResultsTest(unittest.TestCase):
             bench_results.merge([first, second], output, None)
             merged = bench_results.validate(json.loads(output.read_text()))
             self.assertEqual(len(merged["rows"]), 4)
+
+    def test_fixture_compare_cli_writes_locked_markdown(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "comparison.md"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "scripts/bench_results.py"),
+                    "compare",
+                    "--current",
+                    str(ROOT / "bench/fixtures/current.json"),
+                    "--baseline",
+                    str(ROOT / "bench/fixtures/baseline.json"),
+                    "--output",
+                    str(output),
+                ],
+                check=True,
+            )
+            markdown = output.read_text()
+            self.assertIn("Baseline: `baseline`", markdown)
+            self.assertIn("| rust-micro | 1 | 0 | 1 | 0 |", markdown)
+            self.assertIn("unclassified (missing baseline row)", markdown)
+
+    def test_zero_baseline_is_unclassified(self):
+        baseline = {**self.baseline, "rows": [{**self.baseline["rows"][0], "value": 0}]}
+        current = {**self.current, "rows": [self.current["rows"][0]]}
+        row = bench_results.compare_rows(current, baseline, None)[0]
+        self.assertEqual(row.classification, "unclassified")
+        self.assertEqual(row.reason, "zero baseline")
 
     def test_criterion_collector_requires_fresh_complete_manifest(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/bench/test_bench_results.py
+++ b/bench/test_bench_results.py
@@ -42,6 +42,7 @@ class BenchResultsTest(unittest.TestCase):
     def test_ir_compatibility_checks_each_git_pin(self):
         changes = {
             "Cargo.lock": ("Cargo.lock", "lock changed\n", "Cargo.lock differs"),
+            "missing manifest": ("bench/pins.json", None, "pin manifest unavailable"),
             **{
                 key: ("bench/pins.json", {key: "changed"}, f"{label} differs")
                 for key, label in bench_results.IR_PINS.items()
@@ -66,7 +67,9 @@ class BenchResultsTest(unittest.TestCase):
                     self.assertEqual(bench_results.ir_compatible(baseline, baseline), (True, None))
                 finally:
                     os.chdir(previous)
-                if isinstance(change, str):
+                if change is None:
+                    (repository / path).unlink()
+                elif isinstance(change, str):
                     (repository / path).write_text(change)
                 else:
                     pins.update(change)
@@ -160,6 +163,12 @@ class BenchResultsTest(unittest.TestCase):
         self.assertIn("Baseline is stale", markdown)
         self.assertIn("| tier | noise | changed | notable | unclassified |", markdown)
         self.assertNotIn("`micro/noise`", markdown)
+
+    def test_renderer_escapes_benchmark_names(self):
+        current = {**self.current, "rows": [{**self.current["rows"][0], "name": "bad|`name\nrow"}]}
+        rows = bench_results.compare_rows(current, None, None)
+        markdown = bench_results.render(current, None, rows, False)
+        self.assertIn("`bad\\|&#96;name<br>row`", markdown)
 
 
 if __name__ == "__main__":

--- a/bindings/ts/node/benches/ffi.bench.ts
+++ b/bindings/ts/node/benches/ffi.bench.ts
@@ -29,7 +29,7 @@ beforeAll(async () => {
   ]);
   rawA = createRaw();
   cleanup.push(() => rawA.close());
-  rawB = createRaw();
+  rawB = createRaw(true);
   cleanup.push(() => rawB.close());
   rawA.connectAddr(rawB.listenAddrs()[0]);
   await Promise.all([
@@ -95,7 +95,7 @@ function createSdk(): Minip2p {
   });
 }
 
-function createRaw(): NativeEndpoint {
+function createRaw(drainOnDoorbell = false): NativeEndpoint {
   const endpoint = new nativeBinding.NodeEndpoint(
     nativeBinding.generateSecretKey(),
     {
@@ -108,8 +108,18 @@ function createRaw(): NativeEndpoint {
       tcp: { listenAddrs: ["/ip4/127.0.0.1/tcp/0"] },
     }
   );
-  endpoint.start(() => undefined);
+  endpoint.start(() => {
+    if (drainOnDoorbell) {
+      drainAllEvents(endpoint);
+    }
+  });
   return endpoint;
+}
+
+function drainAllEvents(endpoint: NativeEndpoint): void {
+  while (endpoint.drainEvents(256).length === 256) {
+    // The native doorbell is edge-triggered, so empty the queue before returning.
+  }
 }
 
 async function waitRawReady(

--- a/bindings/ts/node/benches/ffi.bench.ts
+++ b/bindings/ts/node/benches/ffi.bench.ts
@@ -1,0 +1,137 @@
+/* oxlint-disable func-style, no-await-in-loop, no-use-before-define, unicorn/no-useless-undefined -- Benchmark fixtures use bounded polling to keep the measured native event path explicit. */
+
+import { setTimeout as delay } from "node:timers/promises";
+
+import { afterAll, beforeAll, bench, describe } from "vitest";
+
+import { Minip2p, generateSecretKey } from "../src/index.js";
+import { nativeBinding } from "../src/native.js";
+import type { NativeEndpoint } from "../src/native.js";
+
+const BURST = 64;
+const TIMEOUT_MS = 10_000;
+const PROTOCOL = "/minip2p/node-bench/1";
+let sdkA: Minip2p;
+let sdkB: Minip2p;
+let rawA: NativeEndpoint;
+let rawB: NativeEndpoint;
+
+beforeAll(async () => {
+  sdkA = createSdk();
+  sdkB = createSdk();
+  await sdkA.connectAddr(sdkB.listenAddrs()[0], { timeoutMs: TIMEOUT_MS });
+  await Promise.all([
+    sdkA.waitPeerReady(sdkB.peerId(), { timeoutMs: TIMEOUT_MS }),
+    sdkB.waitPeerReady(sdkA.peerId(), { timeoutMs: TIMEOUT_MS }),
+  ]);
+  rawA = createRaw();
+  rawB = createRaw();
+  rawA.connectAddr(rawB.listenAddrs()[0]);
+  await Promise.all([
+    waitRawReady(rawA, rawB.peerId()),
+    waitRawReady(rawB, rawA.peerId()),
+  ]);
+});
+
+afterAll(() => {
+  sdkA.close();
+  sdkB.close();
+  rawA.close();
+  rawB.close();
+});
+
+describe("node-ffi", () => {
+  bench("sdk_drain_flood", async () => {
+    await Promise.all(
+      Array.from({ length: BURST }, () =>
+        sdkA.ping(sdkB.peerId(), { timeoutMs: TIMEOUT_MS })
+      )
+    );
+  });
+
+  bench("raw_drain_events", async () => {
+    const streams = Array.from({ length: BURST }, () =>
+      rawA.openStream(rawB.peerId(), PROTOCOL)
+    );
+    let seen = 0;
+    const deadline = Date.now() + TIMEOUT_MS;
+    while (seen < BURST && Date.now() < deadline) {
+      for (const event of rawA.drainEvents(256)) {
+        if (eventTag(event) === "StreamReady") {
+          seen += 1;
+        }
+      }
+      if (seen < BURST) {
+        await delay(0);
+      }
+    }
+    if (seen !== BURST) {
+      throw new Error(`Timed out draining raw events: ${seen}/${BURST}`);
+    }
+    for (const stream of streams) {
+      rawA.abandonStream(rawB.peerId(), stream.streamId);
+    }
+  });
+
+  bench("connected_peers_sync", () => {
+    for (let index = 0; index < 1000; index += 1) {
+      sdkA.connectedPeers();
+    }
+  });
+});
+
+function createSdk(): Minip2p {
+  return Minip2p.create({
+    secretKey: generateSecretKey(),
+    transports: { tcp: { listen: ["/ip4/127.0.0.1/tcp/0"] } },
+  });
+}
+
+function createRaw(): NativeEndpoint {
+  const endpoint = new nativeBinding.NodeEndpoint(
+    nativeBinding.generateSecretKey(),
+    {
+      allowUnsigned: false,
+      autonatServers: [],
+      forceRelay: false,
+      protocols: [PROTOCOL],
+      pubsubRouter: 1,
+      relays: [],
+      tcp: { listenAddrs: ["/ip4/127.0.0.1/tcp/0"] },
+    }
+  );
+  endpoint.start(() => undefined);
+  return endpoint;
+}
+
+async function waitRawReady(
+  endpoint: NativeEndpoint,
+  peerId: string
+): Promise<void> {
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    for (const event of endpoint.drainEvents(256)) {
+      if (eventTag(event) === "PeerReady" && eventPeer(event) === peerId) {
+        return;
+      }
+    }
+    await delay(1);
+  }
+  throw new Error(`Timed out waiting for ${peerId}`);
+}
+
+function eventTag(event: unknown): unknown {
+  return event !== null && typeof event === "object"
+    ? Reflect.get(event, "tag")
+    : undefined;
+}
+
+function eventPeer(event: unknown): unknown {
+  if (event === null || typeof event !== "object") {
+    return undefined;
+  }
+  const inner = Reflect.get(event, "inner");
+  return inner !== null && typeof inner === "object"
+    ? Reflect.get(inner, "peerId")
+    : undefined;
+}

--- a/bindings/ts/node/benches/ffi.bench.ts
+++ b/bindings/ts/node/benches/ffi.bench.ts
@@ -57,7 +57,7 @@ describe("node-ffi", () => {
     const deadline = Date.now() + TIMEOUT_MS;
     while (seen < BURST && Date.now() < deadline) {
       for (const event of rawA.drainEvents(256)) {
-        if (eventTag(event) === "StreamReady") {
+        if (isNativeEvent(event) && event.tag === "StreamReady") {
           seen += 1;
         }
       }
@@ -110,28 +110,24 @@ async function waitRawReady(
 ): Promise<void> {
   const deadline = Date.now() + TIMEOUT_MS;
   while (Date.now() < deadline) {
-    for (const event of endpoint.drainEvents(256)) {
-      if (eventTag(event) === "PeerReady" && eventPeer(event) === peerId) {
-        return;
-      }
+    endpoint.drainEvents(256);
+    if (endpoint.isPeerReady(peerId)) {
+      return;
     }
     await delay(1);
   }
   throw new Error(`Timed out waiting for ${peerId}`);
 }
 
-function eventTag(event: unknown): unknown {
-  return event !== null && typeof event === "object"
-    ? Reflect.get(event, "tag")
-    : undefined;
+interface NativeEvent {
+  readonly tag: string;
 }
 
-function eventPeer(event: unknown): unknown {
-  if (event === null || typeof event !== "object") {
-    return undefined;
-  }
-  const inner = Reflect.get(event, "inner");
-  return inner !== null && typeof inner === "object"
-    ? Reflect.get(inner, "peerId")
-    : undefined;
+function isNativeEvent(value: unknown): value is NativeEvent {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "tag" in value &&
+    typeof value.tag === "string"
+  );
 }

--- a/bindings/ts/node/benches/ffi.bench.ts
+++ b/bindings/ts/node/benches/ffi.bench.ts
@@ -15,17 +15,22 @@ let sdkA: Minip2p;
 let sdkB: Minip2p;
 let rawA: NativeEndpoint;
 let rawB: NativeEndpoint;
+const cleanup: (() => void)[] = [];
 
 beforeAll(async () => {
   sdkA = createSdk();
+  cleanup.push(() => sdkA.close());
   sdkB = createSdk();
+  cleanup.push(() => sdkB.close());
   await sdkA.connectAddr(sdkB.listenAddrs()[0], { timeoutMs: TIMEOUT_MS });
   await Promise.all([
     sdkA.waitPeerReady(sdkB.peerId(), { timeoutMs: TIMEOUT_MS }),
     sdkB.waitPeerReady(sdkA.peerId(), { timeoutMs: TIMEOUT_MS }),
   ]);
   rawA = createRaw();
+  cleanup.push(() => rawA.close());
   rawB = createRaw();
+  cleanup.push(() => rawB.close());
   rawA.connectAddr(rawB.listenAddrs()[0]);
   await Promise.all([
     waitRawReady(rawA, rawB.peerId()),
@@ -34,19 +39,21 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
-  sdkA.close();
-  sdkB.close();
-  rawA.close();
-  rawB.close();
+  for (const close of cleanup.splice(0).toReversed()) {
+    close();
+  }
 });
 
 describe("node-ffi", () => {
   bench("sdk_drain_flood", async () => {
-    await Promise.all(
+    const streams = await Promise.all(
       Array.from({ length: BURST }, () =>
-        sdkA.ping(sdkB.peerId(), { timeoutMs: TIMEOUT_MS })
+        sdkA.openStream(sdkB.peerId(), PROTOCOL, { timeoutMs: TIMEOUT_MS })
       )
     );
+    for (const stream of streams) {
+      stream.abandon();
+    }
   });
 
   bench("raw_drain_events", async () => {
@@ -82,6 +89,7 @@ describe("node-ffi", () => {
 
 function createSdk(): Minip2p {
   return Minip2p.create({
+    protocols: [PROTOCOL],
     secretKey: generateSecretKey(),
     transports: { tcp: { listen: ["/ip4/127.0.0.1/tcp/0"] } },
   });

--- a/bindings/ts/node/package.json
+++ b/bindings/ts/node/package.json
@@ -36,6 +36,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
+    "bench": "vitest bench --run --config ../vitest.config.ts --root . --outputJson ../../../target/bench-node-vitest.json && python3 ../../../scripts/bench_results.py vitest --report ../../../target/bench-node-vitest.json --output ../../../target/bench-results/node-ffi.json --git-sha \"$(git rev-parse HEAD)\"",
     "build": "del-cli dist && tsc -p tsconfig.build.json",
     "clean": "del-cli dist",
     "native:build": "napi build --platform --no-js --dts ../../../target/minip2p-nodejs.d.ts --release --manifest-path ../../../crates/nodejs/Cargo.toml --output-dir . -- --locked",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,7 +23,12 @@ thiserror = { version = "2.0.18", default-features = false }
 
 [dev-dependencies]
 criterion = "0.8.2"
+gungraun = "=0.19.4"
 
 [[bench]]
 name = "multiaddr"
+harness = false
+
+[[bench]]
+name = "multiaddr_ir"
 harness = false

--- a/crates/core/benches/multiaddr_ir.rs
+++ b/crates/core/benches/multiaddr_ir.rs
@@ -1,0 +1,33 @@
+use gungraun::prelude::*;
+use minip2p_core::Multiaddr;
+use std::hint::black_box;
+
+const TEXT: &str = "/dns4/example.com/udp/443/quic-v1";
+
+#[library_benchmark]
+fn parse_text() -> Multiaddr {
+    black_box(TEXT).parse().expect("parse")
+}
+
+fn parsed() -> Multiaddr {
+    TEXT.parse().expect("benchmark address")
+}
+
+#[library_benchmark]
+#[bench::encode_binary(parsed())]
+fn encode_binary(value: Multiaddr) -> Vec<u8> {
+    black_box(value).to_bytes()
+}
+
+fn encoded() -> Vec<u8> {
+    parsed().to_bytes()
+}
+
+#[library_benchmark]
+#[bench::decode_binary(encoded())]
+fn decode_binary(value: Vec<u8>) -> Multiaddr {
+    Multiaddr::from_bytes(black_box(&value)).expect("decode")
+}
+
+library_benchmark_group!(name = benches; benchmarks = parse_text, encode_binary, decode_binary);
+gungraun::main!(library_benchmark_groups = benches);

--- a/crates/discovery/Cargo.toml
+++ b/crates/discovery/Cargo.toml
@@ -24,7 +24,12 @@ thiserror = { version = "2.0.18", default-features = false }
 
 [dev-dependencies]
 criterion = "0.8.2"
+gungraun = "=0.19.4"
 
 [[bench]]
 name = "peer_book"
+harness = false
+
+[[bench]]
+name = "peer_book_ir"
 harness = false

--- a/crates/discovery/benches/peer_book_ir.rs
+++ b/crates/discovery/benches/peer_book_ir.rs
@@ -1,0 +1,64 @@
+use gungraun::prelude::*;
+use minip2p_core::{Multiaddr, PeerId};
+use minip2p_discovery::{Observation, PeerDiscoveryAgent, PeerDiscoveryConfig};
+use minip2p_identity::{KeyType, PublicKey};
+use std::hint::black_box;
+
+const PEERS: usize = 128;
+const ADDRS_PER_PEER: usize = 16;
+
+fn peer(index: usize) -> PeerId {
+    PeerId::from_public_key(&PublicKey::new(KeyType::Ed25519, vec![index as u8; 32]))
+}
+
+fn populated(ttl_ms: u64) -> PeerDiscoveryAgent {
+    let mut agent = PeerDiscoveryAgent::new(
+        peer(usize::MAX),
+        PeerDiscoveryConfig {
+            auto_dial: false,
+            beacon_peer_ttl_ms: ttl_ms,
+            ..PeerDiscoveryConfig::default()
+        },
+    )
+    .expect("valid config");
+    for index in 0..PEERS {
+        let addrs: Vec<Multiaddr> = (0..ADDRS_PER_PEER)
+            .map(|offset| {
+                let port = 10_000 + ((index * ADDRS_PER_PEER + offset) % 50_000) as u16;
+                format!("/ip4/192.0.2.{}/udp/{port}/quic-v1", (index % 250) + 1)
+                    .parse()
+                    .expect("address")
+            })
+            .collect();
+        agent.observe_beacon(
+            Observation {
+                peer: peer(index),
+                addrs,
+            },
+            0,
+        );
+    }
+    agent
+}
+
+#[library_benchmark]
+#[bench::tick_active(populated(u64::MAX / 2))]
+fn tick_active(mut agent: PeerDiscoveryAgent) {
+    agent.handle_tick(black_box(1));
+}
+
+#[library_benchmark]
+#[bench::tick_expire(populated(1))]
+fn tick_expire(mut agent: PeerDiscoveryAgent) {
+    agent.handle_tick(black_box(1));
+    black_box(agent.pending_event_count());
+}
+
+#[library_benchmark]
+#[bench::next_timeout(populated(u64::MAX / 2))]
+fn next_timeout(agent: PeerDiscoveryAgent) {
+    black_box(agent.next_timeout(black_box(1)));
+}
+
+library_benchmark_group!(name = benches; benchmarks = tick_active, tick_expire, next_timeout);
+gungraun::main!(library_benchmark_groups = benches);

--- a/crates/minip2p/Cargo.toml
+++ b/crates/minip2p/Cargo.toml
@@ -64,5 +64,11 @@ getrandom = { version = "0.4.3", optional = true }
 thiserror = { version = "2.0.18", default-features = false, optional = true }
 
 [dev-dependencies]
+criterion = "0.8.2"
 minip2p-relay = { path = "../relay" }
 minip2p-test-support = { path = "../test-support" }
+
+[[bench]]
+name = "endpoint_e2e"
+harness = false
+required-features = ["quic", "tcp"]

--- a/crates/minip2p/benches/endpoint_e2e.rs
+++ b/crates/minip2p/benches/endpoint_e2e.rs
@@ -142,10 +142,14 @@ impl Crossed {
             pending.push(streams);
         }
         let deadline = Instant::now() + TIMEOUT;
+        let mut received = vec![HashMap::<StreamId, Vec<u8>>::new(); self.clients.len()];
         while pending.iter().any(|streams| !streams.is_empty()) {
             assert!(Instant::now() < deadline, "crossed echo timeout");
             for (index, (client, peer)) in self.clients.iter_mut().enumerate() {
-                let Some(event) = client.next_event(Duration::ZERO).expect("client poll") else {
+                let Some(event) = client
+                    .next_event(Duration::from_millis(1))
+                    .expect("client poll")
+                else {
                     continue;
                 };
                 match event {
@@ -172,11 +176,23 @@ impl Crossed {
                         .get(index)
                         .is_some_and(|streams| streams.contains(&stream_id)) =>
                     {
-                        assert_eq!(data, payload);
-                        pending
+                        let bytes = received
                             .get_mut(index)
-                            .expect("client pending set")
-                            .remove(&stream_id);
+                            .expect("client receive map")
+                            .entry(stream_id)
+                            .or_default();
+                        bytes.extend_from_slice(&data);
+                        assert!(
+                            bytes.len() <= payload.len(),
+                            "crossed echo exceeded payload"
+                        );
+                        if bytes.len() == payload.len() {
+                            assert_eq!(bytes, &payload);
+                            pending
+                                .get_mut(index)
+                                .expect("client pending set")
+                                .remove(&stream_id);
+                        }
                     }
                     _ => {}
                 }

--- a/crates/minip2p/benches/endpoint_e2e.rs
+++ b/crates/minip2p/benches/endpoint_e2e.rs
@@ -1,0 +1,322 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use minip2p::{Deadline, Endpoint, Event, PeerAddr, PeerId, StreamId};
+
+const ECHO: &str = "/minip2p/bench/echo/1";
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Copy)]
+enum Kind {
+    Tcp,
+    Quic,
+}
+
+fn bind(kind: Kind) -> Endpoint {
+    let builder = Endpoint::builder()
+        .agent_version("minip2p-bench")
+        .protocol(ECHO);
+    match kind {
+        Kind::Tcp => builder.bind_tcp("127.0.0.1:0"),
+        Kind::Quic => builder.bind_quic("127.0.0.1:0"),
+    }
+    .expect("bind endpoint")
+}
+
+struct EchoServer {
+    address: PeerAddr,
+    stop: Arc<AtomicBool>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl EchoServer {
+    fn start(kind: Kind) -> Self {
+        let mut endpoint = bind(kind);
+        let address = endpoint.listen().expect("listen");
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_stop = Arc::clone(&stop);
+        let thread = thread::spawn(move || {
+            let mut streams = HashSet::<(PeerId, StreamId)>::new();
+            while !worker_stop.load(Ordering::Relaxed) {
+                let event = endpoint
+                    .next_event(Duration::from_millis(5))
+                    .expect("server poll");
+                match event {
+                    Some(Event::StreamReady {
+                        peer_id,
+                        stream_id,
+                        protocol_id,
+                        initiated_locally: false,
+                        ..
+                    }) if protocol_id == ECHO => {
+                        streams.insert((peer_id, stream_id));
+                    }
+                    Some(Event::StreamData {
+                        peer_id,
+                        stream_id,
+                        data,
+                        ..
+                    }) if streams.contains(&(peer_id.clone(), stream_id)) => {
+                        endpoint
+                            .send_stream(&peer_id, stream_id, data)
+                            .expect("echo");
+                    }
+                    Some(Event::StreamRemoteWriteClosed {
+                        peer_id, stream_id, ..
+                    }) if streams.contains(&(peer_id.clone(), stream_id)) => {
+                        endpoint
+                            .close_stream_write(&peer_id, stream_id)
+                            .expect("close echo");
+                    }
+                    Some(Event::StreamClosed {
+                        peer_id, stream_id, ..
+                    }) => {
+                        streams.remove(&(peer_id, stream_id));
+                    }
+                    _ => {}
+                }
+            }
+        });
+        Self {
+            address,
+            stop,
+            thread: Some(thread),
+        }
+    }
+}
+
+impl Drop for EchoServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(thread) = self.thread.take() {
+            thread.join().expect("server thread");
+        }
+    }
+}
+
+struct Pair {
+    _server: EchoServer,
+    client: Endpoint,
+    peer: PeerId,
+}
+
+struct Crossed {
+    _server: EchoServer,
+    clients: Vec<(Endpoint, PeerId)>,
+}
+
+impl Crossed {
+    fn connected(kind: Kind) -> Self {
+        let server = EchoServer::start(kind);
+        let peer = server.address.peer_id().clone();
+        let mut clients = Vec::new();
+        for _ in 0..4 {
+            let mut client = bind(kind);
+            client.dial(&server.address).expect("dial");
+            client
+                .wait_peer_ready(&peer, TIMEOUT)
+                .expect("wait ready")
+                .expect("ready timeout");
+            clients.push((client, peer.clone()));
+        }
+        Self {
+            _server: server,
+            clients,
+        }
+    }
+
+    fn echo_4x4(&mut self) {
+        let payload = vec![0x5a; 64];
+        let mut pending = Vec::new();
+        for (client, peer) in &mut self.clients {
+            let mut streams = HashSet::new();
+            for _ in 0..4 {
+                streams.insert(client.open_stream(peer, ECHO).expect("open stream"));
+            }
+            pending.push(streams);
+        }
+        let deadline = Instant::now() + TIMEOUT;
+        while pending.iter().any(|streams| !streams.is_empty()) {
+            assert!(Instant::now() < deadline, "crossed echo timeout");
+            for (index, (client, peer)) in self.clients.iter_mut().enumerate() {
+                let Some(event) = client.next_event(Duration::ZERO).expect("client poll") else {
+                    continue;
+                };
+                match event {
+                    Event::StreamReady {
+                        stream_id,
+                        protocol_id,
+                        initiated_locally: true,
+                        ..
+                    } if protocol_id == ECHO
+                        && pending
+                            .get(index)
+                            .is_some_and(|streams| streams.contains(&stream_id)) =>
+                    {
+                        client
+                            .send_stream(peer, stream_id, payload.clone())
+                            .expect("send");
+                        client
+                            .close_stream_write(peer, stream_id)
+                            .expect("close write");
+                    }
+                    Event::StreamData {
+                        stream_id, data, ..
+                    } if pending
+                        .get(index)
+                        .is_some_and(|streams| streams.contains(&stream_id)) =>
+                    {
+                        assert_eq!(data, payload);
+                        pending
+                            .get_mut(index)
+                            .expect("client pending set")
+                            .remove(&stream_id);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+impl Pair {
+    fn disconnected(kind: Kind) -> Self {
+        let server = EchoServer::start(kind);
+        let peer = server.address.peer_id().clone();
+        Self {
+            _server: server,
+            client: bind(kind),
+            peer,
+        }
+    }
+
+    fn connected(kind: Kind) -> Self {
+        let mut pair = Self::disconnected(kind);
+        pair.connect();
+        pair
+    }
+
+    fn connect(&mut self) {
+        self.client.dial(&self._server.address).expect("dial");
+        self.client
+            .wait_peer_ready(&self.peer, TIMEOUT)
+            .expect("wait ready")
+            .expect("ready timeout");
+    }
+
+    fn ping(&mut self) {
+        self.client.ping(&self.peer).expect("ping");
+        self.client
+            .wait_ping_rtt(&self.peer, TIMEOUT)
+            .expect("wait ping")
+            .expect("ping timeout");
+    }
+
+    fn echo(&mut self, payload: Vec<u8>, streams: usize) {
+        let mut pending = HashMap::new();
+        for _ in 0..streams {
+            let stream = self
+                .client
+                .open_stream(&self.peer, ECHO)
+                .expect("open stream");
+            pending.insert(stream, (0usize, Vec::with_capacity(payload.len())));
+        }
+        let deadline = Deadline::from(Instant::now() + TIMEOUT);
+        while !pending.is_empty() {
+            match self
+                .client
+                .next_event(deadline)
+                .expect("client poll")
+                .expect("echo timeout")
+            {
+                Event::StreamReady {
+                    peer_id,
+                    stream_id,
+                    protocol_id,
+                    initiated_locally: true,
+                    ..
+                } if peer_id == self.peer
+                    && protocol_id == ECHO
+                    && pending.contains_key(&stream_id) =>
+                {
+                    let end = payload.len().min(32 * 1024);
+                    self.client
+                        .send_stream(
+                            &self.peer,
+                            stream_id,
+                            payload.get(..end).expect("first payload chunk").to_vec(),
+                        )
+                        .expect("send");
+                    pending.get_mut(&stream_id).expect("pending stream").0 = end;
+                }
+                Event::StreamData {
+                    peer_id,
+                    stream_id,
+                    data,
+                    ..
+                } if peer_id == self.peer && pending.contains_key(&stream_id) => {
+                    let (sent, response) = pending.get_mut(&stream_id).expect("pending stream");
+                    response.extend_from_slice(&data);
+                    if response.len() == *sent && *sent < payload.len() {
+                        let end = payload.len().min(*sent + 32 * 1024);
+                        self.client
+                            .send_stream(
+                                &self.peer,
+                                stream_id,
+                                payload
+                                    .get(*sent..end)
+                                    .expect("next payload chunk")
+                                    .to_vec(),
+                            )
+                            .expect("send");
+                        *sent = end;
+                    }
+                    if response.len() == payload.len() {
+                        assert_eq!(*response, payload);
+                        self.client
+                            .close_stream_write(&self.peer, stream_id)
+                            .expect("close write");
+                        pending.remove(&stream_id);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn suite(c: &mut Criterion, kind: Kind, transport: &str) {
+    let mut group = c.benchmark_group(format!("e2e/{transport}"));
+    group.bench_function("setup", |b| {
+        b.iter_batched_ref(
+            || Pair::disconnected(kind),
+            Pair::connect,
+            BatchSize::SmallInput,
+        )
+    });
+    let mut ping = Pair::connected(kind);
+    group.bench_function("ping", |b| b.iter(|| ping.ping()));
+    let mut echo = Pair::connected(kind);
+    group.bench_function("echo_64b", |b| b.iter(|| echo.echo(vec![0x5a; 64], 1)));
+    let mut crossed = Crossed::connected(kind);
+    group.bench_function("echo_64b_crossed_4x4", |b| b.iter(|| crossed.echo_4x4()));
+    let mut transfer = Pair::connected(kind);
+    group.bench_function("transfer_1mib", |b| {
+        b.iter(|| transfer.echo(vec![0x5a; 1024 * 1024], 1))
+    });
+    group.finish();
+}
+
+fn endpoint_e2e(c: &mut Criterion) {
+    suite(c, Kind::Tcp, "tcp");
+    suite(c, Kind::Quic, "quic");
+}
+
+criterion_group!(benches, endpoint_e2e);
+criterion_main!(benches);

--- a/crates/pubsub/Cargo.toml
+++ b/crates/pubsub/Cargo.toml
@@ -32,7 +32,12 @@ thiserror = { version = "2.0.18", default-features = false }
 
 [dev-dependencies]
 criterion = "0.8.2"
+gungraun = "=0.19.4"
 
 [[bench]]
 name = "fanout"
+harness = false
+
+[[bench]]
+name = "fanout_ir"
 harness = false

--- a/crates/pubsub/benches/fanout_ir.rs
+++ b/crates/pubsub/benches/fanout_ir.rs
@@ -1,0 +1,84 @@
+use gungraun::prelude::*;
+use minip2p_identity::Ed25519Keypair;
+use minip2p_pubsub::{
+    FLOODSUB_PROTOCOL_ID, FloodsubAgent, FloodsubConfig, Rpc, SubOpts, encode_frame,
+};
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::{ConnectionId, StreamId};
+use std::hint::black_box;
+
+const PEER_COUNT: u8 = 32;
+const PAYLOAD_LEN: usize = 60 * 1024;
+const TOPIC: &str = "benchmark";
+
+fn subscribed_agent() -> FloodsubAgent {
+    let mut agent = FloodsubAgent::new(
+        Ed25519Keypair::from_secret_key_bytes([1; 32]),
+        FloodsubConfig::default(),
+        0,
+    );
+    let subscription = encode_frame(
+        &Rpc {
+            subscriptions: vec![SubOpts {
+                subscribe: Some(true),
+                topic_id: Some(TOPIC.into()),
+            }],
+            publish: Vec::new(),
+            control: None,
+        }
+        .encode(),
+    );
+    for seed in 2..2 + PEER_COUNT {
+        let peer = Ed25519Keypair::from_secret_key_bytes([seed; 32]).peer_id();
+        let conn_id = ConnectionId::new(u64::from(seed));
+        let stream_id = StreamId::new(u64::from(seed));
+        agent.handle_event(
+            &SwarmEvent::ConnectionEstablished {
+                peer_id: peer.clone(),
+                conn_id,
+            },
+            0,
+        );
+        agent.handle_event(
+            &SwarmEvent::PeerReady {
+                peer_id: peer.clone(),
+                protocols: vec![FLOODSUB_PROTOCOL_ID.into()],
+            },
+            0,
+        );
+        assert!(agent.handle_event(
+            &SwarmEvent::StreamReady {
+                peer_id: peer.clone(),
+                conn_id,
+                stream_id,
+                protocol_id: FLOODSUB_PROTOCOL_ID.into(),
+                initiated_locally: false,
+            },
+            0
+        ));
+        assert!(agent.handle_event(
+            &SwarmEvent::StreamData {
+                peer_id: peer,
+                conn_id,
+                stream_id,
+                data: subscription.clone(),
+            },
+            0
+        ));
+    }
+    agent
+}
+
+fn setup() -> (FloodsubAgent, Vec<u8>) {
+    (subscribed_agent(), vec![0x5a; PAYLOAD_LEN])
+}
+
+#[library_benchmark]
+#[bench::floodsub_publish_32x60_kib(setup())]
+fn floodsub_publish(input: (FloodsubAgent, Vec<u8>)) {
+    let (mut agent, payload) = input;
+    black_box(agent.publish(TOPIC, payload, 0)).expect("publish");
+}
+
+library_benchmark_group!(name = benches; benchmarks = floodsub_publish);
+gungraun::main!(library_benchmark_groups = benches);

--- a/crates/relay-server/Cargo.toml
+++ b/crates/relay-server/Cargo.toml
@@ -34,9 +34,14 @@ thiserror = { version = "2.0.18", default-features = false }
 
 [dev-dependencies]
 criterion = "0.8.2"
+gungraun = "=0.19.4"
 minip2p-identity = { path = "../identity", version = "0.4.11" }
 minip2p-nat = { path = "../nat", version = "0.4.11" }
 
 [[bench]]
 name = "relay_server_event"
+harness = false
+
+[[bench]]
+name = "relay_server_event_ir"
 harness = false

--- a/crates/relay-server/benches/relay_server_event_ir.rs
+++ b/crates/relay-server/benches/relay_server_event_ir.rs
@@ -1,0 +1,64 @@
+use gungraun::prelude::*;
+use minip2p_core::PeerId;
+use minip2p_platform::Now;
+use minip2p_relay::HOP_PROTOCOL_ID;
+use minip2p_relay_server::{RelayServerAgent, RelayServerConfig};
+use minip2p_swarm::SwarmEvent;
+use minip2p_transport::{ConnectionId, StreamId};
+use std::hint::black_box;
+
+const PEERS: u64 = 128;
+const EVENTS_PER_BATCH: usize = 100;
+
+fn populated_agent() -> (RelayServerAgent, SwarmEvent, Now) {
+    let now = Now::from_millis(1);
+    let mut agent = RelayServerAgent::new(
+        PeerId::from_public_key_protobuf(b"relay-server-bench-local"),
+        RelayServerConfig::default(),
+    )
+    .expect("valid config");
+    for index in 0..PEERS {
+        let peer = PeerId::from_public_key_protobuf(&index.to_le_bytes());
+        let conn_id = ConnectionId::new(index + 1);
+        let stream_id = StreamId::new(1);
+        agent.handle_event(
+            &SwarmEvent::ConnectionEstablished {
+                peer_id: peer.clone(),
+                conn_id,
+            },
+            false,
+            Now::from_millis(0),
+        );
+        assert!(agent.handle_event(
+            &SwarmEvent::StreamReady {
+                peer_id: peer,
+                conn_id,
+                stream_id,
+                protocol_id: HOP_PROTOCOL_ID.into(),
+                initiated_locally: false,
+            },
+            false,
+            Now::from_millis(0)
+        ));
+    }
+    agent.handle_tick(now);
+    let event = SwarmEvent::StreamData {
+        peer_id: PeerId::from_public_key_protobuf(b"relay-server-bench-unrelated"),
+        conn_id: ConnectionId::new(PEERS + 1),
+        stream_id: StreamId::new(1),
+        data: Vec::new(),
+    };
+    (agent, event, now)
+}
+
+#[library_benchmark]
+#[bench::relay_handle_event_same_now_128_pending_hops(populated_agent())]
+fn relay_event(input: (RelayServerAgent, SwarmEvent, Now)) {
+    let (mut agent, event, now) = input;
+    for _ in 0..EVENTS_PER_BATCH {
+        black_box(agent.handle_event(black_box(&event), false, black_box(now)));
+    }
+}
+
+library_benchmark_group!(name = benches; benchmarks = relay_event);
+gungraun::main!(library_benchmark_groups = benches);

--- a/crates/yamux/Cargo.toml
+++ b/crates/yamux/Cargo.toml
@@ -28,7 +28,12 @@ thiserror = { version = "2.0.18", default-features = false }
 
 [dev-dependencies]
 criterion = "0.8.2"
+gungraun = "=0.19.4"
 
 [[bench]]
 name = "data_path"
+harness = false
+
+[[bench]]
+name = "data_path_ir"
 harness = false

--- a/crates/yamux/benches/data_path_ir.rs
+++ b/crates/yamux/benches/data_path_ir.rs
@@ -1,0 +1,38 @@
+use gungraun::prelude::*;
+use minip2p_yamux::{FLAG_SYN, Frame, YamuxRole, YamuxSession};
+use std::hint::black_box;
+
+const PAYLOAD_LEN: usize = 64 * 1024;
+
+fn sender() -> (YamuxSession, u32, Vec<u8>) {
+    let mut session = YamuxSession::new(YamuxRole::Client);
+    let stream = session.open_stream().expect("open stream");
+    (session, stream, vec![0x5a; PAYLOAD_LEN])
+}
+
+#[library_benchmark]
+#[bench::session_send_and_drain(sender())]
+fn session_send_and_drain(input: (YamuxSession, u32, Vec<u8>)) {
+    let (mut session, stream, data) = input;
+    session.send(stream, data).expect("send");
+    black_box(session.poll_output());
+}
+
+fn receiver() -> (YamuxSession, Vec<u8>) {
+    let inbound = Frame::data(1, FLAG_SYN, vec![0x5a; PAYLOAD_LEN])
+        .expect("valid frame")
+        .encode();
+    (YamuxSession::new(YamuxRole::Server), inbound)
+}
+
+#[library_benchmark]
+#[bench::session_receive_and_drain(receiver())]
+fn session_receive_and_drain(input: (YamuxSession, Vec<u8>)) {
+    let (mut session, bytes) = input;
+    session.handle_data(&bytes).expect("receive");
+    black_box(session.poll_output());
+    black_box(session.poll_output());
+}
+
+library_benchmark_group!(name = benches; benchmarks = session_send_and_drain, session_receive_and_drain);
+gungraun::main!(library_benchmark_groups = benches);

--- a/justfile
+++ b/justfile
@@ -145,6 +145,19 @@ bench:
     cargo bench -p minip2p-relay-server --bench relay_server_event
     cargo bench -p minip2p-quic --bench idle_poll
     cargo bench -p minip2p-tcp --bench readiness_poll
+    cargo bench -p minip2p-rs --features tcp --bench endpoint_e2e
+    python3 scripts/bench_results.py criterion --output target/bench-results/rust-wall.json --git-sha "$(git rev-parse HEAD)"
+
+bench-ir:
+    GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-core --bench multiaddr_ir
+    GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-yamux --bench data_path_ir
+    GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-discovery --bench peer_book_ir
+    GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-pubsub --bench fanout_ir
+    GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-relay-server --bench relay_server_event_ir
+    python3 scripts/bench_results.py gungraun --output target/bench-results/rust-micro.json --git-sha "$(git rev-parse HEAD)"
+
+bench-results-test:
+    python3 -m unittest discover -s bench -p 'test_*.py'
 
 fuzz seconds="30":
     cargo +nightly fuzz run wire_inputs -- -max_total_time={{seconds}}

--- a/justfile
+++ b/justfile
@@ -150,12 +150,13 @@ bench:
     python3 scripts/bench_results.py criterion --since target/bench-results/criterion-start --output target/bench-results/rust-wall.json --git-sha "$(git rev-parse HEAD)"
 
 bench-ir:
+    python3 scripts/bench_results.py start --output target/bench-results/gungraun-start
     GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-core --bench multiaddr_ir
     GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-yamux --bench data_path_ir
     GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-discovery --bench peer_book_ir
     GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-pubsub --bench fanout_ir
     GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-relay-server --bench relay_server_event_ir
-    python3 scripts/bench_results.py gungraun --output target/bench-results/rust-micro.json --git-sha "$(git rev-parse HEAD)"
+    python3 scripts/bench_results.py gungraun --since target/bench-results/gungraun-start --output target/bench-results/rust-micro.json --git-sha "$(git rev-parse HEAD)"
 
 bench-node:
     cd bindings/ts && pnpm --filter @minip2p/node bench

--- a/justfile
+++ b/justfile
@@ -157,6 +157,9 @@ bench-ir:
     GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-relay-server --bench relay_server_event_ir
     python3 scripts/bench_results.py gungraun --output target/bench-results/rust-micro.json --git-sha "$(git rev-parse HEAD)"
 
+bench-node:
+    cd bindings/ts && pnpm --filter @minip2p/node bench
+
 bench-results-test:
     python3 -m unittest discover -s bench -p 'test_*.py'
 

--- a/justfile
+++ b/justfile
@@ -138,6 +138,7 @@ bindings-android:
     cd bindings/ts && pnpm rn:android
 
 bench:
+    python3 scripts/bench_results.py start --output target/bench-results/criterion-start
     cargo bench -p minip2p-core --bench multiaddr
     cargo bench -p minip2p-yamux --bench data_path
     cargo bench -p minip2p-discovery --bench peer_book
@@ -146,7 +147,7 @@ bench:
     cargo bench -p minip2p-quic --bench idle_poll
     cargo bench -p minip2p-tcp --bench readiness_poll
     cargo bench -p minip2p-rs --features tcp --bench endpoint_e2e
-    python3 scripts/bench_results.py criterion --output target/bench-results/rust-wall.json --git-sha "$(git rev-parse HEAD)"
+    python3 scripts/bench_results.py criterion --since target/bench-results/criterion-start --output target/bench-results/rust-wall.json --git-sha "$(git rev-parse HEAD)"
 
 bench-ir:
     GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-core --bench multiaddr_ir

--- a/scripts/bench_results.py
+++ b/scripts/bench_results.py
@@ -113,7 +113,7 @@ def collect_criterion(root: Path, output: Path, git_sha: str, since: Path) -> No
         raise BenchError(f"cannot read Criterion run marker {since}: {error}") from error
     rows = []
     for estimate in root.glob("**/new/estimates.json"):
-        if estimate.stat().st_mtime_ns < started_at:
+        if estimate.stat().st_mtime_ns <= started_at:
             continue
         relative = estimate.relative_to(root)
         name = "/".join(relative.parts[:-2])
@@ -154,7 +154,7 @@ def collect_gungraun(root: Path, output: Path, git_sha: str, since: Path) -> Non
         raise BenchError(f"cannot read Gungraun run marker {since}: {error}") from error
     rows = []
     for path in root.glob("**/summary.json"):
-        if path.stat().st_mtime_ns < started_at:
+        if path.stat().st_mtime_ns <= started_at:
             continue
         summary = load_json(path)
         identifier = summary.get("id") or summary.get("function_name")
@@ -269,7 +269,14 @@ def display_value(value: float | int | None) -> str:
 
 def markdown_code(value: str) -> str:
     """Render an untrusted value inside a Markdown table code span."""
-    value = value.replace("|", "\\|").replace("\r\n", "<br>").replace("\n", "<br>").replace("`", "&#96;")
+    value = (
+        value.replace("\\", "&#92;")
+        .replace("|", "&#124;")
+        .replace("\r\n", "<br>")
+        .replace("\r", "<br>")
+        .replace("\n", "<br>")
+        .replace("`", "&#96;")
+    )
     return f"`{value}`"
 
 

--- a/scripts/bench_results.py
+++ b/scripts/bench_results.py
@@ -16,6 +16,18 @@ from typing import Any, Iterable
 SCHEMA_VERSION = 1
 TIERS = ("rust-micro", "rust-wall", "node-ffi")
 METRICS = {"rust-micro": "Ir", "rust-wall": "median_ns", "node-ffi": "median_ns"}
+EXPECTED_CRITERION = {
+    "multiaddr/parse_text", "multiaddr/encode_binary", "multiaddr/decode_binary",
+    "yamux/64KiB/session_send_and_drain", "yamux/64KiB/session_receive_and_drain",
+    "peer_book_128_peers_16_addrs/tick_active", "peer_book_128_peers_16_addrs/tick_expire",
+    "peer_book_128_peers_16_addrs/next_timeout", "pubsub/floodsub_publish_32x60KiB",
+    "relay_handle_event_same_now_128_pending_hops",
+    "quic/idle_poll/1", "quic/idle_poll/64", "quic/idle_poll/256", "quic/idle_poll/512",
+    "tcp/readiness_poll/1", "tcp/readiness_poll/64", "tcp/readiness_poll/256", "tcp/readiness_poll/512",
+    "e2e/tcp/setup", "e2e/tcp/ping", "e2e/tcp/echo_64b", "e2e/tcp/echo_64b_crossed_4x4",
+    "e2e/tcp/transfer_1mib", "e2e/quic/setup", "e2e/quic/ping", "e2e/quic/echo_64b",
+    "e2e/quic/echo_64b_crossed_4x4", "e2e/quic/transfer_1mib",
+}
 
 
 class BenchError(ValueError):
@@ -76,17 +88,26 @@ def merge(inputs: list[Path], output: Path, git_sha: str | None) -> None:
     write_results(git_sha, (row for document in documents for row in document["rows"]), output)
 
 
-def collect_criterion(root: Path, output: Path, git_sha: str) -> None:
+def collect_criterion(root: Path, output: Path, git_sha: str, since: Path) -> None:
+    try:
+        started_at = since.stat().st_mtime_ns
+    except OSError as error:
+        raise BenchError(f"cannot read Criterion run marker {since}: {error}") from error
     rows = []
     for estimate in root.glob("**/new/estimates.json"):
+        if estimate.stat().st_mtime_ns < started_at:
+            continue
         relative = estimate.relative_to(root)
         name = "/".join(relative.parts[:-2])
         point = load_json(estimate).get("median", {}).get("point_estimate")
         if point is None:
             raise BenchError(f"missing median.point_estimate in {estimate}")
         rows.append({"tier": "rust-wall", "name": name, "metric": "median_ns", "value": point})
-    if not rows:
-        raise BenchError(f"no Criterion estimates found under {root}")
+    names = {row["name"] for row in rows}
+    if names != EXPECTED_CRITERION:
+        missing = sorted(EXPECTED_CRITERION - names)
+        unexpected = sorted(names - EXPECTED_CRITERION)
+        raise BenchError(f"Criterion row set mismatch; missing={missing}, unexpected={unexpected}")
     write_results(git_sha, rows, output)
 
 
@@ -171,7 +192,7 @@ class ComparedRow:
     name: str
     metric: str
     baseline: float | int | None
-    current: float | int
+    current: float | int | None
     delta: float | None
     classification: str
     direction: str
@@ -205,6 +226,11 @@ def compare_rows(
         classification = "notable" if magnitude >= notable else "changed" if magnitude >= changed else "noise"
         direction = "improved" if delta < 0 else "regressed" if delta > 0 else ""
         compared.append(ComparedRow(*key, baseline_value, row["value"], delta, classification, direction))
+    current_keys = {(row["tier"], row["name"], row["metric"]) for row in current["rows"]}
+    for key, baseline_value in old.items():
+        if key not in current_keys:
+            compared.append(ComparedRow(*key, baseline_value, None, None, "unclassified", "", "missing current row"))
+    compared.sort(key=lambda row: (TIERS.index(row.tier), row.name, row.metric))
     return compared
 
 
@@ -264,7 +290,11 @@ def parser() -> argparse.ArgumentParser:
     criterion_parser.add_argument("--root", type=Path, default=Path("target/criterion"))
     criterion_parser.add_argument("--output", type=Path, required=True)
     criterion_parser.add_argument("--git-sha", required=True)
-    criterion_parser.set_defaults(run=lambda args: collect_criterion(args.root, args.output, args.git_sha))
+    criterion_parser.add_argument("--since", type=Path, required=True)
+    criterion_parser.set_defaults(run=lambda args: collect_criterion(args.root, args.output, args.git_sha, args.since))
+    start_parser = commands.add_parser("start")
+    start_parser.add_argument("--output", type=Path, required=True)
+    start_parser.set_defaults(run=lambda args: (args.output.parent.mkdir(parents=True, exist_ok=True), args.output.touch()))
     vitest_parser = commands.add_parser("vitest")
     vitest_parser.add_argument("--report", type=Path, required=True)
     vitest_parser.add_argument("--output", type=Path, required=True)

--- a/scripts/bench_results.py
+++ b/scripts/bench_results.py
@@ -147,9 +147,15 @@ def collect_vitest(report: Path, output: Path, git_sha: str) -> None:
     write_results(git_sha, rows, output)
 
 
-def collect_gungraun(root: Path, output: Path, git_sha: str) -> None:
+def collect_gungraun(root: Path, output: Path, git_sha: str, since: Path) -> None:
+    try:
+        started_at = since.stat().st_mtime_ns
+    except OSError as error:
+        raise BenchError(f"cannot read Gungraun run marker {since}: {error}") from error
     rows = []
     for path in root.glob("**/summary.json"):
+        if path.stat().st_mtime_ns < started_at:
+            continue
         summary = load_json(path)
         identifier = summary.get("id") or summary.get("function_name")
         name = GUNGRAUN_NAMES.get(identifier)
@@ -190,8 +196,13 @@ def ir_compatible(baseline_tree: str, current_tree: str) -> tuple[bool, str | No
     if git_bytes(baseline_tree, "Cargo.lock") != git_bytes(current_tree, "Cargo.lock"):
         return False, "incompatible Ir pins: Cargo.lock differs"
     try:
-        before = json.loads(git_bytes(baseline_tree, "bench/pins.json"))
-        after = json.loads(git_bytes(current_tree, "bench/pins.json"))
+        before_bytes = git_bytes(baseline_tree, "bench/pins.json")
+        after_bytes = git_bytes(current_tree, "bench/pins.json")
+    except BenchError:
+        return False, "incompatible Ir pins: pin manifest unavailable"
+    try:
+        before = json.loads(before_bytes)
+        after = json.loads(after_bytes)
     except json.JSONDecodeError as error:
         raise BenchError(f"invalid bench/pins.json: {error}") from error
     for key, label in IR_PINS.items():
@@ -256,6 +267,12 @@ def display_value(value: float | int | None) -> str:
     return f"{value:,.2f}"
 
 
+def markdown_code(value: str) -> str:
+    """Render an untrusted value inside a Markdown table code span."""
+    value = value.replace("|", "\\|").replace("\r\n", "<br>").replace("\n", "<br>").replace("`", "&#96;")
+    return f"`{value}`"
+
+
 def render(
     current: dict[str, Any], baseline: dict[str, Any] | None, rows: list[ComparedRow], stale: bool
 ) -> str:
@@ -276,7 +293,7 @@ def render(
         for row in visible:
             delta = "—" if row.delta is None else f"{row.delta:+.2f}%"
             classification = row.classification if row.reason is None else f"{row.classification} ({row.reason})"
-            lines.append(f"| `{row.name}` | {display_value(row.baseline)} | {display_value(row.current)} | {delta} | {classification} | {row.direction} |")
+            lines.append(f"| {markdown_code(row.name)} | {display_value(row.baseline)} | {display_value(row.current)} | {delta} | {classification} | {row.direction} |")
     return "\n".join(lines) + "\n"
 
 
@@ -319,7 +336,8 @@ def parser() -> argparse.ArgumentParser:
     gungraun_parser.add_argument("--root", type=Path, default=Path("target/gungraun"))
     gungraun_parser.add_argument("--output", type=Path, required=True)
     gungraun_parser.add_argument("--git-sha", required=True)
-    gungraun_parser.set_defaults(run=lambda args: collect_gungraun(args.root, args.output, args.git_sha))
+    gungraun_parser.add_argument("--since", type=Path, required=True)
+    gungraun_parser.set_defaults(run=lambda args: collect_gungraun(args.root, args.output, args.git_sha, args.since))
     compare_parser = commands.add_parser("compare")
     compare_parser.add_argument("--current", type=Path, required=True)
     compare_parser.add_argument("--baseline", type=Path)

--- a/scripts/bench_results.py
+++ b/scripts/bench_results.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Normalize benchmark output and compare schema-version-1 result files."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+SCHEMA_VERSION = 1
+TIERS = ("rust-micro", "rust-wall", "node-ffi")
+METRICS = {"rust-micro": "Ir", "rust-wall": "median_ns", "node-ffi": "median_ns"}
+
+
+class BenchError(ValueError):
+    """Invalid benchmark input."""
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise BenchError(f"cannot read {path}: {error}") from error
+
+
+def validate(document: Any) -> dict[str, Any]:
+    if not isinstance(document, dict) or document.get("schema_version") != SCHEMA_VERSION:
+        raise BenchError("results must use schema_version 1")
+    if not isinstance(document.get("git_sha"), str) or not document["git_sha"]:
+        raise BenchError("results require a non-empty git_sha")
+    rows = document.get("rows")
+    if not isinstance(rows, list):
+        raise BenchError("results require a rows array")
+    seen: set[tuple[str, str, str]] = set()
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise BenchError(f"row {index} must be an object")
+        tier, name, metric, value = (row.get(key) for key in ("tier", "name", "metric", "value"))
+        if tier not in TIERS:
+            raise BenchError(f"row {index} has unknown tier {tier!r}")
+        if not isinstance(name, str) or not name:
+            raise BenchError(f"row {index} requires a non-empty name")
+        if metric != METRICS[tier]:
+            raise BenchError(f"row {index} must use metric {METRICS[tier]!r}")
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value < 0:
+            raise BenchError(f"row {index} requires a finite non-negative value")
+        key = (tier, name, metric)
+        if key in seen:
+            raise BenchError(f"duplicate row: {'/'.join(key)}")
+        seen.add(key)
+    return document
+
+
+def write_results(git_sha: str, rows: Iterable[dict[str, Any]], output: Path) -> None:
+    document = validate({"schema_version": SCHEMA_VERSION, "git_sha": git_sha, "rows": list(rows)})
+    document["rows"].sort(key=lambda row: (TIERS.index(row["tier"]), row["name"], row["metric"]))
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(document, indent=2) + "\n")
+
+
+def merge(inputs: list[Path], output: Path, git_sha: str | None) -> None:
+    documents = [validate(load_json(path)) for path in inputs]
+    shas = {document["git_sha"] for document in documents}
+    if git_sha is None:
+        if len(shas) != 1:
+            raise BenchError("input files have different git_sha values")
+        git_sha = shas.pop()
+    elif any(sha != git_sha for sha in shas):
+        raise BenchError("an input git_sha does not match --git-sha")
+    write_results(git_sha, (row for document in documents for row in document["rows"]), output)
+
+
+def collect_criterion(root: Path, output: Path, git_sha: str) -> None:
+    rows = []
+    for estimate in root.glob("**/new/estimates.json"):
+        relative = estimate.relative_to(root)
+        name = "/".join(relative.parts[:-2])
+        point = load_json(estimate).get("median", {}).get("point_estimate")
+        if point is None:
+            raise BenchError(f"missing median.point_estimate in {estimate}")
+        rows.append({"tier": "rust-wall", "name": name, "metric": "median_ns", "value": point})
+    if not rows:
+        raise BenchError(f"no Criterion estimates found under {root}")
+    write_results(git_sha, rows, output)
+
+
+def collect_vitest(report: Path, output: Path, git_sha: str) -> None:
+    rows = []
+    for file in load_json(report).get("files", []):
+        for group in file.get("groups", []):
+            for benchmark in group.get("benchmarks", []):
+                median_ms = benchmark.get("median")
+                name = benchmark.get("name")
+                if not isinstance(name, str) or not isinstance(median_ms, (int, float)):
+                    raise BenchError(f"invalid Vitest benchmark in {report}")
+                rows.append({"tier": "node-ffi", "name": name, "metric": "median_ns", "value": median_ms * 1_000_000})
+    if not rows:
+        raise BenchError(f"no Vitest benchmarks found in {report}")
+    write_results(git_sha, rows, output)
+
+
+def collect_gungraun(root: Path, output: Path, git_sha: str) -> None:
+    name_map = {
+        "parse_text": "multiaddr/parse_text",
+        "encode_binary": "multiaddr/encode_binary",
+        "decode_binary": "multiaddr/decode_binary",
+        "session_send_and_drain": "yamux/64KiB/session_send_and_drain",
+        "session_receive_and_drain": "yamux/64KiB/session_receive_and_drain",
+        "tick_active": "peer_book_128_peers_16_addrs/tick_active",
+        "tick_expire": "peer_book_128_peers_16_addrs/tick_expire",
+        "next_timeout": "peer_book_128_peers_16_addrs/next_timeout",
+        "floodsub_publish_32x60_kib": "pubsub/floodsub_publish_32x60KiB",
+        "relay_handle_event_same_now_128_pending_hops": "relay_handle_event_same_now_128_pending_hops",
+    }
+    rows = []
+    for path in root.glob("**/summary.json"):
+        summary = load_json(path)
+        identifier = summary.get("id") or summary.get("function_name")
+        name = name_map.get(identifier)
+        if name is None:
+            continue
+        ir = None
+        for profile in summary.get("profiles", []):
+            if profile.get("tool") != "Callgrind":
+                continue
+            metric = profile["summaries"]["total"]["summary"]["Callgrind"]["Ir"]["metrics"]
+            ir = metric.get("Left", metric.get("Both", [None])[0])
+        if not isinstance(ir, (int, float)):
+            raise BenchError(f"missing Callgrind Ir in {path}")
+        rows.append({"tier": "rust-micro", "name": name, "metric": "Ir", "value": ir})
+    if len(rows) != 10:
+        raise BenchError(f"expected 10 Gungraun summaries under {root}, found {len(rows)}")
+    write_results(git_sha, rows, output)
+
+
+def git_bytes(tree: str, path: str) -> bytes:
+    result = subprocess.run(
+        ["git", "show", f"{tree}:{path}"], capture_output=True, check=False
+    )
+    if result.returncode:
+        raise BenchError(f"cannot read {path} at {tree}")
+    return result.stdout
+
+
+def ir_compatible(baseline_tree: str, current_tree: str) -> tuple[bool, str | None]:
+    """Compare the five pins that make instruction counts comparable."""
+    checks = (
+        ("Cargo.lock", "Cargo.lock", True),
+        ("Rust toolchain", "bench/pins.json", False),
+    )
+    for label, path, use_hash in checks:
+        before = git_bytes(baseline_tree, path)
+        after = git_bytes(current_tree, path)
+        if use_hash:
+            before = hashlib.sha256(before).digest()
+            after = hashlib.sha256(after).digest()
+        if before != after:
+            return False, f"incompatible Ir pins: {label} differs"
+    return True, None
+
+
+@dataclass(frozen=True)
+class ComparedRow:
+    tier: str
+    name: str
+    metric: str
+    baseline: float | int | None
+    current: float | int
+    delta: float | None
+    classification: str
+    direction: str
+    reason: str | None = None
+
+
+def compare_rows(
+    current: dict[str, Any], baseline: dict[str, Any] | None, ir_reason: str | None
+) -> list[ComparedRow]:
+    old = {} if baseline is None else {
+        (row["tier"], row["name"], row["metric"]): row["value"] for row in baseline["rows"]
+    }
+    compared = []
+    for row in current["rows"]:
+        key = (row["tier"], row["name"], row["metric"])
+        reason = "no baseline" if baseline is None else None
+        if reason is None and row["tier"] == "rust-micro" and ir_reason:
+            reason = ir_reason
+        if reason is None and key not in old:
+            reason = "missing baseline row"
+        baseline_value = old.get(key)
+        if reason is not None:
+            compared.append(ComparedRow(*key, baseline_value, row["value"], None, "unclassified", "", reason))
+            continue
+        if baseline_value == 0:
+            compared.append(ComparedRow(*key, baseline_value, row["value"], None, "unclassified", "", "zero baseline"))
+            continue
+        delta = (row["value"] - baseline_value) / baseline_value * 100
+        magnitude = abs(delta)
+        changed, notable = (1.0, 2.0) if row["tier"] == "rust-micro" else (20.0, 30.0)
+        classification = "notable" if magnitude >= notable else "changed" if magnitude >= changed else "noise"
+        direction = "improved" if delta < 0 else "regressed" if delta > 0 else ""
+        compared.append(ComparedRow(*key, baseline_value, row["value"], delta, classification, direction))
+    return compared
+
+
+def display_value(value: float | int | None) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, int) or value.is_integer():
+        return f"{int(value):,}"
+    return f"{value:,.2f}"
+
+
+def render(
+    current: dict[str, Any], baseline: dict[str, Any] | None, rows: list[ComparedRow], stale: bool
+) -> str:
+    baseline_sha = "none" if baseline is None else baseline["git_sha"]
+    lines = ["<!-- bench-comment -->", "## Benchmark comparison", "", f"Baseline: `{baseline_sha}`"]
+    if stale:
+        lines += ["", "> Baseline is stale: it is not this pull request's merge base."]
+    lines += ["", "| tier | noise | changed | notable | unclassified |", "| --- | ---: | ---: | ---: | ---: |"]
+    for tier in TIERS:
+        tier_rows = [row for row in rows if row.tier == tier]
+        counts = {name: sum(row.classification == name for row in tier_rows) for name in ("noise", "changed", "notable", "unclassified")}
+        lines.append(f"| {tier} | {counts['noise']} | {counts['changed']} | {counts['notable']} | {counts['unclassified']} |")
+    for tier in TIERS:
+        visible = [row for row in rows if row.tier == tier and row.classification != "noise"]
+        if not visible:
+            continue
+        lines += ["", f"### {tier}", "", "| benchmark | baseline | current | Δ% | class | direction |", "| --- | ---: | ---: | ---: | --- | --- |"]
+        for row in visible:
+            delta = "—" if row.delta is None else f"{row.delta:+.2f}%"
+            classification = row.classification if row.reason is None else f"{row.classification} ({row.reason})"
+            lines.append(f"| `{row.name}` | {display_value(row.baseline)} | {display_value(row.current)} | {delta} | {classification} | {row.direction} |")
+    return "\n".join(lines) + "\n"
+
+
+def command_compare(args: argparse.Namespace) -> None:
+    current = validate(load_json(args.current))
+    baseline = None if args.baseline is None else validate(load_json(args.baseline))
+    ir_reason = args.ir_reason
+    if baseline is not None and ir_reason is None and args.check_ir_pins:
+        compatible, ir_reason = ir_compatible(args.baseline_tree or baseline["git_sha"], args.current_tree or current["git_sha"])
+        if compatible:
+            ir_reason = None
+    rows = compare_rows(current, baseline, ir_reason)
+    args.output.write_text(render(current, baseline, rows, args.stale))
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser()
+    commands = root.add_subparsers(dest="command", required=True)
+    merge_parser = commands.add_parser("merge")
+    merge_parser.add_argument("inputs", nargs="+", type=Path)
+    merge_parser.add_argument("--output", type=Path, required=True)
+    merge_parser.add_argument("--git-sha")
+    merge_parser.set_defaults(run=lambda args: merge(args.inputs, args.output, args.git_sha))
+    criterion_parser = commands.add_parser("criterion")
+    criterion_parser.add_argument("--root", type=Path, default=Path("target/criterion"))
+    criterion_parser.add_argument("--output", type=Path, required=True)
+    criterion_parser.add_argument("--git-sha", required=True)
+    criterion_parser.set_defaults(run=lambda args: collect_criterion(args.root, args.output, args.git_sha))
+    vitest_parser = commands.add_parser("vitest")
+    vitest_parser.add_argument("--report", type=Path, required=True)
+    vitest_parser.add_argument("--output", type=Path, required=True)
+    vitest_parser.add_argument("--git-sha", required=True)
+    vitest_parser.set_defaults(run=lambda args: collect_vitest(args.report, args.output, args.git_sha))
+    gungraun_parser = commands.add_parser("gungraun")
+    gungraun_parser.add_argument("--root", type=Path, default=Path("target/gungraun"))
+    gungraun_parser.add_argument("--output", type=Path, required=True)
+    gungraun_parser.add_argument("--git-sha", required=True)
+    gungraun_parser.set_defaults(run=lambda args: collect_gungraun(args.root, args.output, args.git_sha))
+    compare_parser = commands.add_parser("compare")
+    compare_parser.add_argument("--current", type=Path, required=True)
+    compare_parser.add_argument("--baseline", type=Path)
+    compare_parser.add_argument("--output", type=Path, required=True)
+    compare_parser.add_argument("--stale", action="store_true")
+    compare_parser.add_argument("--check-ir-pins", action="store_true")
+    compare_parser.add_argument("--baseline-tree")
+    compare_parser.add_argument("--current-tree")
+    compare_parser.add_argument("--ir-reason", help=argparse.SUPPRESS)
+    compare_parser.set_defaults(run=command_compare)
+    return root
+
+
+def main() -> int:
+    try:
+        args = parser().parse_args()
+        args.run(args)
+        return 0
+    except BenchError as error:
+        print(f"bench-results: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_results.py
+++ b/scripts/bench_results.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import math
 import subprocess
@@ -27,6 +26,25 @@ EXPECTED_CRITERION = {
     "e2e/tcp/setup", "e2e/tcp/ping", "e2e/tcp/echo_64b", "e2e/tcp/echo_64b_crossed_4x4",
     "e2e/tcp/transfer_1mib", "e2e/quic/setup", "e2e/quic/ping", "e2e/quic/echo_64b",
     "e2e/quic/echo_64b_crossed_4x4", "e2e/quic/transfer_1mib",
+}
+GUNGRAUN_NAMES = {
+    "parse_text": "multiaddr/parse_text",
+    "encode_binary": "multiaddr/encode_binary",
+    "decode_binary": "multiaddr/decode_binary",
+    "session_send_and_drain": "yamux/64KiB/session_send_and_drain",
+    "session_receive_and_drain": "yamux/64KiB/session_receive_and_drain",
+    "tick_active": "peer_book_128_peers_16_addrs/tick_active",
+    "tick_expire": "peer_book_128_peers_16_addrs/tick_expire",
+    "next_timeout": "peer_book_128_peers_16_addrs/next_timeout",
+    "floodsub_publish_32x60_kib": "pubsub/floodsub_publish_32x60KiB",
+    "relay_handle_event_same_now_128_pending_hops": "relay_handle_event_same_now_128_pending_hops",
+}
+EXPECTED_VITEST = {"sdk_drain_flood", "raw_drain_events", "connected_peers_sync"}
+IR_PINS = {
+    "rust": "Rust toolchain",
+    "profile": "optimization profile",
+    "gungraun": "Gungraun version",
+    "valgrind": "Valgrind version",
 }
 
 
@@ -121,31 +139,22 @@ def collect_vitest(report: Path, output: Path, git_sha: str) -> None:
                 if not isinstance(name, str) or not isinstance(median_ms, (int, float)):
                     raise BenchError(f"invalid Vitest benchmark in {report}")
                 rows.append({"tier": "node-ffi", "name": name, "metric": "median_ns", "value": median_ms * 1_000_000})
-    if not rows:
-        raise BenchError(f"no Vitest benchmarks found in {report}")
+    names = {row["name"] for row in rows}
+    if names != EXPECTED_VITEST or len(rows) != len(EXPECTED_VITEST):
+        missing = sorted(EXPECTED_VITEST - names)
+        unexpected = sorted(names - EXPECTED_VITEST)
+        raise BenchError(f"Vitest row set mismatch; missing={missing}, unexpected={unexpected}")
     write_results(git_sha, rows, output)
 
 
 def collect_gungraun(root: Path, output: Path, git_sha: str) -> None:
-    name_map = {
-        "parse_text": "multiaddr/parse_text",
-        "encode_binary": "multiaddr/encode_binary",
-        "decode_binary": "multiaddr/decode_binary",
-        "session_send_and_drain": "yamux/64KiB/session_send_and_drain",
-        "session_receive_and_drain": "yamux/64KiB/session_receive_and_drain",
-        "tick_active": "peer_book_128_peers_16_addrs/tick_active",
-        "tick_expire": "peer_book_128_peers_16_addrs/tick_expire",
-        "next_timeout": "peer_book_128_peers_16_addrs/next_timeout",
-        "floodsub_publish_32x60_kib": "pubsub/floodsub_publish_32x60KiB",
-        "relay_handle_event_same_now_128_pending_hops": "relay_handle_event_same_now_128_pending_hops",
-    }
     rows = []
     for path in root.glob("**/summary.json"):
         summary = load_json(path)
         identifier = summary.get("id") or summary.get("function_name")
-        name = name_map.get(identifier)
+        name = GUNGRAUN_NAMES.get(identifier)
         if name is None:
-            continue
+            raise BenchError(f"unexpected Gungraun benchmark {identifier!r} in {path}")
         ir = None
         for profile in summary.get("profiles", []):
             if profile.get("tool") != "Callgrind":
@@ -155,8 +164,12 @@ def collect_gungraun(root: Path, output: Path, git_sha: str) -> None:
         if not isinstance(ir, (int, float)):
             raise BenchError(f"missing Callgrind Ir in {path}")
         rows.append({"tier": "rust-micro", "name": name, "metric": "Ir", "value": ir})
-    if len(rows) != 10:
-        raise BenchError(f"expected 10 Gungraun summaries under {root}, found {len(rows)}")
+    names = {row["name"] for row in rows}
+    expected = set(GUNGRAUN_NAMES.values())
+    if names != expected or len(rows) != len(expected):
+        missing = sorted(expected - names)
+        unexpected = sorted(names - expected)
+        raise BenchError(f"Gungraun row set mismatch; missing={missing}, unexpected={unexpected}")
     write_results(git_sha, rows, output)
 
 
@@ -171,17 +184,15 @@ def git_bytes(tree: str, path: str) -> bytes:
 
 def ir_compatible(baseline_tree: str, current_tree: str) -> tuple[bool, str | None]:
     """Compare the five pins that make instruction counts comparable."""
-    checks = (
-        ("Cargo.lock", "Cargo.lock", True),
-        ("Rust toolchain", "bench/pins.json", False),
-    )
-    for label, path, use_hash in checks:
-        before = git_bytes(baseline_tree, path)
-        after = git_bytes(current_tree, path)
-        if use_hash:
-            before = hashlib.sha256(before).digest()
-            after = hashlib.sha256(after).digest()
-        if before != after:
+    if git_bytes(baseline_tree, "Cargo.lock") != git_bytes(current_tree, "Cargo.lock"):
+        return False, "incompatible Ir pins: Cargo.lock differs"
+    try:
+        before = json.loads(git_bytes(baseline_tree, "bench/pins.json"))
+        after = json.loads(git_bytes(current_tree, "bench/pins.json"))
+    except json.JSONDecodeError as error:
+        raise BenchError(f"invalid bench/pins.json: {error}") from error
+    for key, label in IR_PINS.items():
+        if before.get(key) != after.get(key):
             return False, f"incompatible Ir pins: {label} differs"
     return True, None
 
@@ -269,8 +280,8 @@ def render(
 def command_compare(args: argparse.Namespace) -> None:
     current = validate(load_json(args.current))
     baseline = None if args.baseline is None else validate(load_json(args.baseline))
-    ir_reason = args.ir_reason
-    if baseline is not None and ir_reason is None and args.check_ir_pins:
+    ir_reason = None
+    if baseline is not None and args.check_ir_pins:
         compatible, ir_reason = ir_compatible(args.baseline_tree or baseline["git_sha"], args.current_tree or current["git_sha"])
         if compatible:
             ir_reason = None
@@ -313,7 +324,6 @@ def parser() -> argparse.ArgumentParser:
     compare_parser.add_argument("--check-ir-pins", action="store_true")
     compare_parser.add_argument("--baseline-tree")
     compare_parser.add_argument("--current-tree")
-    compare_parser.add_argument("--ir-reason", help=argparse.SUPPRESS)
     compare_parser.set_defaults(run=command_compare)
     return root
 

--- a/scripts/bench_results.py
+++ b/scripts/bench_results.py
@@ -136,7 +136,7 @@ def collect_vitest(report: Path, output: Path, git_sha: str) -> None:
             for benchmark in group.get("benchmarks", []):
                 median_ms = benchmark.get("median")
                 name = benchmark.get("name")
-                if not isinstance(name, str) or not isinstance(median_ms, (int, float)):
+                if not isinstance(name, str) or isinstance(median_ms, bool) or not isinstance(median_ms, (int, float)):
                     raise BenchError(f"invalid Vitest benchmark in {report}")
                 rows.append({"tier": "node-ffi", "name": name, "metric": "median_ns", "value": median_ms * 1_000_000})
     names = {row["name"] for row in rows}
@@ -160,7 +160,10 @@ def collect_gungraun(root: Path, output: Path, git_sha: str) -> None:
             if profile.get("tool") != "Callgrind":
                 continue
             metric = profile["summaries"]["total"]["summary"]["Callgrind"]["Ir"]["metrics"]
-            ir = metric.get("Left", metric.get("Both", [None])[0])
+            ir = metric.get("Left")
+            if ir is None:
+                both = metric.get("Both") or []
+                ir = both[0] if both else None
         if not isinstance(ir, (int, float)):
             raise BenchError(f"missing Callgrind Ir in {path}")
         rows.append({"tier": "rust-micro", "name": name, "metric": "Ir", "value": ir})
@@ -286,6 +289,7 @@ def command_compare(args: argparse.Namespace) -> None:
         if compatible:
             ir_reason = None
     rows = compare_rows(current, baseline, ir_reason)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(render(current, baseline, rows, args.stale))
 
 

--- a/transports/tcp/benches/readiness_poll.rs
+++ b/transports/tcp/benches/readiness_poll.rs
@@ -9,6 +9,7 @@ use minip2p_core::Multiaddr;
 use minip2p_platform::Now;
 use minip2p_tcp::{StdTcpProvider, TcpEvent, TcpProvider};
 
+// The locked 512-connection sweep needs at least 1,027 open file descriptors.
 const COUNTS: &[usize] = &[1, 64, 256, 512];
 const SETUP_TIMEOUT: Duration = Duration::from_secs(20);
 const CONNECT_BATCH: usize = 32;

--- a/transports/tcp/benches/readiness_poll.rs
+++ b/transports/tcp/benches/readiness_poll.rs
@@ -9,7 +9,7 @@ use minip2p_core::Multiaddr;
 use minip2p_platform::Now;
 use minip2p_tcp::{StdTcpProvider, TcpEvent, TcpProvider};
 
-const COUNTS: &[usize] = &[1, 64, 256];
+const COUNTS: &[usize] = &[1, 64, 256, 512];
 const SETUP_TIMEOUT: Duration = Duration::from_secs(20);
 const CONNECT_BATCH: usize = 32;
 


### PR DESCRIPTION
Closes #137

Adds the local measurement path for all three benchmark tiers:

- ten Gungraun Callgrind mirrors and `just bench-ir`
- public Endpoint TCP/QUIC Criterion e2e scenarios, including 4x4 crossed echo
- Node Vitest Bench coverage for SDK drain, raw drain, and synchronous peer queries
- schema-v1 result collectors/merger, locked classification bands, Ir pin compatibility checks, and comparison Markdown rendering
- fixture coverage for no baseline, incompatible Ir, missing rows, boundaries, merge, and report layout

Validation:

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo bench -p minip2p-rs --features tcp --bench endpoint_e2e -- --test`
- `python3 -m unittest discover -s bench -p "test_*.py" -v`
- Node typecheck, lint, 32 integration tests, and benchmark smoke

Workflow automation is intentionally excluded per the issue boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #137

Adds the local measurement path for all three benchmark tiers: ten Gungraun Callgrind mirrors, TCP/QUIC Criterion e2e scenarios including a 4×4 crossed echo, and Node Vitest bench coverage. A new script normalizes results to schema-v1 JSON, rejects incomplete collections, and classifies deltas against a baseline.

**New Features**
- `just bench` now also runs the e2e suite and writes `target/bench-results/rust-wall.json`; `just bench-ir` writes rust-micro Ir results; `npm run bench` writes node-ffi results.
- Bench targets create start markers, and collectors only pick up results newer than the marker, so stale files in `target/` are ignored.
- `scripts/bench_results.py` collects (`criterion`, `vitest`, `gungraun`), merges, and compares results, rendering a Markdown report with baseline staleness flagged.
- Collectors reject incomplete runs: Criterion row sets must match the expected set, Gungraun must yield exactly 10 summaries, and empty Vitest reports fail.
- Missing baseline rows, zero baselines, and Ir pin drift (`Cargo.lock` or the `bench/pins.json` pins) produce `unclassified` rows with reasons.
- Classification bands are 1%/2% for rust-micro and 20%/30% for rust-wall and node-ffi.
- Fixtures and Python unit tests cover no baseline, incompatible pins, missing rows, boundary classification, merge, and report layout.
- Workflow automation is intentionally out of scope for this issue.

**Dependencies**
- Pins `gungraun` 0.19.4 across five crates and adds `criterion` as a dev-dependency for the new `endpoint_e2e` bench.

<sup>Written for commit 628969f173f0f86b3f2c97c0ac054f5654e4dadc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

