### PR TITLE
chore: add just clean for repo-wide artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Additional constraints: `unsafe` is forbidden workspace-wide; sockets, clocks, a
 just test          # nextest + doctests over the Endpoint feature matrix; needs cargo-nextest
 just clippy        # -D warnings, Endpoint TCP/discovery/mDNS variants, and fuzz/
 just fmt           # also formats fuzz/
+just clean         # Cargo targets, node_modules, Turbo caches, docs output
 just check-nostd   # all no_std crates on thumbv7em-none-eabi
 just fuzz 30       # needs nightly + cargo-fuzz
 ```

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ just test          # workspace tests, Endpoint feature matrix, and doctests
                    # requires cargo-nextest (https://get.nexte.st)
 just clippy        # warnings-as-errors, feature variants, and fuzz crate
 just fmt           # format the workspace and fuzz crate
+just clean         # Cargo targets, node_modules, Turbo caches, docs output
 just check-nostd   # no_std crates on thumbv7em-none-eabi
 just bench
 just fuzz 30       # requires nightly and cargo-fuzz

--- a/justfile
+++ b/justfile
@@ -4,6 +4,11 @@ fmt:
     cargo fmt --all
     cargo fmt --manifest-path fuzz/Cargo.toml
 
+# Wipe Cargo targets, node_modules, Turbo caches, docs output, and other
+# generated artifacts. Keeps code-ref/, fuzz corpus, and local identity keys.
+clean:
+    ./scripts/clean.sh
+
 check:
     cargo check --workspace --all-targets
     cargo check --manifest-path fuzz/Cargo.toml --all-targets

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "turbo run build",
     "clean": "turbo run clean",
+    "clean:all": "./scripts/clean.sh",
     "example": "pnpm --filter react-native-minip2p-example",
     "format": "ultracite fix",
     "lint": "ultracite check",

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -34,7 +34,7 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-root="$(cd "$(dirname "$0")/.." && pwd)"
+root="$(cd "$(dirname "$0")/.." && pwd -P)"
 cd "$root"
 
 # Nested git checkouts and editor/agent state are not build products.
@@ -68,8 +68,14 @@ extras=(
   target-linux
   tmp
   bindings/ts/react-native/lib
+  bindings/ts/react-native/build
+  bindings/ts/react-native/android/build
+  bindings/ts/react-native/android/app/libs
+  bindings/ts/react-native/android/src/main/jniLibs
+  bindings/ts/react-native/ios/build
   examples/react-native/android
   examples/react-native/ios
+  examples/react-native/web-build
   docs/snippets/quickstart/Cargo.lock
   docs/snippets/custom-stream/Cargo.lock
 )
@@ -105,24 +111,67 @@ if [[ ${#paths[@]} -eq 0 ]]; then
   exit 0
 fi
 
-# Drop duplicates and paths nested under another selected path so sizes
-# are not counted twice.
+in_array() {
+  local candidate="$1"
+  shift
+  local existing
+  for existing in "$@"; do
+    if [[ "$candidate" == "$existing" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Keep paths in the array. Newline-delimited sort would split a filename
+# that contains a newline and could turn it into a deletion target outside
+# the repository.
+unique=()
+for path in "${paths[@]}"; do
+  if in_array "$path" "${unique[@]+"${unique[@]}"}"; then
+    continue
+  fi
+  unique+=("$path")
+done
+
 kept=()
-while IFS= read -r path; do
+for path in "${unique[@]}"; do
   nested=false
-  for parent in "${kept[@]+"${kept[@]}"}"; do
-    case "$path" in
-      "$parent"/*)
-        nested=true
-        break
-        ;;
-    esac
+  for other in "${unique[@]}"; do
+    if [[ "$path" == "$other"/* ]]; then
+      nested=true
+      break
+    fi
   done
   if $nested; then
     continue
   fi
   kept+=("$path")
-done < <(printf '%s\n' "${paths[@]}" | sort -u)
+done
+
+in_repo() {
+  local path="$1"
+  local abs parent
+  case "$path" in
+    /* | .. | ../* | */.. | */../*)
+      return 1
+      ;;
+  esac
+  if [[ -d "$path" ]]; then
+    abs="$(cd "$path" && pwd -P)" || return 1
+  else
+    parent="$(cd "$(dirname "$path")" && pwd -P)" || return 1
+    abs="$parent/$(basename "$path")"
+  fi
+  case "$abs" in
+    "$root" | "$root"/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
 
 human_kib() {
   awk -v k="$1" 'BEGIN {
@@ -158,6 +207,10 @@ total_files=0
 removed=0
 
 for path in "${kept[@]}"; do
+  if ! in_repo "$path"; then
+    echo "skipping $path (outside repository)" >&2
+    continue
+  fi
   kib=$(du -sk "$path" 2>/dev/null | awk '{print $1}')
   kib=${kib:-0}
   files=$(find "$path" -type f -print | wc -l | tr -d ' ')

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/clean.sh [--dry-run]
+
+Remove generated artifacts from the minip2p repository: Cargo target
+directories, node_modules, Turbo caches, docs output, native addons, and
+other build products.
+
+Prints a cargo-clean-style summary of files and bytes reclaimed.
+
+Does not remove code-ref/, fuzz corpus, local identity keys, or editor
+state.
+EOF
+}
+
+dry_run=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      dry_run=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+# Nested git checkouts and editor/agent state are not build products.
+skip=(
+  -path './.git' -o
+  -path './code-ref' -o
+  -path './.delta' -o
+  -path './.repos' -o
+  -path './.claude'
+)
+
+dir_names=(
+  -name node_modules -o
+  -name target -o
+  -name .turbo -o
+  -name __pycache__ -o
+  -name .blume -o
+  -name .blume-verify -o
+  -name .expo -o
+  -name .pnpm-store -o
+  -name dist -o
+  -name coverage -o
+  -name artifacts -o
+  -name nitrogen -o
+  -name .cxx -o
+  -name .gradle -o
+  -name DerivedData
+)
+
+extras=(
+  target-linux
+  tmp
+  bindings/ts/react-native/lib
+  examples/react-native/android
+  examples/react-native/ios
+  docs/snippets/quickstart/Cargo.lock
+  docs/snippets/custom-stream/Cargo.lock
+)
+
+paths=()
+
+consider() {
+  local path="$1"
+  if [[ ! -e "$path" && ! -L "$path" ]]; then
+    return 0
+  fi
+  paths+=("$path")
+}
+
+while IFS= read -r -d '' path; do
+  consider "${path#./}"
+done < <(find . \( "${skip[@]}" \) -prune -o -type d \( "${dir_names[@]}" \) -prune -print0)
+
+for path in "${extras[@]}"; do
+  consider "$path"
+done
+
+while IFS= read -r -d '' path; do
+  consider "${path#./}"
+done < <(
+  find . \( "${skip[@]}" \) -prune -o \
+    -type d \( -name node_modules -o -name target \) -prune -o \
+    -type f -name '*.node' -print0
+)
+
+if [[ ${#paths[@]} -eq 0 ]]; then
+  echo "nothing to clean"
+  exit 0
+fi
+
+# Drop duplicates and paths nested under another selected path so sizes
+# are not counted twice.
+kept=()
+while IFS= read -r path; do
+  nested=false
+  for parent in "${kept[@]+"${kept[@]}"}"; do
+    case "$path" in
+      "$parent"/*)
+        nested=true
+        break
+        ;;
+    esac
+  done
+  if $nested; then
+    continue
+  fi
+  kept+=("$path")
+done < <(printf '%s\n' "${paths[@]}" | sort -u)
+
+human_kib() {
+  awk -v k="$1" 'BEGIN {
+    b = k * 1024
+    if (b < 1024) { printf "%.1fB", b; exit }
+    b /= 1024
+    if (b < 1024) { printf "%.1fKiB", b; exit }
+    b /= 1024
+    if (b < 1024) { printf "%.1fMiB", b; exit }
+    b /= 1024
+    if (b < 1024) { printf "%.1fGiB", b; exit }
+    b /= 1024
+    printf "%.1fTiB", b
+  }'
+}
+
+summary_phrase() {
+  local files="$1"
+  local dirs="$2"
+  if [[ "$files" -eq 0 && "$dirs" -eq 1 ]]; then
+    echo "1 directory"
+  elif [[ "$files" -eq 0 ]]; then
+    echo "$dirs directories"
+  elif [[ "$files" -eq 1 ]]; then
+    echo "1 file"
+  else
+    echo "$files files"
+  fi
+}
+
+total_kib=0
+total_files=0
+removed=0
+
+for path in "${kept[@]}"; do
+  kib=$(du -sk "$path" 2>/dev/null | awk '{print $1}')
+  kib=${kib:-0}
+  files=$(find "$path" -type f -print | wc -l | tr -d ' ')
+  files=${files:-0}
+  if $dry_run; then
+    if [[ "$kib" -gt 0 ]]; then
+      echo "would remove $path ($(human_kib "$kib"))"
+    else
+      echo "would remove $path"
+    fi
+  else
+    if [[ "$kib" -gt 0 ]]; then
+      echo "removing $path ($(human_kib "$kib"))"
+    else
+      echo "removing $path"
+    fi
+    rm -rf "$path"
+  fi
+  total_kib=$((total_kib + kib))
+  total_files=$((total_files + files))
+  removed=$((removed + 1))
+done
+
+total=$(human_kib "$total_kib")
+phrase=$(summary_phrase "$total_files" "$removed")
+if $dry_run; then
+  echo "Summary $phrase, $total total"
+else
+  echo "Removed $phrase, $total total"
+fi
+


### PR DESCRIPTION
After the root pnpm workspace landed, leftover package-local `node_modules` still pointed `pnpm dev` at missing binaries. There was also no single command to wipe Cargo targets, Turbo caches, docs output, and native addons together.

`just clean` now runs `scripts/clean.sh`. It deletes generated artifacts across the tree and prints a cargo-clean-style summary of files and bytes reclaimed. `pnpm clean` stays the lighter Turbo dist wipe. `pnpm clean:all` is the same as `just clean`.

The script leaves `code-ref/`, the fuzz corpus, local identity keys, and editor state in place.

Validation:
- `bash -n scripts/clean.sh`
- `./scripts/clean.sh --dry-run` listed leftover `node_modules` and reported `Summary 75920 files, 1.4GiB total`
- `just -n clean`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `just clean` to wipe generated artifacts repo-wide, fixing leftover package-local `node_modules` that broke `pnpm dev` and providing a single command for Cargo targets, Turbo caches, docs output, native addons, and React Native build outputs. Prints a cargo-clean-style summary of files and bytes reclaimed and refuses to delete anything outside the repository.

- Preserves `code-ref/`, fuzz corpus, local identity keys, and editor state.
- Supports `--dry-run` to preview what would be removed.
- `pnpm clean:all` is an alias; `pnpm clean` remains the lighter Turbo dist wipe.

<sup>Written for commit 8be94ea5975cba6b0cfad55ebbe8bc56a5d1e3dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

