### PR TITLE
chore(ci): bump workflow action and tool versions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -49,7 +49,7 @@ jobs:
           sha=$(git -C "$SOURCE_DIR" rev-parse HEAD)
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "image_tag=$sha-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
+      - uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
           role-to-assume: ${{ vars.AWS_BENCH_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/bindings-native.yml
+++ b/.github/workflows/bindings-native.yml
@@ -43,11 +43,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: "24.19.0"
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+          node-version: "24.20.0"
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
-          version: "11.24.0"
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+          version: "11.25.0"
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: "1.91"
           targets: ${{ matrix.target }}
@@ -106,7 +106,7 @@ jobs:
                 clang20-libclang=20.1.8-r1 \
                 nodejs npm
               export PATH=/usr/bin:$PATH
-              npm install --global --prefix /opt/pnpm pnpm@11.24.0
+              npm install --global --prefix /opt/pnpm pnpm@11.25.0
               export PATH=/opt/pnpm/bin:/usr/bin:$PATH
               rustup toolchain install 1.91 --profile minimal
               rustup default 1.91
@@ -142,11 +142,11 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: "24.12.0"
+          node-version: "24.20.0"
       - uses: pnpm/action-setup@v6
         with:
-          version: "11.18.0"
-      - uses: actions/setup-java@v5
+          version: "11.25.0"
+      - uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "17"
@@ -196,10 +196,10 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: "24.12.0"
+          node-version: "24.20.0"
       - uses: pnpm/action-setup@v6
         with:
-          version: "11.18.0"
+          version: "11.25.0"
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-ios,aarch64-apple-ios-sim

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -42,10 +42,10 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: "24.19.0"
+          node-version: "24.20.0"
       - uses: pnpm/action-setup@v6
         with:
-          version: "11.24.0"
+          version: "11.25.0"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v7
         with:
-          node-version: "22.13.0"
+          node-version: "24.20.0"
       - uses: pnpm/action-setup@v6
         with:
-          version: "11.10.0"
+          version: "11.25.0"
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.91"
@@ -186,7 +186,7 @@ jobs:
     env:
       # Pinned so a broken upstream nightly can't fail every PR and the
       # rust-cache key stays stable. Bump deliberately.
-      NIGHTLY_TOOLCHAIN: nightly-2026-07-01
+      NIGHTLY_TOOLCHAIN: nightly-2026-09-04
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable # installs the nightly toolchain below via the toolchain input

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  NODE_VERSION: "24.13.0"
-  PNPM_VERSION: "11.18.0"
+  NODE_VERSION: "24.20.0"
+  PNPM_VERSION: "11.25.0"
 
 jobs:
   verify-release:
@@ -183,10 +183,10 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: "1.91"
           targets: ${{ matrix.target }}
@@ -277,7 +277,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.release.tag_name || github.sha }}
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: "1.91"
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -376,7 +376,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "17"
@@ -490,7 +490,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
@@ -498,7 +498,7 @@ jobs:
         run: |
           sdkmanager "ndk;28.2.13676358"
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/28.2.13676358" >> "$GITHUB_ENV"
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           save-if: false
@@ -608,7 +608,7 @@ jobs:
           save-if: false
       - name: Authenticate with crates.io
         id: crates-io-auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
       - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
@@ -717,7 +717,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/relay-container.yml
+++ b/.github/workflows/relay-container.yml
@@ -70,7 +70,7 @@ jobs:
             echo EOF
           } >>"$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      - uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:

--- a/bindings/ts/package.json
+++ b/bindings/ts/package.json
@@ -24,5 +24,5 @@
     "vitest": "4.1.11",
     "yaml": "2.9.0"
   },
-  "packageManager": "pnpm@11.24.0+sha512.bd27e345e976dcb0be0b7a1228217b049a817e21b1f355c90dbe7dc46671895a8bc1e6d06c24554505ea93ea0b45f489a27ec1bfbc8de6a9659fca0f16fa0000"
+  "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956"
 }

--- a/bindings/ts/tests/workflows/bindings-native.test.mjs
+++ b/bindings/ts/tests/workflows/bindings-native.test.mjs
@@ -60,7 +60,7 @@ test("weekly workflow executes the suite on native runners and musl containers",
     ({ name }) => name === "Build addon"
   ).run;
   assert.match(muslBuild, /PATH=\/opt\/pnpm\/bin:\/usr\/bin:/u);
-  assert.match(muslBuild, /--prefix \/opt\/pnpm pnpm@11\.24\.0/u);
+  assert.match(muslBuild, /--prefix \/opt\/pnpm pnpm@11\.25\.0/u);
   assert.match(
     muslBuild,
     /cargo build --release --locked -p minip2p-relay-server-example/u

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,8 @@ lives in `md/`; `.blume/` and `dist/` are generated and must not be edited.
 
 ## Requirements
 
-- Node.js 22.13 or newer
-- pnpm 11.10.0
+- Node.js 24.20 or newer
+- pnpm 11.25.0
 
 ## Work locally
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
   "name": "minip2p-docs",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.10.0",
+  "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956",
   "scripts": {
     "dev": "blume dev",
     "build": "blume build",


### PR DESCRIPTION
## Summary
- Bump outdated GitHub Actions pins: `configure-aws-credentials` v5→v6.2.4, `pnpm/action-setup` → v6.1.0, `setup-java` v5→v6, `setup-qemu-action` → v4.3.0, `dtolnay/rust-toolchain` stable tip, and `crates-io-auth-action` → v1.0.5.
- Unify Node to 24.20.0 (current LTS) and pnpm to 11.25.0 across CI/publish/bindings, including `packageManager` pins.
- Move the fuzz smoke nightly pin to `nightly-2026-09-04`.

Left alone: actions already on latest SHAs (`checkout`, `setup-node`, artifact actions, docker buildx/login/build-push, rust-cache, etc.), cargo-nextest 0.9.143, cargo-fuzz 0.13.2, and workspace MSRV 1.91. Stayed on pnpm 11 (`latest`) rather than opt-in pnpm 12.

## Test plan
- [ ] CI green on this PR (docs-site, test matrix, fuzz-smoke with the new nightly)
- [ ] Bindings workflows still install Node/pnpm correctly
- [ ] Spot-check bench workflow AWS credential step still assumes the role (v6 is Node 24 runner only; no input changes)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps GitHub Actions pins and unifies Node to 24.20.0 (current LTS) and pnpm to 11.25.0 across CI, publish, bindings, and docs workflows so tooling stays consistent. No behavior changes to the codebase.

**Dependencies**
- Updated `configure-aws-credentials`, `setup-java`, `setup-qemu-action`, `crates-io-auth-action`, `pnpm/action-setup`, and `dtolnay/rust-toolchain` to current pins (v6.2.4, v6, v4.3.0, v1.0.5, v6.1.0, and stable).
- Moved the fuzz smoke nightly to `nightly-2026-09-04`.
- Updated `packageManager` pins, the docs README requirement, and the native workflow test to pnpm 11.25.0 / Node 24.20+.
- Left actions already on latest SHAs, `cargo-nextest` 0.9.143, `cargo-fuzz` 0.13.2, and workspace MSRV 1.91 unchanged.

<sup>Written for commit 1fc03fb19990f2f61b650455b48512563f12a64c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

