### PR TITLE
ci: publish sticky benchmark comments

### DIFF
--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -19,6 +19,8 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Download comparison
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: bench-comparison
@@ -26,17 +28,29 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Validate comparison
+      - name: Resolve and validate PR
         id: comparison
         env:
           ARTIFACT_DIR: ${{ runner.temp }}/bench-comparison
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
           EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          pr_number=$(tr -d '\r\n' < "$ARTIFACT_DIR/pr-number")
+          if [ "$DOWNLOAD_OUTCOME" = success ]; then
+            pr_number=$(tr -d '\r\n' < "$ARTIFACT_DIR/pr-number")
+            test -s "$ARTIFACT_DIR/comparison.md"
+          elif [ "$CONCLUSION" != success ]; then
+            pr_number=$EVENT_PR_NUMBER
+          else
+            echo "successful benchmark run has no comparison artifact" >&2
+            exit 1
+          fi
+
           if ! [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]; then
-            echo "invalid PR number in benchmark artifact" >&2
+            echo "invalid benchmark PR number" >&2
             exit 1
           fi
 
@@ -46,7 +60,6 @@ jobs:
             exit 1
           fi
 
-          test -s "$ARTIFACT_DIR/comparison.md"
           echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
 
       - name: Prepare comment

--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -11,7 +11,9 @@ permissions:
 
 jobs:
   comment:
-    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:

--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -1,0 +1,97 @@
+name: Bench comment
+
+on:
+  workflow_run:
+    workflows: [Bench]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: bench-comment-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: false
+    steps:
+      - name: Download comparison
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: bench-comparison
+          path: ${{ runner.temp }}/bench-comparison
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Validate comparison
+        id: comparison
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/bench-comparison
+          EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          pr_number=$(tr -d '\r\n' < "$ARTIFACT_DIR/pr-number")
+          if ! [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]; then
+            echo "invalid PR number in benchmark artifact" >&2
+            exit 1
+          fi
+
+          actual_head_sha=$(gh api "repos/$GH_REPO/pulls/$pr_number" --jq .head.sha)
+          if [ "$actual_head_sha" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "benchmark artifact does not match the PR head" >&2
+            exit 1
+          fi
+
+          test -s "$ARTIFACT_DIR/comparison.md"
+          echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare comment
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/bench-comparison
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.comparison.outputs.pr-number }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          TARGET: ${{ runner.temp }}/bench-comment.md
+        run: |
+          existing=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate --slurp \
+            --jq '[.[][] | select(.body | contains("<!-- bench-comment -->"))][0].body // empty')
+
+          if [ "$CONCLUSION" = success ]; then
+            cp "$ARTIFACT_DIR/comparison.md" "$TARGET"
+            exit 0
+          fi
+
+          {
+            printf '%s\n' '<!-- bench-comment -->'
+            printf '%s\n' '<!-- bench-status-start -->'
+            printf '> [!WARNING]\n'
+            printf '> Benchmark run [%s](%s). The comparison below is from the last successful run.\n' \
+              "$CONCLUSION" "$RUN_URL"
+            printf '%s\n\n' '<!-- bench-status-end -->'
+            if [ -n "$existing" ]; then
+              printf '%s\n' "$existing" | sed \
+                -e '/^<!-- bench-comment -->$/d' \
+                -e '/^<!-- bench-status-start -->$/,/^<!-- bench-status-end -->$/d'
+            fi
+          } > "$TARGET"
+
+      - name: Upsert sticky comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.comparison.outputs.pr-number }}
+          TARGET: ${{ runner.temp }}/bench-comment.md
+        run: |
+          comment_id=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate --slurp \
+            --jq '[.[][] | select(.body | contains("<!-- bench-comment -->"))][0].id // empty')
+          if [ -n "$comment_id" ]; then
+            gh api --method PATCH "repos/$GH_REPO/issues/comments/$comment_id" -F "body=@$TARGET"
+          else
+            gh api --method POST "repos/$GH_REPO/issues/$PR_NUMBER/comments" -F "body=@$TARGET"
+          fi


### PR DESCRIPTION
Closes #139.

## What changed

- publish Bench comparison artifacts from an isolated `workflow_run` workflow
- validate the artifact PR number and current PR head SHA before using write permissions
- update one marker-based comment through `gh api`, with serialized writes per PR branch
- preserve the last successful comparison under a failure or timeout banner
- leave comments untouched for cancelled runs

## Validation

- `actionlint .github/workflows/bench-comment.yml`
- `git diff --check`

The full comment path cannot run until this workflow exists on `main`, as noted in #139.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `workflow_run` workflow that posts a sticky benchmark comparison comment on pull requests, closing #139. Only benchmark runs triggered by a pull request are considered, so baseline runs are skipped.

- Downloads the comparison artifact from the completed `Bench` workflow.
- Validates the artifact's PR number and head SHA before writing.
- On failed or timed-out runs, preserves the last successful comparison under a warning banner linking to the failed run, even when no artifact was produced.
- Cancelled runs are skipped.
- Concurrency group serializes comment updates per branch to avoid race conditions.
- The full comment path can't be tested until this workflow is merged to `main`, as noted in #139.

<sup>Written for commit 3c570dd1b3110a44861e6f3e6a1bcb885d39a8dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

