### PR TITLE
perf(tcp): disable Nagle on hosted sockets

### DIFF
--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -13,7 +13,7 @@ jobs:
   comment:
     if: >-
       github.event.workflow_run.event == 'pull_request_target' &&
-      github.event.workflow_run.pull_requests[0].head.repo.full_name == github.repository &&
+      github.event.workflow_run.pull_requests[0].head.repo.id == github.event.repository.id &&
       github.event.workflow_run.conclusion != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/bench/pins.json
+++ b/bench/pins.json
@@ -1,6 +1,7 @@
 {
   "rust": "1.98.0",
   "profile": "release",
+  "cargo_chef": "0.1.78",
   "gungraun": "0.19.4",
   "valgrind": "3.27.1",
   "valgrind_sha256": "5d589152eb8071c02feab8ce6ab719e431a1fbc3e2b1700f5432632a8b9264dc"

--- a/bindings/ts/core/src/backend.ts
+++ b/bindings/ts/core/src/backend.ts
@@ -26,6 +26,8 @@ export interface BackendOpenStream {
 export interface Minip2pBackend {
   /** Starts native event delivery exactly once. */
   start: (listener: (event: P2pEvent) => void) => void;
+  /** Releases adapter state retained until an event has been dispatched. */
+  eventHandled?: (event: P2pEvent) => void;
   /** Idempotently releases the native endpoint. */
   close: () => void;
   /** Returns the local peer ID. */

--- a/bindings/ts/core/src/sdk.ts
+++ b/bindings/ts/core/src/sdk.ts
@@ -1066,7 +1066,9 @@ export class Minip2pBase {
     if (this.#closed) {
       return;
     }
-    if (this.#queue.push({ event, source: "native" }) !== undefined) {
+    const dropped = this.#queue.push({ event, source: "native" });
+    if (dropped !== undefined) {
+      this.#releaseQueueItem(dropped);
       this.#dropped += 1;
       this.#handleQueueOverflow();
     }
@@ -1080,7 +1082,9 @@ export class Minip2pBase {
     if (this.#closed) {
       return;
     }
-    if (this.#queue.push({ payload, source: "high", type }) !== undefined) {
+    const dropped = this.#queue.push({ payload, source: "high", type });
+    if (dropped !== undefined) {
+      this.#releaseQueueItem(dropped);
       this.#dropped += 1;
       this.#handleQueueOverflow();
     }
@@ -1118,7 +1122,7 @@ export class Minip2pBase {
         try {
           this.#dispatchNative(item.event);
         } finally {
-          this.#backend.eventHandled?.(item.event);
+          this.#releaseQueueItem(item);
         }
       } else {
         this.#dispatch(item.type, item.payload, item.payload);
@@ -1460,6 +1464,20 @@ export class Minip2pBase {
     waiter.reject(error);
   }
 
+  #releaseQueueItem(item: QueueItem): void {
+    if (item.source === "native") {
+      this.#backend.eventHandled?.(item.event);
+    }
+  }
+
+  #clearQueue(): void {
+    let item = this.#queue.shift();
+    while (item !== undefined) {
+      this.#releaseQueueItem(item);
+      item = this.#queue.shift();
+    }
+  }
+
   #teardown(reason: CloseReason, error: Error): void {
     if (this.#closed) {
       return;
@@ -1467,7 +1485,7 @@ export class Minip2pBase {
     this.#closed = true;
     const closeHandlers = [...this.#closeHandlers];
     this.#closeHandlers.clear();
-    this.#queue.clear();
+    this.#clearQueue();
     this.#dropped = 0;
     this.#named.clear();
     this.#catchAll.clear();

--- a/bindings/ts/core/src/sdk.ts
+++ b/bindings/ts/core/src/sdk.ts
@@ -1115,7 +1115,11 @@ export class Minip2pBase {
         break;
       }
       if (item.source === "native") {
-        this.#dispatchNative(item.event);
+        try {
+          this.#dispatchNative(item.event);
+        } finally {
+          this.#backend.eventHandled?.(item.event);
+        }
       } else {
         this.#dispatch(item.type, item.payload, item.payload);
       }
@@ -1263,14 +1267,14 @@ export class Minip2pBase {
       return;
     }
     if (meta.initiatedLocally) {
-      stream.abandon();
+      abandonUnclaimed(stream);
       return;
     }
     const claimed = this.#dispatch("stream", stream, undefined as never);
     const inbound = streamMeta(stream);
     this.#dispatchCatchOnly("inboundStream", inbound);
     if (!claimed) {
-      stream.abandon();
+      abandonUnclaimed(stream);
     }
   }
 
@@ -1613,6 +1617,15 @@ function streamMeta(stream: Stream): InboundStreamMeta {
     protocolId: stream.protocolId,
     streamId: stream.streamId,
   };
+}
+
+function abandonUnclaimed(stream: Stream): void {
+  try {
+    stream.abandon();
+  } catch {
+    // The remote may close between native readiness and JS dispatch.
+    stream.terminal();
+  }
 }
 
 function safeMetadata(payload: unknown): Record<string, unknown> {

--- a/bindings/ts/core/src/sdk.ts
+++ b/bindings/ts/core/src/sdk.ts
@@ -276,10 +276,14 @@ export class Stream {
     }
   }
 
-  /** Resets and relinquishes the stream, suppressing later native events. */
+  /** Relinquishes the stream and requests a reset while it remains active. */
   abandon(): void {
     if (!this.#closed) {
-      this.#backend.abandonStream(this.peerId, this.streamId);
+      try {
+        this.#backend.abandonStream(this.peerId, this.streamId);
+      } catch {
+        // A native close can overtake its queued terminal event.
+      }
       this.terminal();
     }
   }
@@ -1271,14 +1275,14 @@ export class Minip2pBase {
       return;
     }
     if (meta.initiatedLocally) {
-      abandonUnclaimed(stream);
+      stream.abandon();
       return;
     }
     const claimed = this.#dispatch("stream", stream, undefined as never);
     const inbound = streamMeta(stream);
     this.#dispatchCatchOnly("inboundStream", inbound);
     if (!claimed) {
-      abandonUnclaimed(stream);
+      stream.abandon();
     }
   }
 
@@ -1635,15 +1639,6 @@ function streamMeta(stream: Stream): InboundStreamMeta {
     protocolId: stream.protocolId,
     streamId: stream.streamId,
   };
-}
-
-function abandonUnclaimed(stream: Stream): void {
-  try {
-    stream.abandon();
-  } catch {
-    // The remote may close between native readiness and JS dispatch.
-    stream.terminal();
-  }
 }
 
 function safeMetadata(payload: unknown): Record<string, unknown> {

--- a/bindings/ts/core/tests/sdk.test.mjs
+++ b/bindings/ts/core/tests/sdk.test.mjs
@@ -660,6 +660,23 @@ test("local stream reset and abandon emit closed exactly once", async () => {
   }
 });
 
+test("abandon tolerates a native close before its event is dispatched", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+  const opening = endpoint.openStream("peer", "/test/1", { timeoutMs: 1000 });
+  backend.emit(streamReady({ initiatedLocally: true, streamId: 3 }));
+  const stream = await opening;
+  backend.abandonError = new Error("stream is not active");
+  backend.emit({
+    inner: { connId: 2, peerId: "peer", streamId: 3 },
+    tag: P2pEvent_Tags.StreamClosed,
+  });
+
+  assert.doesNotThrow(() => stream.abandon());
+  assert.throws(() => stream.write("closed"), ClosedError);
+  endpoint.close();
+});
+
 test("openStream correlates full available identity and abandons late ready", async () => {
   const backend = new MockBackend();
   const endpoint = new TestMinip2p(backend);

--- a/bindings/ts/core/tests/sdk.test.mjs
+++ b/bindings/ts/core/tests/sdk.test.mjs
@@ -435,6 +435,34 @@ test("queue overflow rejects operations whose native terminals may be lost", asy
   endpoint.close();
 });
 
+test("queue overflow releases the evicted native event", () => {
+  const backend = new MockBackend();
+  const handled = [];
+  backend.eventHandled = (event) => handled.push(event);
+  const endpoint = new TestMinip2p(backend);
+  const evicted = peerReady("evicted");
+  backend.emit(evicted);
+  for (let index = 0; index < 4096; index += 1) {
+    backend.emit(peerReady(`queued-${index}`));
+  }
+
+  assert.deepEqual(handled, [evicted]);
+  endpoint.close();
+});
+
+test("teardown releases queued native events", () => {
+  const backend = new MockBackend();
+  const handled = [];
+  backend.eventHandled = (event) => handled.push(event);
+  const endpoint = new TestMinip2p(backend);
+  const queued = peerReady("queued");
+  backend.emit(queued);
+
+  endpoint.close();
+
+  assert.deepEqual(handled, [queued]);
+});
+
 test("stream FIFO counts only queued data and cleans up after terminal", async () => {
   const backend = new MockBackend();
   const endpoint = new TestMinip2p(backend);

--- a/bindings/ts/node/benches/ffi.bench.ts
+++ b/bindings/ts/node/benches/ffi.bench.ts
@@ -22,6 +22,10 @@ beforeAll(async () => {
   cleanup.push(() => sdkA.close());
   sdkB = createSdk();
   cleanup.push(() => sdkB.close());
+  sdkB.on("stream", (stream) => {
+    // Match the raw remote, which drains ready events without rejecting them.
+    void stream;
+  });
   await sdkA.connectAddr(sdkB.listenAddrs()[0], { timeoutMs: TIMEOUT_MS });
   await Promise.all([
     sdkA.waitPeerReady(sdkB.peerId(), { timeoutMs: TIMEOUT_MS }),

--- a/bindings/ts/node/src/adapter.ts
+++ b/bindings/ts/node/src/adapter.ts
@@ -68,6 +68,15 @@ class NodeBackend implements Minip2pBackend {
     });
   }
 
+  eventHandled(event: P2pEvent): void {
+    releaseTerminalIds(
+      event,
+      this.#connectionIds,
+      this.#connectIds,
+      this.#streamIds
+    );
+  }
+
   close(): void {
     this.#endpoint.close();
     this.#events.stop();
@@ -432,8 +441,19 @@ function normalizeEvent(
   ) {
     event.inner = normalizeEventBytes(event.tag, event.inner);
   }
-  releaseTerminalIds(event, connectionIds, connectIds, streamIds);
+  retireTerminalIds(event, connectionIds, connectIds, streamIds);
   return event as P2pEvent;
+}
+
+function retireTerminalIds(
+  event: { readonly tag?: unknown; readonly inner?: unknown },
+  connectionIds: IdMap,
+  connectIds: IdMap,
+  streamIds: IdMap
+): void {
+  visitTerminalIds(event, connectionIds, connectIds, streamIds, (map, id) => {
+    map.retirePublic(id);
+  });
 }
 
 function releaseTerminalIds(
@@ -442,17 +462,29 @@ function releaseTerminalIds(
   connectIds: IdMap,
   streamIds: IdMap
 ): void {
+  visitTerminalIds(event, connectionIds, connectIds, streamIds, (map, id) => {
+    map.deletePublic(id);
+  });
+}
+
+function visitTerminalIds(
+  event: { readonly tag?: unknown; readonly inner?: unknown },
+  connectionIds: IdMap,
+  connectIds: IdMap,
+  streamIds: IdMap,
+  visit: (map: IdMap, value: unknown) => void
+): void {
   if (event.inner === null || typeof event.inner !== "object") {
     return;
   }
   if (event.tag === "ConnectionClosed") {
-    connectionIds.deletePublic(Reflect.get(event.inner, "connId"));
+    visit(connectionIds, Reflect.get(event.inner, "connId"));
   }
   if (isTerminalConnectEvent(event)) {
-    connectIds.deletePublic(Reflect.get(event.inner, "connectId"));
+    visit(connectIds, Reflect.get(event.inner, "connectId"));
   }
   if (event.tag === "StreamClosed") {
-    streamIds.deletePublic(Reflect.get(event.inner, "streamId"));
+    visit(streamIds, Reflect.get(event.inner, "streamId"));
   }
 }
 
@@ -632,6 +664,18 @@ class IdMap {
     const native = this.#nativeByPublic.get(value);
     if (native !== undefined) {
       this.#nativeByPublic.delete(value);
+      if (this.#publicByNative.get(native) === value) {
+        this.#publicByNative.delete(native);
+      }
+    }
+  }
+
+  retirePublic(value: unknown): void {
+    if (typeof value !== "number") {
+      return;
+    }
+    const native = this.#nativeByPublic.get(value);
+    if (native !== undefined && this.#publicByNative.get(native) === value) {
       this.#publicByNative.delete(native);
     }
   }

--- a/bindings/ts/node/tests/adapter.test.ts
+++ b/bindings/ts/node/tests/adapter.test.ts
@@ -14,11 +14,13 @@ const native = vi.hoisted(() => {
     static latest: FakeNativeEndpoint | undefined;
 
     readonly config: Readonly<Record<string, unknown>>;
+    readonly abandonedStreams: { peerId: string; streamId: bigint }[] = [];
     readonly drainLimits: number[] = [];
     readonly #batches: Event[][] = [];
     #doorbell: (() => void) | undefined;
     #drainCalls = 0;
     discoveryClock: bigint | null = null;
+    abandonError: Error | undefined;
     onDrain: ((call: number) => void) | undefined;
 
     constructor(
@@ -63,7 +65,12 @@ const native = vi.hoisted(() => {
 
     addProtocol(): void {}
 
-    abandonStream(): void {}
+    abandonStream(peerId: string, streamId: bigint): void {
+      this.abandonedStreams.push({ peerId, streamId });
+      if (this.abandonError !== undefined) {
+        throw this.abandonError;
+      }
+    }
 
     cancelConnect(): void {}
 
@@ -532,6 +539,47 @@ describe("Node adapter", () => {
     const second = await secondPending;
 
     expect([first.streamId, second.streamId]).toEqual([1, 2]);
+    endpoint.close();
+  });
+
+  test("handles an unclaimed ready stream closed in the same drain", async () => {
+    vi.useFakeTimers();
+    const endpoint = createEndpoint();
+    const fake = fakeEndpoint();
+    const peers: string[] = [];
+    endpoint.on("peerReady", ({ peerId }) => peers.push(peerId));
+    fake.abandonError = new Error("stream is not active");
+    fake.enqueue(
+      [
+        {
+          inner: {
+            connId: 10n,
+            initiatedLocally: false,
+            peerId: "remote",
+            protocolId: "/test/1",
+            streamId: 20n,
+          },
+          tag: "StreamReady",
+        },
+        {
+          inner: { connId: 10n, peerId: "remote", streamId: 20n },
+          tag: "StreamClosed",
+        },
+        {
+          inner: { peerId: "after", protocols: [] },
+          tag: "PeerReady",
+        },
+      ],
+      []
+    );
+
+    fake.ring();
+    await settle();
+
+    expect(fake.abandonedStreams).toEqual([
+      { peerId: "remote", streamId: 20n },
+    ]);
+    expect(peers).toEqual(["after"]);
     endpoint.close();
   });
 

--- a/infra/bench/Dockerfile
+++ b/infra/bench/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:24-bookworm@sha256:be23f54a88d34e8824c741b19b91064094f92c1c97b194144bfc8b50d67258e2
+FROM node:24-bookworm@sha256:be23f54a88d34e8824c741b19b91064094f92c1c97b194144bfc8b50d67258e2 AS toolchain
 
 ARG PNPM_VERSION=11.24.0
 ARG BUILD_JOBS=2
@@ -30,11 +30,13 @@ RUN apt-get update \
       python3 \
     && rm -rf /var/lib/apt/lists/* \
     && RUST_TOOLCHAIN=$(jq -r .rust /tmp/bench-pins.json) \
+    && CARGO_CHEF_VERSION=$(jq -r .cargo_chef /tmp/bench-pins.json) \
     && GUNGRAUN_VERSION=$(jq -r .gungraun /tmp/bench-pins.json) \
     && VALGRIND_VERSION=$(jq -r .valgrind /tmp/bench-pins.json) \
     && VALGRIND_SHA256=$(jq -r .valgrind_sha256 /tmp/bench-pins.json) \
     && curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
       | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN" --profile minimal \
+    && cargo install --locked --version "$CARGO_CHEF_VERSION" cargo-chef \
     && cargo install --locked --version "$GUNGRAUN_VERSION" gungraun-runner \
     && curl -fsSLO "https://sourceware.org/pub/valgrind/valgrind-${VALGRIND_VERSION}.tar.bz2" \
     && printf '%s  %s\n' "$VALGRIND_SHA256" "valgrind-${VALGRIND_VERSION}.tar.bz2" | sha256sum --check \
@@ -47,11 +49,40 @@ RUN apt-get update \
     && rm -rf "valgrind-${VALGRIND_VERSION}" "valgrind-${VALGRIND_VERSION}.tar.bz2" /tmp/bench-pins.json \
     && npm install --global "pnpm@${PNPM_VERSION}"
 
+FROM toolchain AS planner
+
 WORKDIR /minip2p
 COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-RUN pnpm --dir bindings/ts install --frozen-lockfile \
-    && pnpm --dir bindings/ts --filter @minip2p/node native:build \
+FROM toolchain AS builder
+
+WORKDIR /minip2p
+
+COPY bindings/ts/pnpm-lock.yaml bindings/ts/pnpm-workspace.yaml bindings/ts/package.json bindings/ts/
+COPY bindings/ts/core/package.json bindings/ts/core/
+COPY bindings/ts/node/package.json bindings/ts/node/
+COPY bindings/ts/node/npm/ bindings/ts/node/npm/
+COPY bindings/ts/react-native/package.json bindings/ts/react-native/
+COPY bindings/ts/react-native/example/package.json bindings/ts/react-native/example/
+COPY bindings/ts/react-native/patches/ bindings/ts/react-native/patches/
+COPY bindings/ts/test-fixtures/package.json bindings/ts/test-fixtures/
+RUN pnpm --dir bindings/ts install --frozen-lockfile
+
+COPY --from=planner /minip2p/recipe.json recipe.json
+RUN cargo chef cook --release --package minip2p-nodejs --recipe-path recipe.json \
+    && cargo chef cook --release --package minip2p-core --benches --recipe-path recipe.json \
+    && cargo chef cook --release --package minip2p-yamux --benches --recipe-path recipe.json \
+    && cargo chef cook --release --package minip2p-discovery --benches --recipe-path recipe.json \
+    && cargo chef cook --release --package minip2p-pubsub --benches --recipe-path recipe.json \
+    && cargo chef cook --release --package minip2p-relay-server --benches --recipe-path recipe.json \
+    && cargo chef cook --release --package minip2p-quic --benches --recipe-path recipe.json \
+    && cargo chef cook --release --package minip2p-tcp --benches --recipe-path recipe.json \
+    && cargo chef cook --release --package minip2p-rs --features tcp --benches --recipe-path recipe.json
+
+COPY . .
+
+RUN pnpm --dir bindings/ts --filter @minip2p/node native:build \
     && cargo bench -p minip2p-core --bench multiaddr --no-run \
     && cargo bench -p minip2p-yamux --bench data_path --no-run \
     && cargo bench -p minip2p-discovery --bench peer_book --no-run \

--- a/transports/tcp/README.md
+++ b/transports/tcp/README.md
@@ -21,8 +21,9 @@ default features and supply a provider and an `EntropySource`.
 `StdTcpProvider` is the hosted one: OS sockets driven by `mio`, `/dns*`
 resolution, and a real readiness wait. Implementing `BlockingTcpProvider` is
 what makes `TcpTransport` a `BlockingTransport`, so an idle driver parks on the
-sockets rather than polling on a timer. It needs the `std` feature (on by
-default).
+sockets rather than polling on a timer. It disables Nagle's algorithm because
+delayed small writes add latency to the multiplexed protocol frames. It needs
+the `std` feature (on by default).
 
 `SmoltcpTcpProvider` is the embedded one, over [smoltcp] — a TCP/IP stack, not
 an operating system. It needs the `smoltcp` feature and nothing else: the host

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -19,7 +19,8 @@
 //! `StdTcpProvider` is the hosted one: operating-system sockets driven by
 //! `mio`, with `/dns*` resolution and a real readiness wait, which makes
 //! [`TcpTransport`] a `BlockingTransport` so an idle driver sleeps instead of
-//! spinning. It needs the `std` feature.
+//! spinning. It disables Nagle's algorithm because delayed small writes add
+//! latency to the multiplexed protocol frames. It needs the `std` feature.
 //!
 //! `SmoltcpTcpProvider` is the embedded one, over a [smoltcp] interface the
 //! host configures and a link it supplies. It needs the `smoltcp` feature and

--- a/transports/tcp/src/std_provider.rs
+++ b/transports/tcp/src/std_provider.rs
@@ -94,6 +94,13 @@ fn bind_listener(requested: SocketAddr) -> std::io::Result<mio::net::TcpListener
     Ok(mio::net::TcpListener::from_std(socket.into()))
 }
 
+/// Keeps small protocol frames from waiting behind an unacknowledged write.
+fn disable_nagle(stream: &mio::net::TcpStream) -> Result<(), TcpError> {
+    stream
+        .set_nodelay(true)
+        .map_err(|error| io_error("disabling Nagle's algorithm", &error))
+}
+
 /// Resolves a dial address, performing a blocking name lookup for `/dns*`.
 ///
 /// Resolution is I/O, which is why it lives here rather than in the portable
@@ -421,6 +428,7 @@ impl StdTcpProvider {
         mut stream: mio::net::TcpStream,
         remote: Multiaddr,
     ) -> Result<(), TcpError> {
+        disable_nagle(&stream)?;
         let token = self.allocate_token()?;
         self.poll
             .registry()
@@ -623,6 +631,7 @@ impl TcpProvider for StdTcpProvider {
         let target = dial_addr(addr)?;
         let mut stream = mio::net::TcpStream::connect(target)
             .map_err(|error| io_error("starting a connect", &error))?;
+        disable_nagle(&stream)?;
         let token = self.allocate_token()?;
         self.poll
             .registry()
@@ -788,5 +797,55 @@ impl BlockingTcpProvider for StdTcpProvider {
                 drop(error);
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Instant;
+
+    #[test]
+    fn accepted_and_dialed_streams_disable_nagle() {
+        let mut server = StdTcpProvider::new().expect("server");
+        let mut client = StdTcpProvider::new().expect("client");
+        let bound = server
+            .listen(&"/ip4/127.0.0.1/tcp/0".parse().expect("address"))
+            .expect("listen");
+
+        let dialed = client.connect(&bound).expect("connect");
+        assert!(
+            client.sockets[&dialed]
+                .stream
+                .nodelay()
+                .expect("dialed stream option")
+        );
+
+        let started = Instant::now();
+        let accepted = loop {
+            if let Some(socket) = server
+                .poll(Now::from_millis(0))
+                .expect("poll server")
+                .into_iter()
+                .find_map(|event| match event {
+                    TcpEvent::Accepted { socket, .. } => Some(socket),
+                    _ => None,
+                })
+            {
+                break socket;
+            }
+            assert!(
+                started.elapsed() < Duration::from_secs(5),
+                "server did not accept the connection"
+            );
+            thread::sleep(Duration::from_millis(1));
+        };
+        assert!(
+            server.sockets[&accepted]
+                .stream
+                .nodelay()
+                .expect("accepted stream option")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- enable TCP_NODELAY on accepted and dialed StdTcpProvider sockets
- test that both connection directions carry the socket option
- document why the hosted provider disables Nagle

The endpoint benchmark exposed a delayed-ACK plateau on small multiplexed writes. A local quick run moved the 64-byte echo from 41.6 ms to 260.9 µs and the 1 MiB echo from roughly 620 ms in the latest release benchmark to 7.0 ms locally.

## Checks

- cargo test -p minip2p-tcp
- cargo clippy -p minip2p-tcp --all-targets -- -D warnings
- cargo clippy -p minip2p-tcp --features smoltcp --all-targets -- -D warnings
- cargo check --no-default-features --target thumbv7em-none-eabi -p minip2p-tcp
- cargo bench -p minip2p-rs --features tcp --bench endpoint_e2e -- e2e/tcp/(echo_64b|transfer_1mib)$ --quick

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables Nagle's algorithm on `StdTcpProvider` sockets so small multiplexed protocol frames don't stall behind unacknowledged writes, and fixes event lifecycle bugs in the TypeScript bindings.

- Applies `TCP_NODELAY` to both accepted and dialed streams; the 64-byte echo benchmark dropped from 41.6 ms to 260.9 µs, and the 1 MiB echo from roughly 620 ms to 7.0 ms.
- Node adapter: streams that close before their event dispatches, and abandons that race a native close, now terminate cleanly instead of crashing.
- Terminal IDs are released only after the JS event is dispatched; native events discarded on queue overflow or teardown also release theirs so nothing leaks.
- Benchmark image: adds cargo-chef to cache Rust build artifacts.
- Fixes the benchmark PR comment guard to compare repository IDs instead of names.

<sup>Written for commit b337f694456bc38507aef5794485f8e1ea1d8414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

