### PR TITLE
fix(react-native): map u64 connection IDs to safe numbers

### DIFF
--- a/bindings/ts/react-native/src/adapter.ts
+++ b/bindings/ts/react-native/src/adapter.ts
@@ -19,6 +19,7 @@ import type {
   Reachability,
   RelayReservationInfo,
 } from "@minip2p/core";
+import { P2pEvent_Tags } from "@minip2p/core/backend";
 import type {
   Minip2pBackend,
   Minip2pBackendFactory,
@@ -421,24 +422,37 @@ function resolveMdnsAutoDial(
  *
  * Native connection IDs span the full `u64` range, so they cannot round-trip
  * through a JavaScript `number`. Each endpoint owns one map so a native ID
- * resolves to the same public ID in events and synchronous results. Entries
- * live for the endpoint lifetime: connection IDs never flow back into native
- * calls, and keeping them means a delayed event cannot alias a newer
- * connection. Stream and connect-attempt IDs are not mapped because they
- * round-trip into native calls, and native allocates them well inside the
- * safe integer range.
+ * resolves to the same public ID in events and synchronous results. An entry
+ * is released once its `ConnectionClosed` event is normalized, which bounds
+ * the map by live connections. Public numbers come from a counter that never
+ * repeats, so an event arriving after the release gets a fresh number instead
+ * of aliasing a live connection. Stream and connect-attempt IDs are not
+ * mapped because they round-trip into native calls, and native allocates
+ * them well inside the safe integer range.
  */
 class ConnectionIdMap {
   readonly #publicByNative = new Map<bigint, number>();
+  readonly #nativeByPublic = new Map<number, bigint>();
+  #next = 1;
 
   toPublic(native: bigint): number {
     const existing = this.#publicByNative.get(native);
     if (existing !== undefined) {
       return existing;
     }
-    const publicId = this.#publicByNative.size + 1;
+    const publicId = this.#next;
+    this.#next += 1;
     this.#publicByNative.set(native, publicId);
+    this.#nativeByPublic.set(publicId, native);
     return publicId;
+  }
+
+  release(publicId: number): void {
+    const native = this.#nativeByPublic.get(publicId);
+    if (native !== undefined) {
+      this.#nativeByPublic.delete(publicId);
+      this.#publicByNative.delete(native);
+    }
   }
 }
 
@@ -446,13 +460,17 @@ function normalizeEvent(
   event: NativeP2pEvent,
   connectionIds: ConnectionIdMap
 ): P2pEvent {
-  return normalizeBigInts(
+  const normalized = normalizeBigInts(
     {
       inner: event.inner,
       tag: event.tag,
     },
     connectionIds
   ) as P2pEvent;
+  if (normalized.tag === P2pEvent_Tags.ConnectionClosed) {
+    connectionIds.release(normalized.inner.connId);
+  }
+  return normalized;
 }
 
 function normalizeKnownPeer(peer: NativeKnownPeerInfo): KnownPeerInfo {

--- a/bindings/ts/react-native/src/adapter.ts
+++ b/bindings/ts/react-native/src/adapter.ts
@@ -51,6 +51,7 @@ import nativeModule from "./NativeMinip2p";
 class ReactNativeBackend implements Minip2pBackend {
   readonly #endpoint: P2pEndpoint;
   readonly #mdnsEnabled: boolean;
+  readonly #connectionIds = new ConnectionIdMap();
   #doorbell: P2pEventDoorbell | undefined;
   #events: EventDrain<NativeP2pEvent> | undefined;
 
@@ -78,7 +79,7 @@ class ReactNativeBackend implements Minip2pBackend {
   start(listener: (event: P2pEvent) => void): void {
     this.#events = new EventDrain(
       (limit) => this.#endpoint.drainEvents(limit),
-      (event) => listener(normalizeEvent(event))
+      (event) => listener(normalizeEvent(event, this.#connectionIds))
     );
     this.#doorbell = {
       onEventsReady: () => {
@@ -199,7 +200,7 @@ class ReactNativeBackend implements Minip2pBackend {
       this.#endpoint.openStream(peerId, protocolId)
     );
     return {
-      connId: u64ToNumber(result.connId, "connId"),
+      connId: this.#connectionIds.toPublic(result.connId),
       streamId: u64ToNumber(result.streamId, "streamId"),
     };
   }
@@ -260,21 +261,19 @@ class ReactNativeBackend implements Minip2pBackend {
 
   dial(address: string): number[] {
     return translateErrors(() => this.#endpoint.dial(address)).map((id) =>
-      u64ToNumber(id, "connectionId")
+      this.#connectionIds.toPublic(id)
     );
   }
 
   dialIp4(address: string): number {
-    return u64ToNumber(
-      translateErrors(() => this.#endpoint.dialIp4(address)),
-      "connectionId"
+    return this.#connectionIds.toPublic(
+      translateErrors(() => this.#endpoint.dialIp4(address))
     );
   }
 
   dialIp6(address: string): number {
-    return u64ToNumber(
-      translateErrors(() => this.#endpoint.dialIp6(address)),
-      "connectionId"
+    return this.#connectionIds.toPublic(
+      translateErrors(() => this.#endpoint.dialIp6(address))
     );
   }
 
@@ -417,11 +416,43 @@ function resolveMdnsAutoDial(
   return mdns.autoDial ?? discovery?.autoDial ?? true;
 }
 
-function normalizeEvent(event: NativeP2pEvent): P2pEvent {
-  return normalizeBigInts({
-    inner: event.inner,
-    tag: event.tag,
-  }) as P2pEvent;
+/**
+ * Maps native `u64` connection identities to small public numbers.
+ *
+ * Native connection IDs span the full `u64` range, so they cannot round-trip
+ * through a JavaScript `number`. Each endpoint owns one map so a native ID
+ * resolves to the same public ID in events and synchronous results. Entries
+ * live for the endpoint lifetime: connection IDs never flow back into native
+ * calls, and keeping them means a delayed event cannot alias a newer
+ * connection. Stream and connect-attempt IDs are not mapped because they
+ * round-trip into native calls, and native allocates them well inside the
+ * safe integer range.
+ */
+class ConnectionIdMap {
+  readonly #publicByNative = new Map<bigint, number>();
+
+  toPublic(native: bigint): number {
+    const existing = this.#publicByNative.get(native);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const publicId = this.#publicByNative.size + 1;
+    this.#publicByNative.set(native, publicId);
+    return publicId;
+  }
+}
+
+function normalizeEvent(
+  event: NativeP2pEvent,
+  connectionIds: ConnectionIdMap
+): P2pEvent {
+  return normalizeBigInts(
+    {
+      inner: event.inner,
+      tag: event.tag,
+    },
+    connectionIds
+  ) as P2pEvent;
 }
 
 function normalizeKnownPeer(peer: NativeKnownPeerInfo): KnownPeerInfo {
@@ -438,19 +469,33 @@ function normalizeReservation(
   return normalizeBigInts(reservation) as RelayReservationInfo;
 }
 
-function normalizeBigInts(value: unknown): unknown {
+/**
+ * Converts native `bigint` fields to numbers. `connId` fields go through the
+ * endpoint's connection map when one is supplied; every other `u64` keeps the
+ * checked conversion.
+ */
+function normalizeBigInts(
+  value: unknown,
+  connectionIds?: ConnectionIdMap,
+  key?: string
+): unknown {
   if (typeof value === "bigint") {
-    return u64ToNumber(value, "native u64");
+    return key === "connId" && connectionIds !== undefined
+      ? connectionIds.toPublic(value)
+      : u64ToNumber(value, "native u64");
   }
   if (value instanceof ArrayBuffer) {
     return value;
   }
   if (Array.isArray(value)) {
-    return value.map((item) => normalizeBigInts(item));
+    return value.map((item) => normalizeBigInts(item, connectionIds));
   }
   if (value !== null && typeof value === "object") {
     return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [key, normalizeBigInts(item)])
+      Object.entries(value).map(([itemKey, item]) => [
+        itemKey,
+        normalizeBigInts(item, connectionIds, itemKey),
+      ])
     );
   }
   return value;

--- a/bindings/ts/react-native/tests/adapter-connection-ids.test.ts
+++ b/bindings/ts/react-native/tests/adapter-connection-ids.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { Minip2p } from "../src/adapter";
+import { FakeNativeEndpoint } from "./fake-native-endpoint";
+import type { FakeEvent } from "./fake-native-endpoint";
+
+vi.mock("../src/native", async () => {
+  const { nativeModuleMock } = await import("./fake-native-endpoint");
+  return nativeModuleMock();
+});
+
+vi.mock("../src/NativeMinip2p", () => ({
+  default: { setMdnsEnabled: vi.fn() },
+}));
+
+const PEER = "12D3KooWPeer";
+const NATIVE_IDS = [1n, 2n ** 56n + 1n, 2n ** 63n + 1n, 2n ** 63n + 2n];
+
+const established = (connId: bigint): FakeEvent => ({
+  inner: { connId, peerId: PEER },
+  tag: "ConnectionEstablished",
+});
+
+const closed = (connId: bigint): FakeEvent => ({
+  inner: { connId, peerId: PEER },
+  tag: "ConnectionClosed",
+});
+
+const isSafeId = (value: number): boolean =>
+  Number.isSafeInteger(value) && value >= 0;
+
+describe("React Native connection identities", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    FakeNativeEndpoint.latest = undefined;
+  });
+
+  test("full-range native connection IDs reach listeners as distinct safe numbers", async () => {
+    vi.useFakeTimers();
+    const endpoint = Minip2p.create({ secretKey: new Uint8Array(32) });
+    const fake = FakeNativeEndpoint.current();
+    const opened: number[] = [];
+    const closedIds: number[] = [];
+    endpoint.on("connectionEstablished", ({ connId }) => opened.push(connId));
+    endpoint.on("connectionClosed", ({ connId }) => closedIds.push(connId));
+    fake.enqueue(
+      NATIVE_IDS.map(established),
+      [closed(2n ** 63n + 1n), closed(1n)],
+      []
+    );
+
+    fake.ring();
+    await vi.runAllTimersAsync();
+
+    expect(opened).toHaveLength(NATIVE_IDS.length);
+    expect(new Set(opened).size).toBe(NATIVE_IDS.length);
+    expect(opened.every(isSafeId)).toBe(true);
+    expect(closedIds).toEqual([opened[2], opened[0]]);
+    endpoint.close();
+  });
+
+  test("openStream and stream events share the connection event's public ID", async () => {
+    vi.useFakeTimers();
+    const endpoint = Minip2p.create({ secretKey: new Uint8Array(32) });
+    const fake = FakeNativeEndpoint.current();
+    const nativeConnId = 2n ** 63n + 1n;
+    const opened: number[] = [];
+    const errors: (number | undefined)[] = [];
+    endpoint.on("connectionEstablished", ({ connId }) => opened.push(connId));
+    endpoint.on("endpointError", ({ connId }) => errors.push(connId));
+    fake.nextStream = { connId: nativeConnId, streamId: 7n };
+    const pending = endpoint.openStream(PEER, "/echo/1.0.0");
+    const streamInner = { connId: nativeConnId, peerId: PEER, streamId: 7n };
+    fake.enqueue(
+      [
+        established(nativeConnId),
+        {
+          inner: {
+            ...streamInner,
+            initiatedLocally: true,
+            protocolId: "/echo/1.0.0",
+          },
+          tag: "StreamReady",
+        },
+        {
+          inner: { ...streamInner, data: new ArrayBuffer(1) },
+          tag: "StreamData",
+        },
+        {
+          inner: {
+            ...streamInner,
+            detail: "boom",
+            kind: 0,
+          },
+          tag: "EndpointError",
+        },
+      ],
+      []
+    );
+    const stream = await (async () => {
+      fake.ring();
+      await vi.runAllTimersAsync();
+      return pending;
+    })();
+    const chunk = await stream.read();
+
+    expect(opened).toEqual([stream.connId]);
+    expect(isSafeId(stream.connId)).toBe(true);
+    expect(stream.streamId).toBe(7);
+    expect(chunk?.byteLength).toBe(1);
+    expect(errors).toEqual([stream.connId]);
+    stream.abandon();
+    endpoint.close();
+  });
+
+  test("dial results map the full u64 range consistently with events", async () => {
+    vi.useFakeTimers();
+    const endpoint = Minip2p.create({ secretKey: new Uint8Array(32) });
+    const fake = FakeNativeEndpoint.current();
+    const opened: number[] = [];
+    endpoint.on("connectionEstablished", ({ connId }) => opened.push(connId));
+
+    fake.dialResults = [2n ** 64n - 1n, 2n ** 63n + 2n];
+    const dialed = endpoint.dial("/ip4/127.0.0.1/udp/4001/quic-v1");
+    fake.dialResults = [2n ** 63n + 2n];
+    const ip4 = endpoint.dialIp4("/ip4/127.0.0.1/udp/4001/quic-v1");
+    fake.dialResults = [2n ** 53n];
+    const ip6 = endpoint.dialIp6("/ip6/::1/udp/4001/quic-v1");
+    fake.enqueue([
+      established(2n ** 63n + 2n),
+      established(2n ** 64n - 1n),
+      established(2n ** 53n),
+    ]);
+    fake.ring();
+    await vi.runAllTimersAsync();
+
+    expect([...dialed, ip6].every(isSafeId)).toBe(true);
+    expect(new Set([...dialed, ip6]).size).toBe(3);
+    expect(ip4).toBe(dialed[1]);
+    expect(opened).toEqual([dialed[1], dialed[0], ip6]);
+    endpoint.close();
+  });
+
+  test("other native u64 fields keep their range checks without blocking the batch", async () => {
+    vi.useFakeTimers();
+    const endpoint = Minip2p.create({ secretKey: new Uint8Array(32) });
+    const fake = FakeNativeEndpoint.current();
+    fake.discoveryNow = 2n ** 63n;
+    const peers: string[] = [];
+    endpoint.on("peerReady", ({ peerId }) => peers.push(peerId));
+    fake.enqueue([
+      {
+        inner: { peerId: PEER, rttMs: 2n ** 63n },
+        tag: "PingRttMeasured",
+      },
+      { inner: { peerId: PEER, protocols: [] }, tag: "PeerReady" },
+    ]);
+
+    fake.ring();
+    await vi.runAllTimersAsync();
+
+    expect(() => endpoint.discoveryNowMs()).toThrow(RangeError);
+    expect(peers).toEqual([PEER]);
+    endpoint.close();
+  });
+});

--- a/bindings/ts/react-native/tests/adapter-connection-ids.test.ts
+++ b/bindings/ts/react-native/tests/adapter-connection-ids.test.ts
@@ -41,21 +41,33 @@ describe("React Native connection identities", () => {
     const fake = FakeNativeEndpoint.current();
     const opened: number[] = [];
     const closedIds: number[] = [];
+    const lateErrors: (number | undefined)[] = [];
     endpoint.on("connectionEstablished", ({ connId }) => opened.push(connId));
     endpoint.on("connectionClosed", ({ connId }) => closedIds.push(connId));
+    endpoint.on("endpointError", ({ connId }) => lateErrors.push(connId));
     fake.enqueue(
       NATIVE_IDS.map(established),
       [closed(2n ** 63n + 1n), closed(1n)],
+      [
+        {
+          inner: { connId: 1n, detail: "late", kind: 0 },
+          tag: "EndpointError",
+        },
+        established(5n),
+      ],
       []
     );
 
     fake.ring();
     await vi.runAllTimersAsync();
 
-    expect(opened).toHaveLength(NATIVE_IDS.length);
-    expect(new Set(opened).size).toBe(NATIVE_IDS.length);
+    expect(opened).toHaveLength(NATIVE_IDS.length + 1);
     expect(opened.every(isSafeId)).toBe(true);
     expect(closedIds).toEqual([opened[2], opened[0]]);
+    // A released ID never comes back: the late error and the new connection
+    // both get numbers distinct from every ID handed out before.
+    const seen = [...opened, ...lateErrors];
+    expect(new Set(seen).size).toBe(seen.length);
     endpoint.close();
   });
 

--- a/bindings/ts/react-native/tests/adapter-event-drain.test.ts
+++ b/bindings/ts/react-native/tests/adapter-event-drain.test.ts
@@ -1,63 +1,12 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { Minip2p } from "../src/adapter";
+import { FakeNativeEndpoint } from "./fake-native-endpoint";
 
-const native = vi.hoisted(() => {
-  interface Event {
-    readonly tag: string;
-    readonly inner: Readonly<Record<string, unknown>>;
-  }
-  interface Doorbell {
-    onEventsReady: () => void;
-  }
-
-  class FakeNativeEndpoint {
-    static latest: FakeNativeEndpoint | undefined;
-
-    readonly drainLimits: number[] = [];
-    readonly #batches: Event[][] = [];
-    #doorbell: Doorbell | undefined;
-
-    constructor() {
-      FakeNativeEndpoint.latest = this;
-    }
-
-    enqueue(...batches: Event[][]): void {
-      this.#batches.push(...batches);
-    }
-
-    ring(): void {
-      this.#doorbell?.onEventsReady();
-    }
-
-    start(doorbell: Doorbell): void {
-      this.#doorbell = doorbell;
-    }
-
-    drainEvents(limit: number): Event[] {
-      this.drainLimits.push(limit);
-      return this.#batches.shift() ?? [];
-    }
-
-    stop(): void {
-      this.#doorbell = undefined;
-    }
-
-    uniffiDestroy(): void {
-      this.#batches.length = 0;
-    }
-  }
-
-  return { FakeNativeEndpoint };
+vi.mock("../src/native", async () => {
+  const { nativeModuleMock } = await import("./fake-native-endpoint");
+  return nativeModuleMock();
 });
-
-vi.mock("../src/native", () => ({
-  FfiError_Tags: {},
-  P2pEndpoint: native.FakeNativeEndpoint,
-  circuitAddress: vi.fn(),
-  generateSecretKey: vi.fn(),
-  peerIdFromSecretKey: vi.fn(),
-}));
 
 vi.mock("../src/NativeMinip2p", () => ({
   default: {
@@ -77,16 +26,13 @@ const settle = async (): Promise<void> => {
 describe("React Native event delivery", () => {
   afterEach(() => {
     vi.useRealTimers();
-    native.FakeNativeEndpoint.latest = undefined;
+    FakeNativeEndpoint.latest = undefined;
   });
 
   test("start drains to empty and does not lose a re-ring", async () => {
     vi.useFakeTimers();
     const endpoint = Minip2p.create({ secretKey: new Uint8Array(32) });
-    const fake = native.FakeNativeEndpoint.latest;
-    if (fake === undefined) {
-      throw new Error("native endpoint was not constructed");
-    }
+    const fake = FakeNativeEndpoint.current();
     const peers: string[] = [];
     endpoint.on("peerReady", ({ peerId }) => peers.push(peerId));
     fake.enqueue([event("first")], [], [event("second")], []);
@@ -104,10 +50,7 @@ describe("React Native event delivery", () => {
   test("an event flood coalesces into one native drain pass", async () => {
     vi.useFakeTimers();
     const endpoint = Minip2p.create({ secretKey: new Uint8Array(32) });
-    const fake = native.FakeNativeEndpoint.latest;
-    if (fake === undefined) {
-      throw new Error("native endpoint was not constructed");
-    }
+    const fake = FakeNativeEndpoint.current();
 
     for (let index = 0; index < 10_000; index += 1) {
       fake.ring();

--- a/bindings/ts/react-native/tests/fake-native-endpoint.ts
+++ b/bindings/ts/react-native/tests/fake-native-endpoint.ts
@@ -1,0 +1,92 @@
+/** In-memory stand-in for the UniFFI `P2pEndpoint` used by adapter tests. */
+
+import { vi } from "vitest";
+
+export interface FakeEvent {
+  readonly tag: string;
+  readonly inner: Readonly<Record<string, unknown>>;
+}
+
+interface Doorbell {
+  onEventsReady: () => void;
+}
+
+export class FakeNativeEndpoint {
+  static latest: FakeNativeEndpoint | undefined;
+
+  readonly drainLimits: number[] = [];
+  /** Native identities returned by the next `openStream` call. */
+  nextStream = { connId: 1n, streamId: 1n };
+  /** Native connection identities returned by the dial methods. */
+  dialResults: bigint[] = [1n];
+  /** Native discovery clock returned by `discoveryNowMs`. */
+  discoveryNow: bigint | undefined = undefined;
+  readonly #batches: FakeEvent[][] = [];
+  #doorbell: Doorbell | undefined;
+
+  constructor() {
+    FakeNativeEndpoint.latest = this;
+  }
+
+  /** Returns the endpoint constructed by the most recent `Minip2p.create`. */
+  static current(): FakeNativeEndpoint {
+    if (FakeNativeEndpoint.latest === undefined) {
+      throw new Error("native endpoint was not constructed");
+    }
+    return FakeNativeEndpoint.latest;
+  }
+
+  enqueue(...batches: FakeEvent[][]): void {
+    this.#batches.push(...batches);
+  }
+
+  ring(): void {
+    this.#doorbell?.onEventsReady();
+  }
+
+  start(doorbell: Doorbell): void {
+    this.#doorbell = doorbell;
+  }
+
+  drainEvents(limit: number): FakeEvent[] {
+    this.drainLimits.push(limit);
+    return this.#batches.shift() ?? [];
+  }
+
+  openStream(): { connId: bigint; streamId: bigint } {
+    return this.nextStream;
+  }
+
+  dial(): bigint[] {
+    return this.dialResults;
+  }
+
+  dialIp4(): bigint {
+    return this.dialResults[0] ?? 0n;
+  }
+
+  dialIp6(): bigint {
+    return this.dialResults[0] ?? 0n;
+  }
+
+  discoveryNowMs(): bigint | undefined {
+    return this.discoveryNow;
+  }
+
+  stop(): void {
+    this.#doorbell = undefined;
+  }
+
+  uniffiDestroy(): void {
+    this.#batches.length = 0;
+  }
+}
+
+/** Factory for `vi.mock("../src/native", nativeModuleMock)`. */
+export const nativeModuleMock = () => ({
+  FfiError_Tags: {},
+  P2pEndpoint: FakeNativeEndpoint,
+  circuitAddress: vi.fn(),
+  generateSecretKey: vi.fn(),
+  peerIdFromSecretKey: vi.fn(),
+});

--- a/bindings/ts/react-native/tests/fake-native-endpoint.ts
+++ b/bindings/ts/react-native/tests/fake-native-endpoint.ts
@@ -2,16 +2,34 @@
 
 import { vi } from "vitest";
 
+import type {
+  OpenStreamResult,
+  P2pEndpointLike,
+  P2pEvent,
+  P2pEventDoorbell,
+} from "../src/native";
+
+/**
+ * Hand-written stand-in for a generated event class instance. The adapter
+ * only reads `tag` and `inner`, so tests enqueue plain literals.
+ */
 export interface FakeEvent {
   readonly tag: string;
   readonly inner: Readonly<Record<string, unknown>>;
 }
 
-interface Doorbell {
-  onEventsReady: () => void;
-}
+/** Endpoint methods the fake implements with the generated signatures. */
+type FakedMethods =
+  | "dial"
+  | "dialIp4"
+  | "dialIp6"
+  | "discoveryNowMs"
+  | "drainEvents"
+  | "openStream"
+  | "start"
+  | "stop";
 
-export class FakeNativeEndpoint {
+export class FakeNativeEndpoint implements Pick<P2pEndpointLike, FakedMethods> {
   static latest: FakeNativeEndpoint | undefined;
 
   readonly drainLimits: number[] = [];
@@ -22,7 +40,7 @@ export class FakeNativeEndpoint {
   /** Native discovery clock returned by `discoveryNowMs`. */
   discoveryNow: bigint | undefined = undefined;
   readonly #batches: FakeEvent[][] = [];
-  #doorbell: Doorbell | undefined;
+  #doorbell: P2pEventDoorbell | undefined;
 
   constructor() {
     FakeNativeEndpoint.latest = this;
@@ -44,16 +62,16 @@ export class FakeNativeEndpoint {
     this.#doorbell?.onEventsReady();
   }
 
-  start(doorbell: Doorbell): void {
+  start(doorbell: P2pEventDoorbell): void {
     this.#doorbell = doorbell;
   }
 
-  drainEvents(limit: number): FakeEvent[] {
+  drainEvents(limit: number): P2pEvent[] {
     this.drainLimits.push(limit);
-    return this.#batches.shift() ?? [];
+    return (this.#batches.shift() ?? []) as unknown as P2pEvent[];
   }
 
-  openStream(): { connId: bigint; streamId: bigint } {
+  openStream(): OpenStreamResult {
     return this.nextStream;
   }
 

--- a/bindings/ts/react-native/tests/fake-native-endpoint.ts
+++ b/bindings/ts/react-native/tests/fake-native-endpoint.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable class-methods-use-this -- The fake mirrors the generated endpoint surface; methods no test reaches throw by name. */
 /** In-memory stand-in for the UniFFI `P2pEndpoint` used by adapter tests. */
 
 import { vi } from "vitest";
@@ -18,18 +19,17 @@ export interface FakeEvent {
   readonly inner: Readonly<Record<string, unknown>>;
 }
 
-/** Endpoint methods the fake implements with the generated signatures. */
-type FakedMethods =
-  | "dial"
-  | "dialIp4"
-  | "dialIp6"
-  | "discoveryNowMs"
-  | "drainEvents"
-  | "openStream"
-  | "start"
-  | "stop";
+const notFaked = (method: keyof P2pEndpointLike): never => {
+  throw new Error(`FakeNativeEndpoint does not fake ${method}`);
+};
 
-export class FakeNativeEndpoint implements Pick<P2pEndpointLike, FakedMethods> {
+/**
+ * Implements the full generated endpoint surface so interface drift fails
+ * `typecheck`. Only the methods the adapter tests reach have behavior; the
+ * rest throw by name so an unexpected call is loud rather than "not a
+ * function".
+ */
+export class FakeNativeEndpoint implements P2pEndpointLike {
   static latest: FakeNativeEndpoint | undefined;
 
   readonly drainLimits: number[] = [];
@@ -97,6 +97,110 @@ export class FakeNativeEndpoint implements Pick<P2pEndpointLike, FakedMethods> {
 
   uniffiDestroy(): void {
     this.#batches.length = 0;
+  }
+
+  abandonStream(): never {
+    return notFaked("abandonStream");
+  }
+
+  activeReservation(): never {
+    return notFaked("activeReservation");
+  }
+
+  addProtocol(): never {
+    return notFaked("addProtocol");
+  }
+
+  cancelConnect(): never {
+    return notFaked("cancelConnect");
+  }
+
+  closeStreamWrite(): never {
+    return notFaked("closeStreamWrite");
+  }
+
+  connect(): never {
+    return notFaked("connect");
+  }
+
+  connectAddr(): never {
+    return notFaked("connectAddr");
+  }
+
+  connectWithAddrs(): never {
+    return notFaked("connectWithAddrs");
+  }
+
+  connectedPeers(): never {
+    return notFaked("connectedPeers");
+  }
+
+  disconnect(): never {
+    return notFaked("disconnect");
+  }
+
+  isPeerReady(): never {
+    return notFaked("isPeerReady");
+  }
+
+  isRunning(): never {
+    return notFaked("isRunning");
+  }
+
+  knownPeers(): never {
+    return notFaked("knownPeers");
+  }
+
+  listenAddrs(): never {
+    return notFaked("listenAddrs");
+  }
+
+  path(): never {
+    return notFaked("path");
+  }
+
+  peerId(): never {
+    return notFaked("peerId");
+  }
+
+  peerInfo(): never {
+    return notFaked("peerInfo");
+  }
+
+  ping(): never {
+    return notFaked("ping");
+  }
+
+  publish(): never {
+    return notFaked("publish");
+  }
+
+  reachability(): never {
+    return notFaked("reachability");
+  }
+
+  resetStream(): never {
+    return notFaked("resetStream");
+  }
+
+  sendStream(): never {
+    return notFaked("sendStream");
+  }
+
+  setActive(): never {
+    return notFaked("setActive");
+  }
+
+  subscribe(): never {
+    return notFaked("subscribe");
+  }
+
+  unsubscribe(): never {
+    return notFaked("unsubscribe");
+  }
+
+  waitStopped(): never {
+    return notFaked("waitStopped");
   }
 }
 


### PR DESCRIPTION
Closes #151

## Summary

- give each React Native backend one endpoint-local map from native `u64` connection ID to a small public `number`
- route `connId` fields in every native event (connection, stream, and endpoint error events) through that map during normalization
- return mapped connection IDs from `openStream()`, `dial()`, `dialIp4()`, and `dialIp6()`
- keep the checked `u64` conversion for every other numeric field, including stream and connect-attempt IDs, which round-trip back into native
- share one in-memory fake native endpoint between the adapter tests and add focused coverage for full-range connection IDs, stream and error events, and dial results

## Validation

- pnpm --filter @minip2p/react-native test
- pnpm --filter @minip2p/react-native typecheck
- pnpm lint
- pnpm test
- pnpm typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes React Native connection handling so full-range u64 connection IDs no longer throw during normalization and abort the rest of the event batch.

- Maps each backend's native u64 connection IDs to small public numbers, used consistently across events, `openStream`, and dial results.
- Releases a connection's mapping when its `ConnectionClosed` event is normalized, bounding the map by live connections; a never-repeating counter ensures late events get fresh numbers instead of aliasing a live one.
- Keeps checked u64 conversion for all other numeric fields, which still round-trip into native calls.
- Shares one fake native endpoint between adapter tests, typed against the full generated endpoint surface so contract drift fails typecheck, and adds coverage for full-range IDs, stream/error events, and dial results.

<sup>Written for commit 3311d246634716a95ac6effb258245a9ac509028. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

