### PR TITLE
ci: stabilize Fargate benchmark runs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -68,7 +68,7 @@ jobs:
           tags: ${{ steps.ecr.outputs.registry }}/minip2p-bench:${{ steps.source.outputs.image_tag }}
           provenance: false
           cache-from: type=gha,scope=bench
-          cache-to: type=gha,mode=max,scope=bench
+          cache-to: ${{ github.event_name != 'pull_request_target' && 'type=gha,mode=max,scope=bench' || '' }}
       - name: Measure
         id: measure
         env:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -66,6 +66,7 @@ jobs:
           file: infra/bench/Dockerfile
           push: true
           tags: ${{ steps.ecr.outputs.registry }}/minip2p-bench:${{ steps.source.outputs.image_tag }}
+          provenance: false
           cache-from: type=gha,scope=bench
           cache-to: type=gha,mode=max,scope=bench
       - name: Measure

--- a/bench/test_bench_results.py
+++ b/bench/test_bench_results.py
@@ -25,7 +25,8 @@ class BenchResultsTest(unittest.TestCase):
         by_name = {row.name: row for row in rows}
         self.assertEqual(by_name["micro/noise"].classification, "noise")
         self.assertEqual(by_name["micro/boundary"].classification, "notable")
-        self.assertEqual(by_name["wall/changed"].classification, "changed")
+        self.assertEqual(by_name["wall/changed"].classification, "informational")
+        self.assertEqual(by_name["wall/changed"].direction, "")
         self.assertEqual(by_name["node/missing"].classification, "unclassified")
         self.assertEqual(by_name["node/missing"].reason, "missing baseline row")
 
@@ -34,10 +35,13 @@ class BenchResultsTest(unittest.TestCase):
         self.assertTrue(all(row.classification == "unclassified" for row in rows))
         self.assertTrue(all(row.reason == "no baseline" for row in rows))
 
-    def test_incompatible_ir_does_not_affect_wall_clock(self):
+    def test_incompatible_ir_keeps_wall_clock_informational(self):
         rows = bench_results.compare_rows(self.current, self.baseline, "incompatible Ir pins: Valgrind differs")
         self.assertTrue(all(row.classification == "unclassified" for row in rows if row.tier == "rust-micro"))
-        self.assertEqual(next(row for row in rows if row.tier == "rust-wall").classification, "changed")
+        self.assertEqual(
+            next(row for row in rows if row.tier == "rust-wall").classification,
+            "informational",
+        )
 
     def test_ir_compatibility_checks_each_git_pin(self):
         changes = {
@@ -126,7 +130,8 @@ class BenchResultsTest(unittest.TestCase):
             )
             markdown = output.read_text()
             self.assertIn("Baseline: `v0.4.11 (baseline)`", markdown)
-            self.assertIn("| rust-micro | 1 | 0 | 1 | 0 |", markdown)
+            self.assertIn("| rust-micro | 1 | 0 | 1 | 0 | 0 |", markdown)
+            self.assertIn("| rust-wall | 0 | 0 | 0 | 1 | 0 |", markdown)
             self.assertIn("unclassified (missing baseline row)", markdown)
 
     def test_zero_baseline_is_unclassified(self):
@@ -199,7 +204,10 @@ class BenchResultsTest(unittest.TestCase):
         rows = bench_results.compare_rows(self.current, self.baseline, None)
         markdown = bench_results.render(self.baseline, rows)
         self.assertIn("Baseline: `baseline`", markdown)
-        self.assertIn("| tier | noise | changed | notable | unclassified |", markdown)
+        self.assertIn(
+            "| tier | noise | changed | notable | informational | unclassified |",
+            markdown,
+        )
         self.assertNotIn("`micro/noise`", markdown)
 
     def test_renderer_escapes_benchmark_names(self):

--- a/docs/plans/pr-benchmarking-pipeline.md
+++ b/docs/plans/pr-benchmarking-pipeline.md
@@ -39,12 +39,13 @@ rows from the comment.
 | Tier | Job | Metric | Harness | Classification bands |
 | --- | --- | --- | --- | --- |
 | `rust-micro` | Gungraun Callgrind `Ir` | Instruction count | Gungraun + `gungraun-runner` + Valgrind via `gungraun/setup-gungraun` | noise `< 1%`, changed `>= 1%` and `< 2%`, notable `>= 2%` |
-| `rust-wall` | Criterion wall-clock | Median latency | Criterion | noise `< 20%`, changed `>= 20%` and `< 30%`, notable `>= 30%` |
-| `node-ffi` | Vitest Bench / Tinybench | Median latency | Vitest Bench under `bindings/ts/node` | same wall-clock bands as `rust-wall` |
+| `rust-wall` | Criterion wall-clock | Median latency | Criterion | informational |
+| `node-ffi` | Vitest Bench / Tinybench | Median latency | Vitest Bench under `bindings/ts/node` | informational |
 
-A value exactly on a boundary enters the higher category. Bands are symmetric
-for improvements and regressions. Direction is labeled `improved` or
-`regressed`; unclassified rows leave direction blank.
+For instruction counts, a value exactly on a boundary enters the higher
+category. Bands are symmetric for improvements and regressions. Wall-clock rows
+are informational because Fargate placement noise is too large for regression
+labels. Informational and unclassified rows leave direction blank.
 
 Reports may show throughput derived from latency. Throughput never drives
 classification.
@@ -174,8 +175,8 @@ a stale note when that SHA is not the PR's merge-base.
   result file.
 - On incompatibility, Ir rows are `unclassified` (show current value and reason;
   do not call it improved or regressed). The next successful main write replaces
-  `latest`. Wall-clock tiers still classify whenever a baseline exists; bands
-  absorb host noise. Node version is not part of the incompatibility set.
+  `latest`. Wall-clock tiers remain informational whenever a baseline exists.
+  Node version is not part of the incompatibility set.
 - New benchmarks without a matching baseline row are `unclassified`.
 
 ### `results.json` shape
@@ -266,11 +267,12 @@ Bootstrap caveat: `bench-comment.yml` only triggers once its file exists on
 ### Sticky comment layout
 
 - One sticky comment, upserted in place.
-- Per-tier summary counts (noise / changed / notable / unclassified).
-- Row tables only for changed, notable, and unclassified rows. Tiers that are
-  all noise still show summary counts and omit the table.
+- Per-tier summary counts (noise / changed / notable / informational /
+  unclassified).
+- Row tables show changed, notable, informational, and unclassified rows. Tiers
+  that are all noise still show summary counts and omit the table.
 - Delta columns: benchmark · baseline · current · Δ% · class · direction
-  (`improved` / `regressed`; blank when unclassified).
+  (`improved` / `regressed`; blank when informational or unclassified).
 
 ### Failures, timeouts, cancels
 

--- a/infra/bench/README.md
+++ b/infra/bench/README.md
@@ -17,7 +17,7 @@ All AWS resources are static and created once by `bootstrap.sh`:
 
 - ECS cluster `minip2p-bench`;
 - ECR repository `minip2p-bench`, immutable tags, with a lifecycle policy that
-  keeps the ten newest images and drops untagged layers after a day;
+  keeps the ten newest tagged images and drops untagged layers after a day;
 - CloudWatch log group `/minip2p/bench` with 14-day retention;
 - task role `minip2p-bench-task` (no AWS access) and execution role
   `minip2p-bench-execution` (pull the image, write logs);

--- a/infra/bench/README.md
+++ b/infra/bench/README.md
@@ -17,8 +17,7 @@ All AWS resources are static and created once by `bootstrap.sh`:
 
 - ECS cluster `minip2p-bench`;
 - ECR repository `minip2p-bench`, immutable tags, with a lifecycle policy that
-  keeps the ten newest images, expires tagged images after 30 days, and drops
-  untagged layers after a day;
+  keeps the ten newest images and drops untagged layers after a day;
 - CloudWatch log group `/minip2p/bench` with 14-day retention;
 - task role `minip2p-bench-task` (no AWS access) and execution role
   `minip2p-bench-execution` (pull the image, write logs);

--- a/infra/bench/README.md
+++ b/infra/bench/README.md
@@ -17,7 +17,8 @@ All AWS resources are static and created once by `bootstrap.sh`:
 
 - ECS cluster `minip2p-bench`;
 - ECR repository `minip2p-bench`, immutable tags, with a lifecycle policy that
-  keeps the ten newest images and drops untagged layers after a day;
+  keeps the ten newest images, expires tagged images after 30 days, and drops
+  untagged layers after a day;
 - CloudWatch log group `/minip2p/bench` with 14-day retention;
 - task role `minip2p-bench-task` (no AWS access) and execution role
   `minip2p-bench-execution` (pull the image, write logs);
@@ -89,8 +90,9 @@ build. The container is the isolation boundary.
 AWS runs set `GUNGRAUN_ALLOW_ASLR=1` because Fargate blocks the syscall Gungraun
 uses to disable ASLR. Instruction counts from AWS runs are comparable with
 other AWS runs that use the same setting, not with local runs that disable
-ASLR. The task also raises both socket-sweep setup timeouts to 120 seconds for
-Fargate's fixed CPU quota.
+ASLR. The task also raises both socket-sweep setup timeouts to 600 seconds for
+Fargate's fixed CPU quota. Comparisons classify instruction-count deltas; they
+show wall-clock deltas as informational because Fargate placement affects them.
 
 The task runs all three tiers sequentially and publishes one result document.
 If any tier fails, the task publishes no rows. This avoids comparing a partial

--- a/infra/bench/bootstrap.sh
+++ b/infra/bench/bootstrap.sh
@@ -29,8 +29,6 @@ if ! aws ecr describe-repositories --repository-names minip2p-bench >/dev/null 2
 fi
 aws ecr put-image-tag-mutability --repository-name minip2p-bench \
   --image-tag-mutability IMMUTABLE >/dev/null
-# ECR expires an image under only its highest-priority matching rule. Apply the
-# tagged count cap before the final all-image age rule so both limits hold.
 aws ecr put-lifecycle-policy --repository-name minip2p-bench \
   --lifecycle-policy-text '{
     "rules": [
@@ -42,14 +40,8 @@ aws ecr put-lifecycle-policy --repository-name minip2p-bench \
       },
       {
         "rulePriority": 2,
-        "description": "Keep only the most recent tagged benchmark images",
-        "selection": {"tagStatus": "tagged", "tagPatternList": ["*"], "countType": "imageCountMoreThan", "countNumber": 10},
-        "action": {"type": "expire"}
-      },
-      {
-        "rulePriority": 3,
-        "description": "Expire remaining benchmark images after 30 days",
-        "selection": {"tagStatus": "any", "countType": "sinceImagePushed", "countUnit": "days", "countNumber": 30},
+        "description": "Keep only the most recent benchmark images",
+        "selection": {"tagStatus": "any", "countType": "imageCountMoreThan", "countNumber": 10},
         "action": {"type": "expire"}
       }
     ]

--- a/infra/bench/bootstrap.sh
+++ b/infra/bench/bootstrap.sh
@@ -40,6 +40,12 @@ aws ecr put-lifecycle-policy --repository-name minip2p-bench \
       },
       {
         "rulePriority": 2,
+        "description": "Expire tagged benchmark images after 30 days",
+        "selection": {"tagStatus": "tagged", "tagPatternList": ["*"], "countType": "sinceImagePushed", "countUnit": "days", "countNumber": 30},
+        "action": {"type": "expire"}
+      },
+      {
+        "rulePriority": 3,
         "description": "Keep only the most recent benchmark images",
         "selection": {"tagStatus": "any", "countType": "imageCountMoreThan", "countNumber": 10},
         "action": {"type": "expire"}

--- a/infra/bench/bootstrap.sh
+++ b/infra/bench/bootstrap.sh
@@ -40,8 +40,8 @@ aws ecr put-lifecycle-policy --repository-name minip2p-bench \
       },
       {
         "rulePriority": 2,
-        "description": "Keep only the most recent benchmark images",
-        "selection": {"tagStatus": "any", "countType": "imageCountMoreThan", "countNumber": 10},
+        "description": "Keep only the most recent tagged benchmark images",
+        "selection": {"tagStatus": "tagged", "tagPatternList": ["*"], "countType": "imageCountMoreThan", "countNumber": 10},
         "action": {"type": "expire"}
       }
     ]

--- a/infra/bench/bootstrap.sh
+++ b/infra/bench/bootstrap.sh
@@ -29,6 +29,8 @@ if ! aws ecr describe-repositories --repository-names minip2p-bench >/dev/null 2
 fi
 aws ecr put-image-tag-mutability --repository-name minip2p-bench \
   --image-tag-mutability IMMUTABLE >/dev/null
+# ECR expires an image under only its highest-priority matching rule. Apply the
+# tagged count cap before the final all-image age rule so both limits hold.
 aws ecr put-lifecycle-policy --repository-name minip2p-bench \
   --lifecycle-policy-text '{
     "rules": [
@@ -40,14 +42,14 @@ aws ecr put-lifecycle-policy --repository-name minip2p-bench \
       },
       {
         "rulePriority": 2,
-        "description": "Expire tagged benchmark images after 30 days",
-        "selection": {"tagStatus": "tagged", "tagPatternList": ["*"], "countType": "sinceImagePushed", "countUnit": "days", "countNumber": 30},
+        "description": "Keep only the most recent tagged benchmark images",
+        "selection": {"tagStatus": "tagged", "tagPatternList": ["*"], "countType": "imageCountMoreThan", "countNumber": 10},
         "action": {"type": "expire"}
       },
       {
         "rulePriority": 3,
-        "description": "Keep only the most recent benchmark images",
-        "selection": {"tagStatus": "any", "countType": "imageCountMoreThan", "countNumber": 10},
+        "description": "Expire remaining benchmark images after 30 days",
+        "selection": {"tagStatus": "any", "countType": "sinceImagePushed", "countUnit": "days", "countNumber": 30},
         "action": {"type": "expire"}
       }
     ]

--- a/scripts/bench_results.py
+++ b/scripts/bench_results.py
@@ -250,9 +250,11 @@ def compare_rows(
             compared.append(ComparedRow(*key, baseline_value, row["value"], None, "unclassified", "", "zero baseline"))
             continue
         delta = (row["value"] - baseline_value) / baseline_value * 100
+        if row["tier"] != "rust-micro":
+            compared.append(ComparedRow(*key, baseline_value, row["value"], delta, "informational", ""))
+            continue
         magnitude = abs(delta)
-        changed, notable = (1.0, 2.0) if row["tier"] == "rust-micro" else (20.0, 30.0)
-        classification = "notable" if magnitude >= notable else "changed" if magnitude >= changed else "noise"
+        classification = "notable" if magnitude >= 2.0 else "changed" if magnitude >= 1.0 else "noise"
         direction = "improved" if delta < 0 else "regressed" if delta > 0 else ""
         compared.append(ComparedRow(*key, baseline_value, row["value"], delta, classification, direction))
     current_keys = {(row["tier"], row["name"], row["metric"]) for row in current["rows"]}
@@ -292,11 +294,12 @@ def render(
     baseline_sha = "none" if baseline is None else baseline["git_sha"]
     baseline_name = baseline_sha if baseline_label is None else f"{baseline_label} ({baseline_sha})"
     lines = ["<!-- bench-comment -->", "## Benchmark comparison", "", f"Baseline: {markdown_code(baseline_name)}"]
-    lines += ["", "| tier | noise | changed | notable | unclassified |", "| --- | ---: | ---: | ---: | ---: |"]
+    classifications = ("noise", "changed", "notable", "informational", "unclassified")
+    lines += ["", "| tier | noise | changed | notable | informational | unclassified |", "| --- | ---: | ---: | ---: | ---: | ---: |"]
     for tier in TIERS:
         tier_rows = [row for row in rows if row.tier == tier]
-        counts = {name: sum(row.classification == name for row in tier_rows) for name in ("noise", "changed", "notable", "unclassified")}
-        lines.append(f"| {tier} | {counts['noise']} | {counts['changed']} | {counts['notable']} | {counts['unclassified']} |")
+        counts = {name: sum(row.classification == name for row in tier_rows) for name in classifications}
+        lines.append(f"| {tier} | {counts['noise']} | {counts['changed']} | {counts['notable']} | {counts['informational']} | {counts['unclassified']} |")
     for tier in TIERS:
         visible = [row for row in rows if row.tier == tier and row.classification != "noise"]
         if not visible:

--- a/scripts/run-fargate-benches.sh
+++ b/scripts/run-fargate-benches.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 export GUNGRAUN_ALLOW_ASLR=1
 # Establishing hundreds of loopback QUIC connections can exceed the local
 # benchmark's setup guard under Fargate's fixed CPU quota. Setup is not timed.
-export MINIP2P_BENCH_SETUP_TIMEOUT_SECS=120
+export MINIP2P_BENCH_SETUP_TIMEOUT_SECS=600
 
 rm -rf target/bench-results
 mkdir -p target/bench-results

--- a/transports/quic/benches/idle_poll.rs
+++ b/transports/quic/benches/idle_poll.rs
@@ -8,6 +8,7 @@ use minip2p_quic::{QuicLimits, QuicNodeConfig, QuicTransport};
 use minip2p_transport::Transport;
 
 const COUNTS: &[usize] = &[1, 64, 256, 512];
+const CONNECT_BATCH: usize = 32;
 const DEFAULT_SETUP_TIMEOUT: Duration = Duration::from_secs(20);
 
 fn idle_poll(c: &mut Criterion) {
@@ -57,27 +58,33 @@ fn establish(count: usize) -> (QuicTransport, QuicTransport, PeerId, PeerId) {
     let server_peer = server_peer_addr.peer_id().clone();
     let client_peer = client.local_peer_id();
 
-    for _ in 0..count {
-        client.dial(&server_peer_addr).expect("start dial");
-    }
-
     let started = Instant::now();
     let mut clock = StdClock::with_epoch(started);
-    loop {
-        let server_events = server.poll(clock.now()).expect("server setup poll");
-        let client_events = client.poll(clock.now()).expect("client setup poll");
-        black_box((server_events, client_events));
-        if server.connection_ids_for_peer(&client_peer).len() == count
-            && client.connection_ids_for_peer(&server_peer).len() == count
-        {
-            return (server, client, server_peer, client_peer);
+    let mut started_connections = 0;
+    while started_connections != count {
+        let batch_target = (started_connections + CONNECT_BATCH).min(count);
+        while started_connections != batch_target {
+            client.dial(&server_peer_addr).expect("start dial");
+            started_connections += 1;
         }
-        assert!(
-            started.elapsed() < setup_timeout,
-            "connection setup timed out"
-        );
-        std::thread::sleep(Duration::from_millis(1));
+        while server.connection_ids_for_peer(&client_peer).len() != batch_target
+            || client.connection_ids_for_peer(&server_peer).len() != batch_target
+        {
+            let server_events = server.poll(clock.now()).expect("server setup poll");
+            let client_events = client.poll(clock.now()).expect("client setup poll");
+            black_box((server_events, client_events));
+            assert!(
+                started.elapsed() < setup_timeout,
+                "only established {}/{} server and {}/{} client connections after starting {started_connections}/{count}",
+                server.connection_ids_for_peer(&client_peer).len(),
+                count,
+                client.connection_ids_for_peer(&server_peer).len(),
+                count,
+            );
+            std::thread::sleep(Duration::from_millis(1));
+        }
     }
+    (server, client, server_peer, client_peer)
 }
 
 criterion_group!(benches, idle_poll);


### PR DESCRIPTION
## Summary

- establish QUIC idle-poll connections in completed batches of 32 and raise the unmeasured Fargate setup guard to 600 seconds
- report Rust and Node wall-clock deltas as informational while retaining instruction-count classification
- disable Buildx provenance so each benchmark run pushes one image manifest
- count only tagged benchmark images in the ten-run ECR cap
- restore the GitHub Actions cache for every trigger but export it only from release and manual runs, since `pull_request_target` cache access is read-only

We are keeping the benchmark task on Fargate.

## Validation

- `python3 -m unittest bench.test_bench_results`
- `cargo bench -p minip2p-quic --bench idle_poll -- --test`
- `cargo bench -p minip2p-quic --bench idle_poll --no-run`
- `cargo fmt --all -- --check`
- `bash -n scripts/run-fargate-benches.sh infra/bench/bootstrap.sh`
- parsed `.github/workflows/bench.yml` with PyYAML and verified its cache-export trigger matrix

## After merge

Dispatch the Bench workflow manually on `main` to exercise the batched QUIC setup on Fargate. If it passes, cut v0.5.1 and approve its benchmark environment run to write the release baseline.