### PR TITLE
Add a runnable Node.js ping example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The default swarm intentionally includes only identify, ping, and registered app
 
 The TypeScript SDK runs on Node.js through `@minip2p/node` and on React Native through `@minip2p/react-native`. Both packages expose the same application interface.
 
+Run the [Node.js ping example](examples/nodejs/README.md) to connect two local peers over QUIC or TCP.
+
 Every crate has its own README with API-specific details.
 
 ## Development

--- a/bindings/ts/node/README.md
+++ b/bindings/ts/node/README.md
@@ -21,6 +21,8 @@ endpoint.close();
 
 The Node binding accepts the same TCP, QUIC, circuit-relay, signed-discovery, and mDNS configuration as `@minip2p/react-native`.
 
+For a runnable two-peer example, see the [Node.js ping example](https://github.com/deepso7/minip2p/tree/main/examples/nodejs).
+
 ## Development
 
 Build the package from this repository and run its test suite with:

--- a/examples/nodejs/README.md
+++ b/examples/nodejs/README.md
@@ -1,0 +1,43 @@
+# Node.js ping example
+
+Run two peers locally with `@minip2p/node`. The listener accepts QUIC and TCP connections. The client connects using the supplied address, waits for Identify, measures a Ping round-trip time, and closes.
+
+## Setup
+
+Use Node.js 24 or newer and the repository's pnpm version. From the repository root:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @minip2p/node native:build
+pnpm exec turbo run build --filter=@minip2p/node
+cd examples/nodejs
+```
+
+The native build requires the repository's Rust toolchain and C/C++ build tools for QUIC.
+
+## Run
+
+Start the listener:
+
+```bash
+pnpm start
+```
+
+It prints two complete multiaddresses, including the peer ID. Ports are assigned automatically:
+
+```text
+/ip4/127.0.0.1/udp/54321/quic-v1/p2p/12D3KooW...
+/ip4/127.0.0.1/tcp/54322/p2p/12D3KooW...
+```
+
+In another terminal, change to `examples/nodejs` and pass one of the printed addresses:
+
+```bash
+pnpm run ping /ip4/127.0.0.1/udp/54321/quic-v1/p2p/12D3KooW...
+```
+
+Replace the entire address above with the listener's output. Use its TCP address to try TCP. The client prints the connected peer and Ping time, then exits. Connection and Identify waits each time out after 10 seconds; Ping times out after 5 seconds.
+
+Press Ctrl+C in the listener terminal to close its endpoint and exit.
+
+Both peers generate a fresh identity on every run. The listener binds to loopback, so only peers on the same machine can connect.

--- a/examples/nodejs/listener.mjs
+++ b/examples/nodejs/listener.mjs
@@ -1,0 +1,20 @@
+import { generateSecretKey, Minip2p } from "@minip2p/node";
+
+const endpoint = Minip2p.create({
+  agentVersion: "minip2p-nodejs-example/0.1.0",
+  secretKey: generateSecretKey(),
+  transports: {
+    quic: { listen: ["/ip4/127.0.0.1/udp/0/quic-v1"] },
+    tcp: { listen: ["/ip4/127.0.0.1/tcp/0"] },
+  },
+});
+
+process.once("SIGINT", () => endpoint.close());
+process.once("SIGTERM", () => endpoint.close());
+
+console.log(`Peer: ${endpoint.peerId()}`);
+console.log("Pass either address to the ping script:");
+for (const address of endpoint.listenAddrs()) {
+  console.log(address);
+}
+console.log("Press Ctrl+C to stop.");

--- a/examples/nodejs/listener.mjs
+++ b/examples/nodejs/listener.mjs
@@ -9,8 +9,12 @@ const endpoint = Minip2p.create({
   },
 });
 
-process.once("SIGINT", () => endpoint.close());
-process.once("SIGTERM", () => endpoint.close());
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => {
+    endpoint.close();
+    process.exit(0);
+  });
+}
 
 console.log(`Peer: ${endpoint.peerId()}`);
 console.log("Pass either address to the ping script:");

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "minip2p-nodejs-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node listener.mjs",
+    "ping": "node ping.mjs"
+  },
+  "dependencies": {
+    "@minip2p/node": "workspace:*"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/examples/nodejs/ping.mjs
+++ b/examples/nodejs/ping.mjs
@@ -1,0 +1,25 @@
+import { generateSecretKey, Minip2p } from "@minip2p/node";
+
+const address = process.argv.at(2);
+if (!address || process.argv.length !== 3) {
+  throw new Error(
+    "Usage: pnpm run ping <multiaddress printed by the listener>"
+  );
+}
+
+const endpoint = Minip2p.create({
+  agentVersion: "minip2p-nodejs-example/0.1.0",
+  secretKey: generateSecretKey(),
+  transports: { quic: {}, tcp: {} },
+});
+
+try {
+  const connected = await endpoint.connectAddr(address, { timeoutMs: 10_000 });
+  await endpoint.waitPeerReady(connected.peerId, { timeoutMs: 10_000 });
+  const rttMs = await endpoint.ping(connected.peerId, { timeoutMs: 5000 });
+
+  console.log(`Connected to ${connected.peerId} over ${connected.path.kind}`);
+  console.log(`Ping: ${rttMs} ms`);
+} finally {
+  endpoint.close();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,12 @@ importers:
         specifier: 1.6.3
         version: 1.6.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@shikijs/themes@4.4.3)(@types/node@26.4.1)(@types/react-dom@19.2.7(@types/react@19.2.18))(@types/react@19.2.18)(@vercel/functions@3.9.5(ws@8.21.3))(csstype@3.2.3)(esbuild@0.28.2)(prettier@3.9.6)(rollup@4.62.5)(supports-color@8.1.1)(terser@5.50.0)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(ws@8.21.3)(yaml@2.9.0)
 
+  examples/nodejs:
+    dependencies:
+      '@minip2p/node':
+        specifier: workspace:*
+        version: link:../../bindings/ts/node
+
   examples/react-native:
     dependencies:
       '@minip2p/react-native':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - bindings/ts/node-platforms/*
   - bindings/ts/react-native
   - examples/react-native
+  - examples/nodejs
   - bindings/ts/test-fixtures
 
 allowBuilds:


### PR DESCRIPTION
Adds a runnable Node.js example under `examples/nodejs`. Start the listener, copy its QUIC or TCP multiaddress, and run the ping client to connect, wait for Identify, and measure a Ping RTT.

The listener closes on SIGINT/SIGTERM. The client bounds network waits and closes its endpoint on success or failure. Includes setup instructions, pnpm workspace registration, and links from the project and Node binding READMEs.

Validation:
- Built the native addon and TypeScript packages.
- Ran the client against the listener over QUIC and TCP.
- Checked missing, malformed, and extra arguments exit unsuccessfully, and SIGINT closes the listener cleanly.
- JavaScript type checking, scoped lint/format checks, and `git diff --check` passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runnable Node.js ping example under `examples/nodejs` that connects two local peers over QUIC or TCP and measures a Ping RTT.

- The listener prints its QUIC and TCP multiaddresses and exits cleanly on SIGINT/SIGTERM.
- The client connects, waits for Identify, pings, and closes its endpoint on success or failure.
- Includes setup instructions and registers the example in the pnpm workspace.
- Links to the example from the project and Node binding READMEs.

<sup>Written for commit 3bc81dd232468ae299c30aca049dc9cccd423539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepso7/minip2p/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

