### PR TITLE
docs: use Tailwind utilities and stack mobile landing buttons

### DIFF
--- a/docs/blume.config.ts
+++ b/docs/blume.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
   },
   navigation: {
     tabs: [
-      { label: "Docs", path: "/", href: "/intro" },
+      { href: "/intro", label: "Docs", path: "/" },
       { label: "Changelog", path: "/changelog" },
     ],
   },

--- a/docs/pages/index.astro
+++ b/docs/pages/index.astro
@@ -24,149 +24,66 @@ const { config, navigation, fontCssVars } = data;
     route: "/",
   }}
 >
-  <div class="landing">
-    <section class="hero" aria-labelledby="hero-title">
-      <p class="eyebrow">A minimal libp2p implementation</p>
-      <div class="hero-copy">
-        <h1 id="hero-title">Peer-to-peer.<br />Keep it simple.</h1>
-        <p class="lede">Connect applications over authenticated QUIC and TCP.</p>
-        <div class="actions">
-          <a class="primary" href="/intro">Read the docs <span aria-hidden="true">↗</span></a>
-          <a class="secondary" href="https://github.com/deepso7/minip2p">GitHub <span aria-hidden="true">↗</span></a>
+  <div class="mx-auto -mt-16 flex min-h-dvh max-w-7xl flex-col px-6 pt-16 lg:px-8">
+    <p class="m-0 shrink-0 pt-3 text-center sm:pt-4 font-mono text-xs text-muted-foreground lg:pt-8 landscape:max-lg:pt-2">
+      A minimal libp2p implementation
+    </p>
+    <section
+      class="grid flex-1 grid-cols-1 content-evenly items-center gap-2 py-3 text-center sm:gap-4 sm:py-4 lg:grid-cols-3 lg:gap-8 lg:py-8 lg:text-left landscape:max-lg:grid-cols-2 landscape:max-lg:gap-2 landscape:max-lg:py-2"
+      aria-labelledby="hero-title"
+    >
+      <div>
+        <h1 class="m-0 text-3xl font-medium leading-tight tracking-tighter sm:text-4xl xl:text-5xl landscape:max-lg:text-3xl" id="hero-title">
+          Peer-to-peer.<br />Keep it simple.
+        </h1>
+        <p class="mx-auto my-3 max-w-xs text-sm leading-relaxed text-muted-foreground lg:mx-0 lg:my-6 lg:text-base landscape:max-lg:my-2">
+          Connect applications over authenticated QUIC and TCP.
+        </p>
+        <div class="mx-auto grid w-48 gap-3 sm:flex sm:w-auto sm:flex-wrap sm:justify-center lg:mx-0 lg:justify-start">
+          <a
+            class="inline-flex items-center justify-center gap-2 rounded-full border border-transparent bg-foreground px-3 py-3 text-sm font-medium text-background no-underline hover:bg-muted-foreground focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent sm:px-4 landscape:max-lg:py-2"
+            href="/intro"
+          >Read the docs <span aria-hidden="true">↗</span></a>
+          <a
+            class="inline-flex items-center justify-center gap-2 rounded-full border border-border px-3 py-3 text-sm font-medium text-foreground no-underline hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent sm:px-4 landscape:max-lg:py-2"
+            href="https://github.com/deepso7/minip2p"
+          >GitHub <span aria-hidden="true">↗</span></a>
         </div>
       </div>
-      <div class="hero-mark">
-        <img src="/logo.svg" alt="minip2p dinosaur connected to peer nodes" width="960" height="640" fetchpriority="high" draggable="false" />
+      <div class="relative isolate order-first w-28 select-none justify-self-center sm:w-48 lg:order-none lg:w-full landscape:max-lg:order-none landscape:max-lg:w-36">
+        <div class="pointer-events-none absolute inset-0 -z-10 scale-150 rounded-full bg-accent/15 blur-3xl" aria-hidden="true"></div>
+        <img
+          class="block h-auto w-full"
+          src="/logo.svg"
+          alt="minip2p dinosaur connected to peer nodes"
+          width="960"
+          height="640"
+          fetchpriority="high"
+          draggable="false"
+        />
       </div>
-      <nav class="platforms" aria-label="Get started by platform">
-        <a href="/rust/install"><span>Rust</span><small>Drive your own event loop.</small></a>
-        <a href="/typescript/start"><span>Node.js &amp; React Native</span><small>Promises and typed events.</small></a>
-        <a href="/rust/embedded-devices"><span>Embedded Rust</span><small>A portable no_std + alloc core.</small></a>
+      <nav class="flex flex-wrap justify-center gap-x-4 gap-y-2 lg:grid lg:justify-self-end lg:gap-7 landscape:max-lg:col-span-full" aria-label="Get started by platform">
+        <a class="group grid gap-1.5 py-1.5 text-foreground no-underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent" href="/rust/install">
+          <span class="text-xs font-medium underline-offset-4 group-hover:underline lg:text-sm">Rust</span>
+          <small class="hidden text-sm text-muted-foreground lg:block">Drive your own event loop.</small>
+        </a>
+        <a class="group grid gap-1.5 py-1.5 text-foreground no-underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent" href="/typescript/start">
+          <span class="text-xs font-medium underline-offset-4 group-hover:underline lg:text-sm">Node.js &amp; React Native</span>
+          <small class="hidden text-sm text-muted-foreground lg:block">Promises and typed events.</small>
+        </a>
+        <a class="group grid gap-1.5 py-1.5 text-foreground no-underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent" href="/rust/embedded-devices">
+          <span class="text-xs font-medium underline-offset-4 group-hover:underline lg:text-sm">Embedded Rust</span>
+          <small class="hidden text-sm text-muted-foreground lg:block">A portable no_std + alloc core.</small>
+        </a>
       </nav>
     </section>
-
+    <footer class="shrink-0 px-6 py-3 text-center sm:py-4 text-xs text-muted-foreground landscape:max-lg:py-2">
+      Made with <svg class="inline-block size-3.5 fill-accent align-middle" viewBox="0 0 24 24" role="img" aria-label="love"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78Z" /></svg> by <a
+        class="text-foreground no-underline underline-offset-4 hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent"
+        href="https://deepso.sh"
+        target="_blank"
+        rel="noopener noreferrer"
+      >deepso</a>
+    </footer>
   </div>
-  <footer slot="footer" class="credit">
-    Made with <svg class="heart" viewBox="0 0 24 24" role="img" aria-label="love" width="14" height="14"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78Z" /></svg> by <a href="https://deepso.sh" target="_blank" rel="noopener noreferrer">deepso</a>
-  </footer>
 </PageLayout>
-
-<style>
-  .credit {
-    padding: 0.75rem 1.5rem;
-    min-height: 3rem;
-    text-align: center;
-    color: var(--blume-muted-foreground);
-    font-size: 0.8125rem;
-  }
-
-  .heart { display: inline-block; fill: var(--blume-accent); vertical-align: -0.125em; }
-  .credit a { color: var(--blume-foreground); }
-  .credit a:hover { text-decoration: underline; text-underline-offset: 4px; }
-
-  .landing {
-    max-width: 90rem;
-    margin: 0 auto;
-    padding: 0 2rem;
-  }
-
-  .hero {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1.15fr) minmax(0, 1fr);
-    grid-template-rows: auto 1fr;
-    align-items: center;
-    column-gap: 2rem;
-    min-height: calc(100dvh - 7rem);
-    padding: clamp(1rem, 4dvh, 2.5rem) 0;
-  }
-  .eyebrow {
-    grid-column: 1 / -1;
-    text-align: center;
-    margin: 0;
-    color: var(--blume-muted-foreground);
-    font-family: var(--blume-font-mono, monospace);
-    font-size: 0.8rem;
-  }
-
-  h1 {
-    margin: 0;
-    font-size: clamp(2.25rem, 3.65vw, 3.5rem);
-    font-weight: 500;
-    letter-spacing: -0.055em;
-    line-height: 1.08;
-  }
-
-  .lede {
-    max-width: 21rem;
-    margin: 1.5rem 0;
-    color: var(--blume-muted-foreground);
-    font-size: 0.9375rem;
-    line-height: 1.7;
-  }
-
-  .hero-mark {
-    position: relative;
-    isolation: isolate;
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
-  .hero-mark::before {
-    content: "";
-    position: absolute;
-    z-index: -1;
-    inset: -45% -25%;
-    background: radial-gradient(ellipse, color-mix(in oklch, var(--blume-accent) 18%, transparent), transparent 65%);
-    pointer-events: none;
-  }
-
-  .hero-mark img { display: block; width: 100%; height: auto; }
-  .platforms { display: grid; gap: 1.75rem; justify-self: end; }
-  .platforms a { display: grid; gap: 0.4rem; color: var(--blume-foreground); }
-  .platforms a span { font-size: 0.875rem; font-weight: 500; }
-  .platforms small { font-size: 0.8125rem; color: var(--blume-muted-foreground); }
-  .platforms a:hover span { text-decoration: underline; text-underline-offset: 4px; }
-  .actions { display: flex; flex-wrap: wrap; gap: 0.75rem; }
-  a { text-decoration: none; }
-  a:focus-visible { outline: 2px solid var(--blume-accent); outline-offset: 5px; }
-  .actions a {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.8rem 1rem;
-    border: 1px solid transparent;
-    border-radius: 2rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-  }
-
-  .primary { background: var(--blume-foreground); color: var(--blume-background); }
-  .primary:hover { background: var(--blume-muted-foreground); }
-  .actions .secondary { color: var(--blume-foreground); border-color: var(--blume-border); }
-  .secondary:hover { background: var(--blume-muted); }
-  @media (max-width: 900px) {
-    .landing { padding-inline: 1.5rem; }
-    .hero { grid-template-columns: 1fr; grid-template-rows: auto auto auto auto; align-content: space-evenly; gap: 1rem; padding: 1rem 0; text-align: center; }
-    .eyebrow { margin: 0; }
-    .hero-mark { grid-row: 2; width: min(55%, 24dvh, 16rem); justify-self: center; }
-    h1 { font-size: clamp(2rem, 5dvh, 3.5rem); }
-    .lede { margin: 0.75rem auto; font-size: 0.875rem; }
-    .actions { justify-content: center; }
-    .platforms { justify-self: stretch; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.75rem; }
-  }
-
-  @media (max-width: 540px) {
-    .platforms { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.5rem 1rem; }
-    .platforms a { padding-block: 0.375rem; }
-    .platforms a span { font-size: 0.75rem; }
-    .platforms small { display: none; }
-  }
-  @media (max-height: 500px) and (min-width: 600px) {
-    .hero { grid-template-columns: 1fr 1fr; grid-template-rows: auto 1fr auto; gap: 0.5rem 1.5rem; }
-    .hero-mark { grid-row: 2; grid-column: 2; width: min(100%, 35dvh); }
-    .platforms { grid-column: 1 / -1; justify-self: center; display: flex; gap: 1.5rem; }
-    .platforms small { display: none; }
-    .lede { margin-block: 0.5rem; }
-    .actions a { padding: 0.5rem 0.75rem; }
-  }
-</style>


### PR DESCRIPTION
Replace the landing page's scoped CSS and custom dimensions with built-in Tailwind utilities, including the logo glow and responsive layout. Stack the Docs and GitHub buttons at equal widths on mobile and adjust spacing to keep the footer visible on small screens.

Validation: `pnpm docs:check` and `git diff --check` pass. Browser checks cover desktop, mobile portrait, and phone landscape; the stacked buttons also fit at 320×568 without scrolling. Blume reports the existing missing Git timestamp warning for the introduction page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the landing page's scoped CSS with built-in Tailwind utilities and stacks the Docs and GitHub buttons at equal widths on mobile so the footer stays visible on small screens.

**Refactors**
- Removes the custom `<style>` block; the logo glow and responsive layout now use utility classes.
- Moves the footer from the `footer slot` into the page container, changing where it renders in the layout.
- Sorts navigation tab keys in `blume.config.ts` for lint compliance.

<sup>Written for commit 33b44aedae54574fc8fc42e61973c58846739444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

