### PR TITLE
QUIC cost assessment: Identify, not quiche, is the 2× gap

### DIFF
--- a/crates/minip2p/Cargo.toml
+++ b/crates/minip2p/Cargo.toml
@@ -79,3 +79,8 @@ minip2p-test-support = { path = "../test-support" }
 name = "endpoint_e2e"
 harness = false
 required-features = ["quic", "tcp"]
+
+[[bench]]
+name = "cost_probe"
+harness = false
+required-features = ["quic"]

--- a/crates/minip2p/benches/cost_probe.rs
+++ b/crates/minip2p/benches/cost_probe.rs
@@ -1,0 +1,259 @@
+//! Endpoint-layer cost probe: Identify-complete setup vs transport-only, plus RSS.
+//!
+//! Complements `minip2p-quic`'s transport probe. `setup` here is dial +
+//! `wait_peer_ready`, which waits for Identify. `oneshot` then opens an
+//! application stream and echoes 64 bytes.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use minip2p::{Endpoint, Event, PeerAddr, PeerId, QuicLimits, StreamId};
+
+const ECHO: &str = "/minip2p/bench/echo/1";
+const TIMEOUT: Duration = Duration::from_secs(10);
+const SAMPLES: usize = 100;
+const WARMUP: usize = 10;
+
+fn main() {
+    println!("minip2p endpoint QUIC cost probe  samples={SAMPLES}  warmup={WARMUP}");
+
+    probe_construct();
+    probe("setup/retry", true, false);
+    probe("setup/no-retry", false, false);
+    probe("oneshot-64b/retry", true, true);
+    probe("oneshot-64b/no-retry", false, true);
+    probe_rss_endpoints();
+}
+
+fn probe_construct() {
+    let mut samples = Vec::with_capacity(SAMPLES);
+    for i in 0..WARMUP + SAMPLES {
+        let started = Instant::now();
+        let endpoint = bind(true);
+        let elapsed = started.elapsed();
+        drop(endpoint);
+        if i >= WARMUP {
+            samples.push(elapsed);
+        }
+    }
+    report("construct/Endpoint", &samples);
+}
+
+fn probe(label: &str, retry: bool, echo: bool) {
+    let server = EchoServer::start(retry);
+    let mut samples = Vec::with_capacity(SAMPLES);
+    for i in 0..WARMUP + SAMPLES {
+        let mut client = bind(retry);
+        let started = Instant::now();
+        client.dial(&server.address).expect("dial");
+        client
+            .wait_peer_ready(server.address.peer_id(), TIMEOUT)
+            .expect("wait")
+            .expect("ready timeout");
+        if echo {
+            do_echo(&mut client, server.address.peer_id());
+        }
+        let elapsed = started.elapsed();
+        drop(client);
+        if i >= WARMUP {
+            samples.push(elapsed);
+        }
+    }
+    drop(server);
+    report(label, &samples);
+}
+
+fn do_echo(client: &mut Endpoint, peer: &PeerId) {
+    let payload = [0x5a; 64];
+    let stream = client.open_stream(peer, ECHO).expect("open");
+    let deadline = Instant::now() + TIMEOUT;
+    let mut sent = false;
+    let mut received = Vec::new();
+    loop {
+        assert!(Instant::now() < deadline, "echo timed out");
+        let Some(event) = client.next_event(Duration::from_millis(50)).expect("poll") else {
+            continue;
+        };
+        match event {
+            Event::StreamReady {
+                peer_id,
+                stream_id,
+                protocol_id,
+                initiated_locally: true,
+                ..
+            } if peer_id == *peer && stream_id == stream && protocol_id == ECHO && !sent => {
+                client
+                    .send_stream(peer, stream, payload.to_vec())
+                    .expect("send");
+                sent = true;
+            }
+            Event::StreamData {
+                peer_id,
+                stream_id,
+                data,
+                ..
+            } if peer_id == *peer && stream_id == stream => {
+                received.extend_from_slice(&data);
+                if received.len() == payload.len() {
+                    assert_eq!(received, payload);
+                    return;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn probe_rss_endpoints() {
+    println!("rss: one Endpoint per client session against one shared server");
+    for count in [1usize, 20, 50] {
+        let (baseline, held, n) = rss_client_endpoints(count);
+        let delta = held.saturating_sub(baseline);
+        let per = delta / count as u64;
+        println!(
+            "  clients={count:<3}  baseline={baseline} kB  held={held} kB  delta={delta} kB  ~{per} kB/client  connected={n}"
+        );
+    }
+}
+
+fn rss_client_endpoints(count: usize) -> (u64, u64, usize) {
+    let server = EchoServer::start(false);
+    let baseline = rss_kb();
+    let mut clients = Vec::with_capacity(count);
+    for _ in 0..count {
+        let mut client = bind(false);
+        client.dial(&server.address).expect("dial");
+        client
+            .wait_peer_ready(server.address.peer_id(), TIMEOUT)
+            .expect("wait")
+            .expect("ready timeout");
+        clients.push(client);
+    }
+    let held = rss_kb();
+    let n = clients.len();
+    drop(clients);
+    drop(server);
+    (baseline, held, n)
+}
+
+fn bind(retry: bool) -> Endpoint {
+    Endpoint::builder()
+        .agent_version("minip2p-cost-probe")
+        .protocol(ECHO)
+        .quic_limits(QuicLimits {
+            require_address_validation: retry,
+            idle_timeout_ms: 30_000,
+            ..QuicLimits::default()
+        })
+        .bind_quic("127.0.0.1:0")
+        .expect("bind")
+}
+
+struct EchoServer {
+    address: PeerAddr,
+    stop: Arc<AtomicBool>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl EchoServer {
+    fn start(retry: bool) -> Self {
+        let mut endpoint = bind(retry);
+        let address = endpoint.listen().expect("listen");
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_stop = Arc::clone(&stop);
+        let thread = thread::spawn(move || {
+            let mut streams = HashSet::<(PeerId, StreamId)>::new();
+            while !worker_stop.load(Ordering::Relaxed) {
+                let event = endpoint
+                    .next_event(Duration::from_millis(20))
+                    .expect("server poll");
+                match event {
+                    Some(Event::StreamReady {
+                        peer_id,
+                        stream_id,
+                        protocol_id,
+                        initiated_locally: false,
+                        ..
+                    }) if protocol_id == ECHO => {
+                        streams.insert((peer_id, stream_id));
+                    }
+                    Some(Event::StreamData {
+                        peer_id,
+                        stream_id,
+                        data,
+                        ..
+                    }) if streams.contains(&(peer_id.clone(), stream_id)) => {
+                        endpoint
+                            .send_stream(&peer_id, stream_id, data)
+                            .expect("echo");
+                    }
+                    Some(Event::StreamClosed {
+                        peer_id, stream_id, ..
+                    }) => {
+                        streams.remove(&(peer_id, stream_id));
+                    }
+                    _ => {}
+                }
+            }
+        });
+        Self {
+            address,
+            stop,
+            thread: Some(thread),
+        }
+    }
+}
+
+impl Drop for EchoServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(thread) = self.thread.take() {
+            thread.join().expect("server");
+        }
+    }
+}
+
+fn report(label: &str, samples: &[Duration]) {
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let last = sorted.len().saturating_sub(1);
+    let p = |hundredths: usize| {
+        let idx = last.saturating_mul(hundredths) / 100;
+        sorted.get(idx.min(last)).copied().expect("samples")
+    };
+    let sum: Duration = sorted.iter().copied().sum();
+    let mean = sum / u32::try_from(sorted.len()).expect("sample count fits u32");
+    println!(
+        "{label:<24}  n={}  p50={}  p90={}  p99={}  mean={}  min={}  max={}",
+        sorted.len(),
+        fmt(p(50)),
+        fmt(p(90)),
+        fmt(p(99)),
+        fmt(mean),
+        fmt(sorted.first().copied().expect("samples")),
+        fmt(sorted.last().copied().expect("samples")),
+    );
+}
+
+fn fmt(d: Duration) -> String {
+    format!("{:.3} ms", d.as_secs_f64() * 1_000.0)
+}
+
+fn rss_kb() -> u64 {
+    let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
+        return 0;
+    };
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            return rest
+                .split_whitespace()
+                .next()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+        }
+    }
+    0
+}

--- a/crates/minip2p/benches/endpoint_e2e.rs
+++ b/crates/minip2p/benches/endpoint_e2e.rs
@@ -19,9 +19,20 @@ enum Kind {
 }
 
 fn bind(kind: Kind) -> Endpoint {
+    bind_with_retry(kind, true)
+}
+
+fn bind_with_retry(kind: Kind, retry: bool) -> Endpoint {
     let builder = Endpoint::builder()
         .agent_version("minip2p-bench")
         .protocol(ECHO);
+    let builder = match kind {
+        Kind::Quic if !retry => builder.quic_limits(minip2p::QuicLimits {
+            require_address_validation: false,
+            ..minip2p::QuicLimits::default()
+        }),
+        _ => builder,
+    };
     match kind {
         Kind::Tcp => builder.bind_tcp("127.0.0.1:0"),
         Kind::Quic => builder.bind_quic("127.0.0.1:0"),
@@ -37,7 +48,11 @@ struct EchoServer {
 
 impl EchoServer {
     fn start(kind: Kind) -> Self {
-        let mut endpoint = bind(kind);
+        Self::start_with_retry(kind, true)
+    }
+
+    fn start_with_retry(kind: Kind, retry: bool) -> Self {
+        let mut endpoint = bind_with_retry(kind, retry);
         let address = endpoint.listen().expect("listen");
         let stop = Arc::new(AtomicBool::new(false));
         let worker_stop = Arc::clone(&stop);
@@ -203,11 +218,15 @@ impl Crossed {
 
 impl Pair {
     fn disconnected(kind: Kind) -> Self {
-        let server = EchoServer::start(kind);
+        Self::disconnected_with_retry(kind, true)
+    }
+
+    fn disconnected_with_retry(kind: Kind, retry: bool) -> Self {
+        let server = EchoServer::start_with_retry(kind, retry);
         let peer = server.address.peer_id().clone();
         Self {
             _server: server,
-            client: bind(kind),
+            client: bind_with_retry(kind, retry),
             peer,
         }
     }
@@ -316,6 +335,35 @@ fn suite(c: &mut Criterion, kind: Kind, transport: &str) {
             BatchSize::SmallInput,
         )
     });
+    group.bench_function("oneshot_64b", |b| {
+        b.iter_batched_ref(
+            || Pair::disconnected(kind),
+            |pair| {
+                pair.connect();
+                pair.echo(vec![0x5a; 64], 1);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    if matches!(kind, Kind::Quic) {
+        group.bench_function("setup_no_retry", |b| {
+            b.iter_batched_ref(
+                || Pair::disconnected_with_retry(kind, false),
+                Pair::connect,
+                BatchSize::SmallInput,
+            )
+        });
+        group.bench_function("oneshot_64b_no_retry", |b| {
+            b.iter_batched_ref(
+                || Pair::disconnected_with_retry(kind, false),
+                |pair| {
+                    pair.connect();
+                    pair.echo(vec![0x5a; 64], 1);
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
     let mut ping = Pair::connected(kind);
     group.bench_function("ping", |b| b.iter(|| ping.ping()));
     let mut echo = Pair::connected(kind);

--- a/docs/research/quic-cost.md
+++ b/docs/research/quic-cost.md
@@ -1,0 +1,188 @@
+# QUIC cost vs HTTPS-like one-shot
+
+Investigation of whether minip2p's QUIC adapter can be tuned toward HTTPS loopback latency and memory without breaking Sans-I/O, sync, or no_std goals.
+
+Pinned to `main` at `786f187` (post v0.5.3, including PR #123). Probes:
+
+```bash
+cargo bench -p minip2p-quic --bench cost_probe
+cargo bench -p minip2p-rs --features quic --bench cost_probe
+cargo bench -p minip2p-quic --bench idle_poll
+```
+
+Numbers below are from a Linux x86_64 cloud VM, rustc 1.91.0, release. They are not the M2 figures in the original comparison. Use the splits, not the absolute milliseconds, when comparing to HTTPS p50 0.49 ms on another host.
+
+## Verdict
+
+The ~2× loopback gap is not hiding in quiche send/recv buffering, pending write queues, or `drain_send_queue`. A warm QUIC transport handshake already sits next to the HTTPS establish+1-RTT number. What HTTPS does not do, minip2p does after the crypto handshake:
+
+1. Stateless Retry (on by default).
+2. Identify (required for `PeerReady`).
+3. A second multistream-select round for the application stream.
+
+Noise and Yamux are TCP-only. QUIC uses libp2p TLS 1.3 via BoringSSL and native QUIC streams. Chasing a QUIC rewrite will not close the gap.
+
+Memory is a different story. Holding 200 idle QUIC connections on two transports costs about 59 kB/conn combined (both sides). One Endpoint per peer session costs about 136 kB per client, which matches the reported 124 kB cold first-touch. Most of that is Endpoint construction (64 KiB stream read buffer, BoringSSL context, swarm/Identify state), not extra bytes inside quiche.
+
+No production patch in this change. The remaining adapter tweaks are real but they shave idle CPU or dual-stack construct time. They do not make one-shot look like HTTPS.
+
+## Measured split
+
+### Transport only (no Identify, no multistream-select)
+
+| Work | p50 | notes |
+| --- | ---: | --- |
+| `Ed25519Keypair::generate` | 0.028 ms | |
+| libp2p TLS cert (P-256 + X.509) | 0.423 ms | inside every `QuicTransport::new` |
+| `QuicTransport::new` | 0.471 ms | cert + BoringSSL context + bind + 64 KiB heap buffer |
+| handshake, Retry on | 0.542 ms | reused client transport |
+| handshake, Retry off | 0.500 ms | `require_address_validation: false` |
+| handshake + native 9-byte echo, Retry on | 0.619 ms | |
+| handshake + native 9-byte echo, Retry off | 0.577 ms | |
+
+Retry is ~40 µs on this loopback, not hundreds. Cert generation is ~0.42 ms and is paid again for every new Endpoint.
+
+`size_of::<quiche::Connection>()` is 15,152 bytes. That is the struct, not RSS. Heap on top of it is the rest of per-connection memory.
+
+### Endpoint (Identify + application stream)
+
+Timed section is dial → `wait_peer_ready` (Identify complete) → optional 64-byte echo. Construction is outside the timer, matching a reused process with a new session.
+
+| Work | p50 |
+| --- | ---: |
+| `Endpoint::bind_quic` | 0.480 ms |
+| setup, Retry on | 0.855 ms |
+| setup, Retry off | 0.753 ms |
+| oneshot 64-byte echo, Retry on | 0.947 ms |
+| oneshot 64-byte echo, Retry off | 0.805 ms |
+
+Against the 0.542 ms transport handshake:
+
+- Identify + its multistream-select: ~0.31 ms
+- Application stream + 64-byte echo: ~0.09 ms
+- Retry on the Endpoint path: ~0.14 ms (noisier than the transport-only 40 µs because the server thread is also running Identify)
+
+Reported user number was QUIC oneshot ~1.04 ms. This VM's oneshot with Retry is 0.95 ms. Same shape.
+
+### Idle poll after PR #123
+
+PR #123 reused the stream read buffer, cached the bound address, and cut idle poll ~73% (64 conns: 48.7 µs → 13.3 µs on M2).
+
+This VM, current main:
+
+| Conns | idle `poll` |
+| ---: | ---: |
+| 1 | 1.43 µs |
+| 64 | 11.4 µs |
+| 256 | 42.4 µs |
+| 512 | 157 µs |
+
+About 0.3 µs per idle connection. Further cuts here help a relay with hundreds of quiet peers. They do not move one-shot latency.
+
+### RSS
+
+Transport pair, many QUIC connections, Retry off, 1-hour idle timeout:
+
+| n | delta RSS | per conn combined |
+| ---: | ---: | ---: |
+| 50 | 3080 kB | ~61 kB |
+| 200 | 11836 kB | ~59 kB |
+
+That is both client and server in one process, so ~30 kB/side. The advertised 10 MB connection window is not preallocated.
+
+One Endpoint per client against one shared server:
+
+| clients | delta RSS | per client |
+| ---: | ---: | ---: |
+| 1 | 164 kB | 164 kB |
+| 20 | 2756 kB | 137 kB |
+| 50 | 6808 kB | 136 kB |
+
+This is the 124 kB cold first-touch shape: a new Endpoint is a 64 KiB stream buffer, a BoringSSL context, a generated cert, mio, swarm, and one quiche connection.
+
+## What PR #123 already took
+
+- One reused `stream_read_buffer` (64 KiB heap) instead of allocating per readable stream.
+- Bound socket address cached; UDP recv still uses a 64 KiB **stack** buffer in `poll`, which is fine.
+- CID indexing without a full-table scan.
+- Idle poll no longer walks work that PR #123 measured as dominant.
+
+Still allocated on the packet path, and not worth a rewrite for one-shot:
+
+- `drain_send_queue` collects stream keys into a `Vec` on every drain. Empty maps do not heap-allocate. Many streams on a busy connection would. Skip-if-empty is a few lines if idle CPU at 512 conns ever shows up in a profile.
+- `poll_streams` runs `drain` + `flush` + GC on every established connection every `poll`, even when nothing was received. Same category.
+- `StreamData` still `to_vec()`s the readable slice. That is the transport contract (owned event payloads), not a quiche mistake.
+
+## Ranked opportunities
+
+Impact is against the stated goals (oneshot latency toward 0.49 ms, idle ~42 kB/conn, cold ~124 kB). Effort and risk are adapter-local unless noted.
+
+### 1. Stop treating Identify as part of one-shot  (high impact, high effort, API/risk)
+
+`PeerReady` waits for Identify. HTTPS has no equivalent round trip. Skipping Identify, or making `open_stream` legal before `PeerReady` when the caller already knows the protocol list, is a swarm change. It is the only lever that can give back the ~0.31 ms.
+
+Do not do this silently. NAT, relay, and DCUtR consume Identify addresses. A one-shot mode would have to say so.
+
+### 2. Reuse an Endpoint  (high impact, no code, no risk)
+
+Cold construct is 0.48 ms, almost entirely libp2p cert generation (0.42 ms). A process that builds one Endpoint per HTTP-like request pays that every time, plus 64 KiB + BoringSSL, which is the 136 kB/client figure.
+
+HTTPS servers load a cert once. minip2p should too: one Endpoint, many `dial`s. Swarm is last-connection-wins per peer, so many concurrent peers need many PeerIds (many clients) or one server accepting many clients. They do not need many Endpoints on the client if the client talks to one server.
+
+### 3. Turn off Retry for trusted listeners  (medium latency, already shipped)
+
+`QuicLimits::require_address_validation` defaults to `true`. That is the right default on the public internet. On loopback or a private one-shot listener it adds a Retry RTT.
+
+This VM: ~40 µs transport-only, ~140 µs on the Endpoint oneshot path. Not the 2×, but it is the only QUIC config knob that is visible in the oneshot number today.
+
+Do not default it off. Amplification defense is why it exists.
+
+### 4. Cache the generated cert on `QuicNodeConfig`  (low latency, small patch, low risk)
+
+`build_quiche_config` calls `generate_certificate` on every `QuicTransport::new`. Dual-stack clones the config and generates twice. An `Arc<OnceLock<(Vec<u8>, Vec<u8>)>>` on the config would share one P-256 cert across those sockets.
+
+Does not help a single `bind_quic`. Helps `dual_stack` construct (~0.42 ms saved). Fine follow-up, not the oneshot gap.
+
+### 5. Shrink or knob the 64 KiB stream read buffer  (medium memory for cold Endpoint, small patch)
+
+`STREAM_READ_BUFFER_SIZE` is 65,535 and lives for the lifetime of the transport. `stream_recv` already loops, so 8 KiB would be correct and would save ~56 kB per Endpoint. Cold 136 kB → ~80 kB. Still above HTTPS 42 kB.
+
+Cost: a 1 MiB transfer becomes more `StreamData` events (owned `Vec`s). Either keep 64 KiB as default and add `QuicLimits::stream_read_buffer_size`, or pick 16 KiB and re-bench `e2e/quic/transfer_1mib`.
+
+Does almost nothing for the 59 kB/conn many-connection hold, where the buffer is amortized.
+
+### 6. Skip `poll_streams` when the connection got no packet  (low idle CPU, small patch, low risk)
+
+After PR #123 this is ~0.3 µs/conn. Only interesting on a relay. Flag connections that received in this `poll` and skip the rest, still running `handle_timeout` / keepalive.
+
+## What not to chase
+
+- **A Tokio or async rewrite.** The driver is already packet-woken via `wait_for_input`. Handshake is not sleeping on the 1 ms timer roundup (`deadline_for_timeout` only affects quiche's loss/idle timers).
+- **Noise XX / Yamux on QUIC.** They are not on this path. TCP pays them; QUIC pays libp2p TLS + native streams + Identify.
+- **quiche itself, datagram caps, connection HashMaps.** Warm handshake is 0.50 ms with Retry off, next to HTTPS 0.49 ms on the other machine. Adapter maps are tiny next to a 15 kB `quiche::Connection`.
+- **Hardcoded 10 MB / 1 MB flow-control windows for RSS.** 200 idle conns are ~30 kB/side. quiche is not reserving the advertised window. Shrinking windows is a throughput/NAT tradeoff with no measured RSS win here.
+- **`drain_send_queue` key collection, pending write queues, as the oneshot story.** Empty-queue collect is a non-allocating iterator. Pending writes exist for flow control, not for a 9-byte echo.
+- **Keepalive / 30 s idle timeout for one-shot.** One-shot connections close. The 15 s ping matters for NAT reservations (`NatConfig::reservation_keep_alive_interval_ms`), which is working as designed (issue #83).
+- **Pretending a QUIC micro-optimization gets to 0.49 ms.** The missing 0.4–0.5 ms is Identify + app negotiation + Retry, sitting on a handshake that is already HTTPS-shaped.
+
+## Config knobs that matter for one-shot or many short-lived peers
+
+Already exist:
+
+- `require_address_validation` (Retry RTT on inbound)
+- `idle_timeout_ms` (30 s default, keepalive at half)
+- `max_connections` / `max_streams_per_connection` / `max_pending_stream_bytes` / `max_pending_datagrams`
+
+Missing, and the only QUIC-local memory knobs that would help one Endpoint per session:
+
+- cert reuse on `QuicNodeConfig` (construct CPU)
+- stream read buffer size (cold RSS)
+- flow-control windows in `QuicLimits` (not shown to affect RSS; useful if a later bulk-transfer tune wants them)
+
+## Recommended next steps
+
+1. If the product is HTTP-like one-shot, decide whether Identify is required before the first application stream. That is a swarm/Endpoint design issue, not a quiche issue.
+2. Document that one Endpoint per request is the expensive shape, and that Retry is optional for trusted listeners.
+3. Optional small follow-ups, each with its own microbench: cert `OnceLock` on `QuicNodeConfig`; `stream_read_buffer_size` limit; idle `poll_streams` skip.
+
+Re-run the probes on the HTTPS comparison host before treating any of these milliseconds as SLOs.

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -37,3 +37,7 @@ minip2p-identity = { path = "../../crates/identity" }
 [[bench]]
 name = "idle_poll"
 harness = false
+
+[[bench]]
+name = "cost_probe"
+harness = false

--- a/transports/quic/benches/cost_probe.rs
+++ b/transports/quic/benches/cost_probe.rs
@@ -1,0 +1,378 @@
+//! One-shot QUIC cost probe: handshake latency, Identify-free echo, and RSS.
+//!
+//! This is an investigation harness, not a Criterion suite. It drives the
+//! socket with `wait_for_input` the same way a production host does, so the
+//! numbers are comparable to Endpoint loopback rather than the 5 ms sleep
+//! used by the QUIC integration tests.
+
+use std::mem::size_of;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use minip2p_core::PeerAddr;
+use minip2p_platform::{Clock, StdClock};
+use minip2p_quic::{QuicLimits, QuicNodeConfig, QuicTransport};
+use minip2p_transport::{BlockingTransport, Transport, TransportEvent, WaitHandle};
+
+const SAMPLES: usize = 200;
+const WARMUP: usize = 20;
+const ECHO: &[u8] = b"tiny-echo";
+const WAIT: Duration = Duration::from_millis(50);
+
+fn main() {
+    println!("minip2p-quic cost probe  samples={SAMPLES}  warmup={WARMUP}");
+    print_sizes();
+
+    probe_construct();
+    probe_construct_parts();
+    probe_handshake("handshake/retry", default_limits(true));
+    probe_handshake("handshake/no-retry", default_limits(false));
+    probe_echo("echo-64b/retry", default_limits(true));
+    probe_echo("echo-64b/no-retry", default_limits(false));
+    probe_rss();
+}
+
+fn default_limits(retry: bool) -> QuicLimits {
+    QuicLimits {
+        require_address_validation: retry,
+        idle_timeout_ms: 30_000,
+        ..QuicLimits::default()
+    }
+}
+
+fn print_sizes() {
+    println!(
+        "sizeof QuicTransport={}  QuicConnection is not public; quiche::Connection={}",
+        size_of::<QuicTransport>(),
+        size_of::<quiche::Connection>(),
+    );
+    println!(
+        "sizeof quiche::Config={}  QuicNodeConfig={}",
+        size_of::<quiche::Config>(),
+        size_of::<QuicNodeConfig>(),
+    );
+}
+
+fn probe_construct() {
+    let mut samples = Vec::with_capacity(SAMPLES);
+    for i in 0..WARMUP + SAMPLES {
+        let started = Instant::now();
+        let transport = QuicTransport::new(QuicNodeConfig::generate(), "127.0.0.1:0")
+            .expect("construct transport");
+        let elapsed = started.elapsed();
+        drop(transport);
+        if i >= WARMUP {
+            samples.push(elapsed);
+        }
+    }
+    report("construct/QuicTransport", &samples);
+}
+
+fn probe_construct_parts() {
+    use minip2p_identity::Ed25519Keypair;
+    let mut keygen = Vec::with_capacity(SAMPLES);
+    let mut certs = Vec::with_capacity(SAMPLES);
+    let mut bind = Vec::with_capacity(SAMPLES);
+    for i in 0..WARMUP + SAMPLES {
+        let started = Instant::now();
+        let keypair = Ed25519Keypair::generate();
+        let after_key = started.elapsed();
+        let _ = minip2p_tls::generate_certificate(&keypair).expect("cert");
+        let after_cert = started.elapsed();
+        let transport =
+            QuicTransport::new(QuicNodeConfig::new(keypair), "127.0.0.1:0").expect("bind");
+        let after_new = started.elapsed();
+        drop(transport);
+        if i >= WARMUP {
+            keygen.push(after_key);
+            certs.push(after_cert.saturating_sub(after_key));
+            bind.push(after_new.saturating_sub(after_cert));
+        }
+    }
+    report("construct/keypair", &keygen);
+    report("construct/libp2p-cert", &certs);
+    report("construct/new(existing-key)", &bind);
+}
+
+fn probe_handshake(label: &str, limits: QuicLimits) {
+    let server = Server::spawn(limits.clone(), Mode::Handshake);
+    let mut samples = Vec::with_capacity(SAMPLES);
+    let mut client = bind_client(limits);
+    for i in 0..WARMUP + SAMPLES {
+        let started = Instant::now();
+        handshake(&mut client, &server.addr);
+        let elapsed = started.elapsed();
+        if i >= WARMUP {
+            samples.push(elapsed);
+        }
+    }
+    drop(server);
+    report(label, &samples);
+}
+
+fn probe_echo(label: &str, limits: QuicLimits) {
+    let server = Server::spawn(limits.clone(), Mode::Echo);
+    let mut samples = Vec::with_capacity(SAMPLES);
+    let mut client = bind_client(limits);
+    for i in 0..WARMUP + SAMPLES {
+        let started = Instant::now();
+        echo(&mut client, &server.addr);
+        let elapsed = started.elapsed();
+        if i >= WARMUP {
+            samples.push(elapsed);
+        }
+    }
+    drop(server);
+    report(label, &samples);
+}
+
+fn probe_rss() {
+    let empty = rss_kb();
+    println!("rss empty process after previous probes: {empty} kB (noisy; see isolated run below)");
+
+    let counts = [1usize, 50, 200];
+    for &count in &counts {
+        let (baseline, held, client_ids, server_ids) = rss_idle_pair(count);
+        let delta = held.saturating_sub(baseline);
+        let per = delta / count as u64;
+        println!(
+            "  idle n={count:<3}  baseline={baseline} kB  held={held} kB  delta={delta} kB  ~{per} kB/conn  (client={client_ids} server={server_ids})"
+        );
+    }
+}
+
+fn rss_idle_pair(count: usize) -> (u64, u64, usize, usize) {
+    let limits = QuicLimits {
+        idle_timeout_ms: 3_600_000,
+        require_address_validation: false,
+        max_connections: count + 8,
+        ..QuicLimits::default()
+    };
+    let mut server = QuicTransport::new(
+        QuicNodeConfig::generate().with_limits(limits.clone()),
+        "127.0.0.1:0",
+    )
+    .expect("server");
+    let mut client = QuicTransport::new(
+        QuicNodeConfig::generate().with_limits(limits),
+        "127.0.0.1:0",
+    )
+    .expect("client");
+    server.listen_on_bound_addr().expect("listen");
+    let addr = server.local_peer_addr().expect("addr");
+    let server_peer = addr.peer_id().clone();
+    let client_peer = client.local_peer_id();
+    let baseline = rss_kb();
+    let mut clock = StdClock::with_epoch(Instant::now());
+    let mut started = 0;
+    while started != count {
+        client.dial(&addr).expect("dial");
+        started += 1;
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while server.connection_ids_for_peer(&client_peer).len() != started
+            || client.connection_ids_for_peer(&server_peer).len() != started
+        {
+            drop(server.poll(clock.now()).expect("server poll"));
+            drop(client.poll(clock.now()).expect("client poll"));
+            assert!(Instant::now() < deadline, "idle pair setup timed out");
+            if server.connection_ids_for_peer(&client_peer).len() != started
+                || client.connection_ids_for_peer(&server_peer).len() != started
+            {
+                thread::sleep(Duration::from_millis(1));
+            }
+        }
+    }
+    drop(server.poll(clock.now()).expect("server poll"));
+    drop(client.poll(clock.now()).expect("client poll"));
+    let held = rss_kb();
+    (
+        baseline,
+        held,
+        client.connection_ids_for_peer(&server_peer).len(),
+        server.connection_ids_for_peer(&client_peer).len(),
+    )
+}
+
+fn handshake(client: &mut QuicTransport, addr: &PeerAddr) {
+    let id = client.dial(addr).expect("dial");
+    drive_client(
+        client,
+        |event| matches!(event, TransportEvent::Connected { id: got, .. } if *got == id),
+    );
+    match client.close(id) {
+        Ok(()) | Err(_) => {}
+    }
+    let mut clock = StdClock::with_epoch(Instant::now());
+    drop(client.poll(clock.now()).expect("reap poll"));
+}
+
+fn echo(client: &mut QuicTransport, addr: &PeerAddr) {
+    let id = client.dial(addr).expect("dial");
+    drive_client(
+        client,
+        |event| matches!(event, TransportEvent::Connected { id: got, .. } if *got == id),
+    );
+    let stream = client.open_stream(id).expect("open");
+    client.send_stream(id, stream, ECHO.to_vec()).expect("send");
+    drive_client(client, |event| {
+        matches!(
+            event,
+            TransportEvent::StreamData {
+                id: got,
+                data,
+                ..
+            } if *got == id && data == ECHO
+        )
+    });
+    match client.close(id) {
+        Ok(()) | Err(_) => {}
+    }
+    let mut clock = StdClock::with_epoch(Instant::now());
+    drop(client.poll(clock.now()).expect("reap poll"));
+}
+
+fn drive_client(client: &mut QuicTransport, mut done: impl FnMut(&TransportEvent) -> bool) {
+    let mut clock = StdClock::with_epoch(Instant::now());
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        assert!(Instant::now() < deadline, "client drive timed out");
+        let events = client.poll(clock.now()).expect("client poll");
+        if events.iter().any(&mut done) {
+            return;
+        }
+        client.wait_for_input(WAIT);
+    }
+}
+
+fn bind_client(limits: QuicLimits) -> QuicTransport {
+    QuicTransport::new(
+        QuicNodeConfig::generate().with_limits(limits),
+        "127.0.0.1:0",
+    )
+    .expect("client bind")
+}
+
+#[derive(Clone, Copy)]
+enum Mode {
+    Handshake,
+    Echo,
+}
+
+struct Server {
+    addr: PeerAddr,
+    stop: Arc<AtomicBool>,
+    interrupt: WaitHandle,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl Server {
+    fn spawn(limits: QuicLimits, mode: Mode) -> Self {
+        let mut server = QuicTransport::new(
+            QuicNodeConfig::generate().with_limits(limits),
+            "127.0.0.1:0",
+        )
+        .expect("server bind");
+        server.listen_on_bound_addr().expect("listen");
+        let addr = server.local_peer_addr().expect("addr");
+        let interrupt = server.wait_handle();
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_stop = Arc::clone(&stop);
+        let thread = thread::spawn(move || {
+            let mut clock = StdClock::with_epoch(Instant::now());
+            let mut echo_streams = Vec::new();
+            while !worker_stop.load(Ordering::Relaxed) {
+                let events = server.poll(clock.now()).expect("server poll");
+                for event in events {
+                    match (mode, event) {
+                        (_, TransportEvent::Connected { id, .. }) => {
+                            if matches!(mode, Mode::Handshake) {
+                                match server.close(id) {
+                                    Ok(()) | Err(_) => {}
+                                }
+                            }
+                        }
+                        (
+                            Mode::Echo,
+                            TransportEvent::StreamData {
+                                id,
+                                stream_id,
+                                data,
+                            },
+                        ) => {
+                            echo_streams.push((id, stream_id));
+                            match server.send_stream(id, stream_id, data) {
+                                Ok(()) | Err(_) => {}
+                            }
+                        }
+                        (_, TransportEvent::Closed { id }) => {
+                            echo_streams.retain(|(conn, _)| *conn != id);
+                        }
+                        _ => {}
+                    }
+                }
+                server.wait_for_input(WAIT);
+            }
+        });
+        Self {
+            addr,
+            stop,
+            interrupt,
+            thread: Some(thread),
+        }
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        self.interrupt.interrupt();
+        if let Some(thread) = self.thread.take() {
+            thread.join().expect("server thread");
+        }
+    }
+}
+
+fn report(label: &str, samples: &[Duration]) {
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let last = sorted.len().saturating_sub(1);
+    let p = |hundredths: usize| {
+        let idx = last.saturating_mul(hundredths) / 100;
+        sorted.get(idx.min(last)).copied().expect("samples")
+    };
+    let sum: Duration = sorted.iter().copied().sum();
+    let mean = sum / u32::try_from(sorted.len()).expect("sample count fits u32");
+    println!(
+        "{label:<24}  n={}  p50={}  p90={}  p99={}  mean={}  min={}  max={}",
+        sorted.len(),
+        fmt(p(50)),
+        fmt(p(90)),
+        fmt(p(99)),
+        fmt(mean),
+        fmt(sorted.first().copied().expect("samples")),
+        fmt(sorted.last().copied().expect("samples")),
+    );
+}
+
+fn fmt(d: Duration) -> String {
+    format!("{:.3} ms", d.as_secs_f64() * 1_000.0)
+}
+
+fn rss_kb() -> u64 {
+    let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
+        return 0;
+    };
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            let kb = rest
+                .split_whitespace()
+                .next()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+            return kb;
+        }
+    }
+    0
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The ~2× loopback gap versus HTTPS is not in the QUIC adapter hot path. A warm transport handshake is already HTTPS-shaped. What HTTPS does not do after crypto, minip2p does: Retry, Identify, then a second multistream-select for the app stream.

No adapter rewrite in this PR. The write-up and probes are the deliverable.

## Verdict

On a Linux x86_64 VM (rustc 1.91.0, not the original M2 host):

| Layer | p50 |
| --- | ---: |
| libp2p TLS cert generation | 0.42 ms |
| `QuicTransport::new` / `Endpoint::bind_quic` | 0.47–0.48 ms |
| QUIC handshake, Retry off | 0.50 ms |
| QUIC handshake, Retry on | 0.54 ms |
| Endpoint `PeerReady` (includes Identify) | 0.75–0.86 ms |
| Endpoint oneshot 64-byte echo | 0.81–0.95 ms |

That oneshot number is the same shape as the reported 1.04 ms. Split against the 0.54 ms handshake:

- Identify + its multistream-select: ~0.31 ms
- Application stream + 64-byte echo: ~0.09 ms
- Retry: ~40 µs transport-only, ~0.14 ms on the Endpoint path

Noise and Yamux are TCP-only. QUIC uses libp2p TLS and native streams. Tweaking `drain_send_queue`, datagram caps, or connection maps will not make one-shot look like HTTPS.

## Memory

- 200 idle QUIC connections on two transports: ~59 kB/conn combined (~30 kB/side). The 10 MB advertised window is not preallocated.
- One Endpoint per client session: ~136 kB/client. Matches the 124 kB cold first-touch. Most of it is Endpoint construct (64 KiB stream read buffer, BoringSSL, swarm), not extra quiche bytes.

PR #123 already cut idle poll ~73%. Current idle poll is ~0.3 µs/conn. Further skip-if-empty work is a relay CPU nicety, not oneshot latency.

## Ranked next steps (not done here)

1. Decide whether Identify is required before the first application stream. That is the only lever that can give back ~0.31 ms. NAT/relay/DCUtR consume Identify addresses, so this is a swarm design choice.
2. Reuse one Endpoint instead of one Endpoint per request. Cold construct is 0.48 ms of P-256 cert generation plus 64 KiB + BoringSSL.
3. `require_address_validation: false` on trusted listeners. Already a knob. Do not change the default.
4. Optional small follow-ups: cache the generated cert on `QuicNodeConfig` (helps dual-stack construct); `stream_read_buffer_size` limit (helps cold RSS, not the 59 kB/conn hold).

## What not to chase

Tokio rewrite, Noise/Yamux on QUIC, quiche internals, shrinking flow-control windows for RSS, keepalive/idle timeout for one-shot, `drain_send_queue` as the oneshot story.

Full write-up: `docs/research/quic-cost.md`. Re-run:

```bash
cargo bench -p minip2p-quic --bench cost_probe
cargo bench -p minip2p-rs --features quic --bench cost_probe
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-197bf3be-b3e0-43b7-8cde-0d0473ff0205?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-197bf3be-b3e0-43b7-8cde-0d0473ff0205&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds QUIC cost-probe benchmarks and a research doc showing the ~2x loopback gap versus HTTPS comes from Identify, a second multistream-select, and Retry—not quiche send/recv buffering. No adapter behavior changes.

**Findings**
- Warm QUIC handshake (Retry off) is 0.50 ms, near HTTPS 0.49 ms; Identify + its select adds ~0.31 ms, app stream + echo ~0.09 ms, Retry ~40 µs transport-only.
- Idle QUIC connections hold ~59 kB/conn combined; one Endpoint per client costs ~136 kB, mostly 64 KiB stream buffer + BoringSSL + cert generation.
- The only lever to close the gap is deciding whether Identify is required before the first app stream; Retry is already a knob for trusted listeners.

<sup>Written for commit 98adbf02869a7b5b51fc1b24cc08b2783c36636d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

