### PR TITLE
ci: collect and compare benchmark results

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,270 @@
+name: Bench
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: "1.98.0"
+  RUST_TARGET: x86_64-unknown-linux-gnu
+  GUNGRAUN_VERSION: "0.19.4"
+  VALGRIND_VERSION: "3.27.1"
+  NODE_VERSION: "24"
+  PNPM_VERSION: "11.24.0"
+
+jobs:
+  rust-micro:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      complete: ${{ steps.result.outputs.complete }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          targets: ${{ env.RUST_TARGET }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: gungraun/setup-gungraun@62591572561bb2f4ed2ae300b8a8bea99ea8ddaf # v1.1.3
+        with:
+          runner-version: ${{ env.GUNGRAUN_VERSION }}
+          runner-target: ${{ env.RUST_TARGET }}
+          valgrind-version: ${{ env.VALGRIND_VERSION }}
+      - name: Measure
+        id: measure
+        continue-on-error: true
+        run: just bench-ir
+      - name: Prepare result slice
+        id: result
+        if: always()
+        env:
+          MEASURE_OUTCOME: ${{ steps.measure.outcome }}
+        run: |
+          complete=false
+          if [ "$MEASURE_OUTCOME" = success ] && python3 scripts/bench_results.py merge target/bench-results/rust-micro.json --output target/bench-artifacts/rust-micro.json --git-sha "$(git rev-parse HEAD)"; then
+            complete=true
+          else
+            mkdir -p target/bench-artifacts
+            jq -n --arg sha "$(git rev-parse HEAD)" '{schema_version: 1, git_sha: $sha, rows: []}' > target/bench-artifacts/rust-micro.json
+          fi
+          echo "complete=$complete" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: bench-rust-micro
+          path: target/bench-artifacts/rust-micro.json
+          if-no-files-found: error
+
+  rust-wall:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      complete: ${{ steps.result.outputs.complete }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          targets: ${{ env.RUST_TARGET }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Measure
+        id: measure
+        continue-on-error: true
+        run: just bench
+      - name: Prepare result slice
+        id: result
+        if: always()
+        env:
+          MEASURE_OUTCOME: ${{ steps.measure.outcome }}
+        run: |
+          complete=false
+          if [ "$MEASURE_OUTCOME" = success ] && python3 scripts/bench_results.py merge target/bench-results/rust-wall.json --output target/bench-artifacts/rust-wall.json --git-sha "$(git rev-parse HEAD)"; then
+            complete=true
+          else
+            mkdir -p target/bench-artifacts
+            jq -n --arg sha "$(git rev-parse HEAD)" '{schema_version: 1, git_sha: $sha, rows: []}' > target/bench-artifacts/rust-wall.json
+          fi
+          echo "complete=$complete" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: bench-rust-wall
+          path: target/bench-artifacts/rust-wall.json
+          if-no-files-found: error
+
+  node-ffi:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      complete: ${{ steps.result.outputs.complete }}
+    defaults:
+      run:
+        working-directory: bindings/ts
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: bindings/ts/pnpm-lock.yaml
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          targets: ${{ env.RUST_TARGET }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build native binding
+        run: pnpm --filter @minip2p/node native:build
+      - name: Measure
+        id: measure
+        continue-on-error: true
+        run: pnpm --filter @minip2p/node bench
+      - name: Prepare result slice
+        id: result
+        if: always()
+        env:
+          MEASURE_OUTCOME: ${{ steps.measure.outcome }}
+        run: |
+          complete=false
+          if [ "$MEASURE_OUTCOME" = success ] && python3 ../../scripts/bench_results.py merge ../../target/bench-results/node-ffi.json --output ../../target/bench-artifacts/node-ffi.json --git-sha "$(git rev-parse HEAD)"; then
+            complete=true
+          else
+            mkdir -p ../../target/bench-artifacts
+            jq -n --arg sha "$(git rev-parse HEAD)" '{schema_version: 1, git_sha: $sha, rows: []}' > ../../target/bench-artifacts/node-ffi.json
+          fi
+          echo "complete=$complete" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: bench-node-ffi
+          path: target/bench-artifacts/node-ffi.json
+          if-no-files-found: error
+
+  baseline:
+    if: >-
+      github.event_name == 'push' &&
+      needs.rust-micro.outputs.complete == 'true' &&
+      needs.rust-wall.outputs.complete == 'true' &&
+      needs.node-ffi.outputs.complete == 'true'
+    needs: [rust-micro, rust-wall, node-ffi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: bench-baseline
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: bench-*
+          path: ${{ runner.temp }}/bench-slices
+          merge-multiple: true
+      - name: Merge result slices
+        run: python3 scripts/bench_results.py merge "$RUNNER_TEMP"/bench-slices/*.json --output "$RUNNER_TEMP/results.json" --git-sha "$GITHUB_SHA"
+      - name: Update baseline branch
+        env:
+          BASELINE_DIR: ${{ runner.temp }}/bench-data
+        run: |
+          git worktree add --detach "$BASELINE_DIR"
+          if git -C "$BASELINE_DIR" fetch --depth=1 origin bench-data; then
+            git -C "$BASELINE_DIR" checkout -B bench-data FETCH_HEAD
+          else
+            git -C "$BASELINE_DIR" checkout --orphan bench-data
+            git -C "$BASELINE_DIR" rm -rf .
+          fi
+          cp "$RUNNER_TEMP/results.json" "$BASELINE_DIR/$GITHUB_SHA.json"
+          printf '%s\n' "$GITHUB_SHA" > "$BASELINE_DIR/latest"
+          git -C "$BASELINE_DIR" add "$GITHUB_SHA.json" latest
+          git -C "$BASELINE_DIR" -c user.name=github-actions -c user.email=41898282+github-actions[bot]@users.noreply.github.com commit -m "bench: $GITHUB_SHA"
+          for attempt in 1 2 3; do
+            if git -C "$BASELINE_DIR" push origin HEAD:bench-data; then
+              exit 0
+            fi
+            git -C "$BASELINE_DIR" pull --rebase origin bench-data
+          done
+          exit 1
+
+  compare:
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs: [rust-micro, rust-wall, node-ffi]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: bench-*
+          path: ${{ runner.temp }}/bench-slices
+          merge-multiple: true
+      - name: Merge result slices
+        run: python3 scripts/bench_results.py merge "$RUNNER_TEMP"/bench-slices/*.json --output "$RUNNER_TEMP/current.json" --git-sha "$(git rev-parse HEAD)"
+      - name: Read baseline
+        id: baseline
+        run: |
+          if ! git fetch --depth=1 origin bench-data; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          baseline_sha=$(git show FETCH_HEAD:latest)
+          git show "FETCH_HEAD:$baseline_sha.json" > "$RUNNER_TEMP/baseline.json"
+          git cat-file -e "$baseline_sha^{commit}" 2>/dev/null || git fetch origin "$baseline_sha"
+          merge_base=$(git merge-base "${{ github.event.pull_request.head.sha }}" "${{ github.event.pull_request.base.sha }}")
+          echo "available=true" >> "$GITHUB_OUTPUT"
+          echo "sha=$baseline_sha" >> "$GITHUB_OUTPUT"
+          if [ "$baseline_sha" = "$merge_base" ]; then
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Compare with baseline
+        if: steps.baseline.outputs.available == 'true'
+        run: >-
+          python3 scripts/bench_results.py compare
+          --current "$RUNNER_TEMP/current.json"
+          --baseline "$RUNNER_TEMP/baseline.json"
+          --output "$RUNNER_TEMP/comparison.md"
+          --check-ir-pins
+          --baseline-tree "${{ steps.baseline.outputs.sha }}"
+          --current-tree "${{ github.event.pull_request.head.sha }}"
+          ${{ steps.baseline.outputs.stale == 'true' && '--stale' || '' }}
+      - name: Compare without baseline
+        if: steps.baseline.outputs.available != 'true'
+        run: python3 scripts/bench_results.py compare --current "$RUNNER_TEMP/current.json" --output "$RUNNER_TEMP/comparison.md"
+      - name: Prepare comparison artifact
+        run: printf '%s\n' "${{ github.event.pull_request.number }}" > "$RUNNER_TEMP/pr-number"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: bench-comparison
+          path: |
+            ${{ runner.temp }}/comparison.md
+            ${{ runner.temp }}/pr-number
+          if-no-files-found: error

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,7 +47,14 @@ jobs:
       - name: Measure
         id: measure
         continue-on-error: true
-        run: just bench-ir
+        run: |
+          python3 scripts/bench_results.py start --output target/bench-results/gungraun-start
+          GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-core --bench multiaddr_ir
+          GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-yamux --bench data_path_ir
+          GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-discovery --bench peer_book_ir
+          GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-pubsub --bench fanout_ir
+          GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-relay-server --bench relay_server_event_ir
+          python3 scripts/bench_results.py gungraun --since target/bench-results/gungraun-start --output target/bench-results/rust-micro.json --git-sha "$(git rev-parse HEAD)"
       - name: Prepare result slice
         id: result
         if: always()
@@ -88,7 +95,17 @@ jobs:
       - name: Measure
         id: measure
         continue-on-error: true
-        run: just bench
+        run: |
+          python3 scripts/bench_results.py start --output target/bench-results/criterion-start
+          cargo bench -p minip2p-core --bench multiaddr
+          cargo bench -p minip2p-yamux --bench data_path
+          cargo bench -p minip2p-discovery --bench peer_book
+          cargo bench -p minip2p-pubsub --bench fanout
+          cargo bench -p minip2p-relay-server --bench relay_server_event
+          cargo bench -p minip2p-quic --bench idle_poll
+          cargo bench -p minip2p-tcp --bench readiness_poll
+          cargo bench -p minip2p-rs --features tcp --bench endpoint_e2e
+          python3 scripts/bench_results.py criterion --since target/bench-results/criterion-start --output target/bench-results/rust-wall.json --git-sha "$(git rev-parse HEAD)"
       - name: Prepare result slice
         id: result
         if: always()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -197,8 +197,8 @@ jobs:
       group: bench-baseline
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: bench-*
           path: ${{ runner.temp }}/bench-slices

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,14 +47,7 @@ jobs:
       - name: Measure
         id: measure
         continue-on-error: true
-        run: |
-          python3 scripts/bench_results.py start --output target/bench-results/gungraun-start
-          GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-core --bench multiaddr_ir
-          GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-yamux --bench data_path_ir
-          GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-discovery --bench peer_book_ir
-          GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-pubsub --bench fanout_ir
-          GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-relay-server --bench relay_server_event_ir
-          python3 scripts/bench_results.py gungraun --since target/bench-results/gungraun-start --output target/bench-results/rust-micro.json --git-sha "$(git rev-parse HEAD)"
+        run: scripts/run-benches.sh ir
       - name: Prepare result slice
         id: result
         if: always()
@@ -95,17 +88,7 @@ jobs:
       - name: Measure
         id: measure
         continue-on-error: true
-        run: |
-          python3 scripts/bench_results.py start --output target/bench-results/criterion-start
-          cargo bench -p minip2p-core --bench multiaddr
-          cargo bench -p minip2p-yamux --bench data_path
-          cargo bench -p minip2p-discovery --bench peer_book
-          cargo bench -p minip2p-pubsub --bench fanout
-          cargo bench -p minip2p-relay-server --bench relay_server_event
-          cargo bench -p minip2p-quic --bench idle_poll
-          cargo bench -p minip2p-tcp --bench readiness_poll
-          cargo bench -p minip2p-rs --features tcp --bench endpoint_e2e
-          python3 scripts/bench_results.py criterion --since target/bench-results/criterion-start --output target/bench-results/rust-wall.json --git-sha "$(git rev-parse HEAD)"
+        run: scripts/run-benches.sh wall
       - name: Prepare result slice
         id: result
         if: always()

--- a/bench/test_bench_results.py
+++ b/bench/test_bench_results.py
@@ -157,6 +157,41 @@ class BenchResultsTest(unittest.TestCase):
             with self.assertRaisesRegex(bench_results.BenchError, "row set mismatch"):
                 bench_results.collect_criterion(root, output, "sha", marker)
 
+    def test_gungraun_collector_reads_tagged_integer_metrics(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "gungraun"
+            marker = Path(directory) / "started"
+            output = Path(directory) / "results.json"
+            marker.touch()
+            for identifier in bench_results.GUNGRAUN_NAMES:
+                summary = root / identifier / "summary.json"
+                summary.parent.mkdir(parents=True)
+                summary.write_text(
+                    json.dumps(
+                        {
+                            "id": identifier,
+                            "profiles": [
+                                {
+                                    "tool": "Callgrind",
+                                    "summaries": {
+                                        "total": {
+                                            "summary": {
+                                                "Callgrind": {
+                                                    "Ir": {"metrics": {"Left": {"Int": 42}}}
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            ],
+                        }
+                    )
+                )
+            bench_results.collect_gungraun(root, output, "sha", marker)
+            rows = json.loads(output.read_text())["rows"]
+            self.assertEqual(len(rows), len(bench_results.GUNGRAUN_NAMES))
+            self.assertTrue(all(row["value"] == 42 for row in rows))
+
     def test_renderer_has_locked_layout(self):
         rows = bench_results.compare_rows(self.current, self.baseline, None)
         markdown = bench_results.render(self.current, self.baseline, rows, True)

--- a/bench/test_bench_results.py
+++ b/bench/test_bench_results.py
@@ -149,6 +149,7 @@ class BenchResultsTest(unittest.TestCase):
                 estimate = root.joinpath(*name.split("/"), "new", "estimates.json")
                 estimate.parent.mkdir(parents=True)
                 estimate.write_text(json.dumps({"median": {"point_estimate": 10}}))
+                estimate.with_name("benchmark.json").write_text(json.dumps({"full_id": name}))
             bench_results.collect_criterion(root, output, "sha", marker)
             self.assertEqual(len(json.loads(output.read_text())["rows"]), len(bench_results.EXPECTED_CRITERION))
 

--- a/justfile
+++ b/justfile
@@ -138,25 +138,10 @@ bindings-android:
     cd bindings/ts && pnpm rn:android
 
 bench:
-    python3 scripts/bench_results.py start --output target/bench-results/criterion-start
-    cargo bench -p minip2p-core --bench multiaddr
-    cargo bench -p minip2p-yamux --bench data_path
-    cargo bench -p minip2p-discovery --bench peer_book
-    cargo bench -p minip2p-pubsub --bench fanout
-    cargo bench -p minip2p-relay-server --bench relay_server_event
-    cargo bench -p minip2p-quic --bench idle_poll
-    cargo bench -p minip2p-tcp --bench readiness_poll
-    cargo bench -p minip2p-rs --features tcp --bench endpoint_e2e
-    python3 scripts/bench_results.py criterion --since target/bench-results/criterion-start --output target/bench-results/rust-wall.json --git-sha "$(git rev-parse HEAD)"
+    scripts/run-benches.sh wall
 
 bench-ir:
-    python3 scripts/bench_results.py start --output target/bench-results/gungraun-start
-    GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-core --bench multiaddr_ir
-    GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-yamux --bench data_path_ir
-    GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-discovery --bench peer_book_ir
-    GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-pubsub --bench fanout_ir
-    GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-relay-server --bench relay_server_event_ir
-    python3 scripts/bench_results.py gungraun --since target/bench-results/gungraun-start --output target/bench-results/rust-micro.json --git-sha "$(git rev-parse HEAD)"
+    scripts/run-benches.sh ir
 
 bench-node:
     cd bindings/ts && pnpm --filter @minip2p/node bench

--- a/scripts/bench_results.py
+++ b/scripts/bench_results.py
@@ -170,6 +170,8 @@ def collect_gungraun(root: Path, output: Path, git_sha: str, since: Path) -> Non
             if ir is None:
                 both = metric.get("Both") or []
                 ir = both[0] if both else None
+            if isinstance(ir, dict):
+                ir = ir.get("Int")
         if not isinstance(ir, (int, float)):
             raise BenchError(f"missing Callgrind Ir in {path}")
         rows.append({"tier": "rust-micro", "name": name, "metric": "Ir", "value": ir})

--- a/scripts/bench_results.py
+++ b/scripts/bench_results.py
@@ -115,8 +115,9 @@ def collect_criterion(root: Path, output: Path, git_sha: str, since: Path) -> No
     for estimate in root.glob("**/new/estimates.json"):
         if estimate.stat().st_mtime_ns <= started_at:
             continue
-        relative = estimate.relative_to(root)
-        name = "/".join(relative.parts[:-2])
+        name = load_json(estimate.with_name("benchmark.json")).get("full_id")
+        if not isinstance(name, str) or not name:
+            raise BenchError(f"missing full_id in {estimate.with_name('benchmark.json')}")
         point = load_json(estimate).get("median", {}).get("point_estimate")
         if point is None:
             raise BenchError(f"missing median.point_estimate in {estimate}")

--- a/scripts/run-benches.sh
+++ b/scripts/run-benches.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eu
+
+case "${1:-}" in
+wall)
+  python3 scripts/bench_results.py start --output target/bench-results/criterion-start
+  cargo bench -p minip2p-core --bench multiaddr
+  cargo bench -p minip2p-yamux --bench data_path
+  cargo bench -p minip2p-discovery --bench peer_book
+  cargo bench -p minip2p-pubsub --bench fanout
+  cargo bench -p minip2p-relay-server --bench relay_server_event
+  cargo bench -p minip2p-quic --bench idle_poll
+  cargo bench -p minip2p-tcp --bench readiness_poll
+  cargo bench -p minip2p-rs --features tcp --bench endpoint_e2e
+  python3 scripts/bench_results.py criterion --since target/bench-results/criterion-start --output target/bench-results/rust-wall.json --git-sha "$(git rev-parse HEAD)"
+  ;;
+ir)
+  python3 scripts/bench_results.py start --output target/bench-results/gungraun-start
+  GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-core --bench multiaddr_ir
+  GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-yamux --bench data_path_ir
+  GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-discovery --bench peer_book_ir
+  GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-pubsub --bench fanout_ir
+  GUNGRAUN_SAVE_SUMMARY=json cargo bench -p minip2p-relay-server --bench relay_server_event_ir
+  python3 scripts/bench_results.py gungraun --since target/bench-results/gungraun-start --output target/bench-results/rust-micro.json --git-sha "$(git rev-parse HEAD)"
+  ;;
+*)
+  echo "usage: $0 wall|ir" >&2
+  exit 2
+  ;;
+esac


### PR DESCRIPTION
Closes #138

Adds the Bench workflow with three parallel measurement jobs, strict main-only baseline writes to `bench-data`, and fork-safe PR comparison artifacts. Failed measurement tiers contribute an empty slice so successful tiers still reach comparison, while any incomplete main run leaves the baseline untouched.

The workflow bootstraps `bench-data` on its first fully successful main run.

Checks run locally:
- `python3 -m unittest discover -s bench -p "test_*.py"`
- `pnpm test:workflows`
- `actionlint .github/workflows/bench.yml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Bench CI workflow that closes #138 by running benchmarks on main and PRs, storing baseline results in `bench-data`, and uploading a comparison artifact for each PR. The Gungraun collector parses tagged integer `Ir` metrics, the Criterion collector reads benchmark identifiers from `benchmark.json`, and the baseline job pins its actions to immutable SHAs.

- Three parallel measurement jobs run the Rust micro, Rust wall, and Node FFI benchmark suites.
- Failed measurement jobs still produce empty result slices so successful ones reach comparison.
- Baseline updates only when all three jobs succeed on main; the first successful run bootstraps the branch.
- PR comparisons fetch the relevant baseline and mark it stale if the merge base changed.
- Benchmark command lists were moved into `scripts/run-benches.sh`, shared by the workflow and the local `just` recipes.

<sup>Written for commit d550803a55f27d30aaf41a268e20acb99d9f83f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

