### PR TITLE
Fix Node benchmark workflow for Vitest 5

### DIFF
--- a/bench/test_bench_results.py
+++ b/bench/test_bench_results.py
@@ -20,6 +20,38 @@ class BenchResultsTest(unittest.TestCase):
         self.current = bench_results.validate(bench_results.load_json(ROOT / "bench/fixtures/current.json"))
         self.baseline = bench_results.validate(bench_results.load_json(ROOT / "bench/fixtures/baseline.json"))
 
+    def test_vitest_5_latency_report(self):
+        report = {
+            "success": True,
+            "testResults": [{"assertionResults": [{
+                "status": "passed",
+                "benchmarks": [{"tasks": [
+                    {"name": name, "latency": {"p50": 2.5}}
+                    for name in sorted(bench_results.EXPECTED_VITEST)
+                ]}],
+            }]}],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "vitest.json"
+            output = Path(directory) / "results.json"
+            source.write_text(json.dumps(report))
+            bench_results.collect_vitest(source, output, "test-sha")
+            result = bench_results.load_json(output)
+            self.assertEqual(result["git_sha"], "test-sha")
+            self.assertEqual({row["name"] for row in result["rows"]}, bench_results.EXPECTED_VITEST)
+            self.assertTrue(all(row["value"] == 2_500_000 for row in result["rows"]))
+
+            report["success"] = False
+            source.write_text(json.dumps(report))
+            with self.assertRaises(bench_results.BenchError):
+                bench_results.collect_vitest(source, output, "test-sha")
+
+            report["success"] = True
+            report["testResults"][0]["assertionResults"][0]["benchmarks"][0]["tasks"].pop()
+            source.write_text(json.dumps(report))
+            with self.assertRaisesRegex(bench_results.BenchError, "row set mismatch"):
+                bench_results.collect_vitest(source, output, "test-sha")
+
     def test_locked_boundaries_and_missing_row(self):
         rows = bench_results.compare_rows(self.current, self.baseline, None)
         by_name = {row.name: row for row in rows}

--- a/bench/test_bench_results.py
+++ b/bench/test_bench_results.py
@@ -20,38 +20,6 @@ class BenchResultsTest(unittest.TestCase):
         self.current = bench_results.validate(bench_results.load_json(ROOT / "bench/fixtures/current.json"))
         self.baseline = bench_results.validate(bench_results.load_json(ROOT / "bench/fixtures/baseline.json"))
 
-    def test_vitest_5_latency_report(self):
-        report = {
-            "success": True,
-            "testResults": [{"assertionResults": [{
-                "status": "passed",
-                "benchmarks": [{"tasks": [
-                    {"name": name, "latency": {"p50": 2.5}}
-                    for name in sorted(bench_results.EXPECTED_VITEST)
-                ]}],
-            }]}],
-        }
-        with tempfile.TemporaryDirectory() as directory:
-            source = Path(directory) / "vitest.json"
-            output = Path(directory) / "results.json"
-            source.write_text(json.dumps(report))
-            bench_results.collect_vitest(source, output, "test-sha")
-            result = bench_results.load_json(output)
-            self.assertEqual(result["git_sha"], "test-sha")
-            self.assertEqual({row["name"] for row in result["rows"]}, bench_results.EXPECTED_VITEST)
-            self.assertTrue(all(row["value"] == 2_500_000 for row in result["rows"]))
-
-            report["success"] = False
-            source.write_text(json.dumps(report))
-            with self.assertRaises(bench_results.BenchError):
-                bench_results.collect_vitest(source, output, "test-sha")
-
-            report["success"] = True
-            report["testResults"][0]["assertionResults"][0]["benchmarks"][0]["tasks"].pop()
-            source.write_text(json.dumps(report))
-            with self.assertRaisesRegex(bench_results.BenchError, "row set mismatch"):
-                bench_results.collect_vitest(source, output, "test-sha")
-
     def test_locked_boundaries_and_missing_row(self):
         rows = bench_results.compare_rows(self.current, self.baseline, None)
         by_name = {row.name: row for row in rows}

--- a/bindings/ts/node/benches/ffi.bench.ts
+++ b/bindings/ts/node/benches/ffi.bench.ts
@@ -2,7 +2,7 @@
 
 import { setTimeout as delay } from "node:timers/promises";
 
-import { afterAll, beforeAll, bench, describe } from "vitest";
+import { afterAll, beforeAll, describe, test } from "vitest";
 
 import { Minip2p, generateSecretKey } from "../src/index.js";
 import { nativeBinding } from "../src/native.js";
@@ -49,45 +49,51 @@ afterAll(() => {
 });
 
 describe("node-ffi", () => {
-  bench("sdk_drain_flood", async () => {
-    const streams = await Promise.all(
-      Array.from({ length: BURST }, () =>
-        sdkA.openStream(sdkB.peerId(), PROTOCOL, { timeoutMs: TIMEOUT_MS })
-      )
-    );
-    for (const stream of streams) {
-      stream.abandon();
-    }
+  test("sdk_drain_flood", async ({ bench }) => {
+    await bench("sdk_drain_flood", async () => {
+      const streams = await Promise.all(
+        Array.from({ length: BURST }, () =>
+          sdkA.openStream(sdkB.peerId(), PROTOCOL, { timeoutMs: TIMEOUT_MS })
+        )
+      );
+      for (const stream of streams) {
+        stream.abandon();
+      }
+    }).run();
   });
 
-  bench("raw_drain_events", async () => {
-    const streams = Array.from({ length: BURST }, () =>
-      rawA.openStream(rawB.peerId(), PROTOCOL)
-    );
-    let seen = 0;
-    const deadline = Date.now() + TIMEOUT_MS;
-    while (seen < BURST && Date.now() < deadline) {
-      for (const event of rawA.drainEvents(256)) {
-        if (isNativeEvent(event) && event.tag === "StreamReady") {
-          seen += 1;
+  test("raw_drain_events", async ({ bench }) => {
+    await bench("raw_drain_events", async () => {
+      const streams = Array.from({ length: BURST }, () =>
+        rawA.openStream(rawB.peerId(), PROTOCOL)
+      );
+      let seen = 0;
+      const deadline = Date.now() + TIMEOUT_MS;
+      while (seen < BURST && Date.now() < deadline) {
+        for (const event of rawA.drainEvents(256)) {
+          if (isNativeEvent(event) && event.tag === "StreamReady") {
+            seen += 1;
+          }
+        }
+        if (seen < BURST) {
+          await delay(0);
         }
       }
-      if (seen < BURST) {
-        await delay(0);
+      if (seen !== BURST) {
+        throw new Error(`Timed out draining raw events: ${seen}/${BURST}`);
       }
-    }
-    if (seen !== BURST) {
-      throw new Error(`Timed out draining raw events: ${seen}/${BURST}`);
-    }
-    for (const stream of streams) {
-      rawA.abandonStream(rawB.peerId(), stream.streamId);
-    }
+      for (const stream of streams) {
+        rawA.abandonStream(rawB.peerId(), stream.streamId);
+      }
+    }).run();
   });
 
-  bench("connected_peers_sync", () => {
-    for (let index = 0; index < 1000; index += 1) {
-      sdkA.connectedPeers();
-    }
+  test("connected_peers_sync", async ({ bench }) => {
+    await bench("connected_peers_sync", () => {
+      for (let index = 0; index < 1000; index += 1) {
+        sdkA.connectedPeers();
+      }
+    }).run();
   });
 });
 

--- a/bindings/ts/node/package.json
+++ b/bindings/ts/node/package.json
@@ -36,7 +36,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "bench": "vitest bench --run --outputJson ../../../target/bench-node-vitest.json && python3 ../../../scripts/bench_results.py vitest --report ../../../target/bench-node-vitest.json --output ../../../target/bench-results/node-ffi.json --git-sha \"${BENCH_GIT_SHA:-$(git rev-parse HEAD)}\"",
+    "bench": "vitest bench --run --reporter=default --reporter=json --outputFile ../../../target/bench-node-vitest.json && python3 ../../../scripts/bench_results.py vitest --report ../../../target/bench-node-vitest.json --output ../../../target/bench-results/node-ffi.json --git-sha \"${BENCH_GIT_SHA:-$(git rev-parse HEAD)}\"",
     "build": "del-cli dist && tsc -p tsconfig.build.json",
     "clean": "del-cli dist",
     "native:build": "napi build --platform --no-js --dts ../../../target/minip2p-nodejs.d.ts --release --manifest-path ../../../crates/nodejs/Cargo.toml --output-dir . -- --locked",

--- a/scripts/bench_results.py
+++ b/scripts/bench_results.py
@@ -132,15 +132,19 @@ def collect_criterion(root: Path, output: Path, git_sha: str, since: Path) -> No
 
 
 def collect_vitest(report: Path, output: Path, git_sha: str) -> None:
+    document = load_json(report)
+    if document.get("success") is not True:
+        raise BenchError(f"Vitest benchmark run did not succeed: {report}")
     rows = []
-    for file in load_json(report).get("files", []):
-        for group in file.get("groups", []):
-            for benchmark in group.get("benchmarks", []):
-                median_ms = benchmark.get("median")
-                name = benchmark.get("name")
-                if not isinstance(name, str) or isinstance(median_ms, bool) or not isinstance(median_ms, (int, float)):
-                    raise BenchError(f"invalid Vitest benchmark in {report}")
-                rows.append({"tier": "node-ffi", "name": name, "metric": "median_ns", "value": median_ms * 1_000_000})
+    for file in document.get("testResults", []):
+        for assertion in file.get("assertionResults", []):
+            for benchmark in assertion.get("benchmarks", []):
+                for task in benchmark.get("tasks", []):
+                    median_ms = task.get("latency", {}).get("p50")
+                    name = task.get("name")
+                    if not isinstance(name, str) or isinstance(median_ms, bool) or not isinstance(median_ms, (int, float)):
+                        raise BenchError(f"invalid Vitest benchmark in {report}")
+                    rows.append({"tier": "node-ffi", "name": name, "metric": "median_ns", "value": median_ms * 1_000_000})
     names = {row["name"] for row in rows}
     if names != EXPECTED_VITEST or len(rows) != len(EXPECTED_VITEST):
         missing = sorted(EXPECTED_VITEST - names)


### PR DESCRIPTION
The benchmark workflow fails at the Node measurements because Vitest 5 removed `--outputJson`. It also replaced the standalone `bench()` API and the benchmark JSON structure.

Use context-based benchmarks and the JSON reporter, then collect `latency.p50` from the new report. The normalized result names and `median_ns` units stay unchanged. Reject unsuccessful runs and keep the required measurement-set check.

Validated with the full local Node benchmark command: all three measurements ran and the collector produced the normalized results. Root lint/format checks and workspace typechecks pass. No test changes are included.

Fixes the measurement failure in https://github.com/deepso7/minip2p/actions/runs/34272327940.
