### PR TITLE
fix(ts): preserve buffered reads after remote FIN

### DIFF
--- a/bindings/ts/core/README.md
+++ b/bindings/ts/core/README.md
@@ -16,7 +16,7 @@ stream.write(new Uint8Array([1, 2, 3]));
 stream.closeWrite();
 ```
 
-Streams are async iterables. Iteration preserves chunk order. A remote write half-close or local shutdown ends the loop quietly. A reset, peer disconnect, or driver failure observed before that EOF rejects the iterator with its terminal error:
+Streams are async iterables. Iteration preserves chunk order, drains bytes buffered before a remote write half-close, and then ends quietly. Local shutdown, reset, peer disconnect, or driver failure rejects the iterator with its terminal error:
 
 ```ts
 for await (const chunk of stream) {

--- a/bindings/ts/core/src/sdk.ts
+++ b/bindings/ts/core/src/sdk.ts
@@ -363,6 +363,8 @@ export class Stream {
       return;
     }
     this.#closed = true;
+    // StreamClosed carries no cause. Once the remote FIN establishes EOF,
+    // later full closure cannot reinterpret that receive-side outcome.
     const hasRemoteEof =
       options.preserveRemoteEof === true && this.#receiveState.kind === "eof";
     if (!hasRemoteEof) {

--- a/bindings/ts/core/src/sdk.ts
+++ b/bindings/ts/core/src/sdk.ts
@@ -103,6 +103,11 @@ interface PendingRead {
   readonly reject: (error: unknown) => void;
 }
 
+type StreamReceiveState =
+  | { readonly kind: "receiving" }
+  | { readonly kind: "eof" }
+  | { readonly kind: "failed"; readonly error: unknown };
+
 interface PingOperation {
   readonly promise: Promise<number>;
   readonly cancel: (error: unknown) => void;
@@ -175,9 +180,8 @@ export class Stream {
   readonly #reads: PendingRead[] = [];
   #fifoBytes = 0;
   #mode: "pull" | "flowing" | undefined;
-  #remoteWriteClosed = false;
+  #receiveState: StreamReceiveState = { kind: "receiving" };
   #closed = false;
-  #terminalError: unknown;
 
   constructor(
     backend: Minip2pBackend,
@@ -238,14 +242,14 @@ export class Stream {
       );
     }
     this.#mode = "pull";
-    if (this.#closed) {
-      return Promise.reject(this.#terminalError);
+    if (this.#receiveState.kind === "failed") {
+      return Promise.reject(this.#receiveState.error);
     }
     const buffered = this.#shift();
     if (buffered !== undefined) {
       return Promise.resolve(buffered);
     }
-    if (this.#remoteWriteClosed) {
+    if (this.#receiveState.kind === "eof") {
       return Promise.resolve(this.#shift());
     }
     return new Promise((resolve, reject) => {
@@ -298,18 +302,12 @@ export class Stream {
    * @yields {Uint8Array} Received binary chunks in order.
    */
   async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array, void, void> {
-    try {
-      while (true) {
-        const chunk = await this.read();
-        if (chunk === undefined) {
-          return;
-        }
-        yield chunk;
+    while (true) {
+      const chunk = await this.read();
+      if (chunk === undefined) {
+        return;
       }
-    } catch (error) {
-      if (!(error instanceof ClosedError)) {
-        throw error;
-      }
+      yield chunk;
     }
   }
 
@@ -344,10 +342,10 @@ export class Stream {
 
   /** @internal */
   remoteWriteClosed(): void {
-    if (this.#closed || this.#remoteWriteClosed) {
+    if (this.#closed || this.#receiveState.kind !== "receiving") {
       return;
     }
-    this.#remoteWriteClosed = true;
+    this.#receiveState = { kind: "eof" };
     this.#emit("remoteWriteClosed");
     if (this.#fifo.length === 0) {
       for (const read of this.#reads.splice(0)) {
@@ -357,16 +355,27 @@ export class Stream {
   }
 
   /** @internal */
-  terminal(error: unknown = new ClosedError()): void {
+  terminal(
+    error: unknown = new ClosedError(),
+    options: { readonly preserveRemoteEof?: boolean } = {}
+  ): void {
     if (this.#closed) {
       return;
     }
     this.#closed = true;
-    this.#terminalError = error;
-    this.#fifo.length = 0;
-    this.#fifoBytes = 0;
+    const hasRemoteEof =
+      options.preserveRemoteEof === true && this.#receiveState.kind === "eof";
+    if (!hasRemoteEof) {
+      this.#receiveState = { error, kind: "failed" };
+      this.#fifo.length = 0;
+      this.#fifoBytes = 0;
+    }
     for (const read of this.#reads.splice(0)) {
-      read.reject(error);
+      if (hasRemoteEof) {
+        read.resolve(this.#shift());
+      } else {
+        read.reject(error);
+      }
     }
     this.#emit("closed");
     this.#listeners.clear();
@@ -1325,7 +1334,9 @@ export class Minip2pBase {
         clearPendingOpen(pending);
         pending.reject(new StreamClosedError());
       }
-      stream?.terminal(new StreamClosedError("The stream closed"));
+      stream?.terminal(new StreamClosedError("The stream closed"), {
+        preserveRemoteEof: true,
+      });
     } else if (event.tag === P2pEvent_Tags.StreamData) {
       stream?.receive(event.inner.data);
     } else {

--- a/bindings/ts/core/tests/sdk.test.mjs
+++ b/bindings/ts/core/tests/sdk.test.mjs
@@ -522,6 +522,31 @@ test("stream async iteration yields chunks in order and ends on remote write clo
   endpoint.close();
 });
 
+test("stream reads buffered chunks before EOF when full closure follows remote write close", async () => {
+  const backend = new MockBackend();
+  const endpoint = new TestMinip2p(backend);
+  const opening = endpoint.openStream("peer", "/test/1", { timeoutMs: 1000 });
+  backend.emit(streamReady({ initiatedLocally: true, streamId: 3 }));
+  const stream = await opening;
+
+  backend.emit(streamData(new Uint8Array([1, 2]), 3));
+  backend.emit(streamData(new Uint8Array([3]), 3));
+  backend.emit({
+    inner: { connId: 2, peerId: "peer", streamId: 3 },
+    tag: P2pEvent_Tags.StreamRemoteWriteClosed,
+  });
+  backend.emit({
+    inner: { connId: 2, peerId: "peer", streamId: 3 },
+    tag: P2pEvent_Tags.StreamClosed,
+  });
+  await tick();
+
+  assert.deepEqual([...(await stream.read())], [1, 2]);
+  assert.deepEqual([...(await stream.read())], [3]);
+  assert.equal(await stream.read(), undefined);
+  endpoint.close();
+});
+
 test("stream async iteration keeps half-close EOF final when StreamClosed follows", async () => {
   const backend = new MockBackend();
   const endpoint = new TestMinip2p(backend);
@@ -548,7 +573,7 @@ test("stream async iteration keeps half-close EOF final when StreamClosed follow
   endpoint.close();
 });
 
-test("stream async iteration ends quietly when the endpoint closes", async () => {
+test("stream async iteration rejects when the endpoint closes", async () => {
   const backend = new MockBackend();
   const endpoint = new TestMinip2p(backend);
   const opening = endpoint.openStream("peer", "/test/1", { timeoutMs: 1000 });
@@ -562,7 +587,7 @@ test("stream async iteration ends quietly when the endpoint closes", async () =>
 
   endpoint.close();
 
-  await reading;
+  await assert.rejects(reading, ClosedError);
 });
 
 test("stream async iteration rejects when the remote stream resets", async () => {
@@ -583,6 +608,7 @@ test("stream async iteration rejects when the remote stream resets", async () =>
   });
 
   await assert.rejects(reading, StreamClosedError);
+  await assert.rejects(stream.read(), StreamClosedError);
   endpoint.close();
 });
 
@@ -604,21 +630,24 @@ test("pending stream read rejects when its connection closes", async () => {
   endpoint.close();
 });
 
-test("stream async iteration remembers a reset while the loop body runs", async () => {
+test("stream async iteration drains buffered data when full closure follows remote write close", async () => {
   const backend = new MockBackend();
   const endpoint = new TestMinip2p(backend);
   const opening = endpoint.openStream("peer", "/test/1", { timeoutMs: 1000 });
   backend.emit(streamReady({ initiatedLocally: true, streamId: 3 }));
   const stream = await opening;
   const { promise: paused, resolve: resume } = Promise.withResolvers();
+  const chunks = [];
   const reading = (async () => {
-    for await (const _chunk of stream) {
+    for await (const chunk of stream) {
+      chunks.push([...chunk]);
       await paused;
     }
   })();
 
   backend.emit(streamData(new Uint8Array([1]), 3));
   await tick();
+  backend.emit(streamData(new Uint8Array([2]), 3));
   backend.emit({
     inner: { connId: 2, peerId: "peer", streamId: 3 },
     tag: P2pEvent_Tags.StreamRemoteWriteClosed,
@@ -630,8 +659,41 @@ test("stream async iteration remembers a reset while the loop body runs", async 
   await tick();
   resume();
 
-  await assert.rejects(reading, StreamClosedError);
+  await reading;
+  assert.deepEqual(chunks, [[1], [2]]);
   endpoint.close();
+});
+
+test("endpoint and connection closure override remote write EOF", async () => {
+  for (const failure of ["endpoint", "connection"]) {
+    const backend = new MockBackend();
+    backend.connected = ["peer"];
+    const endpoint = new TestMinip2p(backend);
+    const opening = endpoint.openStream("peer", "/test/1", {
+      timeoutMs: 1000,
+    });
+    backend.emit(streamReady({ initiatedLocally: true, streamId: 3 }));
+    const stream = await opening;
+    backend.emit(streamData(new Uint8Array([1]), 3));
+    backend.emit({
+      inner: { connId: 2, peerId: "peer", streamId: 3 },
+      tag: P2pEvent_Tags.StreamRemoteWriteClosed,
+    });
+    await tick();
+
+    if (failure === "endpoint") {
+      endpoint.close();
+      await assert.rejects(stream.read(), ClosedError);
+    } else {
+      backend.emit({
+        inner: { connId: 2, peerId: "peer" },
+        tag: P2pEvent_Tags.ConnectionClosed,
+      });
+      await tick();
+      await assert.rejects(stream.read(), PeerDisconnectedError);
+      endpoint.close();
+    }
+  }
 });
 
 test("local stream reset and abandon emit closed exactly once", async () => {
@@ -650,12 +712,38 @@ test("local stream reset and abandon emit closed exactly once", async () => {
       stream.reset();
       stream.abandon();
     });
+    const reading = stream.read();
 
     stream[operation]();
     stream[operation]();
 
     assert.equal(closed, 1);
     assert.deepEqual(backend.operations, [[operation, "peer", 3]]);
+    await assert.rejects(reading, ClosedError);
+    await assert.rejects(stream.read(), ClosedError);
+    endpoint.close();
+  }
+});
+
+test("local stream reset and abandon override remote write EOF", async () => {
+  for (const operation of ["reset", "abandon"]) {
+    const backend = new MockBackend();
+    const endpoint = new TestMinip2p(backend);
+    const opening = endpoint.openStream("peer", "/test/1", {
+      timeoutMs: 1000,
+    });
+    backend.emit(streamReady({ initiatedLocally: true, streamId: 3 }));
+    const stream = await opening;
+    backend.emit(streamData(new Uint8Array([1]), 3));
+    backend.emit({
+      inner: { connId: 2, peerId: "peer", streamId: 3 },
+      tag: P2pEvent_Tags.StreamRemoteWriteClosed,
+    });
+    await tick();
+
+    stream[operation]();
+
+    await assert.rejects(stream.read(), ClosedError);
     endpoint.close();
   }
 });


### PR DESCRIPTION
Closes #150

## Summary

- preserve unread pull-mode chunks when full stream closure follows remote FIN
- keep EOF final for pull reads and async iteration
- retain error semantics for abrupt closure, reset, abandon, shutdown, and connection loss
- model receive termination with an explicit state

## Validation

- pnpm --filter @minip2p/core test
- pnpm --filter @minip2p/core typecheck
- pnpm --filter @minip2p/core build
- pnpm lint
- pnpm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves buffered stream data when a full stream close follows a remote write close, so previously received chunks are still readable after the stream fully closes.

- Tracks receive termination with an explicit state instead of separate flags for remote EOF and terminal errors.
- Full stream closure after a remote EOF keeps buffered chunks readable; abrupt closure, reset, abandon, shutdown, and connection loss still reject reads.
- Async iteration no longer swallows `ClosedError`; it now propagates the error from `read()`.
- README now documents that iteration drains buffered bytes before ending quietly, while local shutdown, reset, disconnect, or driver failure rejects.

<sup>Written for commit 1f4b04e8362bf4d7f8a2e205d5aba3f5ef0e77ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

